### PR TITLE
feat: add external links support for tags

### DIFF
--- a/alembic/versions/ccfd71ba58f6_add_tag_external_links_table.py
+++ b/alembic/versions/ccfd71ba58f6_add_tag_external_links_table.py
@@ -1,0 +1,40 @@
+"""add tag_external_links table
+
+Revision ID: ccfd71ba58f6
+Revises: ec5c5fa4e3e5
+Create Date: 2025-12-26 08:27:22.140606
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ccfd71ba58f6'
+down_revision: str | Sequence[str] | None = 'ec5c5fa4e3e5'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'tag_external_links',
+        sa.Column('url', sa.String(length=2000), nullable=False),
+        sa.Column('link_id', mysql.INTEGER(unsigned=True), nullable=False, autoincrement=True),
+        sa.Column('tag_id', mysql.INTEGER(unsigned=True), nullable=False),
+        sa.Column('date_added', sa.DateTime(), server_default=sa.text('current_timestamp()'), nullable=False),
+        sa.ForeignKeyConstraint(['tag_id'], ['tags.tag_id'], name='fk_tag_external_links_tag_id', ondelete='CASCADE', onupdate='CASCADE'),
+        sa.PrimaryKeyConstraint('link_id'),
+        sa.UniqueConstraint('tag_id', 'url', name='unique_tag_url')
+    )
+    op.create_index('idx_tag_id', 'tag_external_links', ['tag_id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('idx_tag_id', table_name='tag_external_links')
+    op.drop_table('tag_external_links')

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -43,6 +43,7 @@ from app.models.privmsg import Privmsgs
 from app.models.refresh_token import RefreshTokens
 from app.models.review_vote import ReviewVotes
 from app.models.tag import Tags
+from app.models.tag_external_link import TagExternalLinks
 from app.models.tag_history import TagHistory
 from app.models.tag_link import TagLinks
 from app.models.user import Users
@@ -58,6 +59,7 @@ __all__ = [
     # Junction/relationship tables
     "Favorites",
     "TagLinks",
+    "TagExternalLinks",
     "TagHistory",
     "ImageRatings",
     "ImageReports",

--- a/app/models/tag_external_link.py
+++ b/app/models/tag_external_link.py
@@ -13,7 +13,7 @@ This approach eliminates field duplication while maintaining security boundaries
 
 from datetime import UTC, datetime
 
-from sqlalchemy import Index, text
+from sqlalchemy import ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
 
 
@@ -44,7 +44,19 @@ class TagExternalLinks(TagExternalLinkBase, table=True):
 
     __tablename__ = "tag_external_links"
 
+    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
+    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
+    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
+    # these definitions may drift from the actual database structure over time. When in doubt,
+    # treat Alembic migrations as the source of truth for production schema.
     __table_args__ = (
+        ForeignKeyConstraint(
+            ["tag_id"],
+            ["tags.tag_id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="fk_tag_external_links_tag_id",
+        ),
         Index("idx_tag_id", "tag_id"),
         Index("unique_tag_url", "tag_id", "url", unique=True),
     )

--- a/app/models/tag_external_link.py
+++ b/app/models/tag_external_link.py
@@ -1,0 +1,69 @@
+"""
+SQLModel-based TagExternalLink models with inheritance for security
+
+This module defines the TagExternalLinks database model using SQLModel, which combines
+SQLAlchemy and Pydantic functionality. The inheritance structure is:
+
+TagExternalLinkBase (shared public fields)
+    ├─> TagExternalLinks (database table, adds internal fields)
+    └─> API schemas (defined in app/schemas)
+
+This approach eliminates field duplication while maintaining security boundaries.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Index, text
+from sqlmodel import Field, SQLModel
+
+
+class TagExternalLinkBase(SQLModel):
+    """
+    Base model with shared public fields for tag external links.
+
+    These fields are safe to expose via the API and are shared between:
+    - The database table (TagExternalLinks)
+    - API response schemas
+    - API request schemas
+    """
+
+    url: str = Field(max_length=2000)
+
+
+class TagExternalLinks(TagExternalLinkBase, table=True):
+    """
+    Database table for tag external links.
+
+    Stores URLs associated with tags (artist sites, social media, etc.)
+
+    Extends TagExternalLinkBase with:
+    - Primary key
+    - Foreign key to tags
+    - Date tracking
+    """
+
+    __tablename__ = "tag_external_links"
+
+    __table_args__ = (
+        Index("idx_tag_id", "tag_id"),
+        Index("unique_tag_url", "tag_id", "url", unique=True),
+    )
+
+    # Primary key
+    link_id: int | None = Field(default=None, primary_key=True)
+
+    # Foreign key
+    tag_id: int = Field(foreign_key="tags.tag_id", index=True)
+
+    # Timestamp
+    date_added: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column_kwargs={"server_default": text("current_timestamp()")},
+    )
+
+    # Note: Relationships are intentionally omitted.
+    # Foreign keys are sufficient for queries, and omitting relationships avoids:
+    # - Circular import issues
+    # - Accidental eager loading
+    # - Unwanted auto-serialization in API responses
+    # If needed, relationships can be added selectively with proper lazy loading.

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -117,6 +117,8 @@ class TagExternalLinkCreate(BaseModel):
     def validate_url(cls, v: str) -> str:
         """Validate URL has http/https protocol and trim whitespace."""
         v = v.strip()
+        if not v:
+            raise ValueError("URL cannot be empty")
         if not v.startswith(("http://", "https://")):
             raise ValueError("URL must start with http:// or https://")
         if len(v) > 2000:

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -94,6 +94,7 @@ class TagWithStats(TagResponse):
     child_count: int = 0  # Number of child tags that inherit from this tag
     created_by: TagCreator | None = None  # User who created the tag
     date_added: datetime  # When the tag was created
+    links: list[str] = []  # External URLs associated with this tag
 
 
 class TagListResponse(BaseModel):
@@ -104,3 +105,30 @@ class TagListResponse(BaseModel):
     per_page: int
     tags: list[TagResponse]
     invalid_ids: list[str] | None = None  # IDs that were invalid and filtered out
+
+
+class TagExternalLinkCreate(BaseModel):
+    """Schema for adding a new external link to a tag"""
+
+    url: str
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, v: str) -> str:
+        """Validate URL has http/https protocol and trim whitespace."""
+        v = v.strip()
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("URL must start with http:// or https://")
+        if len(v) > 2000:
+            raise ValueError("URL exceeds maximum length of 2000 characters")
+        return v
+
+
+class TagExternalLinkResponse(BaseModel):
+    """Schema for tag external link response"""
+
+    link_id: int
+    url: str
+    date_added: datetime
+
+    model_config = {"from_attributes": True}

--- a/docs/plans/2025-12-25-tag-external-links-design.md
+++ b/docs/plans/2025-12-25-tag-external-links-design.md
@@ -1,0 +1,345 @@
+# Tag External Links Design
+
+**Date:** 2025-12-25
+**Status:** Approved
+
+## Overview
+
+Add support for external links (websites, social media profiles, etc.) to tags, primarily for source and artist tag types. Links are stored in a separate table and managed through dedicated API endpoints.
+
+## Requirements
+
+- Tags can have multiple external URLs (0 to many)
+- URLs should be validated to require http:// or https:// protocol
+- Prevent duplicate URLs within a single tag
+- Links appear in tag detail view (`GET /tags/{tag_id}`) but not in tag lists
+- Managing links requires TAG_UPDATE permission
+- All tag types can have links (not restricted to source/artist)
+
+## Database Schema
+
+### New Table: `tag_external_links`
+
+```sql
+CREATE TABLE tag_external_links (
+    link_id INT AUTO_INCREMENT PRIMARY KEY,
+    tag_id INT NOT NULL,
+    url VARCHAR(2000) NOT NULL,
+    date_added TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (tag_id) REFERENCES tags(tag_id) ON DELETE CASCADE,
+    UNIQUE KEY unique_tag_url (tag_id, url),
+    INDEX idx_tag_id (tag_id)
+);
+```
+
+**Design Decisions:**
+- `link_id`: Auto-increment primary key for addressing individual links
+- `tag_id`: Foreign key with CASCADE delete (if tag is deleted, links are removed)
+- `url`: VARCHAR(2000) supports most URLs
+- `date_added`: Timestamp for ordering and audit trail
+- **UNIQUE constraint on (tag_id, url)**: Prevents duplicate URLs within a tag
+- **Index on tag_id**: Fast lookups when fetching links for a tag
+
+**Future Extensibility:**
+Schema is minimal but can be extended later with:
+- `label` VARCHAR(100) for categorizing links (Twitter, Pixiv, Official Site, etc.)
+- `display_order` INT for explicit ordering control
+- `verified` BOOLEAN for marking verified/official links
+
+## SQLModel Models
+
+**File:** `app/models/tag_external_link.py`
+
+```python
+"""
+SQLModel-based TagExternalLink models with inheritance for security
+
+TagExternalLinkBase (shared public fields)
+    ├─> TagExternalLinks (database table, adds internal fields)
+    └─> API schemas (defined in app/schemas)
+"""
+
+from datetime import UTC, datetime
+from sqlalchemy import Index, text
+from sqlmodel import Field, SQLModel
+
+
+class TagExternalLinkBase(SQLModel):
+    """
+    Base model with shared public fields for tag external links.
+
+    These fields are safe to expose via the API.
+    """
+    url: str = Field(max_length=2000)
+
+
+class TagExternalLinks(TagExternalLinkBase, table=True):
+    """
+    Database table for tag external links.
+
+    Stores URLs associated with tags (artist sites, social media, etc.)
+    """
+
+    __tablename__ = "tag_external_links"
+
+    __table_args__ = (
+        Index("idx_tag_id", "tag_id"),
+        Index("unique_tag_url", "tag_id", "url", unique=True),
+    )
+
+    # Primary key
+    link_id: int | None = Field(default=None, primary_key=True)
+
+    # Foreign key
+    tag_id: int = Field(foreign_key="tags.tag_id", index=True)
+
+    # Timestamp
+    date_added: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column_kwargs={"server_default": text("current_timestamp()")},
+    )
+```
+
+**Pattern Notes:**
+- Follows existing model inheritance pattern (TagBase → Tags)
+- No relationship objects (matches Tags model philosophy)
+- Unique constraint enforced via `__table_args__`
+
+## API Schemas
+
+**File:** `app/schemas/tag.py`
+
+### New Schemas
+
+```python
+class TagExternalLinkCreate(BaseModel):
+    """Schema for adding a new external link to a tag"""
+
+    url: str
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, v: str) -> str:
+        """Validate URL has http/https protocol and trim whitespace."""
+        v = v.strip()
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("URL must start with http:// or https://")
+        if len(v) > 2000:
+            raise ValueError("URL exceeds maximum length of 2000 characters")
+        return v
+
+
+class TagExternalLinkResponse(BaseModel):
+    """Schema for tag external link response"""
+
+    link_id: int
+    url: str
+    date_added: datetime
+
+    model_config = {"from_attributes": True}
+```
+
+### Updated Schema
+
+```python
+class TagWithStats(TagResponse):
+    """Schema for tag response with usage statistics"""
+
+    image_count: int
+    is_alias: bool = False
+    aliased_tag_id: int | None = None
+    parent_tag_id: int | None = None
+    child_count: int = 0
+    created_by: TagCreator | None = None
+    date_added: datetime
+    links: list[str] = []  # NEW: List of external URLs
+```
+
+**Validation Strategy:**
+- URL protocol validation at Pydantic schema level
+- Length validation at schema level (2000 chars)
+- Uniqueness validation at database level (UNIQUE constraint)
+
+## API Endpoints
+
+**File:** `app/api/v1/tags.py`
+
+### New Endpoints
+
+#### `POST /tags/{tag_id}/links`
+
+Add an external link to a tag.
+
+**Request:**
+```json
+{
+  "url": "https://twitter.com/artist_name"
+}
+```
+
+**Response:** 201 Created
+```json
+{
+  "link_id": 123,
+  "url": "https://twitter.com/artist_name",
+  "date_added": "2025-12-25T10:30:00Z"
+}
+```
+
+**Errors:**
+- 404: Tag not found
+- 409: URL already exists for this tag
+- 403: Missing TAG_UPDATE permission
+
+**Implementation:**
+```python
+@router.post("/{tag_id}/links", response_model=TagExternalLinkResponse, status_code=201)
+async def add_tag_link(
+    tag_id: Annotated[int, Path(description="Tag ID")],
+    link_data: TagExternalLinkCreate,
+    _: Annotated[None, Depends(require_permission(Permission.TAG_UPDATE))],
+    db: AsyncSession = Depends(get_db),
+) -> TagExternalLinkResponse:
+    """Add an external link to a tag."""
+    # Verify tag exists
+    tag_result = await db.execute(select(Tags).where(Tags.tag_id == tag_id))
+    if not tag_result.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    # Create new link
+    new_link = TagExternalLinks(tag_id=tag_id, url=link_data.url)
+    db.add(new_link)
+
+    try:
+        await db.commit()
+        await db.refresh(new_link)
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="URL already exists for this tag")
+
+    return TagExternalLinkResponse.model_validate(new_link)
+```
+
+#### `DELETE /tags/{tag_id}/links/{link_id}`
+
+Remove an external link from a tag.
+
+**Response:** 204 No Content
+
+**Errors:**
+- 404: Link not found or doesn't belong to this tag
+- 403: Missing TAG_UPDATE permission
+
+**Implementation:**
+```python
+@router.delete("/{tag_id}/links/{link_id}", status_code=204)
+async def delete_tag_link(
+    tag_id: Annotated[int, Path(description="Tag ID")],
+    link_id: Annotated[int, Path(description="Link ID")],
+    _: Annotated[None, Depends(require_permission(Permission.TAG_UPDATE))],
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Remove an external link from a tag."""
+    # Fetch and verify link belongs to this tag
+    link_result = await db.execute(
+        select(TagExternalLinks).where(
+            TagExternalLinks.link_id == link_id,
+            TagExternalLinks.tag_id == tag_id,
+        )
+    )
+    link = link_result.scalar_one_or_none()
+
+    if not link:
+        raise HTTPException(
+            status_code=404,
+            detail="Link not found or does not belong to this tag"
+        )
+
+    await db.delete(link)
+    await db.commit()
+```
+
+### Updated Endpoint
+
+#### `GET /tags/{tag_id}`
+
+Modified to include external links in response.
+
+**Changes:**
+```python
+@router.get("/{tag_id}", response_model=TagWithStats)
+async def get_tag(...):
+    # ... existing code ...
+
+    # NEW: Fetch external links for this tag
+    links_result = await db.execute(
+        select(TagExternalLinks.url)
+        .where(TagExternalLinks.tag_id == tag_id)
+        .order_by(TagExternalLinks.date_added)
+    )
+    links = links_result.scalars().all()
+
+    return TagWithStats(
+        # ... existing fields ...
+        links=list(links),
+    )
+```
+
+**Performance:**
+- Single additional query to fetch links (acceptable for detail view)
+- Links ordered by `date_added` (most recent additions last)
+- No impact on `list_tags` endpoint (links not included)
+
+## Permission Model
+
+**Required Permission:** `Permission.TAG_UPDATE`
+
+- Adding links: `POST /tags/{tag_id}/links` requires TAG_UPDATE
+- Removing links: `DELETE /tags/{tag_id}/links/{link_id}` requires TAG_UPDATE
+- Viewing links: No permission required (public data in `GET /tags/{tag_id}`)
+
+**Rationale:**
+- Reuses existing permission (no new permission needed)
+- Consistent with tag editing workflows
+- Prevents abuse through existing elevated access controls
+
+## Migration Strategy
+
+1. Create Alembic migration to add `tag_external_links` table
+2. Import new model in `alembic/env.py` for future autogenerate support
+3. No data migration needed (new feature, no existing data)
+
+## Testing Requirements
+
+### Unit Tests
+- URL validation (protocol check, length limits)
+- Schema validation for create/response models
+
+### API Tests (`tests/api/v1/test_tags.py`)
+- Add link to tag (success case)
+- Add duplicate link (409 error)
+- Add link to non-existent tag (404 error)
+- Add link without permission (403 error)
+- Delete link from tag (success case)
+- Delete non-existent link (404 error)
+- Delete link from wrong tag (404 error)
+- Get tag with links (verify links included)
+- Get tag without links (verify empty array)
+- List tags (verify links NOT included)
+
+### Edge Cases
+- Very long URLs (near 2000 char limit)
+- URLs with special characters
+- Multiple links on same tag
+- Deleting tag cascades to links
+
+## Future Enhancements
+
+Potential features that can be added later without schema changes:
+
+1. **Link Labels/Types** - Add `label` column to categorize links
+2. **Display Order** - Add `display_order` column for explicit ordering
+3. **Link Verification** - Add `verified` boolean for marking official links
+4. **Bulk Operations** - `POST /tags/{tag_id}/links/bulk` endpoint
+5. **Link Statistics** - Track click counts or last verified date
+6. **GET /tags/{tag_id}/links** - Dedicated endpoint for listing links with full metadata

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -19,6 +19,7 @@ from app.core.security import get_password_hash
 from app.models.image import Images
 from app.models.permissions import Perms, UserPerms
 from app.models.tag import Tags
+from app.models.tag_external_link import TagExternalLinks
 from app.models.tag_link import TagLinks
 from app.models.user import Users
 
@@ -1288,3 +1289,535 @@ class TestDeleteTag:
             headers={"Authorization": f"Bearer {access_token}"},
         )
         assert response.status_code == 403
+
+
+@pytest.mark.api
+class TestAddTagLink:
+    """Tests for POST /api/v1/tags/{tag_id}/links endpoint."""
+
+    async def test_add_link_to_tag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test adding an external link to a tag."""
+        # Create TAG_UPDATE permission
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Create admin user
+        admin = Users(
+            username="adminlinks",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="adminlinks@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        # Grant TAG_UPDATE permission
+        user_perm = UserPerms(
+            user_id=admin.user_id,
+            perm_id=perm.perm_id,
+            permvalue=1,
+        )
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        # Create tag
+        tag = Tags(title="artist tag", desc="Test artist", type=TagType.ARTIST)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        # Login as admin
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "adminlinks", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Add link to tag
+        link_data = {"url": "https://twitter.com/artist_name"}
+        response = await client.post(
+            f"/api/v1/tags/{tag.tag_id}/links",
+            json=link_data,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["url"] == "https://twitter.com/artist_name"
+        assert "link_id" in data
+        assert "date_added" in data
+
+    async def test_add_link_without_protocol(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that URLs without http/https are rejected."""
+        # Create TAG_UPDATE permission
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Create admin user
+        admin = Users(
+            username="adminproto",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="adminproto@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        # Grant TAG_UPDATE permission
+        user_perm = UserPerms(
+            user_id=admin.user_id,
+            perm_id=perm.perm_id,
+            permvalue=1,
+        )
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        # Create tag
+        tag = Tags(title="test tag", desc="Test", type=TagType.ARTIST)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        # Login as admin
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "adminproto", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Try to add link without protocol
+        link_data = {"url": "twitter.com/artist"}
+        response = await client.post(
+            f"/api/v1/tags/{tag.tag_id}/links",
+            json=link_data,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 422  # Validation error
+
+    async def test_add_duplicate_link(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that adding duplicate URL to same tag returns 409."""
+        # Create TAG_UPDATE permission
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Create admin user
+        admin = Users(
+            username="admindup",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="admindup@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        # Grant TAG_UPDATE permission
+        user_perm = UserPerms(
+            user_id=admin.user_id,
+            perm_id=perm.perm_id,
+            permvalue=1,
+        )
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        # Create tag with existing link
+        tag = Tags(title="test tag", desc="Test", type=TagType.ARTIST)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        link = TagExternalLinks(tag_id=tag.tag_id, url="https://example.com")
+        db_session.add(link)
+        await db_session.commit()
+
+        # Login as admin
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "admindup", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Try to add same URL again
+        link_data = {"url": "https://example.com"}
+        response = await client.post(
+            f"/api/v1/tags/{tag.tag_id}/links",
+            json=link_data,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 409
+
+    async def test_add_link_to_nonexistent_tag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test adding link to non-existent tag returns 404."""
+        # Create TAG_UPDATE permission
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Create admin user
+        admin = Users(
+            username="admin404",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="admin404@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        # Grant TAG_UPDATE permission
+        user_perm = UserPerms(
+            user_id=admin.user_id,
+            perm_id=perm.perm_id,
+            permvalue=1,
+        )
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        # Login as admin
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "admin404", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Try to add link to non-existent tag
+        link_data = {"url": "https://example.com"}
+        response = await client.post(
+            "/api/v1/tags/999999/links",
+            json=link_data,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 404
+
+    async def test_add_link_without_permission(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that users without TAG_UPDATE permission cannot add links."""
+        # Create regular user without permission
+        user = Users(
+            username="regularlinkuser",
+            password=get_password_hash("Password123!"),
+            password_type="bcrypt",
+            salt="",
+            email="regularlink@example.com",
+            active=1,
+            admin=0,
+        )
+        db_session.add(user)
+        await db_session.commit()
+
+        # Create tag
+        tag = Tags(title="test tag", desc="Test", type=TagType.ARTIST)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        # Login
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "regularlinkuser", "password": "Password123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Try to add link
+        link_data = {"url": "https://example.com"}
+        response = await client.post(
+            f"/api/v1/tags/{tag.tag_id}/links",
+            json=link_data,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 403
+
+
+@pytest.mark.api
+class TestDeleteTagLink:
+    """Tests for DELETE /api/v1/tags/{tag_id}/links/{link_id} endpoint."""
+
+    async def test_delete_link_from_tag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test deleting an external link from a tag."""
+        # Create TAG_UPDATE permission
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Create admin user
+        admin = Users(
+            username="admindellink",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="admindellink@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        # Grant TAG_UPDATE permission
+        user_perm = UserPerms(
+            user_id=admin.user_id,
+            perm_id=perm.perm_id,
+            permvalue=1,
+        )
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        # Create tag with link
+        tag = Tags(title="test tag", desc="Test", type=TagType.ARTIST)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        link = TagExternalLinks(tag_id=tag.tag_id, url="https://example.com")
+        db_session.add(link)
+        await db_session.commit()
+        await db_session.refresh(link)
+
+        # Login as admin
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "admindellink", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Delete link
+        response = await client.delete(
+            f"/api/v1/tags/{tag.tag_id}/links/{link.link_id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 204
+
+    async def test_delete_nonexistent_link(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test deleting non-existent link returns 404."""
+        # Create TAG_UPDATE permission
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Create admin user
+        admin = Users(
+            username="admindel404",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="admindel404@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        # Grant TAG_UPDATE permission
+        user_perm = UserPerms(
+            user_id=admin.user_id,
+            perm_id=perm.perm_id,
+            permvalue=1,
+        )
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        # Create tag (without link)
+        tag = Tags(title="test tag", desc="Test", type=TagType.ARTIST)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        # Login as admin
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "admindel404", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Try to delete non-existent link
+        response = await client.delete(
+            f"/api/v1/tags/{tag.tag_id}/links/999999",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 404
+
+    async def test_delete_link_from_wrong_tag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test deleting link using wrong tag_id returns 404."""
+        # Create TAG_UPDATE permission
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Create admin user
+        admin = Users(
+            username="admindelwrong",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="admindelwrong@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        # Grant TAG_UPDATE permission
+        user_perm = UserPerms(
+            user_id=admin.user_id,
+            perm_id=perm.perm_id,
+            permvalue=1,
+        )
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        # Create two tags
+        tag1 = Tags(title="tag1", desc="Test", type=TagType.ARTIST)
+        tag2 = Tags(title="tag2", desc="Test", type=TagType.ARTIST)
+        db_session.add_all([tag1, tag2])
+        await db_session.commit()
+        await db_session.refresh(tag1)
+        await db_session.refresh(tag2)
+
+        # Add link to tag1
+        link = TagExternalLinks(tag_id=tag1.tag_id, url="https://example.com")
+        db_session.add(link)
+        await db_session.commit()
+        await db_session.refresh(link)
+
+        # Login as admin
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "admindelwrong", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Try to delete link from wrong tag
+        response = await client.delete(
+            f"/api/v1/tags/{tag2.tag_id}/links/{link.link_id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 404
+
+    async def test_delete_link_without_permission(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that users without TAG_UPDATE permission cannot delete links."""
+        # Create regular user without permission
+        user = Users(
+            username="regulardellinkuser",
+            password=get_password_hash("Password123!"),
+            password_type="bcrypt",
+            salt="",
+            email="regulardellink@example.com",
+            active=1,
+            admin=0,
+        )
+        db_session.add(user)
+        await db_session.commit()
+
+        # Create tag with link
+        tag = Tags(title="test tag", desc="Test", type=TagType.ARTIST)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        link = TagExternalLinks(tag_id=tag.tag_id, url="https://example.com")
+        db_session.add(link)
+        await db_session.commit()
+        await db_session.refresh(link)
+
+        # Login
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "regulardellinkuser", "password": "Password123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Try to delete link
+        response = await client.delete(
+            f"/api/v1/tags/{tag.tag_id}/links/{link.link_id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 403
+
+
+@pytest.mark.api
+class TestGetTagWithLinks:
+    """Tests for GET /api/v1/tags/{tag_id} endpoint with links."""
+
+    async def test_get_tag_with_links(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that tag details include external links."""
+        # Create tag with links
+        tag = Tags(title="test tag", desc="Test", type=TagType.ARTIST)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        # Add multiple links
+        link1 = TagExternalLinks(tag_id=tag.tag_id, url="https://twitter.com/artist")
+        link2 = TagExternalLinks(tag_id=tag.tag_id, url="https://pixiv.net/users/123")
+        db_session.add_all([link1, link2])
+        await db_session.commit()
+
+        # Get tag details
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert "links" in data
+        assert len(data["links"]) == 2
+        assert "https://twitter.com/artist" in data["links"]
+        assert "https://pixiv.net/users/123" in data["links"]
+
+    async def test_get_tag_without_links(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that tags without links have empty links array."""
+        # Create tag without links
+        tag = Tags(title="test tag", desc="Test", type=TagType.ARTIST)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        # Get tag details
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert "links" in data
+        assert data["links"] == []


### PR DESCRIPTION
Add ability to associate multiple external URLs (websites, social media, etc.) with tags, primarily for source and artist tags.

Database:
- New tag_external_links table with URL, tag_id, and date_added columns
- UNIQUE constraint on (tag_id, url) to prevent duplicates
- CASCADE delete when tag is removed
- Alembic migration for schema changes

API:
- POST /api/v1/tags/{tag_id}/links - add external link to tag
- DELETE /api/v1/tags/{tag_id}/links/{link_id} - remove link from tag
- GET /api/v1/tags/{tag_id} - updated to include links array

Models & Schemas:
- TagExternalLinks model following inheritance pattern
- TagExternalLinkCreate with URL validation (requires http/https)
- TagExternalLinkResponse for link management endpoints
- TagWithStats.links field for tag detail responses

Tests:
- Comprehensive test coverage for all endpoints
- Permission validation (requires TAG_UPDATE)
- URL validation and duplicate prevention