### PR TITLE
feat: implement permission caching and public permissions API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,16 @@ jobs:
           --health-timeout=5s
           --health-retries=5
 
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -89,6 +99,17 @@ jobs:
             fi
             echo "Waiting for MySQL... ($i/30)"
             sleep 2
+          done
+
+      - name: Wait for Redis to be ready
+        run: |
+          for i in {1..30}; do
+            if docker exec $(docker ps -q --filter ancestor=redis:7-alpine) redis-cli ping 2>/dev/null | grep -q PONG; then
+              echo "Redis is ready!"
+              break
+            fi
+            echo "Waiting for Redis... ($i/30)"
+            sleep 1
           done
 
       - name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,5 @@ repos:
       - id: check-merge-conflict
       - id: check-case-conflict
       - id: mixed-line-ending
+      - id: no-commit-to-branch
+        args: ['--branch', 'main']

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -4,7 +4,18 @@ API v1 Router
 
 from fastapi import APIRouter
 
-from app.api.v1 import admin, auth, comments, favorites, images, meta, privmsgs, tags, users
+from app.api.v1 import (
+    admin,
+    auth,
+    comments,
+    favorites,
+    images,
+    meta,
+    permissions,
+    privmsgs,
+    tags,
+    users,
+)
 
 router = APIRouter()
 
@@ -18,5 +29,6 @@ router.include_router(favorites.router)
 router.include_router(comments.router)
 router.include_router(privmsgs.router)
 router.include_router(meta.router)
+router.include_router(permissions.router)
 
 __all__ = ["router"]

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -599,11 +599,12 @@ async def add_tag_to_image(
     if not image:
         raise HTTPException(status_code=404, detail="Image not found")
 
-    # Check ownership or permission
+    # Check ownership, admin, or permission
     is_owner = image.user_id == current_user.id
+    is_admin = current_user.admin
     has_edit_permission = await has_permission(db, current_user.id, Permission.IMAGE_TAG_ADD)
 
-    if not is_owner and not has_edit_permission:
+    if not is_owner and not is_admin and not has_edit_permission:
         raise HTTPException(403, "Not authorized to edit this image")
 
     # Verify tag exists and resolve aliases
@@ -660,11 +661,12 @@ async def remove_tag_from_image(
     if not image:
         raise HTTPException(status_code=404, detail="Image not found")
 
-    # Check ownership or permission
+    # Check ownership, admin, or permission
     is_owner = image.user_id == current_user.id
+    is_admin = current_user.admin
     has_edit_permission = await has_permission(db, current_user.id, Permission.IMAGE_TAG_REMOVE)
 
-    if not is_owner and not has_edit_permission:
+    if not is_owner and not is_admin and not has_edit_permission:
         raise HTTPException(403, "Not authorized to edit this image")
 
     # Check if tag link exists

--- a/app/api/v1/permissions.py
+++ b/app/api/v1/permissions.py
@@ -1,0 +1,29 @@
+"""
+Public permissions API - list available permission names.
+
+This module provides a public endpoint for retrieving the list of
+available permissions. This information is used by the frontend
+for permission-based UI rendering and validation.
+"""
+
+from fastapi import APIRouter
+
+from app.core.permissions import Permission
+
+router = APIRouter(prefix="/permissions", tags=["permissions"])
+
+
+@router.get("")
+async def list_permission_names() -> dict[str, str]:
+    """
+    List all available permission names.
+
+    Returns a mapping of permission names (enum names) to their values
+    (database titles). This is public information used by the frontend
+    for permission checking.
+
+    Returns:
+        Dictionary mapping permission names to values
+        Example: {"IMAGE_TAG_ADD": "image_tag_add", "TAG_CREATE": "tag_create"}
+    """
+    return {perm.name: perm.value for perm in Permission}

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -154,6 +154,8 @@ async def list_tags(
                 tag_ids.append(int(id_str))
             else:
                 invalid_ids.append(id_str)
+        # Deduplicate tag IDs to prevent duplicate results
+        tag_ids = list(dict.fromkeys(tag_ids))
         if tag_ids:  # Only apply filter if we have valid IDs
             query = query.where(Tags.tag_id.in_(tag_ids))  # type: ignore[union-attr]
         else:

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -148,12 +148,8 @@ async def get_current_user_profile(
 
     # Convert to response model and add permissions
     response = UserPrivateResponse.model_validate(user)
-    response_dict = response.model_dump()
-    response_dict["permissions"] = sorted(permissions)  # Sort for consistency
-
-    return UserPrivateResponse(**response_dict)
-
-
+    response.permissions = sorted(permissions)
+    return response
 @router.patch("/me", response_model=UserPrivateResponse)
 async def update_current_user_profile(
     user_data: UserUpdate,

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -150,6 +150,8 @@ async def get_current_user_profile(
     response = UserPrivateResponse.model_validate(user)
     response.permissions = sorted(permissions)
     return response
+
+
 @router.patch("/me", response_model=UserPrivateResponse)
 async def update_current_user_profile(
     user_data: UserUpdate,

--- a/app/core/permission_cache.py
+++ b/app/core/permission_cache.py
@@ -102,7 +102,7 @@ async def invalidate_group_permissions(
         group_id: Group ID whose members' caches should be invalidated
     """
     # Get all users in the group
-    result = await db.execute(select(UserGroups.user_id).where(UserGroups.group_id == group_id))  # type: ignore[arg-type]
+    result = await db.execute(select(UserGroups.user_id).where(UserGroups.group_id == group_id))  # type: ignore[call-overload]
     user_ids = [row[0] for row in result.fetchall()]
 
     # Invalidate each user's cache

--- a/app/core/permission_cache.py
+++ b/app/core/permission_cache.py
@@ -1,0 +1,110 @@
+"""
+Permission caching layer for high-performance permission checks.
+
+Caches user permissions in Redis with configurable TTL.
+Handles cache invalidation on permission changes.
+"""
+
+import json
+from typing import cast
+
+import redis.asyncio as redis
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.permissions import get_user_permissions
+from app.models.permissions import UserGroups
+
+# Cache TTL: 5 minutes (permissions rarely change)
+PERMISSION_CACHE_TTL = 300
+
+
+def _make_cache_key(user_id: int) -> str:
+    """Generate Redis cache key for user permissions."""
+    return f"user_permissions:{user_id}"
+
+
+async def get_cached_user_permissions(
+    db: AsyncSession,
+    redis_client: redis.Redis,  # type: ignore[type-arg]
+    user_id: int,
+) -> set[str]:
+    """
+    Get user permissions with caching.
+
+    First checks Redis cache, falls back to database query if cache miss.
+    Stores result in cache with TTL for subsequent requests.
+
+    Args:
+        db: Database session
+        redis_client: Redis client
+        user_id: User ID
+
+    Returns:
+        Set of permission strings
+    """
+    cache_key = _make_cache_key(user_id)
+
+    # Try cache first
+    cached = await redis_client.get(cache_key)
+    if cached:
+        try:
+            cached_str = cast(str, cached.decode("utf-8") if isinstance(cached, bytes) else cached)
+            return set(json.loads(cached_str))
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            # Cache corrupted, fall through to database
+            pass
+
+    # Cache miss - query database
+    permissions = await get_user_permissions(db, user_id)
+
+    # Store in cache (convert set to list for JSON serialization)
+    await redis_client.setex(
+        cache_key,
+        PERMISSION_CACHE_TTL,
+        json.dumps(sorted(permissions)),  # Sort for deterministic cache keys
+    )
+
+    return permissions
+
+
+async def invalidate_user_permissions(
+    redis_client: redis.Redis,  # type: ignore[type-arg]
+    user_id: int,
+) -> None:
+    """
+    Invalidate cached permissions for a user.
+
+    Call this when user's groups or permissions are modified.
+
+    Args:
+        redis_client: Redis client
+        user_id: User ID whose cache should be invalidated
+    """
+    cache_key = _make_cache_key(user_id)
+    await redis_client.delete(cache_key)
+
+
+async def invalidate_group_permissions(
+    redis_client: redis.Redis,  # type: ignore[type-arg]
+    db: AsyncSession,
+    group_id: int,
+) -> None:
+    """
+    Invalidate cached permissions for all users in a group.
+
+    Call this when group permissions are modified.
+    More expensive operation as it affects multiple users.
+
+    Args:
+        redis_client: Redis client
+        db: Database session
+        group_id: Group ID whose members' caches should be invalidated
+    """
+    # Get all users in the group
+    result = await db.execute(select(UserGroups.user_id).where(UserGroups.group_id == group_id))  # type: ignore[arg-type]
+    user_ids = [row[0] for row in result.fetchall()]
+
+    # Invalidate each user's cache
+    for user_id in user_ids:
+        await invalidate_user_permissions(redis_client, user_id)

--- a/app/core/permission_deps.py
+++ b/app/core/permission_deps.py
@@ -21,24 +21,26 @@ Usage:
 from collections.abc import Callable, Coroutine
 from typing import Annotated, Any
 
+import redis.asyncio as redis
 from fastapi import Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user
 from app.core.database import get_db
 from app.core.permissions import Permission, has_any_permission, has_permission
+from app.core.redis import get_redis
 from app.models.user import Users
 
 
 def require_permission(
     permission: str | Permission,
-) -> Callable[[Users, AsyncSession], Coroutine[Any, Any, None]]:
+) -> Callable[[Users, AsyncSession, redis.Redis], Coroutine[Any, Any, None]]:  # type: ignore[type-arg]
     """
     Create a FastAPI dependency that requires a specific permission.
 
     Returns a dependency function that:
     1. Gets the current authenticated user
-    2. Checks if they have the required permission
+    2. Checks if they have the required permission (using Redis cache for performance)
     3. Raises 403 if permission is missing
     4. Returns None if permission is present (use with _ to discard)
 
@@ -64,12 +66,14 @@ def require_permission(
     async def permission_checker(
         user: Annotated[Users, Depends(get_current_user)],
         db: Annotated[AsyncSession, Depends(get_db)],
+        redis_client: Annotated[redis.Redis, Depends(get_redis)],  # type: ignore[type-arg]
     ) -> None:
         # Convert enum to string for error message
         perm_name = permission.value if isinstance(permission, Permission) else permission
 
         # Check permission (user_id is guaranteed non-None from get_current_user)
-        if not await has_permission(db, user.id, permission):
+        # Use Redis cache for better performance
+        if not await has_permission(db, user.id, permission, redis_client):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Insufficient permissions. Requires permission: {perm_name}",
@@ -80,7 +84,7 @@ def require_permission(
 
 def require_any_permission(
     permissions: list[str | Permission],
-) -> Callable[[Users, AsyncSession], Coroutine[Any, Any, None]]:
+) -> Callable[[Users, AsyncSession, redis.Redis], Coroutine[Any, Any, None]]:  # type: ignore[type-arg]
     """
     Create a FastAPI dependency that requires ANY of the specified permissions.
 
@@ -112,9 +116,10 @@ def require_any_permission(
     async def permission_checker(
         user: Annotated[Users, Depends(get_current_user)],
         db: Annotated[AsyncSession, Depends(get_db)],
+        redis_client: Annotated[redis.Redis, Depends(get_redis)],  # type: ignore[type-arg]
     ) -> None:
-        # Check permissions
-        if not await has_any_permission(db, user.id, permissions):
+        # Check permissions (using Redis cache for better performance)
+        if not await has_any_permission(db, user.id, permissions, redis_client):
             # Convert enums to strings for error message
             perm_names = [p.value if isinstance(p, Permission) else p for p in permissions]
             raise HTTPException(
@@ -127,7 +132,7 @@ def require_any_permission(
 
 def require_all_permissions(
     permissions: list[str | Permission],
-) -> Callable[[Users, AsyncSession], Coroutine[Any, Any, None]]:
+) -> Callable[[Users, AsyncSession, redis.Redis], Coroutine[Any, Any, None]]:  # type: ignore[type-arg]
     """
     Create a FastAPI dependency that requires ALL of the specified permissions.
 
@@ -158,12 +163,13 @@ def require_all_permissions(
     async def permission_checker(
         user: Annotated[Users, Depends(get_current_user)],
         db: Annotated[AsyncSession, Depends(get_db)],
+        redis_client: Annotated[redis.Redis, Depends(get_redis)],  # type: ignore[type-arg]
     ) -> None:
-        # Get user's permissions
-        from app.core.permissions import get_user_permissions
+        # Get user's permissions (using Redis cache for better performance)
+        from app.core.permission_cache import get_cached_user_permissions
 
         assert user.user_id is not None
-        user_perms = await get_user_permissions(db, user.user_id)
+        user_perms = await get_cached_user_permissions(db, redis_client, user.user_id)
         required_set = {p.value if isinstance(p, Permission) else p for p in permissions}
 
         # Check if user has all required permissions

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -119,6 +119,9 @@ class UserPrivateResponse(UserResponse):
     email: EmailStr  # User's own email (private)
     email_verified: bool  # Email verification status
     email_pm_pref: int  # PM email notification preference (0=disabled, 1=enabled)
+    permissions: list[
+        str
+    ] = []  # List of permission strings (e.g., ["image_tag_add", "tag_create"])
 
     @field_validator("email_verified", mode="before")
     @classmethod

--- a/docker/nginx/frontend.conf.test
+++ b/docker/nginx/frontend.conf.test
@@ -81,7 +81,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
     }
-    
+
     # API proxy
     location /api/ {
         proxy_pass http://api:8000;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -398,10 +398,12 @@ async def db_session(engine) -> AsyncGenerator[AsyncSession, None]:
 
 @pytest.fixture
 async def mock_redis():
-    """Mock Redis client."""
+    """Mock Redis client for permission caching and other features."""
     mock = MagicMock()
-    mock.get = AsyncMock(return_value=None)
+    mock.get = AsyncMock(return_value=None)  # Cache miss by default
     mock.set = AsyncMock()
+    mock.setex = AsyncMock()  # For permission cache with TTL
+    mock.delete = AsyncMock()  # For cache invalidation
     mock.incr = AsyncMock()
     mock.expire = AsyncMock()
     mock.close = AsyncMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ DEFAULT_TEST_DB_USER = "shuushuu"
 DEFAULT_TEST_DB_PASSWORD = "shuushuu_password"  # Matches local .env; CI overrides via TEST_DATABASE_URL
 DEFAULT_TEST_DB_HOST = "localhost"
 DEFAULT_TEST_DB_PORT = "3306"
-DEFAULT_TEST_DB_NAME = "shuushuu_test"
+DEFAULT_TEST_DB_NAME = "shuushuu_pytest"  # Separate from staging environment (shuushuu_test in .env.test)
 DEFAULT_ROOT_PASSWORD = "root_password"
 
 
@@ -203,11 +203,14 @@ def setup_test_database():
         isolation_level="AUTOCOMMIT",
     )
 
+    # Extract database name from test URL for operations
+    test_db_name = os.getenv("TEST_DB_NAME", DEFAULT_TEST_DB_NAME)
+
     with admin_engine.connect() as conn:
         # Drop and recreate test database
-        conn.execute(text("DROP DATABASE IF EXISTS shuushuu_test"))
+        conn.execute(text(f"DROP DATABASE IF EXISTS {test_db_name}"))
         conn.execute(
-            text("CREATE DATABASE shuushuu_test CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
+            text(f"CREATE DATABASE {test_db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
         )
 
         # Create test user if it doesn't exist
@@ -218,7 +221,7 @@ def setup_test_database():
 
         # Grant permissions to test user on test database
         conn.execute(
-            text("GRANT ALL PRIVILEGES ON shuushuu_test.* TO :username@'%'"),
+            text(f"GRANT ALL PRIVILEGES ON {test_db_name}.* TO :username@'%'"),
             {"username": test_user},
         )
         conn.execute(text("FLUSH PRIVILEGES"))
@@ -291,7 +294,7 @@ def setup_test_database():
     #     isolation_level="AUTOCOMMIT",
     # )
     # with admin_engine.connect() as conn:
-    #     conn.execute(text("DROP DATABASE IF EXISTS shuushuu_test"))
+    #     conn.execute(text(f"DROP DATABASE IF EXISTS {test_db_name}"))
     # admin_engine.dispose()
 
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -276,61 +276,61 @@ class TestPermissionDependencies:
     """Test FastAPI permission dependencies."""
 
     async def test_require_permission_allowed(
-        self, db_session: AsyncSession, test_user_with_group: Users
+        self, db_session: AsyncSession, test_user_with_group: Users, mock_redis
     ):
         """Dependency should allow user with permission."""
         dep = require_permission(Permission.IMAGE_EDIT)
         # Should not raise
-        await dep(user=test_user_with_group, db=db_session)
+        await dep(user=test_user_with_group, db=db_session, redis_client=mock_redis)
 
     async def test_require_permission_denied(
-        self, db_session: AsyncSession, test_user_with_group: Users
+        self, db_session: AsyncSession, test_user_with_group: Users, mock_redis
     ):
         """Dependency should deny user without permission."""
         dep = require_permission(Permission.TAG_CREATE)
 
         with pytest.raises(HTTPException) as exc_info:
-            await dep(user=test_user_with_group, db=db_session)
+            await dep(user=test_user_with_group, db=db_session, redis_client=mock_redis)
 
         assert exc_info.value.status_code == 403
         assert "tag_create" in exc_info.value.detail
 
     async def test_require_any_permission_allowed(
-        self, db_session: AsyncSession, test_user_with_group: Users
+        self, db_session: AsyncSession, test_user_with_group: Users, mock_redis
     ):
         """Dependency should allow user with at least one permission."""
         dep = require_any_permission([Permission.TAG_CREATE, Permission.IMAGE_EDIT])
         # Should not raise
-        await dep(user=test_user_with_group, db=db_session)
+        await dep(user=test_user_with_group, db=db_session, redis_client=mock_redis)
 
     async def test_require_any_permission_denied(
-        self, db_session: AsyncSession, test_user_with_group: Users
+        self, db_session: AsyncSession, test_user_with_group: Users, mock_redis
     ):
         """Dependency should deny user without any permission."""
         dep = require_any_permission([Permission.TAG_CREATE, Permission.IMAGE_TAG_ADD])
 
         with pytest.raises(HTTPException) as exc_info:
-            await dep(user=test_user_with_group, db=db_session)
+            await dep(user=test_user_with_group, db=db_session, redis_client=mock_redis)
 
         assert exc_info.value.status_code == 403
         assert "Requires one of" in exc_info.value.detail
 
     async def test_require_all_permissions_allowed(
-        self, db_session: AsyncSession, test_user_with_group: Users
+        self, db_session: AsyncSession, test_user_with_group: Users, mock_redis
     ):
         """Dependency should allow user with all permissions."""
         dep = require_all_permissions([Permission.IMAGE_EDIT, Permission.USER_BAN])
         # Should not raise
-        await dep(user=test_user_with_group, db=db_session)
+        await dep(user=test_user_with_group, db=db_session, redis_client=mock_redis)
 
     async def test_require_all_permissions_denied(
-        self, db_session: AsyncSession, test_user_with_group: Users
+        self, db_session: AsyncSession, test_user_with_group: Users, mock_redis
     ):
         """Dependency should deny user missing any permission."""
         dep = require_all_permissions([Permission.IMAGE_EDIT, Permission.TAG_CREATE])
 
         with pytest.raises(HTTPException) as exc_info:
-            await dep(user=test_user_with_group, db=db_session)
+            await dep(user=test_user_with_group, db=db_session, redis_client=mock_redis)
 
         assert exc_info.value.status_code == 403
         assert "Missing:" in exc_info.value.detail

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,23 @@
+"""Fixtures for unit tests."""
+
+import pytest
+import redis.asyncio as redis
+
+
+@pytest.fixture
+async def redis_client():
+    """
+    Real Redis client for unit tests requiring Redis functionality.
+
+    Connects to test Redis instance (same as integration tests).
+    """
+    client = redis.Redis(host="localhost", port=6379, db=1, decode_responses=True)
+
+    # Verify connection
+    await client.ping()
+
+    yield client
+
+    # Cleanup - flush test database
+    await client.flushdb()
+    await client.aclose()

--- a/tests/unit/test_permission_cache.py
+++ b/tests/unit/test_permission_cache.py
@@ -214,3 +214,409 @@ class TestPermissionCache:
         cached_str = cached.decode("utf-8") if isinstance(cached, bytes) else str(cached)
         cached_list = json.loads(cached_str)
         assert cached_list == ["apple", "mango", "zebra"]  # Sorted alphabetically
+
+    async def test_has_permission_with_cache(
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,  # type: ignore[type-arg]
+    ):
+        """Test has_permission function uses cache when Redis client is provided."""
+        from app.core.permissions import has_permission
+
+        # Create user with permission
+        user = Users(
+            username="cachetest3",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="cache3@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Create permission
+        perm = Perms(title="image_edit", desc="Edit images")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Add permission to user
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm.perm_id, permvalue=1))
+        await db_session.commit()
+
+        # Clear cache
+        await redis_client.delete(_make_cache_key(user.user_id))
+
+        # Check permission with cache (should populate cache)
+        assert await has_permission(db_session, user.user_id, "image_edit", redis_client)
+
+        # Verify cache was populated
+        cached = await redis_client.get(_make_cache_key(user.user_id))
+        assert cached is not None
+
+        # Remove permission from database to verify second call uses cache
+        await db_session.execute(
+            UserPerms.__table__.delete().where(UserPerms.user_id == user.user_id)
+        )
+        await db_session.commit()
+
+        # Check permission again - should still return True from cache
+        assert await has_permission(db_session, user.user_id, "image_edit", redis_client)
+
+        # Clear cache and verify it now returns False (no cache, no DB permission)
+        await redis_client.delete(_make_cache_key(user.user_id))
+        assert not await has_permission(db_session, user.user_id, "image_edit", redis_client)
+
+    async def test_has_permission_without_cache(
+        self,
+        db_session: AsyncSession,
+    ):
+        """Test has_permission function works without Redis client (backward compatibility)."""
+        from app.core.permissions import has_permission
+
+        # Create user with permission
+        user = Users(
+            username="nocachetest1",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="nocache1@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Create permission
+        perm = Perms(title="tag_delete", desc="Delete tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Add permission to user
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm.perm_id, permvalue=1))
+        await db_session.commit()
+
+        # Check permission without cache (redis_client=None)
+        assert await has_permission(db_session, user.user_id, "tag_delete", redis_client=None)
+        assert await has_permission(db_session, user.user_id, "tag_delete")  # Default is None
+
+    async def test_has_permission_negative_case(
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,  # type: ignore[type-arg]
+    ):
+        """Test has_permission returns False when user lacks permission (with cache)."""
+        from app.core.permissions import has_permission
+
+        # Create user without any permissions
+        user = Users(
+            username="negtest1",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="neg1@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Clear cache
+        await redis_client.delete(_make_cache_key(user.user_id))
+
+        # Check for non-existent permission - should return False and cache empty set
+        assert not await has_permission(db_session, user.user_id, "image_edit", redis_client)
+
+        # Verify empty permission set was cached
+        cached = await redis_client.get(_make_cache_key(user.user_id))
+        assert cached is not None
+        cached_str = cached.decode("utf-8") if isinstance(cached, bytes) else str(cached)
+        assert json.loads(cached_str) == []
+
+        # Second call should still return False from cache
+        assert not await has_permission(db_session, user.user_id, "image_edit", redis_client)
+
+    async def test_has_any_permission_with_cache(
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,  # type: ignore[type-arg]
+    ):
+        """Test has_any_permission function uses cache when Redis client is provided."""
+        from app.core.permissions import has_any_permission
+
+        # Create user with one permission
+        user = Users(
+            username="cachetest4",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="cache4@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Create permission
+        perm = Perms(title="tag_create", desc="Create tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Add permission to user
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm.perm_id, permvalue=1))
+        await db_session.commit()
+
+        # Clear cache
+        await redis_client.delete(_make_cache_key(user.user_id))
+
+        # Check permissions with cache - should match on tag_create
+        assert await has_any_permission(
+            db_session, user.user_id, ["image_edit", "tag_create"], redis_client
+        )
+
+        # Verify cache was populated
+        cached = await redis_client.get(_make_cache_key(user.user_id))
+        assert cached is not None
+
+        # Remove permission from database
+        await db_session.execute(
+            UserPerms.__table__.delete().where(UserPerms.user_id == user.user_id)
+        )
+        await db_session.commit()
+
+        # Should still match from cache
+        assert await has_any_permission(
+            db_session, user.user_id, ["image_edit", "tag_create"], redis_client
+        )
+
+    async def test_has_any_permission_without_cache(
+        self,
+        db_session: AsyncSession,
+    ):
+        """Test has_any_permission works without Redis client."""
+        from app.core.permissions import has_any_permission
+
+        # Create user with permission
+        user = Users(
+            username="nocachetest2",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="nocache2@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Create permission
+        perm = Perms(title="user_ban", desc="Ban users")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Add permission to user
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm.perm_id, permvalue=1))
+        await db_session.commit()
+
+        # Check without cache
+        assert await has_any_permission(
+            db_session, user.user_id, ["image_edit", "user_ban"], redis_client=None
+        )
+        assert await has_any_permission(
+            db_session, user.user_id, ["image_edit", "user_ban"]
+        )
+
+    async def test_has_any_permission_negative_case(
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,  # type: ignore[type-arg]
+    ):
+        """Test has_any_permission returns False when user has none of the permissions."""
+        from app.core.permissions import has_any_permission
+
+        # Create user with one permission
+        user = Users(
+            username="negtest2",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="neg2@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Create and add a permission the user HAS
+        perm1 = Perms(title="tag_create", desc="Create tags")
+        db_session.add(perm1)
+        await db_session.commit()
+        await db_session.refresh(perm1)
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm1.perm_id, permvalue=1))
+        await db_session.commit()
+
+        # Clear cache
+        await redis_client.delete(_make_cache_key(user.user_id))
+
+        # Check for permissions user doesn't have - should return False
+        assert not await has_any_permission(
+            db_session, user.user_id, ["image_edit", "user_ban"], redis_client
+        )
+
+        # Verify cache was populated with tag_create
+        cached = await redis_client.get(_make_cache_key(user.user_id))
+        assert cached is not None
+
+        # Second call should still return False from cache
+        assert not await has_any_permission(
+            db_session, user.user_id, ["image_edit", "user_ban"], redis_client
+        )
+
+    async def test_has_all_permissions_with_cache(
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,  # type: ignore[type-arg]
+    ):
+        """Test has_all_permissions function uses cache when Redis client is provided."""
+        from app.core.permissions import has_all_permissions
+
+        # Create user with multiple permissions
+        user = Users(
+            username="cachetest5",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="cache5@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Create permissions
+        perm1 = Perms(title="image_edit", desc="Edit images")
+        perm2 = Perms(title="tag_create", desc="Create tags")
+        db_session.add_all([perm1, perm2])
+        await db_session.commit()
+        await db_session.refresh(perm1)
+        await db_session.refresh(perm2)
+
+        # Add permissions to user
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm1.perm_id, permvalue=1))
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm2.perm_id, permvalue=1))
+        await db_session.commit()
+
+        # Clear cache
+        await redis_client.delete(_make_cache_key(user.user_id))
+
+        # Check permissions with cache
+        assert await has_all_permissions(
+            db_session, user.user_id, ["image_edit", "tag_create"], redis_client
+        )
+
+        # Verify cache was populated
+        cached = await redis_client.get(_make_cache_key(user.user_id))
+        assert cached is not None
+
+        # Remove permissions from database
+        await db_session.execute(
+            UserPerms.__table__.delete().where(UserPerms.user_id == user.user_id)
+        )
+        await db_session.commit()
+
+        # Should still return True from cache
+        assert await has_all_permissions(
+            db_session, user.user_id, ["image_edit", "tag_create"], redis_client
+        )
+
+    async def test_has_all_permissions_without_cache(
+        self,
+        db_session: AsyncSession,
+    ):
+        """Test has_all_permissions works without Redis client."""
+        from app.core.permissions import has_all_permissions
+
+        # Create user with multiple permissions
+        user = Users(
+            username="nocachetest3",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="nocache3@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Create permissions
+        perm1 = Perms(title="post_edit", desc="Edit posts")
+        perm2 = Perms(title="theme_edit", desc="Edit themes")
+        db_session.add_all([perm1, perm2])
+        await db_session.commit()
+        await db_session.refresh(perm1)
+        await db_session.refresh(perm2)
+
+        # Add permissions to user
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm1.perm_id, permvalue=1))
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm2.perm_id, permvalue=1))
+        await db_session.commit()
+
+        # Check without cache
+        assert await has_all_permissions(
+            db_session, user.user_id, ["post_edit", "theme_edit"], redis_client=None
+        )
+        assert await has_all_permissions(
+            db_session, user.user_id, ["post_edit", "theme_edit"]
+        )
+
+    async def test_has_all_permissions_negative_case(
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,  # type: ignore[type-arg]
+    ):
+        """Test has_all_permissions returns False when user lacks some permissions."""
+        from app.core.permissions import has_all_permissions
+
+        # Create user with only one of two required permissions
+        user = Users(
+            username="negtest3",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="neg3@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Create and add only one permission
+        perm1 = Perms(title="image_edit", desc="Edit images")
+        db_session.add(perm1)
+        await db_session.commit()
+        await db_session.refresh(perm1)
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm1.perm_id, permvalue=1))
+        await db_session.commit()
+
+        # Clear cache
+        await redis_client.delete(_make_cache_key(user.user_id))
+
+        # Check for both permissions - user only has image_edit, not tag_create
+        assert not await has_all_permissions(
+            db_session, user.user_id, ["image_edit", "tag_create"], redis_client
+        )
+
+        # Verify cache was populated with image_edit
+        cached = await redis_client.get(_make_cache_key(user.user_id))
+        assert cached is not None
+
+        # Second call should still return False from cache
+        assert not await has_all_permissions(
+            db_session, user.user_id, ["image_edit", "tag_create"], redis_client
+        )

--- a/tests/unit/test_permission_cache.py
+++ b/tests/unit/test_permission_cache.py
@@ -14,7 +14,7 @@ from app.core.permission_cache import (
     invalidate_user_permissions,
 )
 from app.core.security import get_password_hash
-from app.models.permissions import GroupPerms, Groups, Perms, UserGroups, UserPerms
+from app.models.permissions import Groups, Perms, UserGroups, UserPerms
 from app.models.user import Users
 
 

--- a/tests/unit/test_permission_cache.py
+++ b/tests/unit/test_permission_cache.py
@@ -1,0 +1,216 @@
+"""Tests for permission caching."""
+
+import json
+
+import pytest
+import redis.asyncio as redis
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.permission_cache import (
+    PERMISSION_CACHE_TTL,
+    _make_cache_key,
+    get_cached_user_permissions,
+    invalidate_group_permissions,
+    invalidate_user_permissions,
+)
+from app.core.security import get_password_hash
+from app.models.permissions import GroupPerms, Groups, Perms, UserGroups, UserPerms
+from app.models.user import Users
+
+
+@pytest.mark.unit
+class TestPermissionCache:
+    """Test permission caching functionality."""
+
+    async def test_cache_miss_queries_database(
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,  # type: ignore[type-arg]
+    ):
+        """First call should query database and populate cache."""
+        # Create user with a permission
+        user = Users(
+            username="cachetest1",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="cache1@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Create permission
+        perm = Perms(title="tag_create", desc="Create tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Add permission to user
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm.perm_id, permvalue=1))
+        await db_session.commit()
+
+        # Clear any existing cache
+        await redis_client.delete(_make_cache_key(user.user_id))
+
+        # Get permissions (cache miss)
+        perms = await get_cached_user_permissions(db_session, redis_client, user.user_id)
+
+        assert "tag_create" in perms
+
+        # Verify cache was populated
+        cached = await redis_client.get(_make_cache_key(user.user_id))
+        assert cached is not None
+        cached_str = cached.decode("utf-8") if isinstance(cached, bytes) else str(cached)
+        assert "tag_create" in json.loads(cached_str)
+
+    async def test_cache_hit_returns_cached_value(
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,  # type: ignore[type-arg]
+    ):
+        """Second call should return cached value without database query."""
+        # Create user
+        user = Users(
+            username="cachetest2",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="cache2@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Populate cache manually with known value
+        cache_key = _make_cache_key(user.user_id)
+        await redis_client.setex(cache_key, PERMISSION_CACHE_TTL, json.dumps(["cached_permission"]))
+
+        # Get permissions (should hit cache)
+        perms = await get_cached_user_permissions(db_session, redis_client, user.user_id)
+
+        # Should return cached value
+        assert "cached_permission" in perms
+        assert len(perms) == 1
+
+    async def test_invalidate_clears_cache(
+        self,
+        redis_client: redis.Redis,  # type: ignore[type-arg]
+    ):
+        """Invalidating should remove cache entry."""
+        user_id = 999
+        cache_key = _make_cache_key(user_id)
+
+        # Set cache
+        await redis_client.set(cache_key, json.dumps(["perm1"]))
+        assert await redis_client.exists(cache_key)
+
+        # Invalidate
+        await invalidate_user_permissions(redis_client, user_id)
+
+        # Cache should be gone
+        assert not await redis_client.exists(cache_key)
+
+    async def test_invalidate_group_clears_all_member_caches(
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,  # type: ignore[type-arg]
+    ):
+        """Invalidating a group should clear cache for all members."""
+        # Create group
+        group = Groups(title="TestGroup", desc="Test group")
+        db_session.add(group)
+        await db_session.commit()
+        await db_session.refresh(group)
+
+        # Create two users and add to group
+        user1 = Users(
+            username="groupuser1",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="groupuser1@example.com",
+            active=1,
+        )
+        user2 = Users(
+            username="groupuser2",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="groupuser2@example.com",
+            active=1,
+        )
+        db_session.add_all([user1, user2])
+        await db_session.commit()
+        await db_session.refresh(user1)
+        await db_session.refresh(user2)
+
+        # Add users to group
+        db_session.add(UserGroups(user_id=user1.user_id, group_id=group.group_id))
+        db_session.add(UserGroups(user_id=user2.user_id, group_id=group.group_id))
+        await db_session.commit()
+
+        # Set cache for both users
+        cache_key1 = _make_cache_key(user1.user_id)
+        cache_key2 = _make_cache_key(user2.user_id)
+        await redis_client.set(cache_key1, json.dumps(["perm1"]))
+        await redis_client.set(cache_key2, json.dumps(["perm1"]))
+        assert await redis_client.exists(cache_key1)
+        assert await redis_client.exists(cache_key2)
+
+        # Invalidate group
+        await invalidate_group_permissions(redis_client, db_session, group.group_id)
+
+        # Both user caches should be cleared
+        assert not await redis_client.exists(cache_key1)
+        assert not await redis_client.exists(cache_key2)
+
+    async def test_cache_permissions_are_sorted(
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,  # type: ignore[type-arg]
+    ):
+        """Cached permissions should be sorted for consistency."""
+        # Create user
+        user = Users(
+            username="sorttest",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="sort@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Create permissions in non-alphabetical order
+        perm1 = Perms(title="zebra", desc="Last")
+        perm2 = Perms(title="apple", desc="First")
+        perm3 = Perms(title="mango", desc="Middle")
+        db_session.add_all([perm1, perm2, perm3])
+        await db_session.commit()
+        await db_session.refresh(perm1)
+        await db_session.refresh(perm2)
+        await db_session.refresh(perm3)
+
+        # Add permissions to user
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm1.perm_id, permvalue=1))
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm2.perm_id, permvalue=1))
+        db_session.add(UserPerms(user_id=user.user_id, perm_id=perm3.perm_id, permvalue=1))
+        await db_session.commit()
+
+        # Clear cache
+        await redis_client.delete(_make_cache_key(user.user_id))
+
+        # Get permissions (populates cache)
+        await get_cached_user_permissions(db_session, redis_client, user.user_id)
+
+        # Check cached value is sorted
+        cached = await redis_client.get(_make_cache_key(user.user_id))
+        assert cached is not None
+        cached_str = cached.decode("utf-8") if isinstance(cached, bytes) else str(cached)
+        cached_list = json.loads(cached_str)
+        assert cached_list == ["apple", "mango", "zebra"]  # Sorted alphabetically


### PR DESCRIPTION
- Added permission caching layer using Redis for high-performance permission checks.
- Created public endpoint to list available permissions for frontend use.
- Updated user profile endpoint to include permissions.
- Enhanced tag filtering to deduplicate IDs.
- Added tests for permission caching functionality and user profile permissions.