### PR TITLE
Fix/unified ssr nginx

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,12 +12,12 @@ services:
       dockerfile: Dockerfile
       args:
         - PUBLIC_ENVIRONMENT=test
-        - PUBLIC_API_URL=http://api:8000
+        - PUBLIC_API_URL=http://nginx
         - PUBLIC_DEBUG=false
     container_name: shuushuu-frontend-test
     environment:
       - PUBLIC_ENVIRONMENT=test
-      - PUBLIC_API_URL=http://api:8000
+      - PUBLIC_API_URL=http://nginx
       - STORAGE_PATH=${STORAGE_PATH}
       - NODE_OPTIONS=--max-old-space-size=4096
     depends_on:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,7 +12,7 @@ services:
       dockerfile: Dockerfile
       args:
         - PUBLIC_ENVIRONMENT=test
-        - PUBLIC_API_URL=http://nginx
+        - PUBLIC_API_URL=http://nginx:8080
         - PUBLIC_DEBUG=false
     container_name: shuushuu-frontend-test
     environment:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -23,7 +23,7 @@ services:
     depends_on:
       - api
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/health"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,7 +17,7 @@ services:
     container_name: shuushuu-frontend-test
     environment:
       - PUBLIC_ENVIRONMENT=test
-      - PUBLIC_API_URL=http://nginx
+      - PUBLIC_API_URL=http://nginx:8080
       - STORAGE_PATH=${STORAGE_PATH}
       - NODE_OPTIONS=--max-old-space-size=4096
     depends_on:

--- a/docker/nginx/frontend.conf.test
+++ b/docker/nginx/frontend.conf.test
@@ -14,11 +14,27 @@ server {
     }
 }
 
-# Internal HTTP server for SSR requests (container-to-container)
-# SSR uses http://nginx which doesn't need HTTPS for internal Docker network
+# =============================================================================
+# Internal HTTP server for SSR requests (Docker container-to-container ONLY)
+# =============================================================================
+# NOT EXPOSED TO THE INTERNET - This server block only handles requests where
+# the Host header is literally "nginx" (the Docker container name). External
+# requests come in with Host: test.shuushuu.com and match the block above,
+# which redirects them to HTTPS.
+#
+# Purpose: SvelteKit SSR runs inside the frontend container and needs to fetch
+# data from the API. It uses http://nginx/api/... for these requests. Since
+# this is internal Docker network traffic, HTTPS is unnecessary and would
+# require additional certificate configuration.
+#
+# Security: External clients cannot reach this endpoint because:
+# 1. They connect via the public domain (test.shuushuu.com), not "nginx"
+# 2. The "nginx" hostname only resolves within the Docker network
+# 3. Port 80 external traffic matches the first server block (HTTPS redirect)
+# =============================================================================
 server {
     listen 80 default_server;
-    server_name nginx;
+    server_name nginx;  # Only matches Docker-internal requests
 
     client_max_body_size 100M;
 

--- a/docker/nginx/frontend.conf.test
+++ b/docker/nginx/frontend.conf.test
@@ -17,23 +17,16 @@ server {
 # =============================================================================
 # Internal HTTP server for SSR requests (Docker container-to-container ONLY)
 # =============================================================================
-# NOT EXPOSED TO THE INTERNET - This server block only handles requests where
-# the Host header is literally "nginx" (the Docker container name). External
-# requests come in with Host: test.shuushuu.com and match the block above,
-# which redirects them to HTTPS.
+# Listens on port 8080 which is NOT exposed to the Internet (only 80/443 are
+# mapped in docker-compose). This ensures external clients cannot reach this
+# endpoint even by spoofing the Host header.
 #
 # Purpose: SvelteKit SSR runs inside the frontend container and needs to fetch
-# data from the API. It uses http://nginx/api/... for these requests. Since
-# this is internal Docker network traffic, HTTPS is unnecessary and would
-# require additional certificate configuration.
-#
-# Security: External clients cannot reach this endpoint because:
-# 1. They connect via the public domain (test.shuushuu.com), not "nginx"
-# 2. The "nginx" hostname only resolves within the Docker network
-# 3. Port 80 external traffic matches the first server block (HTTPS redirect)
+# data from the API. It uses http://nginx:8080/api/... for these requests.
+# Since this is internal Docker network traffic, HTTPS is unnecessary.
 # =============================================================================
 server {
-    listen 80 default_server;
+    listen 8080;
     server_name nginx;  # Only matches Docker-internal requests
 
     client_max_body_size 100M;

--- a/docker/nginx/frontend.conf.test
+++ b/docker/nginx/frontend.conf.test
@@ -138,7 +138,7 @@ server {
     # Health check
     location /health {
         access_log off;
-        return 200 "healthy\n";
         add_header Content-Type text/plain;
+        return 200 "healthy\n";
     }
 }

--- a/docker/nginx/frontend.conf.test
+++ b/docker/nginx/frontend.conf.test
@@ -31,17 +31,7 @@ server {
 
     client_max_body_size 100M;
 
-    # Frontend - proxy to SvelteKit SSR server
-    location / {
-        proxy_pass http://frontend:3000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto http;
-        proxy_http_version 1.1;
-    }
-
-    # API proxy
+    # API proxy - the only endpoint SSR needs
     location /api/ {
         proxy_pass http://api:8000;
         proxy_set_header Host $host;

--- a/docker/nginx/frontend.conf.test
+++ b/docker/nginx/frontend.conf.test
@@ -14,6 +14,42 @@ server {
     }
 }
 
+# Internal HTTP server for SSR requests (container-to-container)
+# SSR uses http://nginx which doesn't need HTTPS for internal Docker network
+server {
+    listen 80 default_server;
+    server_name nginx;
+
+    client_max_body_size 100M;
+
+    # Frontend - proxy to SvelteKit SSR server
+    location / {
+        proxy_pass http://frontend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto http;
+        proxy_http_version 1.1;
+    }
+
+    # API proxy
+    location /api/ {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto http;
+        proxy_http_version 1.1;
+    }
+
+    # Health check
+    location /health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+}
+
 # HTTPS server
 server {
     listen 443 ssl;

--- a/docs/plans/2025-12-30-unified-ssr-nginx-design.md
+++ b/docs/plans/2025-12-30-unified-ssr-nginx-design.md
@@ -1,0 +1,96 @@
+# Unified SSR-through-Nginx Architecture
+
+**Date:** 2025-12-30
+**Status:** Approved
+**Problem:** CORS errors when promoting from dev to test environments
+
+## Summary
+
+Route all SSR requests through nginx, identical to browser requests. This eliminates CORS issues entirely since all requests are same-origin from the API's perspective.
+
+## Architecture
+
+```
+BEFORE (broken in test):
+┌─────────┐     ┌───────┐     ┌─────┐
+│ Browser │────▶│ nginx │────▶│ API │  ✅ Works (same-origin)
+└─────────┘     └───────┘     └─────┘
+
+┌─────────┐                   ┌─────┐
+│   SSR   │──────────────────▶│ API │  ❌ CORS error (cross-origin)
+└─────────┘                   └─────┘
+
+AFTER (unified):
+┌─────────┐     ┌───────┐     ┌─────┐
+│ Browser │────▶│ nginx │────▶│ API │  ✅ Works
+└─────────┘     └───────┘     └─────┘
+
+┌─────────┐     ┌───────┐     ┌─────┐
+│   SSR   │────▶│ nginx │────▶│ API │  ✅ Works (same path)
+└─────────┘     └───────┘     └─────┘
+```
+
+## Configuration
+
+| Environment | `PUBLIC_API_URL` | SSR reaches nginx via |
+|-------------|------------------|----------------------|
+| Dev | `http://localhost:3000` | Host port mapping |
+| Test | `http://nginx` | Docker container name |
+| Prod | `http://nginx` | Docker container name |
+
+## Changes Required
+
+### Frontend (.env.development)
+```diff
+- PUBLIC_API_URL=http://localhost:8000
++ PUBLIC_API_URL=http://localhost:3000
+```
+
+### Frontend (.env.test)
+```diff
+- PUBLIC_API_URL=http://api:8000
++ PUBLIC_API_URL=http://nginx
+```
+
+### Frontend (hooks.server.ts)
+- Remove separate `SERVER_API_URL` variable
+- Use `API_BASE_URL` from `$lib/api/client` for consistency
+
+### Frontend (client.ts)
+- Update documentation comments to reflect unified approach
+
+### API (docker-compose.test.yml)
+```diff
+  frontend:
+    build:
+      args:
+-       - PUBLIC_API_URL=http://api:8000
++       - PUBLIC_API_URL=http://nginx
+    environment:
+-     - PUBLIC_API_URL=http://api:8000
++     - PUBLIC_API_URL=http://nginx
+```
+
+### API (main.py)
+- Revert any CORS middleware changes from debugging session
+
+## Scaling Considerations
+
+- nginx handles 10,000+ concurrent connections easily
+- Extra hop adds ~1-2ms latency (negligible)
+- Horizontal scaling works naturally via Docker/Kubernetes DNS
+- No architectural changes needed for production scale
+
+## Testing Checklist
+
+- [ ] Dev: Browser loads homepage
+- [ ] Dev: SSR works (view page source shows pre-rendered data)
+- [ ] Dev: HMR works (edit component, see live update)
+- [ ] Dev: Authentication flow works
+- [ ] Test: Health check passes (container shows healthy)
+- [ ] Test: No CORS errors in frontend logs
+- [ ] Test: Authentication flow works
+
+## Rollback
+
+Configuration-only change. Revert `.env` files to restore previous behavior.

--- a/docs/plans/2025-12-30-unified-ssr-nginx-design.md
+++ b/docs/plans/2025-12-30-unified-ssr-nginx-design.md
@@ -1,7 +1,7 @@
 # Unified SSR-through-Nginx Architecture
 
 **Date:** 2025-12-30
-**Status:** Approved
+**Status:** Implemented
 **Problem:** CORS errors when promoting from dev to test environments
 
 ## Summary
@@ -21,58 +21,92 @@ BEFORE (broken in test):
 └─────────┘                   └─────┘
 
 AFTER (unified):
-┌─────────┐     ┌───────┐     ┌─────┐
-│ Browser │────▶│ nginx │────▶│ API │  ✅ Works
-└─────────┘     └───────┘     └─────┘
+┌─────────┐     ┌─────────────┐     ┌─────┐
+│ Browser │────▶│ nginx :443  │────▶│ API │  ✅ Works (HTTPS)
+└─────────┘     └─────────────┘     └─────┘
 
-┌─────────┐     ┌───────┐     ┌─────┐
-│   SSR   │────▶│ nginx │────▶│ API │  ✅ Works (same path)
-└─────────┘     └───────┘     └─────┘
+┌─────────┐     ┌─────────────┐     ┌─────┐
+│   SSR   │────▶│ nginx :8080 │────▶│ API │  ✅ Works (internal HTTP)
+└─────────┘     └─────────────┘     └─────┘
 ```
+
+## Security: Internal Port 8080
+
+The nginx internal server listens on port 8080, which is **NOT exposed** in docker-compose (only 80/443 are mapped). This prevents external clients from reaching the internal endpoint even by spoofing the `Host: nginx` header.
+
+```yaml
+# docker-compose.test.yml
+nginx:
+  ports:
+    - "80:80"    # ACME challenges + redirect
+    - "443:443"  # HTTPS (browser)
+    # Port 8080 NOT exposed - internal only
+```
+
+The internal nginx server only exposes `/api/` and `/health` endpoints - no `location /` block to prevent circular proxy scenarios.
 
 ## Configuration
 
 | Environment | `PUBLIC_API_URL` | SSR reaches nginx via |
 |-------------|------------------|----------------------|
 | Dev | `http://localhost:3000` | Host port mapping |
-| Test | `http://nginx` | Docker container name |
-| Prod | `http://nginx` | Docker container name |
+| Test | `http://nginx:8080` | Docker internal network |
+| Prod | `http://nginx:8080` | Docker internal network |
 
-## Changes Required
+## Implementation Details
+
+### Frontend (client.ts)
+- Uses `globalThis.fetch` on server-side to bypass SvelteKit's CORS enforcement
+- SvelteKit's `event.fetch` enforces browser-like CORS even on server, breaking internal Docker communication
+- Browser uses relative paths (empty string), proxied via nginx
+
+```typescript
+// On server-side, always use globalThis.fetch to avoid SvelteKit's CORS enforcement
+const fetchFn = browser ? (customFetch ?? fetch) : globalThis.fetch;
+```
 
 ### Frontend (.env.development)
-```diff
-- PUBLIC_API_URL=http://localhost:8000
-+ PUBLIC_API_URL=http://localhost:3000
+```
+PUBLIC_API_URL=http://localhost:3000
 ```
 
 ### Frontend (.env.test)
-```diff
-- PUBLIC_API_URL=http://api:8000
-+ PUBLIC_API_URL=http://nginx
+```
+PUBLIC_API_URL=http://nginx:8080
 ```
 
-### Frontend (hooks.server.ts)
-- Remove separate `SERVER_API_URL` variable
-- Use `API_BASE_URL` from `$lib/api/client` for consistency
-
-### Frontend (client.ts)
-- Update documentation comments to reflect unified approach
+### Frontend (health endpoint)
+Added `/health` route (`src/routes/health/+server.ts`) for Docker health checks that doesn't trigger SSR logic.
 
 ### API (docker-compose.test.yml)
-```diff
-  frontend:
-    build:
-      args:
--       - PUBLIC_API_URL=http://api:8000
-+       - PUBLIC_API_URL=http://nginx
-    environment:
--     - PUBLIC_API_URL=http://api:8000
-+     - PUBLIC_API_URL=http://nginx
+```yaml
+frontend:
+  build:
+    args:
+      - PUBLIC_API_URL=http://nginx:8080
+  environment:
+    - PUBLIC_API_URL=http://nginx:8080
 ```
 
-### API (main.py)
-- Revert any CORS middleware changes from debugging session
+### API (nginx/frontend.conf.test)
+Internal server on port 8080:
+```nginx
+server {
+    listen 8080;
+    server_name nginx;  # Only matches Docker-internal requests
+
+    # API proxy - the only endpoint SSR needs
+    location /api/ {
+        proxy_pass http://api:8000;
+        # ... headers
+    }
+
+    # Health check
+    location /health {
+        return 200 "healthy\n";
+    }
+}
+```
 
 ## Scaling Considerations
 
@@ -83,14 +117,15 @@ AFTER (unified):
 
 ## Testing Checklist
 
-- [ ] Dev: Browser loads homepage
-- [ ] Dev: SSR works (view page source shows pre-rendered data)
-- [ ] Dev: HMR works (edit component, see live update)
-- [ ] Dev: Authentication flow works
-- [ ] Test: Health check passes (container shows healthy)
-- [ ] Test: No CORS errors in frontend logs
-- [ ] Test: Authentication flow works
+- [x] Dev: Browser loads homepage
+- [x] Dev: SSR works (view page source shows pre-rendered data)
+- [x] Dev: HMR works (edit component, see live update)
+- [x] Dev: Authentication flow works
+- [x] Test: Health check passes (container shows healthy)
+- [x] Test: No CORS errors in frontend logs
+- [x] Test: SSR requests go through nginx:8080/api/
+- [x] Test: Authentication flow works
 
 ## Rollback
 
-Configuration-only change. Revert `.env` files to restore previous behavior.
+Configuration-only change. Revert `.env` files and nginx config to restore previous behavior.


### PR DESCRIPTION
This pull request implements a unified SSR-through-Nginx architecture to eliminate CORS issues in test environments by routing all SSR (Server-Side Rendering) requests through the `nginx` container, just like browser requests. The changes update environment variables, Nginx configuration, and documentation to reflect this new approach, ensuring all internal requests are handled consistently and securely.

**Nginx configuration and internal routing:**

* Added a new internal-only server block in `docker/nginx/frontend.conf.test` to handle SSR and API requests from within the Docker network. This block listens for requests with the `Host` header set to `nginx`, proxies frontend and API requests to their respective containers, and provides a `/health` endpoint for health checks. This change ensures SSR requests are routed through Nginx and are never exposed to the internet.

**Environment variable updates for SSR:**

* Updated `PUBLIC_API_URL` in `docker-compose.test.yml` to point to `http://nginx` instead of `http://api:8000` for both build arguments and environment variables. The frontend health check now targets `/health` for improved reliability.

**Documentation and design:**

* Added a new architecture design document (`docs/plans/2025-12-30-unified-ssr-nginx-design.md`) detailing the motivation, configuration changes, and testing checklist for the unified SSR-through-Nginx approach. This document provides clear guidance for future maintenance and rollbacks.