### PR TITLE
Alembic migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,8 +74,6 @@ dmypy.json
 # UV lock file (optional - some prefer to commit this)
 # uv.lock
 
-# Alembic
-/alembic/versions/
 
 # Storage directories
 /storage/

--- a/alembic/README
+++ b/alembic/README
@@ -1,1 +1,102 @@
-Generic single-database configuration.
+# Alembic Migrations
+
+Database migrations for shuushuu-api using Alembic.
+
+## Setup for Different Scenarios
+
+### New Developer (Empty Database)
+
+If you're starting fresh with an empty database:
+
+```bash
+# Run all migrations from baseline to head
+uv run alembic upgrade head
+```
+
+This creates all tables and applies all schema changes.
+
+### Existing Database (Legacy PHP Dump)
+
+If you're restoring from a legacy PHP database dump:
+
+```bash
+# 1. Restore your database from the SQL dump
+mysql -u user -p database_name < legacy_dump.sql
+
+# 2. Mark all migrations as applied (without running them)
+uv run alembic stamp head
+```
+
+This tells Alembic that the database is already at the latest schema version.
+
+## Common Commands
+
+```bash
+# Show current migration version
+uv run alembic current
+
+# Show migration history
+uv run alembic history
+
+# Upgrade to latest
+uv run alembic upgrade head
+
+# Upgrade one step
+uv run alembic upgrade +1
+
+# Downgrade one step
+uv run alembic downgrade -1
+
+# Show pending migrations
+uv run alembic history --indicate-current
+```
+
+## Creating New Migrations
+
+```bash
+# Auto-generate migration from model changes
+uv run alembic revision --autogenerate -m "description of changes"
+
+# Create empty migration for manual edits
+uv run alembic revision -m "description of changes"
+```
+
+After generating, review the migration file in `alembic/versions/` and adjust as needed.
+
+## Migration Notes
+
+### Column Types for MariaDB
+
+When creating foreign keys that reference existing tables, ensure column types match exactly:
+
+- `users.user_id` is `INT(10) UNSIGNED` - use `mysql.INTEGER(unsigned=True)`
+- `images.image_id` is `INT(10) UNSIGNED` - use `mysql.INTEGER(unsigned=True)`
+- `image_reports.report_id` is `INT(10) UNSIGNED` - use `mysql.INTEGER(unsigned=True)`
+
+Example:
+```python
+from sqlalchemy.dialects import mysql
+
+op.add_column(
+    "my_table",
+    sa.Column("user_id", mysql.INTEGER(unsigned=True), nullable=True),
+)
+```
+
+### Column Renames
+
+To rename columns without changing their type, use raw SQL:
+
+```python
+op.execute("ALTER TABLE my_table RENAME COLUMN `old_name` TO `new_name`")
+```
+
+This preserves the exact column definition (unsigned, nullable, default, etc.).
+
+## Environment Variables
+
+Alembic uses `DATABASE_URL_SYNC` from your environment or `.env` file:
+
+```
+DATABASE_URL_SYNC=mysql+pymysql://user:password@localhost:3306/database?charset=utf8mb4
+```

--- a/alembic/versions/176f47a1d07f_add_refresh_tokens_table.py
+++ b/alembic/versions/176f47a1d07f_add_refresh_tokens_table.py
@@ -1,0 +1,57 @@
+"""add_refresh_tokens_table
+
+Revision ID: 176f47a1d07f
+Revises: 8619a9fc7189
+Create Date: 2025-11-11 21:39:33.095753
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '176f47a1d07f'
+down_revision: Union[str, Sequence[str], None] = '8619a9fc7189'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Create refresh_tokens table
+    # Note: user_id must be UNSIGNED to match users.user_id
+    op.create_table(
+        'refresh_tokens',
+        sa.Column('id', mysql.INTEGER(unsigned=True), nullable=False, autoincrement=True),
+        sa.Column('user_id', mysql.INTEGER(unsigned=True), nullable=False),
+        sa.Column('token_hash', sa.String(length=255), nullable=False),
+        sa.Column('family_id', sa.String(length=255), nullable=False),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('current_timestamp()'), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=False),
+        sa.Column('revoked', mysql.TINYINT(1), nullable=False, server_default='0'),
+        sa.Column('revoked_at', sa.DateTime(), nullable=True),
+        sa.Column('ip_address', sa.String(length=45), nullable=True),
+        sa.Column('user_agent', sa.String(length=255), nullable=True),
+        sa.Column('parent_token_id', mysql.INTEGER(unsigned=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.user_id'], name='fk_refresh_tokens_user_id', onupdate='CASCADE', ondelete='CASCADE'),
+    )
+
+    # Create indexes
+    op.create_index('idx_refresh_tokens_user_id', 'refresh_tokens', ['user_id'])
+    op.create_index('idx_refresh_tokens_token_hash', 'refresh_tokens', ['token_hash'], unique=True)
+    op.create_index('idx_refresh_tokens_family_id', 'refresh_tokens', ['family_id'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Drop indexes
+    op.drop_index('idx_refresh_tokens_family_id', table_name='refresh_tokens')
+    op.drop_index('idx_refresh_tokens_token_hash', table_name='refresh_tokens')
+    op.drop_index('idx_refresh_tokens_user_id', table_name='refresh_tokens')
+
+    # Drop table
+    op.drop_table('refresh_tokens')

--- a/alembic/versions/198d753671e3_add_account_lockout_fields.py
+++ b/alembic/versions/198d753671e3_add_account_lockout_fields.py
@@ -1,0 +1,41 @@
+"""Add account lockout fields
+
+Revision ID: 198d753671e3
+Revises: e4c0f75b08cb
+Create Date: 2025-11-13 21:25:48.884549
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '198d753671e3'
+down_revision: Union[str, Sequence[str], None] = 'e4c0f75b08cb'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # ALTER TABLE users
+    # ADD COLUMN failed_login_attempts INT DEFAULT 0,
+    # ADD COLUMN lockout_until TIMESTAMP NULL;
+    op.add_column(
+        'users',
+        sa.Column('failed_login_attempts', sa.Integer(), nullable=False, server_default='0'),
+    )
+    op.add_column(
+        'users',
+        sa.Column('lockout_until', sa.DateTime(), nullable=True),
+    )
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # ALTER TABLE users
+    # DROP COLUMN failed_login_attempts,
+    # DROP COLUMN lockout_until;
+    op.drop_column('users', 'lockout_until')
+    op.drop_column('users', 'failed_login_attempts')

--- a/alembic/versions/6f22c3978270_add_fulltext_index_to_posts_post_text.py
+++ b/alembic/versions/6f22c3978270_add_fulltext_index_to_posts_post_text.py
@@ -1,0 +1,66 @@
+"""add fulltext index to posts.post_text
+
+Revision ID: 6f22c3978270
+Revises: 8d66158eb568
+Create Date: 2025-11-03 11:51:58.773420
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6f22c3978270'
+down_revision: Union[str, Sequence[str], None] = '8d66158eb568'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Add FULLTEXT index to posts.post_text for fast comment searching.
+
+    This enables the /comments/search/text endpoint to use MySQL's native
+    full-text search (MATCH ... AGAINST), which is generally faster than
+    LIKE pattern matching on large datasets.
+
+    The index supports:
+    - Natural language search with relevance ranking
+    - Boolean search with operators (+word, -word, "phrase", word*)
+    - Word stemming and stop word filtering
+
+    Performance impact:
+    - Significantly speeds up text searches
+    - Index size: ~50-70% of column data size
+    - Slight overhead on INSERT/UPDATE operations
+    """
+    # Use raw SQL for MySQL-specific FULLTEXT index
+    # Note: FULLTEXT indexes can only be created on TEXT/VARCHAR columns
+    # and are available on InnoDB tables (MySQL 5.6+)
+    op.create_index(
+        'idx_post_text_fulltext',
+        'posts',
+        ['post_text'],
+        mysql_prefix='FULLTEXT'
+    )
+    # op.execute(
+    #     "CREATE FULLTEXT INDEX idx_post_text_fulltext ON posts(post_text)"
+    # )
+
+
+def downgrade() -> None:
+    """
+    Remove FULLTEXT index from posts.post_text.
+
+    This will cause the /comments/search/text endpoint to fail unless
+    the code is reverted to use LIKE pattern matching instead.
+    """
+    op.drop_index(
+        'idx_post_text_fulltext',
+        table_name='posts'
+    )
+    # op.execute(
+    #     "DROP INDEX idx_post_text_fulltext ON posts"
+    # )

--- a/alembic/versions/79e1a49d9e90_update_perms.py
+++ b/alembic/versions/79e1a49d9e90_update_perms.py
@@ -1,0 +1,102 @@
+"""Update permissions to follow {OBJECT}_{ACTION} naming convention
+Also removes deprecated permissions and adds new image tag management perms.
+
+Revision ID: 79e1a49d9e90
+Revises: b8df3d41cab8
+Create Date: 2025-11-20 22:46:09.980720
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '79e1a49d9e90'
+down_revision: Union[str, Sequence[str], None] = 'b8df3d41cab8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+deprecated_perms = [
+    'image_check_dupes',
+    'image_edit_filename',
+    'level_tagger',
+    'level_mod',
+    'level_admin'
+]
+
+def upgrade() -> None:
+    """Rename permissions to follow {OBJECT}_{ACTION} naming convention."""
+    # Tag permissions
+    op.execute("UPDATE perms SET title = 'tag_create' WHERE title = 'createtag'")
+    op.execute("UPDATE perms SET title = 'tag_edit' WHERE title = 'edittag'")
+    op.execute("UPDATE perms SET title = 'tag_update' WHERE title = 'renametag'")
+    op.execute("UPDATE perms SET title = 'tag_delete' WHERE title = 'deletetag'")
+
+    # Image permissions
+    op.execute("UPDATE perms SET title = 'image_edit_meta' WHERE title = 'editimgmeta'")
+    op.execute("UPDATE perms SET title = 'image_edit' WHERE title = 'editimg'")
+    op.execute("UPDATE perms SET title = 'image_mark_repost' WHERE title = 'repost'")
+
+    # User/Group permissions
+    op.execute("UPDATE perms SET title = 'group_manage' WHERE title = 'allgroup'")
+    op.execute("UPDATE perms SET title = 'group_perm_manage' WHERE title = 'allgroupperm'")
+    op.execute("UPDATE perms SET title = 'user_edit_profile' WHERE title = 'editprofile'")
+    op.execute("UPDATE perms SET title = 'user_ban' WHERE title = 'ban'")
+
+    # Content moderation
+    op.execute("UPDATE perms SET title = 'post_edit' WHERE title = 'editpost'")
+
+    # Special permissions
+    op.execute("UPDATE perms SET title = 'theme_edit' WHERE title = 'themeeditor'")
+    op.execute("UPDATE perms SET title = 'rating_revoke' WHERE title = 'revokerating'")
+    op.execute("UPDATE perms SET title = 'report_revoke' WHERE title = 'revokereports'")
+
+    # Remove deprecated permissions if they exist
+    for perm in deprecated_perms:
+        op.execute(f"DELETE FROM perms WHERE title = '{perm}'")
+
+    # Add new perms
+    op.execute("INSERT INTO perms (title, `desc`) VALUES ('image_tag_add', 'Add tags to images')")
+    op.execute("INSERT INTO perms (title, `desc`) VALUES ('image_tag_remove', 'Remove tags from images')")
+    op.execute("INSERT INTO perms (title, `desc`) VALUES ('privmsg_view', 'View private messages')")
+
+
+def downgrade() -> None:
+    """Revert permissions to original naming convention."""
+    # Tag permissions
+    op.execute("UPDATE perms SET title = 'createtag' WHERE title = 'tag_create'")
+    op.execute("UPDATE perms SET title = 'edittag' WHERE title = 'tag_edit'")
+    op.execute("UPDATE perms SET title = 'renametag' WHERE title = 'tag_update'")
+    op.execute("UPDATE perms SET title = 'deletetag' WHERE title = 'tag_delete'")
+
+    # Image permissions
+    op.execute("UPDATE perms SET title = 'editimgmeta' WHERE title = 'image_edit_meta'")
+    op.execute("UPDATE perms SET title = 'editimg' WHERE title = 'image_edit'")
+    op.execute("UPDATE perms SET title = 'repost' WHERE title = 'image_mark_repost'")
+
+    # User/Group permissions
+    op.execute("UPDATE perms SET title = 'allgroup' WHERE title = 'group_manage'")
+    op.execute("UPDATE perms SET title = 'allgroupperm' WHERE title = 'group_perm_manage'")
+    op.execute("UPDATE perms SET title = 'editprofile' WHERE title = 'user_edit_profile'")
+    op.execute("UPDATE perms SET title = 'ban' WHERE title = 'user_ban'")
+
+    # Content moderation
+    op.execute("UPDATE perms SET title = 'editpost' WHERE title = 'post_edit'")
+
+    # Special permissions
+    op.execute("UPDATE perms SET title = 'themeeditor' WHERE title = 'theme_edit'")
+    op.execute("UPDATE perms SET title = 'revokerating' WHERE title = 'rating_revoke'")
+    op.execute("UPDATE perms SET title = 'revokereports' WHERE title = 'report_revoke'")
+
+    for perm in deprecated_perms:
+        # Re-add deprecated permissions with generic descriptions
+        op.execute(
+            f"INSERT INTO perms (title, `desc`) VALUES ('{perm}', 'Deprecated permission {perm}')"
+        )
+
+    # Remove newly added perms
+    op.execute("DELETE FROM perms WHERE title = 'image_tag_add'")
+    op.execute("DELETE FROM perms WHERE title = 'image_tag_remove'")
+    op.execute("DELETE FROM perms WHERE title = 'privmsg_view'")

--- a/alembic/versions/8619a9fc7189_drop_unused_columns_from_privmsgs.py
+++ b/alembic/versions/8619a9fc7189_drop_unused_columns_from_privmsgs.py
@@ -1,0 +1,41 @@
+"""drop unused columns from privmsgs, set date non-nullable
+
+
+Revision ID: 8619a9fc7189
+Revises: 6f22c3978270
+Create Date: 2025-11-09 16:18:27.956105
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '8619a9fc7189'
+down_revision: Union[str, Sequence[str], None] = '6f22c3978270'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_column('privmsgs', 'type')
+    op.drop_column('privmsgs', 'card')
+    op.drop_column('privmsgs', 'cardpath')
+    op.alter_column('privmsgs', 'date',
+               existing_type=sa.DATETIME(),
+               server_default=sa.text('current_timestamp()'),
+               nullable=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column('privmsgs', sa.Column('type', sa.Integer(), nullable=True))
+    op.add_column('privmsgs', sa.Column('card', sa.Integer(), nullable=True))
+    op.add_column('privmsgs', sa.Column('cardpath', sa.String(255), nullable=True))
+    op.alter_column('privmsgs', 'date',
+               existing_type=sa.DATETIME(),
+               nullable=True,
+               server_default=sa.text('current_timestamp()'))

--- a/alembic/versions/8d66158eb568_initial_schema_from_existing_database.py
+++ b/alembic/versions/8d66158eb568_initial_schema_from_existing_database.py
@@ -1,0 +1,512 @@
+"""Initial schema from existing database
+
+Revision ID: 8d66158eb568
+Revises:
+Create Date: 2025-10-29 20:19:41.188630
+
+This baseline migration creates the schema as it exists in the legacy PHP database.
+For existing databases: run `alembic stamp head` instead of `alembic upgrade head`.
+For new databases: run `alembic upgrade head` to create all tables.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "8d66158eb568"
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create initial schema from legacy database dump."""
+    # Disable FK checks during table creation to avoid ordering issues
+    op.execute("SET FOREIGN_KEY_CHECKS=0")
+
+    # ===== Independent tables (no FK dependencies) =====
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `banners` (
+          `banner_id` smallint(4) unsigned NOT NULL AUTO_INCREMENT,
+          `path` varchar(255) NOT NULL DEFAULT '',
+          `author` varchar(255) NOT NULL DEFAULT '',
+          `leftext` char(3) NOT NULL DEFAULT 'png',
+          `midext` char(3) NOT NULL DEFAULT 'png',
+          `rightext` char(3) NOT NULL DEFAULT 'png',
+          `full` tinyint(1) NOT NULL DEFAULT 0,
+          `event_id` int(11) unsigned NOT NULL DEFAULT 0,
+          `active` tinyint(1) NOT NULL DEFAULT 1,
+          `date` datetime DEFAULT current_timestamp(),
+          PRIMARY KEY (`banner_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `donations` (
+          `date` datetime NOT NULL DEFAULT current_timestamp(),
+          `user_id` int(10) unsigned DEFAULT NULL,
+          `nick` varchar(30) DEFAULT NULL,
+          `amount` int(3) DEFAULT NULL,
+          KEY `idx_date` (`date`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `eva_theme` (
+          `theme_id` int(11) NOT NULL AUTO_INCREMENT,
+          `theme_content` longtext DEFAULT NULL,
+          `active_month_from` tinyint(2) NOT NULL DEFAULT 0,
+          `active_month_to` tinyint(2) NOT NULL DEFAULT 0,
+          `active_day_from` tinyint(2) NOT NULL DEFAULT 0,
+          `active_day_to` tinyint(2) NOT NULL DEFAULT 0,
+          `active` tinyint(1) NOT NULL DEFAULT 0,
+          `theme_name` varchar(255) NOT NULL DEFAULT '',
+          `banner` varchar(255) NOT NULL DEFAULT '',
+          PRIMARY KEY (`theme_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `groups` (
+          `group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+          `title` varchar(50) DEFAULT NULL,
+          `desc` varchar(75) DEFAULT NULL,
+          PRIMARY KEY (`group_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `image_ratings_avg` (
+          `type` char(3) DEFAULT NULL,
+          `avg` float DEFAULT NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `perms` (
+          `perm_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+          `title` varchar(50) DEFAULT NULL,
+          `desc` varchar(75) DEFAULT NULL,
+          PRIMARY KEY (`perm_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `tips` (
+          `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+          `tip` varchar(255) DEFAULT NULL,
+          `type` int(1) NOT NULL DEFAULT 0,
+          PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci
+    """)
+
+    # ===== Core tables with self-references =====
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `users` (
+          `user_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+          `forum_id` mediumint(8) unsigned DEFAULT NULL,
+          `date_joined` datetime NOT NULL DEFAULT current_timestamp(),
+          `last_login` datetime DEFAULT current_timestamp(),
+          `active` tinyint(1) NOT NULL DEFAULT 0,
+          `admin` tinyint(1) NOT NULL DEFAULT 0,
+          `username` varchar(30) NOT NULL,
+          `password` varchar(40) NOT NULL,
+          `salt` char(16) NOT NULL,
+          `timezone` decimal(5,2) NOT NULL DEFAULT 0.00,
+          `email_pm_pref` tinyint(1) NOT NULL DEFAULT 1,
+          `spoiler_warning_pref` tinyint(1) NOT NULL DEFAULT 1,
+          `thumb_layout` tinyint(1) NOT NULL DEFAULT 0,
+          `sorting_pref` varchar(100) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL DEFAULT 'image_id',
+          `sorting_pref_order` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL DEFAULT 'DESC',
+          `images_per_page` int(3) NOT NULL DEFAULT 10,
+          `show_all_images` tinyint(1) NOT NULL DEFAULT 0,
+          `show_all_meta` tinyint(1) NOT NULL DEFAULT 0,
+          `show_all_posts` tinyint(1) NOT NULL DEFAULT 0,
+          `show_ip` tinyint(1) NOT NULL DEFAULT 0,
+          `bookmark` int(10) unsigned DEFAULT NULL,
+          `posts` mediumint(8) unsigned NOT NULL DEFAULT 0,
+          `image_posts` mediumint(8) NOT NULL DEFAULT 0,
+          `favorites` int(10) unsigned NOT NULL DEFAULT 0,
+          `email` varchar(120) NOT NULL,
+          `show_email` tinyint(4) NOT NULL DEFAULT 0,
+          `avatar` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL DEFAULT '',
+          `avatar_type` tinyint(2) NOT NULL DEFAULT 0,
+          `gender` char(1) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL DEFAULT '',
+          `location` varchar(100) DEFAULT NULL,
+          `website` varchar(100) DEFAULT NULL,
+          `aim` varchar(50) DEFAULT NULL,
+          `interests` varchar(255) DEFAULT NULL,
+          `user_title` varchar(50) DEFAULT NULL,
+          `actkey` varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL DEFAULT '',
+          `newpassword` varchar(40) DEFAULT NULL,
+          `newsalt` char(16) DEFAULT NULL,
+          `maximgperday` int(3) NOT NULL DEFAULT 15,
+          `rating_ratio` float NOT NULL DEFAULT 0,
+          `infected` tinyint(1) DEFAULT 0,
+          `infected_by` int(11) unsigned NOT NULL DEFAULT 0,
+          `date_infected` int(11) NOT NULL DEFAULT 0,
+          `last_login_new` datetime DEFAULT NULL,
+          PRIMARY KEY (`user_id`),
+          UNIQUE KEY `username` (`username`),
+          KEY `fk_bookmark` (`bookmark`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `images` (
+          `image_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+          `user_id` int(10) unsigned NOT NULL,
+          `date_added` datetime DEFAULT current_timestamp(),
+          `useragent` varchar(255) NOT NULL DEFAULT '',
+          `ip` varchar(15) NOT NULL DEFAULT '',
+          `status_user_id` int(10) unsigned DEFAULT NULL,
+          `status_updated` datetime DEFAULT NULL,
+          `status` tinyint(2) NOT NULL DEFAULT 1,
+          `locked` tinyint(1) NOT NULL DEFAULT 0,
+          `last_updated` datetime DEFAULT NULL,
+          `last_post` datetime DEFAULT NULL,
+          `filename` varchar(120) DEFAULT NULL,
+          `ext` varchar(10) NOT NULL,
+          `md5_hash` varchar(32) NOT NULL DEFAULT '',
+          `original_filename` varchar(120) DEFAULT NULL,
+          `filesize` int(9) unsigned NOT NULL DEFAULT 0,
+          `width` smallint(6) unsigned NOT NULL DEFAULT 0,
+          `height` smallint(6) unsigned NOT NULL DEFAULT 0,
+          `total_pixels` decimal(6,3) unsigned DEFAULT NULL,
+          `medium` tinyint(1) NOT NULL DEFAULT 0,
+          `large` tinyint(1) NOT NULL DEFAULT 0,
+          `posts` smallint(4) unsigned NOT NULL DEFAULT 0,
+          `favorites` smallint(4) unsigned NOT NULL DEFAULT 0,
+          `caption` varchar(35) NOT NULL DEFAULT '',
+          `image_source` varchar(255) DEFAULT NULL,
+          `artist` varchar(200) DEFAULT NULL,
+          `characters` text DEFAULT NULL,
+          `miscmeta` varchar(255) DEFAULT NULL,
+          `rating` float NOT NULL DEFAULT 0,
+          `bayesian_rating` float NOT NULL DEFAULT 0,
+          `num_ratings` int(4) unsigned NOT NULL DEFAULT 0,
+          `replacement_id` int(10) unsigned DEFAULT NULL,
+          `reviewed` tinyint(1) NOT NULL DEFAULT 0,
+          `change_id` int(10) NOT NULL DEFAULT 0,
+          PRIMARY KEY (`image_id`),
+          KEY `change_id` (`change_id`),
+          KEY `idx_bayesian_rating` (`bayesian_rating`),
+          KEY `idx_top_images` (`num_ratings`),
+          KEY `idx_total_pixels` (`total_pixels`),
+          KEY `idx_favorites` (`favorites`),
+          KEY `idx_filename` (`filename`),
+          KEY `idx_status` (`status`),
+          KEY `fk_images_user_id` (`user_id`),
+          KEY `fk_images_status_user_id` (`status_user_id`),
+          KEY `fk_images_replacement_id` (`replacement_id`),
+          KEY `idx_last_post` (`last_post`),
+          CONSTRAINT `fk_images_replacement_id` FOREIGN KEY (`replacement_id`) REFERENCES `images` (`image_id`) ON DELETE SET NULL ON UPDATE CASCADE,
+          CONSTRAINT `fk_images_status_user_id` FOREIGN KEY (`status_user_id`) REFERENCES `users` (`user_id`) ON DELETE SET NULL ON UPDATE CASCADE,
+          CONSTRAINT `fk_images_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `tags` (
+          `tag_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+          `title` varchar(150) DEFAULT NULL,
+          `desc` varchar(200) DEFAULT NULL,
+          `alias` int(10) unsigned DEFAULT NULL,
+          `inheritedfrom_id` int(10) unsigned DEFAULT NULL,
+          `date_added` datetime NOT NULL DEFAULT current_timestamp(),
+          `user_id` int(10) unsigned DEFAULT NULL,
+          `type` tinyint(1) NOT NULL DEFAULT 1,
+          PRIMARY KEY (`tag_id`),
+          KEY `type_alias` (`type`,`alias`),
+          KEY `fk_tags_inheritedfrom_id` (`inheritedfrom_id`),
+          KEY `fk_tags_user_id` (`user_id`),
+          KEY `fk_tags_alias` (`alias`),
+          CONSTRAINT `fk_tags_alias` FOREIGN KEY (`alias`) REFERENCES `tags` (`tag_id`) ON DELETE SET NULL ON UPDATE CASCADE,
+          CONSTRAINT `fk_tags_inheritedfrom_id` FOREIGN KEY (`inheritedfrom_id`) REFERENCES `tags` (`tag_id`) ON DELETE SET NULL ON UPDATE CASCADE,
+          CONSTRAINT `fk_tags_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE SET NULL ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    # ===== Add FK constraint for users.bookmark (circular dep with images) =====
+    op.execute("""
+        ALTER TABLE `users`
+        ADD CONSTRAINT `fk_bookmark` FOREIGN KEY (`bookmark`) REFERENCES `images` (`image_id`) ON DELETE SET NULL ON UPDATE CASCADE
+    """)
+
+    # ===== Tables dependent on users =====
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `bans` (
+          `ban_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+          `user_id` int(10) unsigned NOT NULL,
+          `banned_by` int(10) unsigned DEFAULT NULL,
+          `ip` varchar(15) DEFAULT NULL,
+          `action` enum('None','One Week Ban','Two Week Ban','One Month Ban','Permanent Ban') DEFAULT NULL,
+          `reason` tinytext DEFAULT NULL,
+          `message` varchar(255) DEFAULT NULL,
+          `viewed` tinyint(1) NOT NULL DEFAULT 0,
+          `date` datetime DEFAULT current_timestamp(),
+          `expires` datetime DEFAULT NULL,
+          PRIMARY KEY (`ban_id`),
+          KEY `fk_bans_user_id` (`user_id`),
+          KEY `fk_bans_banned_by` (`banned_by`),
+          CONSTRAINT `fk_bans_banned_by` FOREIGN KEY (`banned_by`) REFERENCES `users` (`user_id`) ON DELETE SET NULL ON UPDATE CASCADE,
+          CONSTRAINT `fk_bans_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `news` (
+          `news_id` smallint(8) unsigned NOT NULL AUTO_INCREMENT,
+          `user_id` int(10) unsigned NOT NULL,
+          `title` varchar(128) DEFAULT NULL,
+          `news_text` text DEFAULT NULL,
+          `date` datetime DEFAULT current_timestamp(),
+          `edited` datetime DEFAULT NULL,
+          PRIMARY KEY (`news_id`),
+          KEY `fk_news_user_id` (`user_id`),
+          CONSTRAINT `fk_news_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `privmsgs` (
+          `privmsg_id` int(11) NOT NULL AUTO_INCREMENT,
+          `from_user_id` int(10) unsigned NOT NULL,
+          `to_user_id` int(10) unsigned NOT NULL,
+          `subject` varchar(255) NOT NULL DEFAULT '',
+          `text` text DEFAULT NULL,
+          `viewed` tinyint(1) NOT NULL DEFAULT 0,
+          `from_del` tinyint(1) NOT NULL DEFAULT 0,
+          `to_del` tinyint(1) NOT NULL DEFAULT 0,
+          `type` tinyint(1) NOT NULL DEFAULT 1,
+          `card` tinyint(1) NOT NULL DEFAULT 0,
+          `cardpath` varchar(255) NOT NULL DEFAULT '',
+          `date` datetime DEFAULT current_timestamp(),
+          PRIMARY KEY (`privmsg_id`),
+          KEY `fk_privmsgs_from_user_id` (`from_user_id`),
+          KEY `fk_privmsgs_to_user_id` (`to_user_id`),
+          CONSTRAINT `fk_privmsgs_from_user_id` FOREIGN KEY (`from_user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+          CONSTRAINT `fk_privmsgs_to_user_id` FOREIGN KEY (`to_user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `quicklinks` (
+          `quicklink_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+          `user_id` int(10) unsigned DEFAULT NULL,
+          `link` varchar(32) DEFAULT NULL,
+          PRIMARY KEY (`quicklink_id`),
+          KEY `fk_quicklinks_user_id` (`user_id`),
+          CONSTRAINT `fk_quicklinks_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `user_sessions` (
+          `session_id` varchar(50) NOT NULL DEFAULT '',
+          `user_id` int(10) unsigned NOT NULL,
+          `last_used` datetime NOT NULL DEFAULT current_timestamp(),
+          `last_view_date` datetime DEFAULT current_timestamp(),
+          `ip` varchar(16) NOT NULL DEFAULT '',
+          `lastpage` varchar(200) DEFAULT NULL,
+          `last_search` datetime DEFAULT current_timestamp(),
+          PRIMARY KEY (`session_id`),
+          KEY `ip` (`ip`),
+          KEY `fk_user_sessions_user_id` (`user_id`),
+          CONSTRAINT `fk_user_sessions_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    # ===== Junction tables for permissions =====
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `group_perms` (
+          `group_id` int(10) unsigned NOT NULL,
+          `perm_id` int(10) unsigned NOT NULL,
+          `permvalue` tinyint(1) DEFAULT NULL,
+          PRIMARY KEY (`group_id`,`perm_id`),
+          KEY `fk_group_perms_perm_id` (`perm_id`),
+          CONSTRAINT `fk_group_perms_group_id` FOREIGN KEY (`group_id`) REFERENCES `groups` (`group_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+          CONSTRAINT `fk_group_perms_perm_id` FOREIGN KEY (`perm_id`) REFERENCES `perms` (`perm_id`) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `user_groups` (
+          `user_id` int(11) NOT NULL,
+          `group_id` int(11) NOT NULL,
+          PRIMARY KEY (`user_id`,`group_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `user_perms` (
+          `user_id` int(11) NOT NULL,
+          `perm_id` int(11) NOT NULL,
+          `permvalue` tinyint(1) NOT NULL DEFAULT 1,
+          PRIMARY KEY (`user_id`,`perm_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    # ===== Tables dependent on images =====
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `favorites` (
+          `user_id` int(10) unsigned NOT NULL,
+          `image_id` int(10) unsigned NOT NULL,
+          `fav_date` datetime DEFAULT current_timestamp(),
+          PRIMARY KEY (`user_id`,`image_id`),
+          KEY `fk_favorites_image_id` (`image_id`),
+          CONSTRAINT `fk_favorites_image_id` FOREIGN KEY (`image_id`) REFERENCES `images` (`image_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+          CONSTRAINT `fk_favorites_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `image_ratings` (
+          `user_id` int(10) unsigned NOT NULL,
+          `image_id` int(10) unsigned NOT NULL,
+          `rating` tinyint(2) NOT NULL DEFAULT 0,
+          `date` datetime DEFAULT current_timestamp(),
+          PRIMARY KEY (`user_id`,`image_id`),
+          KEY `fk_image_ratings_image_id` (`image_id`),
+          CONSTRAINT `fk_image_ratings_image_id` FOREIGN KEY (`image_id`) REFERENCES `images` (`image_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+          CONSTRAINT `fk_image_ratings_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `image_reports` (
+          `image_report_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+          `image_id` int(10) unsigned NOT NULL,
+          `user_id` int(10) unsigned NOT NULL,
+          `open` tinyint(1) NOT NULL DEFAULT 1,
+          `category` tinyint(3) unsigned DEFAULT NULL,
+          `text` text DEFAULT NULL,
+          `date` datetime DEFAULT current_timestamp(),
+          PRIMARY KEY (`image_report_id`),
+          KEY `open` (`open`),
+          KEY `fk_image_reports_user_id` (`user_id`),
+          KEY `fk_image_reports_image_id` (`image_id`),
+          CONSTRAINT `fk_image_reports_image_id` FOREIGN KEY (`image_id`) REFERENCES `images` (`image_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+          CONSTRAINT `fk_image_reports_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `image_reviews` (
+          `image_review_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+          `image_id` int(10) unsigned DEFAULT NULL,
+          `user_id` int(10) unsigned DEFAULT NULL,
+          `vote` tinyint(1) DEFAULT NULL,
+          PRIMARY KEY (`image_review_id`),
+          UNIQUE KEY `image_id` (`image_id`,`user_id`),
+          KEY `fk_image_reviews_user_id` (`user_id`),
+          CONSTRAINT `fk_image_reviews_image_id` FOREIGN KEY (`image_id`) REFERENCES `images` (`image_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+          CONSTRAINT `fk_image_reviews_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `posts` (
+          `post_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+          `image_id` int(10) unsigned DEFAULT NULL,
+          `user_id` int(10) unsigned NOT NULL,
+          `useragent` varchar(255) NOT NULL DEFAULT '',
+          `ip` varchar(15) NOT NULL DEFAULT '',
+          `date` datetime NOT NULL DEFAULT current_timestamp(),
+          `last_updated` datetime DEFAULT NULL,
+          `last_updated_user_id` int(10) unsigned DEFAULT NULL,
+          `update_count` int(3) unsigned NOT NULL DEFAULT 0,
+          `post_text` text NOT NULL,
+          PRIMARY KEY (`post_id`),
+          KEY `idx_date` (`date`),
+          KEY `fk_posts_user_id` (`user_id`),
+          KEY `fk_posts_image_id` (`image_id`),
+          KEY `fk_posts_last_updated_user_id` (`last_updated_user_id`),
+          CONSTRAINT `fk_posts_image_id` FOREIGN KEY (`image_id`) REFERENCES `images` (`image_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+          CONSTRAINT `fk_posts_last_updated_user_id` FOREIGN KEY (`last_updated_user_id`) REFERENCES `users` (`user_id`) ON DELETE SET NULL ON UPDATE CASCADE,
+          CONSTRAINT `fk_posts_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    # ===== Tables dependent on tags =====
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `tag_history` (
+          `tag_history_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+          `image_id` int(10) unsigned DEFAULT NULL,
+          `tag_id` int(10) unsigned DEFAULT NULL,
+          `user_id` int(10) unsigned DEFAULT NULL,
+          `action` char(1) DEFAULT NULL,
+          `date` datetime DEFAULT current_timestamp(),
+          PRIMARY KEY (`tag_history_id`),
+          KEY `image_id` (`image_id`),
+          KEY `user_id` (`user_id`),
+          KEY `fk_tag_history_tag_id` (`tag_id`),
+          CONSTRAINT `fk_tag_history_image_id` FOREIGN KEY (`image_id`) REFERENCES `images` (`image_id`) ON DELETE SET NULL ON UPDATE CASCADE,
+          CONSTRAINT `fk_tag_history_tag_id` FOREIGN KEY (`tag_id`) REFERENCES `tags` (`tag_id`) ON DELETE SET NULL ON UPDATE CASCADE,
+          CONSTRAINT `fk_tag_history_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE SET NULL ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci
+    """)
+
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS `tag_links` (
+          `tag_id` int(10) unsigned NOT NULL,
+          `image_id` int(10) unsigned NOT NULL,
+          `user_id` int(10) unsigned DEFAULT NULL,
+          `date_linked` datetime DEFAULT current_timestamp(),
+          PRIMARY KEY (`tag_id`,`image_id`),
+          KEY `fk_tag_links_user_id` (`user_id`),
+          KEY `fk_tag_links_image_id` (`image_id`),
+          CONSTRAINT `fk_tag_links_image_id` FOREIGN KEY (`image_id`) REFERENCES `images` (`image_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+          CONSTRAINT `fk_tag_links_tag_id` FOREIGN KEY (`tag_id`) REFERENCES `tags` (`tag_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+          CONSTRAINT `fk_tag_links_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE SET NULL ON UPDATE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+    """)
+
+    # Re-enable FK checks
+    op.execute("SET FOREIGN_KEY_CHECKS=1")
+
+
+def downgrade() -> None:
+    """Drop all tables in reverse order."""
+    op.execute("SET FOREIGN_KEY_CHECKS=0")
+
+    # Drop in reverse dependency order
+    tables = [
+        "tag_links",
+        "tag_history",
+        "posts",
+        "image_reviews",
+        "image_reports",
+        "image_ratings",
+        "favorites",
+        "user_perms",
+        "user_groups",
+        "group_perms",
+        "user_sessions",
+        "quicklinks",
+        "privmsgs",
+        "news",
+        "bans",
+        "tags",
+        "images",
+        "users",
+        "tips",
+        "perms",
+        "image_ratings_avg",
+        "groups",
+        "eva_theme",
+        "donations",
+        "banners",
+    ]
+
+    for table in tables:
+        op.execute(f"DROP TABLE IF EXISTS `{table}`")
+
+    op.execute("SET FOREIGN_KEY_CHECKS=1")

--- a/alembic/versions/a1b2c3d4e5f6_add_reporting_review_system.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_reporting_review_system.py
@@ -1,0 +1,463 @@
+"""Add reporting and review system tables and columns
+
+This migration:
+1. Updates image_reports table:
+   - Renames 'open' to 'status' (converts 1→0 pending, 0→2 dismissed)
+   - Renames 'text' to 'reason_text'
+   - Renames 'date' to 'created_at'
+   - Renames 'image_report_id' to 'report_id'
+   - Adds reviewed_by, reviewed_at columns
+
+2. Renames image_reviews to review_votes and updates it:
+   - Renames 'image_review_id' to 'vote_id'
+   - Adds review_id, comment, created_at columns
+
+3. Creates new image_reviews table for review sessions
+
+4. Creates admin_actions audit log table
+
+5. Adds new permissions for report/review management
+
+Revision ID: a1b2c3d4e5f6
+Revises: 79e1a49d9e90
+Create Date: 2025-11-22
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "79e1a49d9e90"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply reporting and review system changes."""
+
+    # =========================================================================
+    # 1. Update image_reports table
+    # =========================================================================
+
+    # Rename columns using raw SQL to preserve exact column types (MariaDB)
+    op.execute("ALTER TABLE image_reports RENAME COLUMN `text` TO `reason_text`")
+    op.execute("ALTER TABLE image_reports RENAME COLUMN `date` TO `created_at`")
+    op.execute("ALTER TABLE image_reports RENAME COLUMN `image_report_id` TO `report_id`")
+
+    # Drop the old 'open' index before renaming the column
+    op.drop_index("open", table_name="image_reports")
+
+    # Rename 'open' column to 'status' using raw SQL
+    op.execute("ALTER TABLE image_reports RENAME COLUMN `open` TO `status`")
+
+    # Convert existing values: open=1 → status=0 (pending), open=0 → status=2 (dismissed)
+    # Must do this AFTER rename but BEFORE adding new index
+    op.execute(
+        """
+        UPDATE image_reports
+        SET status = CASE
+            WHEN status = 1 THEN 0  -- pending
+            WHEN status = 0 THEN 2  -- dismissed
+            ELSE status
+        END
+        """
+    )
+
+    # Add new columns (use UNSIGNED to match users.user_id type)
+    op.add_column(
+        "image_reports",
+        sa.Column("reviewed_by", mysql.INTEGER(unsigned=True), nullable=True),
+    )
+    op.add_column(
+        "image_reports",
+        sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+    )
+
+    # Add foreign key for reviewed_by
+    op.create_foreign_key(
+        "fk_image_reports_reviewed_by",
+        "image_reports",
+        "users",
+        ["reviewed_by"],
+        ["user_id"],
+        ondelete="SET NULL",
+        onupdate="CASCADE",
+    )
+
+    # Add indexes
+    op.create_index("idx_image_reports_status", "image_reports", ["status"])
+    op.create_index("fk_image_reports_reviewed_by", "image_reports", ["reviewed_by"])
+
+    # =========================================================================
+    # 2. Rename image_reviews to review_votes and update
+    # =========================================================================
+
+    # Rename the table
+    op.rename_table("image_reviews", "review_votes")
+
+    # Rename primary key column using raw SQL to preserve exact column type
+    op.execute("ALTER TABLE review_votes RENAME COLUMN `image_review_id` TO `vote_id`")
+
+    # Add new columns (review_id unsigned to match image_reviews.review_id)
+    op.add_column(
+        "review_votes",
+        sa.Column("review_id", mysql.INTEGER(unsigned=True), nullable=True),
+    )
+    op.add_column(
+        "review_votes",
+        sa.Column("comment", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "review_votes",
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=True,
+            server_default=sa.text("current_timestamp()"),
+        ),
+    )
+
+    # Set created_at for existing rows
+    op.execute("UPDATE review_votes SET created_at = NOW() WHERE created_at IS NULL")
+
+    # Update foreign key constraint names (drop old, create new)
+    # Must drop FKs first, then index, then create new index, then new FKs
+    op.drop_constraint("fk_image_reviews_image_id", "review_votes", type_="foreignkey")
+    op.drop_constraint("fk_image_reviews_user_id", "review_votes", type_="foreignkey")
+
+    # Rename existing unique index (must be after FK drop, before new FK create)
+    op.drop_index("image_id", table_name="review_votes")
+    op.create_index(
+        "idx_review_votes_image_user",
+        "review_votes",
+        ["image_id", "user_id"],
+        unique=True,
+    )
+
+    # Now create new FKs
+    op.create_foreign_key(
+        "fk_review_votes_image_id",
+        "review_votes",
+        "images",
+        ["image_id"],
+        ["image_id"],
+        ondelete="CASCADE",
+        onupdate="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_review_votes_user_id",
+        "review_votes",
+        "users",
+        ["user_id"],
+        ["user_id"],
+        ondelete="CASCADE",
+        onupdate="CASCADE",
+    )
+
+    # =========================================================================
+    # 3. Create new image_reviews table for review sessions
+    # =========================================================================
+
+    op.create_table(
+        "image_reviews",
+        sa.Column("review_id", mysql.INTEGER(unsigned=True), primary_key=True, autoincrement=True),
+        sa.Column("image_id", mysql.INTEGER(unsigned=True), nullable=False),
+        sa.Column("source_report_id", mysql.INTEGER(unsigned=True), nullable=True),
+        sa.Column("initiated_by", mysql.INTEGER(unsigned=True), nullable=True),
+        sa.Column("review_type", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("deadline", sa.DateTime(), nullable=True),
+        sa.Column("extension_used", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("status", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("outcome", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=True,
+            server_default=sa.text("current_timestamp()"),
+        ),
+        sa.Column("closed_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["image_id"],
+            ["images.image_id"],
+            name="fk_image_reviews_image_id",
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_report_id"],
+            ["image_reports.report_id"],
+            name="fk_image_reviews_source_report_id",
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["initiated_by"],
+            ["users.user_id"],
+            name="fk_image_reviews_initiated_by",
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+        ),
+    )
+
+    op.create_index("fk_image_reviews_image_id", "image_reviews", ["image_id"])
+    op.create_index(
+        "fk_image_reviews_source_report_id", "image_reviews", ["source_report_id"]
+    )
+    op.create_index("fk_image_reviews_initiated_by", "image_reviews", ["initiated_by"])
+    op.create_index("idx_image_reviews_status", "image_reviews", ["status"])
+    op.create_index("idx_image_reviews_deadline", "image_reviews", ["deadline"])
+
+    # Now add review_id FK to review_votes (after image_reviews table exists)
+    op.create_foreign_key(
+        "fk_review_votes_review_id",
+        "review_votes",
+        "image_reviews",
+        ["review_id"],
+        ["review_id"],
+        ondelete="CASCADE",
+        onupdate="CASCADE",
+    )
+    op.create_index("fk_review_votes_review_id", "review_votes", ["review_id"])
+
+    # Unique index for new votes with review sessions
+    # MariaDB treats NULL as distinct in unique indexes, so legacy votes
+    # with review_id=NULL won't conflict with each other
+    op.create_index(
+        "idx_review_votes_review_user",
+        "review_votes",
+        ["review_id", "user_id"],
+        unique=True,
+    )
+
+    # =========================================================================
+    # 4. Create admin_actions audit log table
+    # =========================================================================
+
+    op.create_table(
+        "admin_actions",
+        sa.Column("action_id", mysql.INTEGER(unsigned=True), primary_key=True, autoincrement=True),
+        sa.Column("user_id", mysql.INTEGER(unsigned=True), nullable=True),
+        sa.Column("action_type", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("report_id", mysql.INTEGER(unsigned=True), nullable=True),
+        sa.Column("review_id", mysql.INTEGER(unsigned=True), nullable=True),
+        sa.Column("image_id", mysql.INTEGER(unsigned=True), nullable=True),
+        sa.Column("details", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=True,
+            server_default=sa.text("current_timestamp()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.user_id"],
+            name="fk_admin_actions_user_id",
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["report_id"],
+            ["image_reports.report_id"],
+            name="fk_admin_actions_report_id",
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["review_id"],
+            ["image_reviews.review_id"],
+            name="fk_admin_actions_review_id",
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["image_id"],
+            ["images.image_id"],
+            name="fk_admin_actions_image_id",
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+        ),
+    )
+
+    op.create_index("fk_admin_actions_user_id", "admin_actions", ["user_id"])
+    op.create_index("fk_admin_actions_report_id", "admin_actions", ["report_id"])
+    op.create_index("fk_admin_actions_review_id", "admin_actions", ["review_id"])
+    op.create_index("fk_admin_actions_image_id", "admin_actions", ["image_id"])
+    op.create_index("idx_admin_actions_created_at", "admin_actions", ["created_at"])
+    op.create_index("idx_admin_actions_action_type", "admin_actions", ["action_type"])
+
+    # =========================================================================
+    # 5. Add new permissions
+    # =========================================================================
+
+    op.execute(
+        "INSERT INTO perms (title, `desc`) VALUES ('report_view', 'View report triage queue')"
+    )
+    op.execute(
+        "INSERT INTO perms (title, `desc`) VALUES ('report_manage', 'Dismiss/action/escalate reports')"
+    )
+    op.execute(
+        "INSERT INTO perms (title, `desc`) VALUES ('review_view', 'View open reviews')"
+    )
+    op.execute(
+        "INSERT INTO perms (title, `desc`) VALUES ('review_start', 'Initiate appropriateness review')"
+    )
+    op.execute(
+        "INSERT INTO perms (title, `desc`) VALUES ('review_vote', 'Cast votes on reviews')"
+    )
+    op.execute(
+        "INSERT INTO perms (title, `desc`) VALUES ('review_close_early', 'Close review before deadline')"
+    )
+
+
+def downgrade() -> None:
+    """Revert reporting and review system changes."""
+
+    # =========================================================================
+    # 5. Remove permissions
+    # =========================================================================
+
+    op.execute("DELETE FROM perms WHERE title = 'report_view'")
+    op.execute("DELETE FROM perms WHERE title = 'report_manage'")
+    op.execute("DELETE FROM perms WHERE title = 'review_view'")
+    op.execute("DELETE FROM perms WHERE title = 'review_start'")
+    op.execute("DELETE FROM perms WHERE title = 'review_vote'")
+    op.execute("DELETE FROM perms WHERE title = 'review_close_early'")
+
+    # =========================================================================
+    # 4. Drop admin_actions table
+    # =========================================================================
+
+    op.drop_table("admin_actions")
+
+    # =========================================================================
+    # 3. Drop new image_reviews table
+    # =========================================================================
+
+    # First drop indexes and FK from review_votes
+    op.drop_index("idx_review_votes_review_user", table_name="review_votes")
+    op.drop_constraint("fk_review_votes_review_id", "review_votes", type_="foreignkey")
+    op.drop_index("fk_review_votes_review_id", table_name="review_votes")
+
+    op.drop_table("image_reviews")
+
+    # =========================================================================
+    # 2. Rename review_votes back to image_reviews
+    # =========================================================================
+
+    # Drop new columns
+    op.drop_column("review_votes", "review_id")
+    op.drop_column("review_votes", "comment")
+    op.drop_column("review_votes", "created_at")
+
+    # Restore foreign key names
+    op.drop_constraint("fk_review_votes_image_id", "review_votes", type_="foreignkey")
+    op.drop_constraint("fk_review_votes_user_id", "review_votes", type_="foreignkey")
+
+    op.create_foreign_key(
+        "fk_image_reviews_image_id",
+        "review_votes",
+        "images",
+        ["image_id"],
+        ["image_id"],
+        ondelete="CASCADE",
+        onupdate="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_image_reviews_user_id",
+        "review_votes",
+        "users",
+        ["user_id"],
+        ["user_id"],
+        ondelete="CASCADE",
+        onupdate="CASCADE",
+    )
+
+    # Restore unique index name
+    op.drop_index("idx_review_votes_image_user", table_name="review_votes")
+    op.create_index(
+        "image_id", "review_votes", ["image_id", "user_id"], unique=True
+    )
+
+    # Rename primary key column back
+    op.alter_column(
+        "review_votes",
+        "vote_id",
+        new_column_name="image_review_id",
+        existing_type=sa.Integer(),
+        existing_nullable=False,
+    )
+
+    # Rename table back
+    op.rename_table("review_votes", "image_reviews")
+
+    # =========================================================================
+    # 1. Revert image_reports changes
+    # =========================================================================
+
+    # Drop new columns and indexes
+    op.drop_constraint(
+        "fk_image_reports_reviewed_by", "image_reports", type_="foreignkey"
+    )
+    op.drop_index("fk_image_reports_reviewed_by", table_name="image_reports")
+    op.drop_column("image_reports", "reviewed_by")
+    op.drop_column("image_reports", "reviewed_at")
+
+    # Revert status values: 0 (pending) → 1 (open), 2 (dismissed) → 0 (closed)
+    op.execute(
+        """
+        UPDATE image_reports
+        SET status = CASE
+            WHEN status = 0 THEN 1  -- pending back to open=1
+            WHEN status = 2 THEN 0  -- dismissed back to open=0
+            ELSE status
+        END
+        """
+    )
+
+    # Drop status index
+    op.drop_index("idx_image_reports_status", table_name="image_reports")
+
+    # Rename 'status' back to 'open'
+    op.alter_column(
+        "image_reports",
+        "status",
+        new_column_name="open",
+        existing_type=sa.Integer(),
+        existing_nullable=False,
+    )
+
+    # Recreate original index
+    op.create_index("open", "image_reports", ["open"])
+
+    # Rename 'report_id' back to 'image_report_id'
+    op.alter_column(
+        "image_reports",
+        "report_id",
+        new_column_name="image_report_id",
+        existing_type=sa.Integer(),
+        existing_nullable=False,
+    )
+
+    # Rename 'created_at' back to 'date'
+    op.alter_column(
+        "image_reports",
+        "created_at",
+        new_column_name="date",
+        existing_type=sa.DateTime(),
+        existing_nullable=True,
+    )
+
+    # Rename 'reason_text' back to 'text'
+    op.alter_column(
+        "image_reports",
+        "reason_text",
+        new_column_name="text",
+        existing_type=sa.Text(),
+        existing_nullable=True,
+    )

--- a/alembic/versions/b8df3d41cab8_remove_deprecated_user_fields.py
+++ b/alembic/versions/b8df3d41cab8_remove_deprecated_user_fields.py
@@ -1,0 +1,49 @@
+"""Remove deprecated user fields
+Remove user fields that will be retired.
+
+Revision ID: b8df3d41cab8
+Revises: 198d753671e3
+Create Date: 2025-11-15 07:53:39.881284
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b8df3d41cab8'
+down_revision: Union[str, Sequence[str], None] = '198d753671e3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Drop deprecated user preference columns
+    op.drop_column("users", "show_all_posts")
+    op.drop_column("users", "show_all_meta")
+    op.drop_column("users", "show_email")
+    op.drop_column("users", "show_ip")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Recreate deprecated columns with sensible defaults
+    op.add_column(
+        "users",
+        sa.Column("show_all_posts", sa.SmallInteger(), nullable=False, server_default=sa.text("0")),
+    )
+    op.add_column(
+        "users",
+        sa.Column("show_all_meta", sa.SmallInteger(), nullable=False, server_default=sa.text("0")),
+    )
+    op.add_column(
+        "users",
+        sa.Column("show_email", sa.SmallInteger(), nullable=False, server_default=sa.text("0")),
+    )
+    op.add_column(
+        "users",
+        sa.Column("show_ip", sa.SmallInteger(), nullable=False, server_default=sa.text("0")),
+    )

--- a/alembic/versions/e4c0f75b08cb_update_users_password_to_bcrypt.py
+++ b/alembic/versions/e4c0f75b08cb_update_users_password_to_bcrypt.py
@@ -1,0 +1,62 @@
+"""update_users_password_to_bcrypt
+
+Revision ID: e4c0f75b08cb
+Revises: 176f47a1d07f
+Create Date: 2025-11-11 21:40:25.783898
+
+This migration updates the users table to support bcrypt password hashing.
+
+IMPORTANT: This migration does NOT migrate existing passwords from MD5+salt to bcrypt.
+You have two options:
+
+1. Force password reset: Users must reset their passwords to use the new system
+2. Dual authentication: Keep old MD5+salt fields temporarily and migrate gradually
+
+The current implementation:
+- Extends password field to 255 chars (bcrypt needs 60+ chars)
+- Keeps old password/salt fields for backward compatibility
+- Your auth code should check bcrypt first, fall back to MD5+salt if needed
+
+To complete migration:
+- Update your login code to migrate MD5 passwords to bcrypt on successful login
+- After all users migrated, run another migration to drop old password/salt columns
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e4c0f75b08cb'
+down_revision: Union[str, Sequence[str], None] = '176f47a1d07f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Extend password field to support bcrypt hashes (60 chars needed, 255 for safety)
+    # Old MD5 hashes are 40 chars, so this is safe
+    op.alter_column('users', 'password',
+                    existing_type=sa.String(length=40),
+                    type_=sa.String(length=255),
+                    existing_nullable=False)
+
+    # Add new column to track password type (for migration period)
+    # Values: 'md5' (legacy), 'bcrypt' (new)
+    op.add_column('users', sa.Column('password_type', sa.String(length=10),
+                                     nullable=False, server_default='md5'))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Remove password type tracking column
+    op.drop_column('users', 'password_type')
+
+    # Revert password field length
+    # WARNING: This will fail if any bcrypt hashes exist (they're longer than 40 chars)
+    op.alter_column('users', 'password',
+                    existing_type=sa.String(length=255),
+                    type_=sa.String(length=40),
+                    existing_nullable=False)

--- a/app/models/tag.py
+++ b/app/models/tag.py
@@ -68,7 +68,6 @@ class Tags(TagBase, table=True):
     - Internal metadata
 
     Internal fields (should NOT be exposed via public API):
-    - tw_tagid: Internal tag wizard ID
     - user_id: Creator user (privacy-sensitive)
     """
 
@@ -119,7 +118,6 @@ class Tags(TagBase, table=True):
 
     # Internal fields
     user_id: int | None = Field(default=None, foreign_key="users.user_id")
-    tw_tagid: int | None = Field(default=None)
 
     # Note: Relationships are intentionally omitted.
     # Foreign keys are sufficient for queries, and omitting relationships avoids:


### PR DESCRIPTION
feat(migrations): add reporting and review system, remove deprecated user fields, and update password hashing

- Added migration to implement a reporting and review system with new tables and columns.
- Removed deprecated user preference fields from the users table.
- Updated users table to support bcrypt password hashing, extending the password field and adding a password type column.
- Cleaned up the Tags model by removing the internal tw_tagid field.