### PR TITLE
fix: resolve tag aliases when searching images in ANY mode

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -192,9 +192,14 @@ async def list_images(
                     )
             else:
                 # Images must have ANY of the specified tags
+                # Resolve aliases for all tags to support searching by alias names
+                resolved_tag_ids = []
+                for tag_id in tag_ids:
+                    _, resolved_tag_id = await resolve_tag_alias(db, tag_id)
+                    resolved_tag_ids.append(resolved_tag_id)
                 query = query.where(
                     Images.image_id.in_(  # type: ignore[union-attr]
-                        select(TagLinks.image_id).where(TagLinks.tag_id.in_(tag_ids))  # type: ignore[call-overload,attr-defined]
+                        select(TagLinks.image_id).where(TagLinks.tag_id.in_(resolved_tag_ids))  # type: ignore[call-overload,attr-defined]
                     )
                 )
 

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -344,14 +344,14 @@ class TestTagSearchValidation:
         await db_session.flush()
 
         # Create the "real" tag
-        real_tag = Tags(title="neko mimi", desc="Cat ears", type=TagType.THEME)
+        real_tag = Tags(title="cat ears", desc="Cat ears", type=TagType.THEME)
         db_session.add(real_tag)
         await db_session.flush()
 
         # Create an alias tag that points to the real tag
         alias_tag = Tags(
-            title="cat ears",
-            desc="Alias for neko mimi",
+            title="neko mimi",
+            desc="Alias for cat ears",
             type=TagType.THEME,
             alias_of=real_tag.tag_id,
         )


### PR DESCRIPTION
When searching for images by tag ID, both ANY and ALL modes now properly resolve alias tags to their actual tag IDs. Previously, only ALL mode resolved aliases, causing searches by alias names to return 0 results.

Example: Searching for tag 'neko mimi' (an alias) now correctly finds images tagged with 'cat ears' (the real tag).

Includes comprehensive tests for alias resolution in both search modes.

Fixes: If searching for an alias like `neko mimi`, the search returns 0 images. This should be resolved to its alias_of tag id