### PR TITLE
Feat/review response enhancements

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -1103,7 +1103,7 @@ async def list_reviews(
     )
 
     if status_filter is not None:
-        query = query.where(ImageReviews.status == status_filter)  # type: ignore[arg-type]
+        query = query.where(ImageReviews.status == status_filter)
 
     # Count total
     count_query = select(func.count()).select_from(query.subquery())
@@ -1125,7 +1125,7 @@ async def list_reviews(
             select(
                 func.count().label("total"),
                 func.sum(ReviewVotes.vote).label("keep_votes"),  # vote=1 is keep
-            ).where(ReviewVotes.review_id == review.review_id)  # type: ignore[arg-type]
+            ).where(ReviewVotes.review_id == review.review_id)
         )
         vote_row = vote_result.one()
         vote_count = vote_row.total or 0
@@ -1173,7 +1173,7 @@ async def get_review(
         )
         .outerjoin(Users, ImageReviews.initiated_by == Users.user_id)
         .outerjoin(ImageReports, ImageReviews.source_report_id == ImageReports.report_id)
-        .where(ImageReviews.review_id == review_id)  # type: ignore[arg-type]
+        .where(ImageReviews.review_id == review_id)
     )
     row = result.one_or_none()
 

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -216,6 +216,9 @@ class ReviewResponse(BaseModel):
     review_id: int
     image_id: int
     source_report_id: int | None
+    source_report_category: int | None = None
+    source_report_category_label: str | None = None
+    source_report_reason: str | None = None
     initiated_by: int | None
     initiated_by_username: str | None = None
     review_type: int
@@ -246,6 +249,11 @@ class ReviewResponse(BaseModel):
         # Outcome
         outcome_labels = {0: "Pending", 1: "Keep", 2: "Remove"}
         self.outcome_label = outcome_labels.get(self.outcome, "Unknown")
+        # Source report category label
+        if self.source_report_category is not None:
+            self.source_report_category_label = ReportCategory.LABELS.get(
+                self.source_report_category, "Unknown"
+            )
 
 
 class ReviewDetailResponse(ReviewResponse):

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -249,11 +249,6 @@ class ReviewResponse(BaseModel):
         # Outcome
         outcome_labels = {0: "Pending", 1: "Keep", 2: "Remove"}
         self.outcome_label = outcome_labels.get(self.outcome, "Unknown")
-        # Source report category label
-        if self.source_report_category is not None:
-            self.source_report_category_label = ReportCategory.LABELS.get(
-                self.source_report_category, "Unknown"
-            )
 
 
 class ReviewDetailResponse(ReviewResponse):


### PR DESCRIPTION
This pull request enhances the review listing and detail endpoints in the admin API by including additional contextual information about the source report and the user who initiated the review. These improvements provide admins with more complete data for each review, such as the category and reason of the originating report and the username of the initiator. The changes also update the response schemas to support these new fields.

**API Response Enhancements:**

* The `list_reviews` and `get_review` endpoints now join additional tables to include the initiating user's username and the source report's category and reason in their responses. [[1]](diffhunk://#diff-341011c305a8cbd06563dbd26e2735fb8a7448bbcea35e380fac1b94bb45ae98L1094-R1106) [[2]](diffhunk://#diff-341011c305a8cbd06563dbd26e2735fb8a7448bbcea35e380fac1b94bb45ae98L1152-R1184)
* The endpoints populate new fields in the response, including `initiated_by_username`, `source_report_category`, `source_report_category_label`, and `source_report_reason`. Category labels are looked up from `ReportCategory.LABELS`. [[1]](diffhunk://#diff-341011c305a8cbd06563dbd26e2735fb8a7448bbcea35e380fac1b94bb45ae98L1109-R1142) [[2]](diffhunk://#diff-341011c305a8cbd06563dbd26e2735fb8a7448bbcea35e380fac1b94bb45ae98R1207-R1213)

**Schema Updates:**

* The `ReviewResponse` and `ReviewDetailResponse` models in `report.py` are updated to include the new fields for source report category, label, reason, and initiator username.
* The `model_post_init` method is updated to set the `source_report_category_label` based on the category value, ensuring the label is always available when a category is present.