### PR TITLE
refactor: consolidate UserSummary into shared common.py schema

### DIFF
--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -14,6 +14,7 @@ from app.schemas.comment import (
     CommentStatsResponse,
     CommentUpdate,
 )
+from app.schemas.common import UserSummary
 from app.schemas.image import (
     ImageCreate,
     ImageHashSearchResponse,
@@ -45,6 +46,8 @@ from app.schemas.user import (
 )
 
 __all__ = [
+    # Common schemas
+    "UserSummary",
     # Image schemas
     "ImageBase",
     "ImageCreate",

--- a/app/schemas/comment.py
+++ b/app/schemas/comment.py
@@ -7,22 +7,8 @@ from datetime import datetime
 from pydantic import BaseModel, Field, computed_field, field_validator
 
 from app.models.comment import CommentBase
+from app.schemas.common import UserSummary
 from app.utils.markdown import normalize_legacy_entities, parse_markdown
-
-
-class UserSummary(BaseModel):
-    """
-    Minimal user information for embedding in comment responses.
-
-    Used to avoid N+1 queries when clients need basic user info
-    without fetching the full user profile.
-    """
-
-    user_id: int
-    username: str
-    avatar: str | None = None
-
-    model_config = {"from_attributes": True}
 
 
 class CommentCreate(BaseModel):

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -1,0 +1,31 @@
+"""
+Shared/common Pydantic schemas used across multiple endpoints
+"""
+
+from pydantic import BaseModel, computed_field
+
+from app.config import settings
+
+
+class UserSummary(BaseModel):
+    """
+    Minimal user information for embedding in responses.
+
+    Used across image, comment, and other endpoints to avoid N+1 queries
+    when clients need basic user info without fetching the full user profile.
+    """
+
+    user_id: int
+    username: str
+    avatar: str | None = None  # Avatar filename from database
+
+    # Allow Pydantic to read from SQLAlchemy model attributes (not just dicts)
+    model_config = {"from_attributes": True}
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def avatar_url(self) -> str | None:
+        """Generate avatar URL from avatar field"""
+        if self.avatar:
+            return f"{settings.IMAGE_BASE_URL}/storage/avatars/{self.avatar}"
+        return None

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -9,25 +9,7 @@ from pydantic import BaseModel, Field, computed_field, field_validator
 
 from app.config import TagType, settings
 from app.models.image import ImageBase
-
-
-class UserSummary(BaseModel):
-    """Minimal user info for embedding"""
-
-    user_id: int
-    username: str
-    avatar: str | None = None  # Avatar filename from database
-
-    # Allow Pydantic to read from SQLAlchemy model attributes (not just dicts)
-    model_config = {"from_attributes": True}
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def avatar_url(self) -> str | None:
-        """Generate avatar URL from avatar field"""
-        if self.avatar:
-            return f"{settings.IMAGE_BASE_URL}/storage/avatars/{self.avatar}"
-        return None
+from app.schemas.common import UserSummary
 
 
 class TagSummary(BaseModel):


### PR DESCRIPTION
This pull request refactors the `UserSummary` schema to improve code reuse and maintainability. The `UserSummary` model, previously duplicated in both the `comment.py` and `image.py` schema files, is now defined in a new shared module, `common.py`, and imported where needed. This change reduces duplication and centralizes logic for minimal user information embedded in API responses.

**Schema refactoring and code deduplication:**

* Created a new shared schema file `app/schemas/common.py` and moved the `UserSummary` model there, including its computed `avatar_url` property.
* Removed duplicate definitions of `UserSummary` from both `app/schemas/comment.py` and `app/schemas/image.py`, updating imports to use the shared version. [[1]](diffhunk://#diff-3a8fc2a58c55c8ae1210938e04daf90673eebc00e83989d46b4a2f4e9c3a3361R10-L27) [[2]](diffhunk://#diff-c3fdecc51069ce4b8678855b78ef390819bcd79c02e738a3ba679797b2aa06c7L12-R12)
* Updated the exports in `app/schemas/__init__.py` to include `UserSummary` and import it from the new shared module. [[1]](diffhunk://#diff-6e8f919a6d4fadb3bc8ab59063772e2db733dbb02d71e04ae8f9c22cb79e20a8R17) [[2]](diffhunk://#diff-6e8f919a6d4fadb3bc8ab59063772e2db733dbb02d71e04ae8f9c22cb79e20a8R49-R50)