### PR TITLE
feat(tags): include alias_of_name in tag list response

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -123,7 +123,7 @@ async def list_tags(
     - Get child tags of a parent: `/tags?parent_tag_id=10`
     - Exclude alias tags: `/tags?search=sakura&exclude_aliases=true`
     """
-    # Alias for the parent tag (if it's an alias)
+    # Create table alias to retrieve the title of the tag that this tag is aliased to
     AliasedTag = aliased(Tags)
 
     query = select(Tags, AliasedTag.title.label("alias_of_name")).outerjoin(  # type: ignore[union-attr]

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -7,6 +7,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy import case, desc, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from app.api.dependencies import ImageSortParams, PaginationParams
 from app.core.database import get_db
@@ -122,7 +123,13 @@ async def list_tags(
     - Get child tags of a parent: `/tags?parent_tag_id=10`
     - Exclude alias tags: `/tags?search=sakura&exclude_aliases=true`
     """
-    query = select(Tags)
+    # Alias for the parent tag (if it's an alias)
+    AliasedTag = aliased(Tags)
+
+    query = select(Tags, AliasedTag.title.label("alias_of_name")).outerjoin(  # type: ignore[union-attr]
+        AliasedTag,
+        Tags.alias_of == AliasedTag.tag_id,  # type: ignore[arg-type]
+    )
 
     # Apply filters
     invalid_ids: list[str] = []
@@ -164,7 +171,7 @@ async def list_tags(
             search_terms = search.split()
             fulltext_query_str = " ".join(f"+{term}*" for term in search_terms)
             query = query.where(
-                text("MATCH (title) AGAINST (:search IN BOOLEAN MODE)").bindparams(
+                text("MATCH (tags.title) AGAINST (:search IN BOOLEAN MODE)").bindparams(
                     search=fulltext_query_str
                 )
             )
@@ -206,7 +213,7 @@ async def list_tags(
             # Finally alphabetical for consistent ordering
             # Must use the same fulltext_query_str as the WHERE clause
             query = query.order_by(
-                text("MATCH (title) AGAINST (:search IN BOOLEAN MODE) DESC"),
+                text("MATCH (tags.title) AGAINST (:search IN BOOLEAN MODE) DESC"),
                 desc(Tags.usage_count),  # type: ignore[arg-type]  # Most popular tags first
                 func.lower(Tags.title),  # Tertiary sort: alphabetical (case-insensitive)
             ).params(search=fulltext_query_str)
@@ -222,13 +229,22 @@ async def list_tags(
 
     # Execute
     result = await db.execute(query)
-    tags = result.scalars().all()
+    rows = result.all()
+
+    tags_list = []
+    for row in rows:
+        tag = row[0]
+        alias_name = row[1]
+
+        tag_resp = TagResponse.model_validate(tag)
+        tag_resp.alias_of_name = alias_name
+        tags_list.append(tag_resp)
 
     return TagListResponse(
         total=total or 0,
         page=pagination.page,
         per_page=pagination.per_page,
-        tags=[TagResponse.model_validate(tag) for tag in tags],
+        tags=tags_list,
         invalid_ids=invalid_ids if invalid_ids else None,
     )
 

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -69,6 +69,7 @@ class TagResponse(TagBase):
 
     tag_id: int
     alias_of: int | None = None
+    alias_of_name: str | None = None
     is_alias: bool = False
 
     # NOTE: No normalization/escaping for title and desc.

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -322,6 +322,228 @@ class TestListTags:
         assert data["tags"][0]["type"] == TagType.THEME
 
 
+@pytest.mark.api
+class TestAliasOfName:
+    """Tests for alias_of_name field in tag list responses.
+    
+    This feature was added to include the title of the tag being aliased
+    in the tag list response, requiring a self-join on the Tags table.
+    """
+
+    async def test_alias_of_name_when_tag_has_alias(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that alias_of_name is populated when a tag has an alias_of value."""
+        # Create the original tag
+        original_tag = Tags(
+            title="maid outfit",
+            desc="Maid clothing",
+            type=TagType.THEME,
+        )
+        db_session.add(original_tag)
+        await db_session.commit()
+        await db_session.refresh(original_tag)
+
+        # Create an alias tag that points to the original
+        alias_tag = Tags(
+            title="maid dress",
+            desc="Alternative name for maid outfit",
+            type=TagType.THEME,
+            alias_of=original_tag.tag_id,
+        )
+        db_session.add(alias_tag)
+        await db_session.commit()
+        await db_session.refresh(alias_tag)
+
+        # Get the tag list
+        response = await client.get("/api/v1/tags/")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Find the alias tag in the response
+        alias_tag_response = None
+        original_tag_response = None
+        for tag in data["tags"]:
+            if tag["tag_id"] == alias_tag.tag_id:
+                alias_tag_response = tag
+            if tag["tag_id"] == original_tag.tag_id:
+                original_tag_response = tag
+
+        # Verify alias_of_name is populated for the alias tag
+        assert alias_tag_response is not None
+        assert alias_tag_response["alias_of"] == original_tag.tag_id
+        assert alias_tag_response["alias_of_name"] == "maid outfit"
+        assert alias_tag_response["is_alias"] is True
+
+        # Verify original tag has no alias_of_name
+        assert original_tag_response is not None
+        assert original_tag_response["alias_of"] is None
+        assert original_tag_response["alias_of_name"] is None
+        assert original_tag_response["is_alias"] is False
+
+    async def test_alias_of_name_when_tag_has_no_alias(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that alias_of_name is None when a tag doesn't have an alias_of value."""
+        # Create a regular tag with no alias
+        regular_tag = Tags(
+            title="summer dress",
+            desc="Summer clothing",
+            type=TagType.THEME,
+        )
+        db_session.add(regular_tag)
+        await db_session.commit()
+        await db_session.refresh(regular_tag)
+
+        # Get the tag list
+        response = await client.get("/api/v1/tags/")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Find the tag in the response
+        tag_response = None
+        for tag in data["tags"]:
+            if tag["tag_id"] == regular_tag.tag_id:
+                tag_response = tag
+                break
+
+        # Verify alias_of_name is None
+        assert tag_response is not None
+        assert tag_response["alias_of"] is None
+        assert tag_response["alias_of_name"] is None
+        assert tag_response["is_alias"] is False
+
+    async def test_alias_of_name_with_filtering(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that alias_of_name works correctly with type filtering."""
+        # Create original tags of different types
+        character_tag = Tags(
+            title="sakura kinomoto",
+            desc="Character from Cardcaptor Sakura",
+            type=TagType.CHARACTER,
+        )
+        theme_tag = Tags(
+            title="school uniform",
+            desc="School clothing",
+            type=TagType.THEME,
+        )
+        db_session.add_all([character_tag, theme_tag])
+        await db_session.commit()
+        await db_session.refresh(character_tag)
+        await db_session.refresh(theme_tag)
+
+        # Create alias tags
+        character_alias = Tags(
+            title="kinomoto sakura",
+            desc="Alternative name order",
+            type=TagType.CHARACTER,
+            alias_of=character_tag.tag_id,
+        )
+        theme_alias = Tags(
+            title="school outfit",
+            desc="Alternative name",
+            type=TagType.THEME,
+            alias_of=theme_tag.tag_id,
+        )
+        db_session.add_all([character_alias, theme_alias])
+        await db_session.commit()
+        await db_session.refresh(character_alias)
+        await db_session.refresh(theme_alias)
+
+        # Filter by CHARACTER type
+        response = await client.get(f"/api/v1/tags/?type={TagType.CHARACTER}")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should only get CHARACTER tags, and only the expected ones
+        character_ids = {character_tag.tag_id, character_alias.tag_id}
+        assert {tag["tag_id"] for tag in data["tags"]} == character_ids
+        for tag in data["tags"]:
+            assert tag["type"] == TagType.CHARACTER
+            # If it's an alias, verify alias_of_name is populated
+            if tag["tag_id"] == character_alias.tag_id:
+                assert tag["alias_of_name"] == "sakura kinomoto"
+                assert tag["is_alias"] is True
+
+    async def test_alias_of_name_with_search(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that alias_of_name works correctly with full-text search."""
+        # Create original tag
+        original_tag = Tags(
+            title="cat ears",
+            desc="Feline ears",
+            type=TagType.THEME,
+        )
+        db_session.add(original_tag)
+        await db_session.commit()
+        await db_session.refresh(original_tag)
+
+        # Create alias tag
+        alias_tag = Tags(
+            title="neko ears",
+            desc="Japanese for cat ears",
+            type=TagType.THEME,
+            alias_of=original_tag.tag_id,
+        )
+        db_session.add(alias_tag)
+        await db_session.commit()
+        await db_session.refresh(alias_tag)
+
+        # Search for "neko" (should find the alias)
+        response = await client.get("/api/v1/tags/?search=neko")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should find the alias tag
+        assert data["total"] >= 1
+        neko_tag = None
+        for tag in data["tags"]:
+            if tag["tag_id"] == alias_tag.tag_id:
+                neko_tag = tag
+                break
+
+        # Verify alias_of_name is populated
+        assert neko_tag is not None
+        assert neko_tag["alias_of_name"] == "cat ears"
+        assert neko_tag["is_alias"] is True
+
+    async def test_alias_of_name_with_exclude_aliases_filter(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that alias tags are excluded when exclude_aliases=true."""
+        # Create original tag
+        original_tag = Tags(
+            title="blue eyes",
+            desc="Blue colored eyes",
+            type=TagType.THEME,
+        )
+        db_session.add(original_tag)
+        await db_session.commit()
+        await db_session.refresh(original_tag)
+
+        # Create alias tag
+        alias_tag = Tags(
+            title="blue colored eyes",
+            desc="Alternative name",
+            type=TagType.THEME,
+            alias_of=original_tag.tag_id,
+        )
+        db_session.add(alias_tag)
+        await db_session.commit()
+        await db_session.refresh(alias_tag)
+
+        # Get tags excluding aliases
+        response = await client.get("/api/v1/tags/?exclude_aliases=true")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should not include the alias tag
+        tag_ids = {tag["tag_id"] for tag in data["tags"]}
+        assert alias_tag.tag_id not in tag_ids
+        assert original_tag.tag_id in tag_ids
+
 
 @pytest.mark.api
 class TestFuzzyTagSearch:


### PR DESCRIPTION
This pull request enhances the tag listing API by including the name of the alias tag in the response when applicable. It introduces a database join to retrieve the alias tag's title, updates the response schema to support this new field, and ensures full-text search queries and ordering work correctly with the updated query. The most important changes are grouped below.

### API Response Improvements

* The `TagResponse` schema in `app/schemas/tag.py` now includes a new field `alias_of_name` to provide the title of the alias tag if present.
* The tag listing endpoint in `app/api/v1/tags.py` constructs each tag response with the new `alias_of_name` field, improving the clarity of alias relationships in the API output.

### Database Query Enhancements

* The tag listing query now uses SQLAlchemy's `aliased` to join the `Tags` table to itself, allowing retrieval of the alias tag's title alongside each tag. [[1]](diffhunk://#diff-e30daf564e2bc838f70c5580926eca6e4b25924fd41bbf24dc99bf9ab54d444bR10) [[2]](diffhunk://#diff-e30daf564e2bc838f70c5580926eca6e4b25924fd41bbf24dc99bf9ab54d444bL125-R132)

### Full-Text Search Adjustments

* All full-text search and ordering clauses now explicitly reference the `tags.title` column to ensure correct query behavior after the join. [[1]](diffhunk://#diff-e30daf564e2bc838f70c5580926eca6e4b25924fd41bbf24dc99bf9ab54d444bL167-R174) [[2]](diffhunk://#diff-e30daf564e2bc838f70c5580926eca6e4b25924fd41bbf24dc99bf9ab54d444bL209-R216)