### PR TITLE
fix: support both trailing slash patterns in API routes without redirects

### DIFF
--- a/app/api/v1/comments.py
+++ b/app/api/v1/comments.py
@@ -25,7 +25,8 @@ from app.schemas.comment import (
 router = APIRouter(prefix="/comments", tags=["comments"])
 
 
-@router.get("/", response_model=CommentListResponse)
+@router.get("/", response_model=CommentListResponse, include_in_schema=False)
+@router.get("", response_model=CommentListResponse)
 async def list_comments(
     pagination: Annotated[PaginationParams, Depends()],
     sorting: Annotated[CommentSortParams, Depends()],
@@ -330,7 +331,13 @@ async def get_comment_stats(db: AsyncSession = Depends(get_db)) -> CommentStatsR
     )
 
 
-@router.post("/", response_model=CommentResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/",
+    response_model=CommentResponse,
+    status_code=status.HTTP_201_CREATED,
+    include_in_schema=False,
+)
+@router.post("", response_model=CommentResponse, status_code=status.HTTP_201_CREATED)
 async def create_comment(
     body: CommentCreate,
     current_user: Annotated[Users, Depends(get_current_user)],

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -76,7 +76,8 @@ def _get_client_ip(request: Request) -> str:
     return request.client.host if request.client else "0.0.0.0"
 
 
-@router.get("/", response_model=ImageDetailedListResponse)
+@router.get("/", response_model=ImageDetailedListResponse, include_in_schema=False)
+@router.get("", response_model=ImageDetailedListResponse)
 async def list_images(
     pagination: Annotated[PaginationParams, Depends()],
     sorting: Annotated[ImageSortParams, Depends()],

--- a/app/api/v1/privmsgs.py
+++ b/app/api/v1/privmsgs.py
@@ -22,7 +22,10 @@ from app.tasks.queue import enqueue_job
 router = APIRouter(prefix="/privmsgs", tags=["privmsgs"])
 
 
-@router.post("/", response_model=PrivmsgMessage, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/", response_model=PrivmsgMessage, status_code=status.HTTP_201_CREATED, include_in_schema=False
+)
+@router.post("", response_model=PrivmsgMessage, status_code=status.HTTP_201_CREATED)
 async def send_privmsg(
     privmsg: PrivmsgCreate,
     current_user: VerifiedUser,

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -97,7 +97,8 @@ async def get_tag_hierarchy(db: AsyncSession, tag_id: int) -> list[int]:
     return tag_ids
 
 
-@router.get("/", response_model=TagListResponse)
+@router.get("/", response_model=TagListResponse, include_in_schema=False)
+@router.get("", response_model=TagListResponse)
 async def list_tags(
     pagination: Annotated[PaginationParams, Depends()],
     search: Annotated[str | None, Query(description="Search tags by name")] = None,
@@ -456,7 +457,8 @@ async def get_tag(
     )
 
 
-@router.post("/", response_model=TagResponse)
+@router.post("/", response_model=TagResponse, include_in_schema=False)
+@router.post("", response_model=TagResponse)
 async def create_tag(
     tag_data: TagCreate,
     _: Annotated[None, Depends(require_permission(Permission.TAG_CREATE))],

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -55,7 +55,8 @@ from app.tasks.queue import enqueue_job
 router = APIRouter(prefix="/users", tags=["users"])
 
 
-@router.get("/", response_model=UserListResponse)
+@router.get("/", response_model=UserListResponse, include_in_schema=False)
+@router.get("", response_model=UserListResponse)
 async def list_users(
     pagination: Annotated[PaginationParams, Depends()],
     sorting: Annotated[UserSortParams, Depends()],
@@ -551,7 +552,8 @@ async def get_user_favorites(
     )
 
 
-@router.post("/", response_model=UserCreateResponse)
+@router.post("/", response_model=UserCreateResponse, include_in_schema=False)
+@router.post("", response_model=UserCreateResponse)
 async def create_user(
     user_data: UserCreate,
     request: Request,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       dockerfile: Dockerfile
     container_name: shuushuu-api
     user: "${UID:-1000}:${GID:-1000}"
-    command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --reload-exclude '.venv/*' --reload-exclude 'tests/*' --reload-exclude '*.pyc' --reload-exclude '__pycache__/*'
     ports:
       - "8000:8000"
     environment:

--- a/tests/api/v1/test_comments.py
+++ b/tests/api/v1/test_comments.py
@@ -21,7 +21,7 @@ from app.models.user import Users
 
 @pytest.mark.api
 class TestListComments:
-    """Tests for GET /api/v1/comments/ endpoint."""
+    """Tests for GET /api/v1/comments endpoint."""
 
     async def test_list_comments(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
@@ -43,7 +43,7 @@ class TestListComments:
             db_session.add(comment)
         await db_session.commit()
 
-        response = await client.get("/api/v1/comments/")
+        response = await client.get("/api/v1/comments")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] >= 5
@@ -86,7 +86,7 @@ class TestListComments:
         await db_session.commit()
 
         # Filter by image1
-        response = await client.get(f"/api/v1/comments/?image_id={image1.image_id}")
+        response = await client.get(f"/api/v1/comments?image_id={image1.image_id}")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 3
@@ -111,7 +111,7 @@ class TestListComments:
         await db_session.commit()
 
         # Filter by user 2
-        response = await client.get("/api/v1/comments/?user_id=2")
+        response = await client.get("/api/v1/comments?user_id=2")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
@@ -142,7 +142,7 @@ class TestListComments:
         await db_session.commit()
 
         # Search for "awesome"
-        response = await client.get("/api/v1/comments/?search_text=awesome&search_mode=like")
+        response = await client.get("/api/v1/comments?search_text=awesome&search_mode=like")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
@@ -314,7 +314,7 @@ class TestGetCommentStats:
 
 @pytest.mark.api
 class TestCreateComment:
-    """Tests for POST /api/v1/comments/ endpoint."""
+    """Tests for POST /api/v1/comments endpoint."""
 
     async def test_create_top_level_comment(
         self,
@@ -331,7 +331,7 @@ class TestCreateComment:
         await db_session.refresh(image)
 
         response = await authenticated_client.post(
-            "/api/v1/comments/",
+            "/api/v1/comments",
             json={
                 "image_id": image.image_id,
                 "post_text": "Great artwork!",
@@ -373,7 +373,7 @@ class TestCreateComment:
 
         # Create reply
         response = await authenticated_client.post(
-            "/api/v1/comments/",
+            "/api/v1/comments",
             json={
                 "image_id": image.image_id,
                 "post_text": "Thanks!",
@@ -388,7 +388,7 @@ class TestCreateComment:
     async def test_create_comment_requires_auth(self, client: AsyncClient):
         """Test that creating a comment requires authentication."""
         response = await client.post(
-            "/api/v1/comments/",
+            "/api/v1/comments",
             json={
                 "image_id": 999,
                 "post_text": "Comment",
@@ -402,7 +402,7 @@ class TestCreateComment:
     ):
         """Test creating a comment on non-existent image."""
         response = await authenticated_client.post(
-            "/api/v1/comments/",
+            "/api/v1/comments",
             json={
                 "image_id": 99999,
                 "post_text": "Comment",
@@ -425,7 +425,7 @@ class TestCreateComment:
         await db_session.refresh(image)
 
         response = await authenticated_client.post(
-            "/api/v1/comments/",
+            "/api/v1/comments",
             json={
                 "image_id": image.image_id,
                 "post_text": "Reply",
@@ -467,7 +467,7 @@ class TestCreateComment:
 
         # Try to reply on image2 with parent from image1
         response = await authenticated_client.post(
-            "/api/v1/comments/",
+            "/api/v1/comments",
             json={
                 "image_id": image2.image_id,
                 "post_text": "Reply on wrong image",
@@ -490,7 +490,7 @@ class TestCreateComment:
         await db_session.refresh(image)
 
         response = await authenticated_client.post(
-            "/api/v1/comments/",
+            "/api/v1/comments",
             json={
                 "image_id": image.image_id,
                 "post_text": "",

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -17,11 +17,11 @@ from app.models import Favorites, ImageRatings, Images, TagLinks, Tags, Users
 
 @pytest.mark.api
 class TestImagesList:
-    """Tests for GET /api/v1/images/ endpoint."""
+    """Tests for GET /api/v1/images endpoint."""
 
     async def test_list_images_empty(self, client: AsyncClient):
         """Test listing images when database is empty."""
-        await client.get("/api/v1/images/")
+        await client.get("/api/v1/images")
 
         # assert response.status_code == 200
         # data = response.json()
@@ -40,7 +40,7 @@ class TestImagesList:
         await db_session.commit()
         await db_session.refresh(image)
 
-        response = await client.get("/api/v1/images/")
+        response = await client.get("/api/v1/images")
 
         assert response.status_code == 200
         data = response.json()
@@ -70,7 +70,7 @@ class TestImagesList:
         await db_session.commit()
 
         # Test first page
-        response = await client.get("/api/v1/images/?page=1&per_page=10")
+        response = await client.get("/api/v1/images?page=1&per_page=10")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 25
@@ -79,14 +79,14 @@ class TestImagesList:
         assert len(data["images"]) == 10
 
         # Test second page
-        response = await client.get("/api/v1/images/?page=2&per_page=10")
+        response = await client.get("/api/v1/images?page=2&per_page=10")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 2
         assert len(data["images"]) == 10
 
         # Test third page
-        response = await client.get("/api/v1/images/?page=3&per_page=10")
+        response = await client.get("/api/v1/images?page=3&per_page=10")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 3
@@ -95,11 +95,11 @@ class TestImagesList:
     async def test_list_images_invalid_pagination(self, client: AsyncClient):
         """Test invalid pagination parameters."""
         # Negative page
-        response = await client.get("/api/v1/images/?page=0")
+        response = await client.get("/api/v1/images?page=0")
         assert response.status_code == 422
 
         # Too large per_page
-        response = await client.get("/api/v1/images/?per_page=200")
+        response = await client.get("/api/v1/images?per_page=200")
         assert response.status_code == 422
 
     async def test_list_images_includes_tags(
@@ -126,7 +126,7 @@ class TestImagesList:
         await db_session.commit()
 
         # Call list_images
-        response = await client.get("/api/v1/images/")
+        response = await client.get("/api/v1/images")
 
         assert response.status_code == 200
         data = response.json()
@@ -172,7 +172,7 @@ class TestImagesFiltering:
         await db_session.commit()
 
         # Filter by user_id=2
-        response = await client.get("/api/v1/images/?user_id=2")
+        response = await client.get("/api/v1/images?user_id=2")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 3
@@ -196,7 +196,7 @@ class TestImagesFiltering:
         await db_session.commit()
 
         # Filter min_width
-        response = await client.get("/api/v1/images/?min_width=1920")
+        response = await client.get("/api/v1/images?min_width=1920")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 2  # 1920x1080 and 3840x2160
@@ -204,7 +204,7 @@ class TestImagesFiltering:
             assert img["width"] >= 1920
 
         # Filter max_width
-        response = await client.get("/api/v1/images/?max_width=1920")
+        response = await client.get("/api/v1/images?max_width=1920")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 2  # 800x600 and 1920x1080
@@ -227,7 +227,7 @@ class TestImagesFiltering:
         await db_session.commit()
 
         # Filter by minimum rating
-        response = await client.get("/api/v1/images/?min_rating=5.0")
+        response = await client.get("/api/v1/images?min_rating=5.0")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 3  # 5.0, 7.5, 10.0
@@ -260,7 +260,7 @@ class TestTagSearchValidation:
 
         # Try to search with more tags than allowed
         tags_param = ",".join(str(tid) for tid in tag_ids)
-        response = await client.get(f"/api/v1/images/?tags={tags_param}")
+        response = await client.get(f"/api/v1/images?tags={tags_param}")
 
         assert response.status_code == 400
         data = response.json()
@@ -293,7 +293,7 @@ class TestTagSearchValidation:
 
         # Search with exactly MAX_SEARCH_TAGS tags should succeed
         tags_param = ",".join(str(tid) for tid in tag_ids)
-        response = await client.get(f"/api/v1/images/?tags={tags_param}&tags_mode=all")
+        response = await client.get(f"/api/v1/images?tags={tags_param}&tags_mode=all")
 
         assert response.status_code == 200
         data = response.json()
@@ -327,7 +327,7 @@ class TestTagSearchValidation:
 
         # Search with fewer tags should succeed
         tags_param = ",".join(str(tid) for tid in tag_ids)
-        response = await client.get(f"/api/v1/images/?tags={tags_param}")
+        response = await client.get(f"/api/v1/images?tags={tags_param}")
 
         assert response.status_code == 200
         data = response.json()
@@ -364,7 +364,7 @@ class TestTagSearchValidation:
         await db_session.commit()
 
         # Search by alias tag ID should find the image
-        response = await client.get(f"/api/v1/images/?tags={alias_tag.tag_id}")
+        response = await client.get(f"/api/v1/images?tags={alias_tag.tag_id}")
 
         assert response.status_code == 200
         data = response.json()
@@ -416,7 +416,7 @@ class TestTagSearchValidation:
 
         # Search by alias IDs in ANY mode should find both images
         response = await client.get(
-            f"/api/v1/images/?tags={alias1.tag_id},{alias2.tag_id}&tags_mode=any"
+            f"/api/v1/images?tags={alias1.tag_id},{alias2.tag_id}&tags_mode=any"
         )
 
         assert response.status_code == 200
@@ -455,7 +455,7 @@ class TestImagesSorting:
 
         # Sort descending (newest first) - default
         # Since images were inserted in chronological order, newest = highest image_id
-        response = await client.get("/api/v1/images/?sort_by=date_added&sort_order=DESC")
+        response = await client.get("/api/v1/images?sort_by=date_added&sort_order=DESC")
         assert response.status_code == 200
         data = response.json()
 
@@ -464,7 +464,7 @@ class TestImagesSorting:
         assert data["images"][-1]["filename"] == "date-2024-01-01"
 
         # Sort ascending (oldest first)
-        response = await client.get("/api/v1/images/?sort_by=date_added&sort_order=ASC")
+        response = await client.get("/api/v1/images?sort_by=date_added&sort_order=ASC")
         assert response.status_code == 200
         data = response.json()
         assert data["images"][0]["filename"] == "date-2024-01-01"
@@ -494,7 +494,7 @@ class TestImageDetail:
 
     async def test_get_nonexistent_image(self, client: AsyncClient):
         """Test getting an image that doesn't exist."""
-        response = await client.get("/api/v1/images/999999")
+        response = await client.get("/api/v1/images999999")
         assert response.status_code == 404
 
 
@@ -688,7 +688,7 @@ class TestFavoritedByUserIdFilter:
         await db_session.commit()
 
         # Filter by user1's favorites
-        response = await client.get(f"/api/v1/images/?favorited_by_user_id={user1.user_id}")
+        response = await client.get(f"/api/v1/images?favorited_by_user_id={user1.user_id}")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 3
@@ -696,7 +696,7 @@ class TestFavoritedByUserIdFilter:
         assert favorited_filenames == {"fav-test-0", "fav-test-1", "fav-test-2"}
 
         # Filter by user2's favorites
-        response = await client.get(f"/api/v1/images/?favorited_by_user_id={user2.user_id}")
+        response = await client.get(f"/api/v1/images?favorited_by_user_id={user2.user_id}")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 3
@@ -728,7 +728,7 @@ class TestFavoritedByUserIdFilter:
         await db_session.commit()
 
         # Filter by user's favorites (should be empty)
-        response = await client.get(f"/api/v1/images/?favorited_by_user_id={user.user_id}")
+        response = await client.get(f"/api/v1/images?favorited_by_user_id={user.user_id}")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 0
@@ -816,7 +816,7 @@ class TestFavoritedByUserIdFilter:
 
         # Test: favorited_by_user_id + user_id filter
         response = await client.get(
-            f"/api/v1/images/?favorited_by_user_id={favoriter.user_id}&user_id={uploader.user_id}"
+            f"/api/v1/images?favorited_by_user_id={favoriter.user_id}&user_id={uploader.user_id}"
         )
         assert response.status_code == 200
         data = response.json()
@@ -826,7 +826,7 @@ class TestFavoritedByUserIdFilter:
 
         # Test: favorited_by_user_id + tags filter
         response = await client.get(
-            f"/api/v1/images/?favorited_by_user_id={favoriter.user_id}&tags={tag1.tag_id}"
+            f"/api/v1/images?favorited_by_user_id={favoriter.user_id}&tags={tag1.tag_id}"
         )
         assert response.status_code == 200
         data = response.json()
@@ -864,7 +864,7 @@ class TestFavoritedByUserIdFilter:
 
         # Test first page
         response = await client.get(
-            f"/api/v1/images/?favorited_by_user_id={user.user_id}&page=1&per_page=10"
+            f"/api/v1/images?favorited_by_user_id={user.user_id}&page=1&per_page=10"
         )
         assert response.status_code == 200
         data = response.json()
@@ -875,7 +875,7 @@ class TestFavoritedByUserIdFilter:
 
         # Test second page
         response = await client.get(
-            f"/api/v1/images/?favorited_by_user_id={user.user_id}&page=2&per_page=10"
+            f"/api/v1/images?favorited_by_user_id={user.user_id}&page=2&per_page=10"
         )
         assert response.status_code == 200
         data = response.json()
@@ -885,7 +885,7 @@ class TestFavoritedByUserIdFilter:
 
         # Test third page (remaining 5 images)
         response = await client.get(
-            f"/api/v1/images/?favorited_by_user_id={user.user_id}&page=3&per_page=10"
+            f"/api/v1/images?favorited_by_user_id={user.user_id}&page=3&per_page=10"
         )
         assert response.status_code == 200
         data = response.json()
@@ -1071,7 +1071,7 @@ class TestImageFavorites:
         self, authenticated_client: AsyncClient
     ):
         """Test favoriting a nonexistent image returns 404."""
-        response = await authenticated_client.post("/api/v1/images/999999/favorite")
+        response = await authenticated_client.post("/api/v1/images999999/favorite")
         assert response.status_code == 404
         data = response.json()
         assert "not found" in data["detail"].lower()
@@ -1080,7 +1080,7 @@ class TestImageFavorites:
         self, authenticated_client: AsyncClient
     ):
         """Test unfavoriting a nonexistent image returns 404."""
-        response = await authenticated_client.delete("/api/v1/images/999999/favorite")
+        response = await authenticated_client.delete("/api/v1/images999999/favorite")
         assert response.status_code == 404
         data = response.json()
         assert "not found" in data["detail"].lower()
@@ -1260,7 +1260,7 @@ class TestTagUsageCount:
 
 @pytest.mark.api
 class TestCommentFilters:
-    """Tests for comment-based filtering in GET /api/v1/images/ endpoint."""
+    """Tests for comment-based filtering in GET /api/v1/images endpoint."""
 
     async def test_filter_by_commenter(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
@@ -1317,21 +1317,21 @@ class TestCommentFilters:
         await db_session.commit()
 
         # Filter by user1's comments - should get only image1
-        response = await client.get(f"/api/v1/images/?commenter={user1.id}")
+        response = await client.get(f"/api/v1/images?commenter={user1.id}")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
         assert data["images"][0]["filename"] == "img1"
 
         # Filter by user2's comments - should get only image2
-        response = await client.get(f"/api/v1/images/?commenter={user2.id}")
+        response = await client.get(f"/api/v1/images?commenter={user2.id}")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
         assert data["images"][0]["filename"] == "img2"
 
         # No results for non-existent commenter
-        response = await client.get("/api/v1/images/?commenter=9999")
+        response = await client.get("/api/v1/images?commenter=9999")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 0
@@ -1389,7 +1389,7 @@ class TestCommentFilters:
         await db_session.commit()
 
         # Search for "awesome" using LIKE mode (always works, doesn't need fulltext index)
-        response = await client.get("/api/v1/images/?commentsearch=awesome&commentsearch_mode=like")
+        response = await client.get("/api/v1/images?commentsearch=awesome&commentsearch_mode=like")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 2
@@ -1397,14 +1397,14 @@ class TestCommentFilters:
         assert filenames == {"img1", "img2"}
 
         # Search for "terrible" - should get only image3
-        response = await client.get("/api/v1/images/?commentsearch=terrible&commentsearch_mode=like")
+        response = await client.get("/api/v1/images?commentsearch=terrible&commentsearch_mode=like")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
         assert data["images"][0]["filename"] == "img3"
 
         # Search for non-existent text
-        response = await client.get("/api/v1/images/?commentsearch=nonexistent&commentsearch_mode=like")
+        response = await client.get("/api/v1/images?commentsearch=nonexistent&commentsearch_mode=like")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 0
@@ -1449,7 +1449,7 @@ class TestCommentFilters:
         await db_session.commit()
 
         # Filter by user1's comments - should get image exactly once
-        response = await client.get(f"/api/v1/images/?commenter={user1.id}")
+        response = await client.get(f"/api/v1/images?commenter={user1.id}")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
@@ -1508,7 +1508,7 @@ class TestCommentFilters:
         # Filter: user1's comments containing "awesome"
         # Should get only image1 (user1 commented, and comment text contains "awesome")
         # Use LIKE mode to work in test environment
-        response = await client.get(f"/api/v1/images/?commenter={user1.id}&commentsearch=awesome&commentsearch_mode=like")
+        response = await client.get(f"/api/v1/images?commenter={user1.id}&commentsearch=awesome&commentsearch_mode=like")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
@@ -1562,7 +1562,7 @@ class TestCommentFilters:
 
         # LIKE search: "cat" as substring should match "concatenation"
         # Works in all environments (doesn't require FULLTEXT index)
-        response = await client.get("/api/v1/images/?commentsearch=cat&commentsearch_mode=like")
+        response = await client.get("/api/v1/images?commentsearch=cat&commentsearch_mode=like")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
@@ -1613,7 +1613,7 @@ class TestCommentFilters:
         await db_session.commit()
 
         # Filter: hascomments=true should return only image1 and image3
-        response = await client.get("/api/v1/images/?hascomments=true")
+        response = await client.get("/api/v1/images?hascomments=true")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 2
@@ -1663,7 +1663,7 @@ class TestCommentFilters:
         await db_session.commit()
 
         # Filter: hascomments=false should return only image2 and image3
-        response = await client.get("/api/v1/images/?hascomments=false")
+        response = await client.get("/api/v1/images?hascomments=false")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 2

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -494,7 +494,7 @@ class TestImageDetail:
 
     async def test_get_nonexistent_image(self, client: AsyncClient):
         """Test getting an image that doesn't exist."""
-        response = await client.get("/api/v1/images999999")
+        response = await client.get("/api/v1/images/999999")
         assert response.status_code == 404
 
 
@@ -1071,7 +1071,7 @@ class TestImageFavorites:
         self, authenticated_client: AsyncClient
     ):
         """Test favoriting a nonexistent image returns 404."""
-        response = await authenticated_client.post("/api/v1/images999999/favorite")
+        response = await authenticated_client.post("/api/v1/images/999999/favorite")
         assert response.status_code == 404
         data = response.json()
         assert "not found" in data["detail"].lower()
@@ -1080,7 +1080,7 @@ class TestImageFavorites:
         self, authenticated_client: AsyncClient
     ):
         """Test unfavoriting a nonexistent image returns 404."""
-        response = await authenticated_client.delete("/api/v1/images999999/favorite")
+        response = await authenticated_client.delete("/api/v1/images/999999/favorite")
         assert response.status_code == 404
         data = response.json()
         assert "not found" in data["detail"].lower()

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -795,7 +795,7 @@ class TestGetTag:
 
     async def test_get_nonexistent_tag(self, client: AsyncClient):
         """Test getting a tag that doesn't exist."""
-        response = await client.get("/api/v1/tags999999")
+        response = await client.get("/api/v1/tags/999999")
         assert response.status_code == 404
 
     async def test_get_tag_includes_creator_and_date(
@@ -917,7 +917,7 @@ class TestGetImagesByTag:
 
     async def test_get_images_by_nonexistent_tag(self, client: AsyncClient):
         """Test getting images for non-existent tag."""
-        response = await client.get("/api/v1/tags999999/images")
+        response = await client.get("/api/v1/tags/999999/images")
         assert response.status_code == 404
 
 
@@ -1566,7 +1566,7 @@ class TestAddTagLink:
         # Try to add link to non-existent tag
         link_data = {"url": "https://example.com"}
         response = await client.post(
-            "/api/v1/tags999999/links",
+            "/api/v1/tags/999999/links",
             json=link_data,
             headers={"Authorization": f"Bearer {access_token}"},
         )

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -26,7 +26,7 @@ from app.models.user import Users
 
 @pytest.mark.api
 class TestListTags:
-    """Tests for GET /api/v1/tags/ endpoint."""
+    """Tests for GET /api/v1/tags endpoint."""
 
     async def test_list_tags(self, client: AsyncClient, db_session: AsyncSession):
         """Test listing tags."""
@@ -40,7 +40,7 @@ class TestListTags:
             db_session.add(tag)
         await db_session.commit()
 
-        response = await client.get("/api/v1/tags/")
+        response = await client.get("/api/v1/tags")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] >= 5
@@ -56,7 +56,7 @@ class TestListTags:
         await db_session.commit()
 
         # Search for "school"
-        response = await client.get("/api/v1/tags/?search=school")
+        response = await client.get("/api/v1/tags?search=school")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
@@ -74,7 +74,7 @@ class TestListTags:
         await db_session.commit()
 
         # Filter by THEME type
-        response = await client.get(f"/api/v1/tags/?type={TagType.THEME}")
+        response = await client.get(f"/api/v1/tags?type={TagType.THEME}")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 2
@@ -96,7 +96,7 @@ class TestListTags:
         await db_session.refresh(tag3)
 
         # Filter by specific IDs
-        response = await client.get(f"/api/v1/tags/?ids={tag1.tag_id},{tag3.tag_id}")
+        response = await client.get(f"/api/v1/tags?ids={tag1.tag_id},{tag3.tag_id}")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 2
@@ -118,7 +118,7 @@ class TestListTags:
         await db_session.refresh(tag2)
 
         # Mix valid IDs with invalid ones (non-numeric)
-        response = await client.get(f"/api/v1/tags/?ids={tag1.tag_id},abc,{tag2.tag_id},xyz")
+        response = await client.get(f"/api/v1/tags?ids={tag1.tag_id},abc,{tag2.tag_id},xyz")
         assert response.status_code == 200
         data = response.json()
 
@@ -141,7 +141,7 @@ class TestListTags:
         await db_session.commit()
 
         # Only invalid IDs
-        response = await client.get("/api/v1/tags/?ids=abc,xyz,foo")
+        response = await client.get("/api/v1/tags?ids=abc,xyz,foo")
         assert response.status_code == 200
         data = response.json()
 
@@ -164,7 +164,7 @@ class TestListTags:
         await db_session.refresh(tag1)
 
         # IDs with empty strings (trailing commas, double commas)
-        response = await client.get(f"/api/v1/tags/?ids={tag1.tag_id},,")
+        response = await client.get(f"/api/v1/tags?ids={tag1.tag_id},,")
         assert response.status_code == 200
         data = response.json()
 
@@ -191,7 +191,7 @@ class TestListTags:
 
         # Request with duplicate IDs (e.g., ids=1,1,1,2,2,3)
         response = await client.get(
-            f"/api/v1/tags/?ids={tag1.tag_id},{tag1.tag_id},{tag1.tag_id},"
+            f"/api/v1/tags?ids={tag1.tag_id},{tag1.tag_id},{tag1.tag_id},"
             f"{tag2.tag_id},{tag2.tag_id},{tag3.tag_id}"
         )
         assert response.status_code == 200
@@ -236,7 +236,7 @@ class TestListTags:
         await db_session.refresh(child2)
 
         # Filter by parent tag ID
-        response = await client.get(f"/api/v1/tags/?parent_tag_id={parent_tag.tag_id}")
+        response = await client.get(f"/api/v1/tags?parent_tag_id={parent_tag.tag_id}")
         assert response.status_code == 200
         data = response.json()
 
@@ -260,7 +260,7 @@ class TestListTags:
         await db_session.refresh(parent_tag)
 
         # Filter by this parent tag ID
-        response = await client.get(f"/api/v1/tags/?parent_tag_id={parent_tag.tag_id}")
+        response = await client.get(f"/api/v1/tags?parent_tag_id={parent_tag.tag_id}")
         assert response.status_code == 200
         data = response.json()
 
@@ -301,7 +301,7 @@ class TestListTags:
         await db_session.refresh(grandchild_tag)
 
         # Filter by parent tag ID
-        response = await client.get(f"/api/v1/tags/?parent_tag_id={parent_tag.tag_id}")
+        response = await client.get(f"/api/v1/tags?parent_tag_id={parent_tag.tag_id}")
         assert response.status_code == 200
         data = response.json()
 
@@ -342,7 +342,7 @@ class TestListTags:
 
         # Filter by parent tag ID and type
         response = await client.get(
-            f"/api/v1/tags/?parent_tag_id={parent_tag.tag_id}&type={TagType.THEME}"
+            f"/api/v1/tags?parent_tag_id={parent_tag.tag_id}&type={TagType.THEME}"
         )
         assert response.status_code == 200
         data = response.json()
@@ -387,7 +387,7 @@ class TestAliasOfName:
         await db_session.refresh(alias_tag)
 
         # Get the tag list
-        response = await client.get("/api/v1/tags/")
+        response = await client.get("/api/v1/tags")
         assert response.status_code == 200
         data = response.json()
 
@@ -427,7 +427,7 @@ class TestAliasOfName:
         await db_session.refresh(regular_tag)
 
         # Get the tag list
-        response = await client.get("/api/v1/tags/")
+        response = await client.get("/api/v1/tags")
         assert response.status_code == 200
         data = response.json()
 
@@ -483,7 +483,7 @@ class TestAliasOfName:
         await db_session.refresh(theme_alias)
 
         # Filter by CHARACTER type
-        response = await client.get(f"/api/v1/tags/?type={TagType.CHARACTER}")
+        response = await client.get(f"/api/v1/tags?type={TagType.CHARACTER}")
         assert response.status_code == 200
         data = response.json()
 
@@ -523,7 +523,7 @@ class TestAliasOfName:
         await db_session.refresh(alias_tag)
 
         # Search for "neko" (should find the alias)
-        response = await client.get("/api/v1/tags/?search=neko")
+        response = await client.get("/api/v1/tags?search=neko")
         assert response.status_code == 200
         data = response.json()
 
@@ -566,7 +566,7 @@ class TestAliasOfName:
         await db_session.refresh(alias_tag)
 
         # Get tags excluding aliases
-        response = await client.get("/api/v1/tags/?exclude_aliases=true")
+        response = await client.get("/api/v1/tags?exclude_aliases=true")
         assert response.status_code == 200
         data = response.json()
 
@@ -601,7 +601,7 @@ class TestFuzzyTagSearch:
         await db_session.commit()
 
         # Search for "sa" (2 chars) - should match prefix only
-        response = await client.get("/api/v1/tags/?search=sa")
+        response = await client.get("/api/v1/tags?search=sa")
         assert response.status_code == 200
         data = response.json()
         # Should find tags starting with "sa" (sakura kinomoto, sakura card)
@@ -637,7 +637,7 @@ class TestFuzzyTagSearch:
         # Uses FULLTEXT with +sakura* +kinomoto* (AND logic - both words required)
         # So it matches tags with BOTH "sakura" AND "kinomoto", regardless of order
         # But NOT "sakura mitsuki" since it lacks "kinomoto"
-        response = await client.get("/api/v1/tags/?search=sakura%20kinomoto")
+        response = await client.get("/api/v1/tags?search=sakura%20kinomoto")
         assert response.status_code == 200
         data = response.json()
 
@@ -667,7 +667,7 @@ class TestFuzzyTagSearch:
         await db_session.commit()
 
         # Search for "school" (6 chars, full word)
-        response = await client.get("/api/v1/tags/?search=school")
+        response = await client.get("/api/v1/tags?search=school")
         assert response.status_code == 200
         data = response.json()
         # FULLTEXT matches complete words, so "school" should find:
@@ -691,7 +691,7 @@ class TestFuzzyTagSearch:
         await db_session.commit()
 
         # Search for "cat" (3 chars) - should use full-text
-        response = await client.get("/api/v1/tags/?search=cat")
+        response = await client.get("/api/v1/tags?search=cat")
         assert response.status_code == 200
         data = response.json()
 
@@ -717,7 +717,7 @@ class TestFuzzyTagSearch:
         await db_session.commit()
 
         # Search for "maid" (4 chars) - should use full-text with exact match prioritization
-        response = await client.get("/api/v1/tags/?search=maid")
+        response = await client.get("/api/v1/tags?search=maid")
         assert response.status_code == 200
         data = response.json()
 
@@ -740,7 +740,7 @@ class TestFuzzyTagSearch:
         await db_session.commit()
 
         # Search for lowercase "sa"
-        response = await client.get("/api/v1/tags/?search=sa")
+        response = await client.get("/api/v1/tags?search=sa")
         assert response.status_code == 200
         data = response.json()
         # Should find all tags starting with "sa" (case-insensitive)
@@ -758,7 +758,7 @@ class TestFuzzyTagSearch:
         await db_session.commit()
 
         # Search for "sakura" with type filter (CHARACTER only)
-        response = await client.get("/api/v1/tags/?search=sakura&type=4")
+        response = await client.get("/api/v1/tags?search=sakura&type=4")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 2  # Both CHARACTER tags
@@ -766,7 +766,7 @@ class TestFuzzyTagSearch:
             assert tag["type"] == TagType.CHARACTER
 
         # Search for "sakura" excluding aliases
-        response = await client.get("/api/v1/tags/?search=sakura&exclude_aliases=true")
+        response = await client.get("/api/v1/tags?search=sakura&exclude_aliases=true")
         assert response.status_code == 200
         data = response.json()
         # Should not include alias tags
@@ -795,7 +795,7 @@ class TestGetTag:
 
     async def test_get_nonexistent_tag(self, client: AsyncClient):
         """Test getting a tag that doesn't exist."""
-        response = await client.get("/api/v1/tags/999999")
+        response = await client.get("/api/v1/tags999999")
         assert response.status_code == 404
 
     async def test_get_tag_includes_creator_and_date(
@@ -917,13 +917,13 @@ class TestGetImagesByTag:
 
     async def test_get_images_by_nonexistent_tag(self, client: AsyncClient):
         """Test getting images for non-existent tag."""
-        response = await client.get("/api/v1/tags/999999/images")
+        response = await client.get("/api/v1/tags999999/images")
         assert response.status_code == 404
 
 
 @pytest.mark.api
 class TestCreateTag:
-    """Tests for POST /api/v1/tags/ endpoint (admin only)."""
+    """Tests for POST /api/v1/tags endpoint (admin only)."""
 
     async def test_create_tag_as_admin(
         self, client: AsyncClient, db_session: AsyncSession
@@ -972,7 +972,7 @@ class TestCreateTag:
             "type": TagType.THEME,
         }
         response = await client.post(
-            "/api/v1/tags/",
+            "/api/v1/tags",
             json=tag_data,
             headers={"Authorization": f"Bearer {access_token}"},
         )
@@ -1012,7 +1012,7 @@ class TestCreateTag:
             "type": TagType.THEME,
         }
         response = await client.post(
-            "/api/v1/tags/",
+            "/api/v1/tags",
             json=tag_data,
             headers={"Authorization": f"Bearer {access_token}"},
         )
@@ -1025,7 +1025,7 @@ class TestCreateTag:
             "desc": "Should not be created",
             "type": TagType.THEME,
         }
-        response = await client.post("/api/v1/tags/", json=tag_data)
+        response = await client.post("/api/v1/tags", json=tag_data)
         assert response.status_code == 401
 
     async def test_create_duplicate_tag(
@@ -1079,7 +1079,7 @@ class TestCreateTag:
             "type": TagType.THEME,
         }
         response = await client.post(
-            "/api/v1/tags/",
+            "/api/v1/tags",
             json=tag_data,
             headers={"Authorization": f"Bearer {access_token}"},
         )
@@ -1566,7 +1566,7 @@ class TestAddTagLink:
         # Try to add link to non-existent tag
         link_data = {"url": "https://example.com"}
         response = await client.post(
-            "/api/v1/tags/999999/links",
+            "/api/v1/tags999999/links",
             json=link_data,
             headers={"Authorization": f"Bearer {access_token}"},
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,7 +328,7 @@ async def engine():
         result = await conn.execute(
             text(
                 "SELECT table_name FROM information_schema.tables "
-                "WHERE table_schema = 'shuushuu_test' AND table_type = 'BASE TABLE'"
+                f"WHERE table_schema = '{DEFAULT_TEST_DB_NAME}' AND table_type = 'BASE TABLE'"
             )
         )
         tables = [row[0] for row in result]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.database import get_db
@@ -324,11 +325,15 @@ async def engine():
         # Disable foreign key checks temporarily
         await conn.execute(text("SET FOREIGN_KEY_CHECKS = 0"))
 
+        # Get database name from the connection URL
+        db_url = make_url(TEST_DATABASE_URL)
+        db_name = db_url.database
+
         # Get all tables
         result = await conn.execute(
             text(
                 "SELECT table_name FROM information_schema.tables "
-                f"WHERE table_schema = '{DEFAULT_TEST_DB_NAME}' AND table_type = 'BASE TABLE'"
+                f"WHERE table_schema = '{db_name}' AND table_type = 'BASE TABLE'"
             )
         )
         tables = [row[0] for row in result]


### PR DESCRIPTION
- Add double decorators to list endpoints supporting both /tags and /tags/
- Hide trailing slash routes from OpenAPI docs with include_in_schema=False
- Fix critical test database cleanup bug (wrong database name in conftest.py)
- Update all test files to use canonical routes without trailing slashes
- Exclude .venv and test directories from uvicorn file watcher to prevent API hangs

This eliminates 307 redirects and CORS issues while maintaining backward compatibility with frontend code that expects trailing slashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)