### PR TITLE
fix: prioritize exact matches in tag search results

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -200,12 +200,17 @@ async def list_tags(
                 func.lower(Tags.title),  # Alphabetical within each priority group
             )
         else:
-            # Long query (full-text): sort by relevance, then popularity, then alphabetically
-            # MATCH ... AGAINST returns relevance score; order by it descending first
-            # Then sort by usage_count (most popular first) to break relevance ties
-            # Finally alphabetical for consistent ordering
+            # Long query (full-text): prioritize exact matches, then sort by relevance
+            # 1. Exact matches first (e.g., searching "maid" finds "maid" tag first)
+            # 2. Then by relevance score from FULLTEXT search
+            # 3. Then by popularity (usage_count)
+            # 4. Finally alphabetical for consistent ordering
             # Must use the same fulltext_query_str as the WHERE clause
             query = query.order_by(
+                case(
+                    (func.lower(Tags.title) == search.lower(), 0),  # Exact match (case-insensitive)
+                    else_=1,  # Non-exact matches
+                ),
                 text("MATCH (title) AGAINST (:search IN BOOLEAN MODE) DESC"),
                 desc(Tags.usage_count),  # type: ignore[arg-type]  # Most popular tags first
                 func.lower(Tags.title),  # Tertiary sort: alphabetical (case-insensitive)

--- a/scripts/backfill_tag_usage_counts.py
+++ b/scripts/backfill_tag_usage_counts.py
@@ -10,7 +10,7 @@ The triggers will maintain these counts going forward automatically.
 """
 
 import asyncio
-from sqlalchemy import select, func, update
+from sqlalchemy import select, func, update, text
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 
@@ -70,6 +70,8 @@ async def backfill_usage_counts() -> None:
         print(f"  Total usage count: {stats[1]}")
         print(f"  Average usage per tag: {stats[2]:.2f}" if stats and stats[2] is not None else "  Average usage per tag: 0.00")
         print(f"  Most used tag has: {stats[3]} images")
+
+    await engine.dispose()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tag search with queries >= 3 characters now prioritizes exact matches (e.g., searching 'maid' returns 'maid' tag first, before 'maid outfit' or 'head maid'). This aligns with the short query behavior and improves UX for tag suggestions.

Changes:
- Modified tag search sorting for long queries to use case statement that prioritizes exact matches, then relevance, then popularity
- Added test case for exact match prioritization with 'maid' example
- Fixed backfill_tag_usage_counts.py script (missing 'text' import) and improved event loop cleanup. This script is needed because usage_count is used in tag ordering logic.

The fix addresses the issue where searching for 'maid' would not list the 'maid' tag in the suggestions.