### PR TITLE
feat: add image visibility protection with X-Accel-Redirect

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -303,7 +303,7 @@ async def list_images(
 
     # Secondary sort by image_id ensures consistent ordering when primary sort has ties
     # (e.g., multiple images with same favorites count). Use descending for "newest first".
-    secondary_order = desc(Images.image_id)
+    secondary_order = desc(Images.image_id)  # type: ignore[var-annotated,arg-type]
 
     # Subquery: Apply all filters, sort, and limit to get matching image_ids
     # When comment filters are used with JOIN, apply distinct() to avoid duplicate rows

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -301,6 +301,10 @@ async def list_images(
     else:
         subquery_order = asc(sort_column)
 
+    # Secondary sort by image_id ensures consistent ordering when primary sort has ties
+    # (e.g., multiple images with same favorites count). Use descending for "newest first".
+    secondary_order = desc(Images.image_id)
+
     # Subquery: Apply all filters, sort, and limit to get matching image_ids
     # When comment filters are used with JOIN, apply distinct() to avoid duplicate rows
     # (one image can have multiple comments)
@@ -312,7 +316,7 @@ async def list_images(
         image_id_subquery = image_id_subquery.distinct()
 
     imageset = (
-        image_id_subquery.order_by(subquery_order)
+        image_id_subquery.order_by(subquery_order, secondary_order)
         .offset(pagination.offset)
         .limit(pagination.per_page)
         .subquery("imageset")
@@ -327,7 +331,7 @@ async def list_images(
             selectinload(Images.tag_links).selectinload(TagLinks.tag),  # type: ignore[arg-type]
         )
         .join(imageset, Images.image_id == imageset.c.image_id)  # type: ignore[arg-type]
-        .order_by(subquery_order)  # Re-apply same sort order
+        .order_by(subquery_order, secondary_order)  # Re-apply same sort order
     )
 
     # Execute query

--- a/app/api/v1/media.py
+++ b/app/api/v1/media.py
@@ -1,0 +1,54 @@
+"""
+Media file serving endpoints with permission checks.
+
+Routes:
+- GET /images/{filename} - Serve fullsize image with permission check
+- GET /thumbs/{filename} - Serve thumbnail with permission check
+
+These endpoints return X-Accel-Redirect headers for nginx to serve the actual files.
+Authentication is cookie-based (access_token HTTPOnly cookie).
+
+Note: Future enhancement could support ?token=xxx query param for non-browser clients.
+"""
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+def parse_image_id_from_filename(filename: str) -> int | None:
+    """
+    Extract image_id from filename like '2026-01-02-1112196.png'.
+
+    Args:
+        filename: The filename to parse (e.g., "2026-01-02-1112196.png")
+
+    Returns:
+        The image_id as integer, or None if parsing fails
+    """
+    if not filename or "." not in filename:
+        return None
+
+    try:
+        # Remove extension: "2026-01-02-1112196.png" -> "2026-01-02-1112196"
+        name_without_ext = filename.rsplit(".", 1)[0]
+        # Get last segment after dash: "2026-01-02-1112196" -> "1112196"
+        image_id_str = name_without_ext.rsplit("-", 1)[-1]
+        return int(image_id_str)
+    except (ValueError, IndexError):
+        return None
+
+
+def get_extension_from_filename(filename: str) -> str:
+    """
+    Extract file extension from filename.
+
+    Args:
+        filename: The filename to parse
+
+    Returns:
+        The extension (without dot), or empty string if no extension
+    """
+    if "." not in filename:
+        return ""
+    return filename.rsplit(".", 1)[-1]

--- a/app/api/v1/media.py
+++ b/app/api/v1/media.py
@@ -135,13 +135,14 @@ async def _serve_image(
     if image is None:
         raise HTTPException(status_code=404)
 
+    # Permission check first - prevents leaking info about protected images
+    if not await can_view_image_file(image, current_user, db):
+        raise HTTPException(status_code=404)
+
     # Check if variant exists (medium/large are optional)
     if image_type == "medium" and not image.medium:
         raise HTTPException(status_code=404)
     if image_type == "large" and not image.large:
-        raise HTTPException(status_code=404)
-
-    if not await can_view_image_file(image, current_user, db):
         raise HTTPException(status_code=404)
 
     # Use database extension for fullsize/medium/large, always jpeg for thumbnails

--- a/app/api/v1/media.py
+++ b/app/api/v1/media.py
@@ -150,5 +150,6 @@ async def _serve_image(
     else:
         ext = image.ext
 
-    internal_path = f"/internal/{image_type}/{image.md5_hash}.{ext}"
+    # Files are stored with filename (e.g., 2025-12-29-1112174.jpeg)
+    internal_path = f"/internal/{image_type}/{image.filename}.{ext}"
     return Response(status_code=200, headers={"X-Accel-Redirect": internal_path})

--- a/app/main.py
+++ b/app/main.py
@@ -132,5 +132,11 @@ from app.api.v1 import router as api_v1_router  # noqa: E402
 
 app.include_router(api_v1_router, prefix="/api/v1")
 
+from app.api.v1.media import router as media_router  # noqa: E402
+
+# Mount media routes at root level (not under /api/v1)
+# These serve image files with permission checks via X-Accel-Redirect
+app.include_router(media_router)
+
 # Note: Static images are served directly by nginx for better performance
 # See docker/nginx/frontend.conf.template for configuration

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -93,14 +93,14 @@ class ImageResponse(ImageBase):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def url(self) -> str:
-        """Generate image URL"""
-        return f"{settings.IMAGE_BASE_URL}/images/fullsize/{self.filename}.{self.ext}"
+        """Generate image URL (protected path with permission check)"""
+        return f"{settings.IMAGE_BASE_URL}/images/{self.filename}.{self.ext}"
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def thumbnail_url(self) -> str:
-        """Generate thumbnail URL"""
-        return f"{settings.IMAGE_BASE_URL}/images/thumbs/{self.filename}.jpeg"  # Currently all thumbs are jpeg
+        """Generate thumbnail URL (protected path with permission check)"""
+        return f"{settings.IMAGE_BASE_URL}/thumbs/{self.filename}.jpeg"
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -105,17 +105,17 @@ class ImageResponse(ImageBase):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def medium_url(self) -> str | None:
-        """Generate medium variant URL (1280px edge) if available"""
+        """Generate medium variant URL (1280px edge, protected path) if available"""
         if self.medium:
-            return f"{settings.IMAGE_BASE_URL}/images/medium/{self.filename}.{self.ext}"
+            return f"{settings.IMAGE_BASE_URL}/medium/{self.filename}.{self.ext}"
         return None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def large_url(self) -> str | None:
-        """Generate large variant URL (2048px edge) if available"""
+        """Generate large variant URL (2048px edge, protected path) if available"""
         if self.large:
-            return f"{settings.IMAGE_BASE_URL}/images/large/{self.filename}.{self.ext}"
+            return f"{settings.IMAGE_BASE_URL}/large/{self.filename}.{self.ext}"
         return None
 
 

--- a/app/services/image_visibility.py
+++ b/app/services/image_visibility.py
@@ -65,6 +65,7 @@ async def can_view_image_file(
         return True
 
     # Moderators can view all - check for IMAGE_EDIT or REVIEW_VIEW
+    assert user.user_id is not None
     return await has_any_permission(
         db,
         user.user_id,

--- a/app/services/image_visibility.py
+++ b/app/services/image_visibility.py
@@ -1,0 +1,72 @@
+"""
+Image visibility service.
+
+Determines whether a user can view an image file based on:
+- Image status (public vs protected)
+- User ownership (owners can view their own images)
+- User permissions (moderators can view all images)
+
+Note: This controls FILE access only. API metadata endpoints remain unrestricted.
+"""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus
+from app.core.permissions import Permission, has_any_permission
+from app.models.image import Images
+from app.models.user import Users
+
+# Public statuses that anyone can view
+# REPOST (-1), ACTIVE (1), SPOILER (2)
+PUBLIC_IMAGE_STATUSES: frozenset[int] = frozenset(
+    {
+        ImageStatus.REPOST,
+        ImageStatus.ACTIVE,
+        ImageStatus.SPOILER,
+    }
+)
+
+
+async def can_view_image_file(
+    image: Images,
+    user: Users | None,
+    db: AsyncSession,
+) -> bool:
+    """
+    Check if a user can view an image file.
+
+    Visibility rules:
+    - Public statuses (-1, 1, 2): Anyone can view
+    - Owner: Can view their own images regardless of status
+    - Moderators: Users with IMAGE_EDIT or REVIEW_VIEW can view all
+
+    Args:
+        image: The image to check visibility for
+        user: The requesting user (None for anonymous)
+        db: Database session for permission lookups
+
+    Returns:
+        True if user can view the image file, False otherwise
+
+    Note:
+        Future enhancement: Support ?token=xxx query param for non-browser clients.
+        See design doc for details.
+    """
+    # Public statuses are visible to all
+    if image.status in PUBLIC_IMAGE_STATUSES:
+        return True
+
+    # Anonymous users can only see public statuses
+    if user is None:
+        return False
+
+    # Owner can view their own images
+    if image.user_id == user.user_id:
+        return True
+
+    # Moderators can view all - check for IMAGE_EDIT or REVIEW_VIEW
+    return await has_any_permission(
+        db,
+        user.user_id,
+        [Permission.IMAGE_EDIT, Permission.REVIEW_VIEW],
+    )

--- a/docker/nginx/frontend-production.conf.template
+++ b/docker/nginx/frontend-production.conf.template
@@ -61,38 +61,74 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Serve images directly from storage
-    # Note: This path will be substituted with $STORAGE_PATH at container startup
-    # Use ^~ to give these locations priority over regex locations
-    location ^~ /storage/fullsize/ {
+    # Protected image routes - proxy to FastAPI for permission checks
+    location ~ "^/images/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $http_host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ "^/thumbs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $http_host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ "^/medium/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $http_host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ "^/large/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $http_host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Internal locations - only accessible via X-Accel-Redirect from FastAPI
+    location /internal/fullsize/ {
+        internal;
         alias ${STORAGE_PATH}/fullsize/;
-        autoindex off;
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
 
-    location ^~ /storage/large/ {
-        alias ${STORAGE_PATH}/large/;
-        autoindex off;
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-    }
-
-    location ^~ /storage/medium/ {
-        alias ${STORAGE_PATH}/medium/;
-        autoindex off;
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-    }
-
-    location ^~ /storage/thumbs/ {
+    location /internal/thumbs/ {
+        internal;
         alias ${STORAGE_PATH}/thumbs/;
-        autoindex off;
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
 
-    location ^~ /storage/avatars/ {
+    location /internal/medium/ {
+        internal;
+        alias ${STORAGE_PATH}/medium/;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /internal/large/ {
+        internal;
+        alias ${STORAGE_PATH}/large/;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Avatars - no protection needed, serve directly
+    location ^~ /images/avatars/ {
         alias ${STORAGE_PATH}/avatars/;
         autoindex off;
         expires 1m;

--- a/docker/nginx/frontend.conf.dev
+++ b/docker/nginx/frontend.conf.dev
@@ -5,7 +5,71 @@ server {
 
     client_max_body_size 100M;
 
-    # Image storage - serve static files from specific subdirectories
+    # Protected image routes - proxy to FastAPI for permission checks
+    # These use X-Accel-Redirect to serve files after permission verification
+    # Pattern: /images/YYYY-MM-DD-ID.ext (e.g., /images/2025-12-29-1112174.jpeg)
+    location ~ "^/images/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location ~ "^/thumbs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location ~ "^/medium/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location ~ "^/large/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # Internal locations - only accessible via X-Accel-Redirect from FastAPI
+    location /internal/fullsize/ {
+        internal;
+        alias ${STORAGE_PATH}/fullsize/;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /internal/thumbs/ {
+        internal;
+        alias ${STORAGE_PATH}/thumbs/;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /internal/medium/ {
+        internal;
+        alias ${STORAGE_PATH}/medium/;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /internal/large/ {
+        internal;
+        alias ${STORAGE_PATH}/large/;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Legacy image storage paths - serve static files directly (for backwards compatibility)
     location /images/thumbs/ {
         alias ${STORAGE_PATH}/thumbs/;
         expires 30d;

--- a/docker/nginx/frontend.conf.dev
+++ b/docker/nginx/frontend.conf.dev
@@ -69,33 +69,9 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
-    # Legacy image storage paths - serve static files directly (for backwards compatibility)
-    location /images/thumbs/ {
-        alias ${STORAGE_PATH}/thumbs/;
-        expires 30d;
-        add_header Cache-Control "public, immutable";
-    }
-
-    location /images/fullsize/ {
-        alias ${STORAGE_PATH}/fullsize/;
-        expires 30d;
-        add_header Cache-Control "public, immutable";
-    }
-
+    # Avatars - no protection needed, serve directly
     location /images/avatars/ {
         alias ${STORAGE_PATH}/avatars/;
-        expires 30d;
-        add_header Cache-Control "public, immutable";
-    }
-
-    location /images/medium/ {
-        alias ${STORAGE_PATH}/medium/;
-        expires 30d;
-        add_header Cache-Control "public, immutable";
-    }
-
-    location /images/large/ {
-        alias ${STORAGE_PATH}/large/;
         expires 30d;
         add_header Cache-Control "public, immutable";
     }

--- a/docker/nginx/frontend.conf.template
+++ b/docker/nginx/frontend.conf.template
@@ -61,35 +61,73 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Serve images directly from storage
-    location ^~ /images/fullsize/ {
+    # Protected image routes - proxy to FastAPI for permission checks
+    location ~ "^/images/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $http_host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ "^/thumbs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $http_host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ "^/medium/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $http_host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ "^/large/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $http_host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Internal locations - only accessible via X-Accel-Redirect from FastAPI
+    location /internal/fullsize/ {
+        internal;
         alias ${STORAGE_PATH}/fullsize/;
-        autoindex off;
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
 
-    location ^~ /images/large/ {
-        alias ${STORAGE_PATH}/large/;
-        autoindex off;
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-    }
-
-    location ^~ /images/medium/ {
-        alias ${STORAGE_PATH}/medium/;
-        autoindex off;
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-    }
-
-    location ^~ /images/thumbs/ {
+    location /internal/thumbs/ {
+        internal;
         alias ${STORAGE_PATH}/thumbs/;
-        autoindex off;
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
 
+    location /internal/medium/ {
+        internal;
+        alias ${STORAGE_PATH}/medium/;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /internal/large/ {
+        internal;
+        alias ${STORAGE_PATH}/large/;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Avatars - no protection needed, serve directly
     location ^~ /images/avatars/ {
         alias ${STORAGE_PATH}/avatars/;
         autoindex off;

--- a/docker/nginx/frontend.conf.test
+++ b/docker/nginx/frontend.conf.test
@@ -74,33 +74,75 @@ server {
 
     client_max_body_size 100M;
 
-    # Image storage - serve static files from specific subdirectories
-    location /images/thumbs/ {
-        alias ${STORAGE_PATH}/thumbs/;
-        expires 30d;
-        add_header Cache-Control "public, immutable";
+    # Protected image routes - proxy to FastAPI for permission checks
+    location ~ "^/images/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location /images/fullsize/ {
+    location ~ "^/thumbs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ "^/medium/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ "^/large/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+        proxy_pass http://api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Internal locations - only accessible via X-Accel-Redirect from FastAPI
+    location /internal/fullsize/ {
+        internal;
         alias ${STORAGE_PATH}/fullsize/;
-        expires 30d;
+        expires 1y;
         add_header Cache-Control "public, immutable";
     }
 
+    location /internal/thumbs/ {
+        internal;
+        alias ${STORAGE_PATH}/thumbs/;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /internal/medium/ {
+        internal;
+        alias ${STORAGE_PATH}/medium/;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /internal/large/ {
+        internal;
+        alias ${STORAGE_PATH}/large/;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Avatars - no protection needed, serve directly
     location /images/avatars/ {
         alias ${STORAGE_PATH}/avatars/;
-        expires 30d;
-        add_header Cache-Control "public, immutable";
-    }
-
-    location /images/medium/ {
-        alias ${STORAGE_PATH}/medium/;
-        expires 30d;
-        add_header Cache-Control "public, immutable";
-    }
-
-    location /images/large/ {
-        alias ${STORAGE_PATH}/large/;
         expires 30d;
         add_header Cache-Control "public, immutable";
     }

--- a/docs/image-serving-nginx.md
+++ b/docs/image-serving-nginx.md
@@ -1,0 +1,247 @@
+# Image Serving via Nginx
+
+## Overview
+
+Images are served directly by nginx for optimal performance, rather than going through the FastAPI application server. This approach:
+
+- **Reduces FastAPI load** - Static files don't consume application resources
+- **Improves performance** - nginx is highly optimized for static file serving
+- **Enables caching** - Long cache headers (1 year) for immutable image files
+- **Scales better** - Can add CDN or separate image servers later
+
+## Architecture
+
+```
+Client Request
+    ↓
+nginx (port 80/3000)
+    ├─ /api/v1/* → FastAPI (port 8000)
+    └─ /storage/fullsize/* → Filesystem (/shuushuu/images/fullsize/)
+    └─ /storage/thumbs/* → Filesystem (/shuushuu/images/thumbs/)
+```
+
+## Configuration
+
+### Backend (FastAPI)
+
+**File: `app/config.py`**
+```python
+IMAGE_BASE_URL: str = "http://localhost:3000"
+```
+
+This setting controls the base URL prepended to image paths in API responses.
+
+**Environment Variable:**
+```bash
+IMAGE_BASE_URL=http://localhost:3000  # Development
+IMAGE_BASE_URL=https://your-domain.com  # Production
+IMAGE_BASE_URL=https://cdn.your-domain.com  # With CDN
+```
+
+**File: `app/schemas/image.py`**
+```python
+@computed_field
+@property
+def url(self) -> str:
+    """Generate image URL"""
+    return f"{settings.IMAGE_BASE_URL}/storage/fullsize/{self.filename}.{self.ext}"
+
+@computed_field
+@property
+def thumbnail_url(self) -> str:
+    """Generate thumbnail URL"""
+    return f"{settings.IMAGE_BASE_URL}/storage/thumbs/{self.filename}.jpeg"
+```
+
+These computed fields generate complete URLs that the frontend can use directly.
+
+### Nginx
+
+**File: `docker/nginx/frontend.conf.template`**
+```nginx
+# Serve images directly from storage
+location ^~ /storage/fullsize/ {
+    alias ${STORAGE_PATH}/fullsize/;
+    autoindex off;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+}
+
+location ^~ /storage/thumbs/ {
+    alias ${STORAGE_PATH}/thumbs/;
+    autoindex off;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+}
+```
+
+The `^~` prefix gives these locations priority over regex locations.
+
+### Frontend (SvelteKit)
+
+The frontend simply uses the URLs returned by the API:
+
+```svelte
+<!-- Image detail page -->
+<a href={data.image.url}>
+  <img src={data.image.thumbnail_url} alt={data.image.title} />
+</a>
+
+<!-- Gallery page -->
+<img src={img.thumbnail_url} alt={`Image ${img.image_id}`} />
+```
+
+No manual URL construction needed - the API provides complete URLs.
+
+## API Response Example
+
+```json
+{
+  "image_id": 1111520,
+  "filename": "2024-11-15-1111520",
+  "ext": "jpeg",
+  "url": "http://localhost:3000/storage/fullsize/2024-11-15-1111520.jpeg",
+  "thumbnail_url": "http://localhost:3000/storage/thumbs/2024-11-15-1111520.jpeg",
+  ...
+}
+```
+
+## Deployment Considerations
+
+### Development
+- Images served via nginx on port 3000
+- `IMAGE_BASE_URL=http://localhost:3000`
+
+### Production
+- Configure nginx to serve images from filesystem or mounted volume
+- Set `IMAGE_BASE_URL` to your domain (e.g., `https://e-shuushuu.net`)
+- Consider adding a CDN for global distribution
+
+### CDN Integration
+To serve images from a CDN:
+
+1. Sync images to CDN storage (S3, Cloudflare R2, etc.)
+2. Set `IMAGE_BASE_URL=https://cdn.your-domain.com`
+3. Images will automatically use CDN URLs in API responses
+
+No frontend changes needed - it just uses whatever URLs the API provides.
+
+## Cache Headers
+
+Images use aggressive caching since they're immutable (filename includes upload date):
+
+```nginx
+expires 1y;
+add_header Cache-Control "public, immutable";
+```
+
+This means:
+- Browsers cache for 1 year
+- `immutable` tells browsers the file will never change
+- Reduces bandwidth and improves load times
+
+## Protected Image Serving (Visibility Control)
+
+Some images require permission checks before serving (e.g., images under review, flagged inappropriate). For these, we use X-Accel-Redirect to maintain nginx's file-serving performance while adding FastAPI permission checks.
+
+### Legacy-Compatible URL Pattern
+
+To maintain compatibility with the original e-shuushuu.net URLs, protected images use:
+- `/images/{date}-{image_id}.{ext}` (e.g., `/images/2026-01-02-1112196.png`)
+- `/thumbs/{date}-{image_id}.{ext}` (e.g., `/thumbs/2026-01-02-1112196.png`)
+
+### Request Flow
+
+```
+Client → nginx → FastAPI (permission check) → X-Accel-Redirect → nginx → file
+```
+
+1. nginx proxies `/images/*` and `/thumbs/*` requests to FastAPI
+2. FastAPI checks if user can view the image (based on status, ownership, permissions)
+3. If authorized: returns `X-Accel-Redirect: /internal/{type}/{hash}.{ext}`
+4. If unauthorized: returns 404 (not 403, to hide existence)
+5. nginx serves from internal location (not directly accessible)
+
+### Nginx Configuration
+
+Add these locations to your nginx config:
+
+```nginx
+# Proxy protected image requests to FastAPI for permission checks
+location ~ ^/images/\d{4}-\d{2}-\d{2}-\d+\.(png|jpg|jpeg|gif|webp)$ {
+    proxy_pass http://fastapi:8000;
+    proxy_set_header Host $host;
+    proxy_set_header Cookie $http_cookie;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location ~ ^/thumbs/\d{4}-\d{2}-\d{2}-\d+\.(png|jpg|jpeg|gif|webp)$ {
+    proxy_pass http://fastapi:8000;
+    proxy_set_header Host $host;
+    proxy_set_header Cookie $http_cookie;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+# Internal locations - only accessible via X-Accel-Redirect from FastAPI
+# These serve actual files from storage using md5 hash filenames
+location /internal/fullsize/ {
+    internal;  # Cannot be accessed directly by clients
+    alias ${STORAGE_PATH}/fullsize/;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+}
+
+location /internal/thumbs/ {
+    internal;  # Cannot be accessed directly by clients
+    alias ${STORAGE_PATH}/thumbs/;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+}
+```
+
+### Visibility Rules
+
+| Status | Status Code | Public? |
+|--------|-------------|---------|
+| ACTIVE (1) | Active | Yes |
+| SPOILER (2) | Marked spoiler | Yes |
+| REPOST (-1) | Duplicate | Yes |
+| REVIEW (-4) | Under review | No* |
+| INAPPROPRIATE (-2) | Flagged | No* |
+| OTHER (0) | Uncategorized | No* |
+
+*Protected images are visible to:
+- The image uploader (owner)
+- Users with `IMAGE_EDIT` or `REVIEW_VIEW` permission
+
+### Authentication
+
+Permission checks use the `access_token` HTTPOnly cookie for authentication. Anonymous users can only view public status images.
+
+### Caching Considerations
+
+Since the same URL can return different responses based on authentication:
+- nginx should NOT cache responses from `/images/*` or `/thumbs/*`
+- The internal locations (`/internal/*`) use immutable caching since they bypass permission checks
+
+To prevent nginx caching protected paths, ensure proxy_cache is disabled:
+
+```nginx
+location ~ ^/images/ {
+    proxy_cache off;  # Don't cache permission-dependent responses
+    # ... rest of config
+}
+```
+
+## Migration Notes
+
+Previous setup had FastAPI serving images via `app.mount()`:
+```python
+# Old code (removed)
+app.mount("/storage/fullsize", StaticFiles(directory=f"{settings.STORAGE_PATH}/fullsize"))
+app.mount("/storage/thumbs", StaticFiles(directory=f"{settings.STORAGE_PATH}/thumbs"))
+```
+
+This was replaced with nginx serving for better performance.

--- a/docs/image-serving-nginx.md
+++ b/docs/image-serving-nginx.md
@@ -158,9 +158,9 @@ To maintain compatibility with the original e-shuushuu.net URLs, protected image
 Client → nginx → FastAPI (permission check) → X-Accel-Redirect → nginx → file
 ```
 
-1. nginx proxies `/images/*` and `/thumbs/*` requests to FastAPI
+1. nginx proxies `/images/*`, `/thumbs/*`, `/medium/*`, `/large/*` requests to FastAPI
 2. FastAPI checks if user can view the image (based on status, ownership, permissions)
-3. If authorized: returns `X-Accel-Redirect: /internal/{type}/{hash}.{ext}`
+3. If authorized: returns `X-Accel-Redirect: /internal/{type}/{filename}.{ext}`
 4. If unauthorized: returns 404 (not 403, to hide existence)
 5. nginx serves from internal location (not directly accessible)
 
@@ -203,7 +203,7 @@ location ~ ^/large/\d{4}-\d{2}-\d{2}-\d+\.(png|jpg|jpeg|gif|webp)$ {
 }
 
 # Internal locations - only accessible via X-Accel-Redirect from FastAPI
-# These serve actual files from storage using md5 hash filenames
+# Files are stored with the filename format (e.g., 2025-12-29-1112174.jpeg)
 location /internal/fullsize/ {
     internal;  # Cannot be accessed directly by clients
     alias ${STORAGE_PATH}/fullsize/;

--- a/docs/image-serving-nginx.md
+++ b/docs/image-serving-nginx.md
@@ -255,17 +255,26 @@ Permission checks use the `access_token` HTTPOnly cookie for authentication. Ano
 ### Caching Considerations
 
 Since the same URL can return different responses based on authentication:
-- nginx should NOT cache responses from `/images/*` or `/thumbs/*`
+- nginx should NOT cache responses from `/images/*`, `/thumbs/*`, `/medium/*`, `/large/*`
 - The internal locations (`/internal/*`) use immutable caching since they bypass permission checks
 
-To prevent nginx caching protected paths, ensure proxy_cache is disabled:
+To prevent nginx caching protected paths, add `proxy_cache off` to each proxy location:
 
 ```nginx
-location ~ ^/images/ {
+location ~ "^/images/..." {
     proxy_cache off;  # Don't cache permission-dependent responses
-    # ... rest of config
+    proxy_pass http://api:8000;
+    # ... other headers
+}
+
+location ~ "^/thumbs/..." {
+    proxy_cache off;  # Don't cache permission-dependent responses
+    proxy_pass http://api:8000;
+    # ... other headers
 }
 ```
+
+Note: The development config (`frontend.conf.dev`) doesn't enable proxy caching by default, so this is primarily relevant for production deployments with caching enabled.
 
 ## Migration Notes
 

--- a/docs/plans/2026-01-02-image-visibility-protection-design.md
+++ b/docs/plans/2026-01-02-image-visibility-protection-design.md
@@ -18,12 +18,13 @@ Protect image files from unauthorized viewing while keeping API metadata accessi
 
 **Status reference:**
 - `-4` REVIEW — Under moderator review (protected)
-- `-3` LOW_QUALITY — Marked low quality (protected)
 - `-2` INAPPROPRIATE — Flagged inappropriate (protected)
 - `-1` REPOST — Duplicate/repost (public)
 - `0` OTHER — Uncategorized/flagged (protected)
 - `1` ACTIVE — Normal public image (public)
 - `2` SPOILER — Visible but marked spoiler (public)
+
+Note: LOW_QUALITY (-3) is defined in config but not currently a valid status in the Images model.
 
 ## Architecture
 

--- a/docs/plans/2026-01-02-image-visibility-protection-design.md
+++ b/docs/plans/2026-01-02-image-visibility-protection-design.md
@@ -133,7 +133,9 @@ async def _serve_image(
         raise HTTPException(status_code=404)  # 404, not 403
 
     # Return X-Accel-Redirect to internal nginx location
-    internal_path = f"/internal/{image_type}/{image.file_hash}.{_get_extension(filename)}"
+    # Files stored with filename (e.g., 2025-12-29-1112174.jpeg)
+    ext = "jpeg" if image_type == "thumbs" else image.ext
+    internal_path = f"/internal/{image_type}/{image.filename}.{ext}"
     return Response(
         status_code=200,
         headers={"X-Accel-Redirect": internal_path},

--- a/docs/plans/2026-01-02-image-visibility-protection-design.md
+++ b/docs/plans/2026-01-02-image-visibility-protection-design.md
@@ -1,0 +1,248 @@
+# Image Visibility Protection Design
+
+**Date:** 2026-01-02
+**Status:** Approved
+**Problem:** Users can view disabled images (status 0, -1, -2, -3, -4) by accessing file URLs directly, even when those images are under review or marked inappropriate.
+
+## Goal
+
+Protect image files from unauthorized viewing while keeping API metadata accessible. Only admins, moderators, and the image uploader should be able to view protected image files.
+
+## Visibility Rules
+
+| User Type | Can View |
+|-----------|----------|
+| Anonymous / Regular users | `status IN (-1, 1, 2)` — REPOST, ACTIVE, SPOILER |
+| Image uploader | Own images regardless of status |
+| Users with `IMAGE_EDIT` or `REVIEW_VIEW` permission | All images |
+
+**Status reference:**
+- `-4` REVIEW — Under moderator review (protected)
+- `-3` LOW_QUALITY — Marked low quality (protected)
+- `-2` INAPPROPRIATE — Flagged inappropriate (protected)
+- `-1` REPOST — Duplicate/repost (public)
+- `0` OTHER — Uncategorized/flagged (protected)
+- `1` ACTIVE — Normal public image (public)
+- `2` SPOILER — Visible but marked spoiler (public)
+
+## Architecture
+
+### Request Flow
+
+```
+Browser → nginx → FastAPI → (permission check) → X-Accel-Redirect → nginx → file
+```
+
+### URL Patterns
+
+Public-facing URLs (unchanged from legacy):
+- Fullsize: `/images/{date}-{image_id}.{ext}` (e.g., `/images/2026-01-02-1112196.png`)
+- Thumbnail: `/thumbs/{date}-{image_id}.{ext}` (e.g., `/thumbs/2026-01-02-1112196.png`)
+
+Internal nginx locations (not directly accessible):
+- `/internal/fullsize/{hash}.{ext}`
+- `/internal/thumbs/{hash}.{ext}`
+
+### Authentication
+
+Cookie-based using existing `access_token` HTTPOnly cookie.
+
+```python
+# Future enhancement: Support query param for non-browser clients
+# token = request.cookies.get("access_token") or request.query_params.get("token")
+```
+
+### Error Handling
+
+Unauthorized requests return **404 Not Found** (not 403) to avoid revealing existence of hidden content.
+
+### Caching
+
+Normal nginx caching is allowed. The goal is preventing new unauthorized access, not purging existing browser caches.
+
+## Implementation
+
+### New Files
+
+**`app/api/v1/media.py`** — File serving endpoints
+
+```python
+from fastapi import APIRouter, Depends, Request, Response
+from fastapi.exceptions import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.auth import get_current_user_optional
+from app.models import Users, Images
+from app.services.image import can_view_image_file
+from app.config import settings
+
+router = APIRouter()
+
+@router.get("/images/{filename}")
+async def serve_fullsize_image(
+    filename: str,
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[Users | None, Depends(get_current_user_optional)],
+) -> Response:
+    """
+    Serve fullsize image with permission check.
+
+    Authentication: Cookie-based (access_token).
+    # TODO: Support ?token=xxx query param for non-browser clients
+    """
+    return await _serve_image(filename, "fullsize", db, current_user)
+
+
+@router.get("/thumbs/{filename}")
+async def serve_thumbnail(
+    filename: str,
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[Users | None, Depends(get_current_user_optional)],
+) -> Response:
+    """
+    Serve thumbnail with permission check.
+
+    Authentication: Cookie-based (access_token).
+    # TODO: Support ?token=xxx query param for non-browser clients
+    """
+    return await _serve_image(filename, "thumbs", db, current_user)
+
+
+async def _serve_image(
+    filename: str,
+    image_type: str,  # "fullsize" or "thumbs"
+    db: AsyncSession,
+    current_user: Users | None,
+) -> Response:
+    # Parse image_id from filename (e.g., "2026-01-02-1112196.png" -> 1112196)
+    image_id = _parse_image_id(filename)
+    if image_id is None:
+        raise HTTPException(status_code=404)
+
+    # Fetch image
+    image = await db.get(Images, image_id)
+    if image is None:
+        raise HTTPException(status_code=404)
+
+    # Permission check
+    if not await can_view_image_file(image, current_user, db):
+        raise HTTPException(status_code=404)  # 404, not 403
+
+    # Return X-Accel-Redirect to internal nginx location
+    internal_path = f"/internal/{image_type}/{image.file_hash}.{_get_extension(filename)}"
+    return Response(
+        status_code=200,
+        headers={"X-Accel-Redirect": internal_path},
+    )
+
+
+def _parse_image_id(filename: str) -> int | None:
+    """Extract image_id from filename like '2026-01-02-1112196.png'"""
+    try:
+        name = filename.rsplit(".", 1)[0]  # Remove extension
+        image_id_str = name.rsplit("-", 1)[-1]  # Get last segment after dash
+        return int(image_id_str)
+    except (ValueError, IndexError):
+        return None
+
+
+def _get_extension(filename: str) -> str:
+    """Extract extension from filename"""
+    return filename.rsplit(".", 1)[-1] if "." in filename else ""
+```
+
+### Modified Files
+
+**`app/services/image.py`** — Add visibility helper
+
+```python
+from app.core.permissions import has_permission, Permission
+
+# Public statuses that anyone can view
+PUBLIC_IMAGE_STATUSES = (-1, 1, 2)  # REPOST, ACTIVE, SPOILER
+
+
+async def can_view_image_file(
+    image: Images,
+    user: Users | None,
+    db: AsyncSession,
+) -> bool:
+    """
+    Check if a user can view an image file.
+
+    Visibility rules:
+    - Public statuses (-1, 1, 2): Anyone can view
+    - Owner: Can view their own images regardless of status
+    - Moderators: Users with IMAGE_EDIT or REVIEW_VIEW can view all
+    """
+    # Public statuses are visible to all
+    if image.status in PUBLIC_IMAGE_STATUSES:
+        return True
+
+    # Anonymous users can only see public statuses
+    if user is None:
+        return False
+
+    # Owner can view their own images
+    if image.user_id == user.user_id:
+        return True
+
+    # Moderators can view all
+    if await has_permission(user.user_id, Permission.IMAGE_EDIT, db):
+        return True
+    if await has_permission(user.user_id, Permission.REVIEW_VIEW, db):
+        return True
+
+    return False
+```
+
+**`app/core/auth.py`** — Ensure `get_current_user_optional` exists
+
+This dependency should return `None` for anonymous users instead of raising 401.
+
+### nginx Configuration
+
+```nginx
+# Proxy image/thumb requests to FastAPI for permission check
+location ~ ^/images/\d{4}-\d{2}-\d{2}-\d+\.(png|jpg|jpeg|gif|webp)$ {
+    proxy_pass http://fastapi:8000;
+    proxy_set_header Host $host;
+    proxy_set_header Cookie $http_cookie;
+}
+
+location ~ ^/thumbs/\d{4}-\d{2}-\d{2}-\d+\.(png|jpg|jpeg|gif|webp)$ {
+    proxy_pass http://fastapi:8000;
+    proxy_set_header Host $host;
+    proxy_set_header Cookie $http_cookie;
+}
+
+# Internal locations - only accessible via X-Accel-Redirect
+# STORAGE_PATH should be substituted from environment variable
+location /internal/fullsize/ {
+    internal;
+    alias /path/to/storage/fullsize/;  # Use STORAGE_PATH from env
+}
+
+location /internal/thumbs/ {
+    internal;
+    alias /path/to/storage/thumbs/;  # Use STORAGE_PATH from env
+}
+```
+
+## Scope Clarification
+
+**Protected by this design:**
+- Image file access (`/images/*.png`, `/thumbs/*.png`)
+
+**NOT changed by this design:**
+- API metadata endpoints (`/api/v1/images`, `/api/v1/images/{id}`) — These continue to return metadata for all images regardless of status
+- The frontend is responsible for checking image status and displaying placeholders for disabled images
+
+## Future Enhancements
+
+1. **Query param authentication** — Support `?token=xxx` for non-browser clients (API apps, tools)
+2. **Signed URLs** — Time-limited URLs for specific use cases
+3. **Rate limiting** — Prevent enumeration attacks on image IDs

--- a/docs/plans/2026-01-02-image-visibility-protection-impl.md
+++ b/docs/plans/2026-01-02-image-visibility-protection-impl.md
@@ -1,0 +1,900 @@
+# Image Visibility Protection Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Protect image files from unauthorized viewing using X-Accel-Redirect, while allowing metadata API access.
+
+**Architecture:** New `/images/` and `/thumbs/` endpoints at root level (not under /api/v1) that check visibility permissions and return X-Accel-Redirect headers for nginx to serve files. The existing `get_optional_current_user` auth dependency is reused.
+
+**Tech Stack:** FastAPI, SQLAlchemy async, existing permission system (`has_any_permission`)
+
+**Design Doc:** `docs/plans/2026-01-02-image-visibility-protection-design.md`
+
+---
+
+## Task 1: Create Image Visibility Service - Unit Tests
+
+**Files:**
+- Create: `tests/unit/test_image_visibility.py`
+- Create: `app/services/image_visibility.py`
+
+**Step 1: Write failing tests for visibility logic**
+
+```python
+"""Tests for image visibility service."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from unittest.mock import AsyncMock, patch
+
+from app.config import ImageStatus
+from app.models.image import Images
+from app.models.user import Users
+from app.services.image_visibility import PUBLIC_IMAGE_STATUSES, can_view_image_file
+
+
+class TestPublicImageStatuses:
+    """Test the PUBLIC_IMAGE_STATUSES constant."""
+
+    def test_public_statuses_include_repost(self):
+        """REPOST (-1) should be publicly visible."""
+        assert ImageStatus.REPOST in PUBLIC_IMAGE_STATUSES
+
+    def test_public_statuses_include_active(self):
+        """ACTIVE (1) should be publicly visible."""
+        assert ImageStatus.ACTIVE in PUBLIC_IMAGE_STATUSES
+
+    def test_public_statuses_include_spoiler(self):
+        """SPOILER (2) should be publicly visible."""
+        assert ImageStatus.SPOILER in PUBLIC_IMAGE_STATUSES
+
+    def test_public_statuses_exclude_review(self):
+        """REVIEW (-4) should NOT be publicly visible."""
+        assert ImageStatus.REVIEW not in PUBLIC_IMAGE_STATUSES
+
+    def test_public_statuses_exclude_inappropriate(self):
+        """INAPPROPRIATE (-2) should NOT be publicly visible."""
+        assert ImageStatus.INAPPROPRIATE not in PUBLIC_IMAGE_STATUSES
+
+    def test_public_statuses_exclude_other(self):
+        """OTHER (0) should NOT be publicly visible."""
+        assert ImageStatus.OTHER not in PUBLIC_IMAGE_STATUSES
+
+
+class TestCanViewImageFile:
+    """Tests for can_view_image_file function."""
+
+    @pytest.fixture
+    def mock_image(self):
+        """Create a mock image with configurable status and user_id."""
+        image = Images(
+            image_id=1,
+            filename="test",
+            ext="png",
+            md5_hash="abc123",
+            filesize=1000,
+            width=100,
+            height=100,
+            user_id=10,
+            status=ImageStatus.ACTIVE,
+        )
+        return image
+
+    @pytest.fixture
+    def mock_user(self):
+        """Create a mock user."""
+        user = Users(
+            user_id=20,
+            username="testuser",
+            password="hash",
+            password_type="bcrypt",
+            salt="1234567890123456",
+            email="test@example.com",
+        )
+        return user
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock database session."""
+        return AsyncMock(spec=AsyncSession)
+
+    # === Public status tests ===
+
+    async def test_active_image_visible_to_anonymous(self, mock_image, mock_db):
+        """ACTIVE images are visible to anonymous users."""
+        mock_image.status = ImageStatus.ACTIVE
+        result = await can_view_image_file(mock_image, None, mock_db)
+        assert result is True
+
+    async def test_spoiler_image_visible_to_anonymous(self, mock_image, mock_db):
+        """SPOILER images are visible to anonymous users."""
+        mock_image.status = ImageStatus.SPOILER
+        result = await can_view_image_file(mock_image, None, mock_db)
+        assert result is True
+
+    async def test_repost_image_visible_to_anonymous(self, mock_image, mock_db):
+        """REPOST images are visible to anonymous users."""
+        mock_image.status = ImageStatus.REPOST
+        result = await can_view_image_file(mock_image, None, mock_db)
+        assert result is True
+
+    # === Protected status tests - anonymous ===
+
+    async def test_review_image_hidden_from_anonymous(self, mock_image, mock_db):
+        """REVIEW images are hidden from anonymous users."""
+        mock_image.status = ImageStatus.REVIEW
+        result = await can_view_image_file(mock_image, None, mock_db)
+        assert result is False
+
+    async def test_inappropriate_image_hidden_from_anonymous(self, mock_image, mock_db):
+        """INAPPROPRIATE images are hidden from anonymous users."""
+        mock_image.status = ImageStatus.INAPPROPRIATE
+        result = await can_view_image_file(mock_image, None, mock_db)
+        assert result is False
+
+    async def test_other_image_hidden_from_anonymous(self, mock_image, mock_db):
+        """OTHER images are hidden from anonymous users."""
+        mock_image.status = ImageStatus.OTHER
+        result = await can_view_image_file(mock_image, None, mock_db)
+        assert result is False
+
+    # === Protected status tests - non-owner regular user ===
+
+    async def test_review_image_hidden_from_non_owner(self, mock_image, mock_user, mock_db):
+        """REVIEW images are hidden from non-owner regular users."""
+        mock_image.status = ImageStatus.REVIEW
+        mock_image.user_id = 999  # Different from mock_user.user_id
+        with patch("app.services.image_visibility.has_any_permission", new_callable=AsyncMock) as mock_perm:
+            mock_perm.return_value = False
+            result = await can_view_image_file(mock_image, mock_user, mock_db)
+        assert result is False
+
+    # === Owner visibility tests ===
+
+    async def test_owner_can_view_review_image(self, mock_image, mock_user, mock_db):
+        """Owners can view their own REVIEW images."""
+        mock_image.status = ImageStatus.REVIEW
+        mock_image.user_id = mock_user.user_id
+        result = await can_view_image_file(mock_image, mock_user, mock_db)
+        assert result is True
+
+    async def test_owner_can_view_inappropriate_image(self, mock_image, mock_user, mock_db):
+        """Owners can view their own INAPPROPRIATE images."""
+        mock_image.status = ImageStatus.INAPPROPRIATE
+        mock_image.user_id = mock_user.user_id
+        result = await can_view_image_file(mock_image, mock_user, mock_db)
+        assert result is True
+
+    # === Moderator visibility tests ===
+
+    async def test_moderator_with_image_edit_can_view_review(self, mock_image, mock_user, mock_db):
+        """Users with IMAGE_EDIT permission can view REVIEW images."""
+        mock_image.status = ImageStatus.REVIEW
+        mock_image.user_id = 999  # Not the owner
+        with patch("app.services.image_visibility.has_any_permission", new_callable=AsyncMock) as mock_perm:
+            mock_perm.return_value = True
+            result = await can_view_image_file(mock_image, mock_user, mock_db)
+        assert result is True
+
+    async def test_permission_check_uses_correct_permissions(self, mock_image, mock_user, mock_db):
+        """Verify that IMAGE_EDIT and REVIEW_VIEW permissions are checked."""
+        mock_image.status = ImageStatus.REVIEW
+        mock_image.user_id = 999  # Not the owner
+        with patch("app.services.image_visibility.has_any_permission", new_callable=AsyncMock) as mock_perm:
+            mock_perm.return_value = False
+            await can_view_image_file(mock_image, mock_user, mock_db)
+            # Verify the correct permissions were checked
+            from app.core.permissions import Permission
+            mock_perm.assert_called_once()
+            call_args = mock_perm.call_args
+            assert call_args[0][1] == mock_user.user_id
+            permissions_arg = call_args[0][2]
+            assert Permission.IMAGE_EDIT in permissions_arg
+            assert Permission.REVIEW_VIEW in permissions_arg
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_image_visibility.py -v`
+Expected: FAIL - `ModuleNotFoundError: No module named 'app.services.image_visibility'`
+
+**Step 3: Create minimal implementation**
+
+```python
+"""
+Image visibility service.
+
+Determines whether a user can view an image file based on:
+- Image status (public vs protected)
+- User ownership (owners can view their own images)
+- User permissions (moderators can view all images)
+
+Note: This controls FILE access only. API metadata endpoints remain unrestricted.
+"""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus
+from app.core.permissions import Permission, has_any_permission
+from app.models.image import Images
+from app.models.user import Users
+
+
+# Public statuses that anyone can view
+# REPOST (-1), ACTIVE (1), SPOILER (2)
+PUBLIC_IMAGE_STATUSES: frozenset[int] = frozenset({
+    ImageStatus.REPOST,
+    ImageStatus.ACTIVE,
+    ImageStatus.SPOILER,
+})
+
+
+async def can_view_image_file(
+    image: Images,
+    user: Users | None,
+    db: AsyncSession,
+) -> bool:
+    """
+    Check if a user can view an image file.
+
+    Visibility rules:
+    - Public statuses (-1, 1, 2): Anyone can view
+    - Owner: Can view their own images regardless of status
+    - Moderators: Users with IMAGE_EDIT or REVIEW_VIEW can view all
+
+    Args:
+        image: The image to check visibility for
+        user: The requesting user (None for anonymous)
+        db: Database session for permission lookups
+
+    Returns:
+        True if user can view the image file, False otherwise
+
+    Note:
+        Future enhancement: Support ?token=xxx query param for non-browser clients.
+        See design doc for details.
+    """
+    # Public statuses are visible to all
+    if image.status in PUBLIC_IMAGE_STATUSES:
+        return True
+
+    # Anonymous users can only see public statuses
+    if user is None:
+        return False
+
+    # Owner can view their own images
+    if image.user_id == user.user_id:
+        return True
+
+    # Moderators can view all - check for IMAGE_EDIT or REVIEW_VIEW
+    return await has_any_permission(
+        db,
+        user.user_id,
+        [Permission.IMAGE_EDIT, Permission.REVIEW_VIEW],
+    )
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_image_visibility.py -v`
+Expected: PASS (all tests)
+
+**Step 5: Commit**
+
+```bash
+git add tests/unit/test_image_visibility.py app/services/image_visibility.py
+git commit -m "feat: add image visibility service with TDD tests"
+```
+
+---
+
+## Task 2: Create Media Router - Filename Parsing Tests
+
+**Files:**
+- Create: `tests/api/v1/test_media.py`
+- Create: `app/api/v1/media.py`
+
+**Step 1: Write failing tests for filename parsing**
+
+```python
+"""Tests for media file serving endpoints."""
+
+import pytest
+
+from app.api.v1.media import parse_image_id_from_filename, get_extension_from_filename
+
+
+class TestFilenameParsing:
+    """Tests for filename parsing utilities."""
+
+    def test_parse_valid_filename(self):
+        """Parse image_id from valid filename like '2026-01-02-1112196.png'."""
+        result = parse_image_id_from_filename("2026-01-02-1112196.png")
+        assert result == 1112196
+
+    def test_parse_filename_with_jpeg(self):
+        """Parse image_id from jpeg filename."""
+        result = parse_image_id_from_filename("2025-12-31-999.jpeg")
+        assert result == 999
+
+    def test_parse_invalid_filename_no_id(self):
+        """Return None for filename without image_id."""
+        result = parse_image_id_from_filename("invalid.png")
+        assert result is None
+
+    def test_parse_invalid_filename_no_extension(self):
+        """Return None for filename without extension."""
+        result = parse_image_id_from_filename("2026-01-02-1112196")
+        assert result is None
+
+    def test_parse_invalid_filename_non_numeric_id(self):
+        """Return None for filename with non-numeric id."""
+        result = parse_image_id_from_filename("2026-01-02-abc.png")
+        assert result is None
+
+    def test_parse_empty_filename(self):
+        """Return None for empty filename."""
+        result = parse_image_id_from_filename("")
+        assert result is None
+
+    def test_get_extension_png(self):
+        """Get extension from png filename."""
+        result = get_extension_from_filename("2026-01-02-123.png")
+        assert result == "png"
+
+    def test_get_extension_jpeg(self):
+        """Get extension from jpeg filename."""
+        result = get_extension_from_filename("test.jpeg")
+        assert result == "jpeg"
+
+    def test_get_extension_none(self):
+        """Return empty string for filename without extension."""
+        result = get_extension_from_filename("noextension")
+        assert result == ""
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/api/v1/test_media.py::TestFilenameParsing -v`
+Expected: FAIL - `ModuleNotFoundError: No module named 'app.api.v1.media'`
+
+**Step 3: Create minimal implementation (parsing only)**
+
+```python
+"""
+Media file serving endpoints with permission checks.
+
+Routes:
+- GET /images/{filename} - Serve fullsize image with permission check
+- GET /thumbs/{filename} - Serve thumbnail with permission check
+
+These endpoints return X-Accel-Redirect headers for nginx to serve the actual files.
+Authentication is cookie-based (access_token HTTPOnly cookie).
+
+Note: Future enhancement could support ?token=xxx query param for non-browser clients.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Response
+from fastapi.exceptions import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import get_optional_current_user
+from app.core.database import get_db
+from app.models.image import Images
+from app.models.user import Users
+from app.services.image_visibility import can_view_image_file
+
+router = APIRouter()
+
+
+def parse_image_id_from_filename(filename: str) -> int | None:
+    """
+    Extract image_id from filename like '2026-01-02-1112196.png'.
+
+    Args:
+        filename: The filename to parse (e.g., "2026-01-02-1112196.png")
+
+    Returns:
+        The image_id as integer, or None if parsing fails
+    """
+    if not filename or "." not in filename:
+        return None
+
+    try:
+        # Remove extension: "2026-01-02-1112196.png" -> "2026-01-02-1112196"
+        name_without_ext = filename.rsplit(".", 1)[0]
+        # Get last segment after dash: "2026-01-02-1112196" -> "1112196"
+        image_id_str = name_without_ext.rsplit("-", 1)[-1]
+        return int(image_id_str)
+    except (ValueError, IndexError):
+        return None
+
+
+def get_extension_from_filename(filename: str) -> str:
+    """
+    Extract file extension from filename.
+
+    Args:
+        filename: The filename to parse
+
+    Returns:
+        The extension (without dot), or empty string if no extension
+    """
+    if "." not in filename:
+        return ""
+    return filename.rsplit(".", 1)[-1]
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/api/v1/test_media.py::TestFilenameParsing -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/api/v1/test_media.py app/api/v1/media.py
+git commit -m "feat: add media router with filename parsing utilities"
+```
+
+---
+
+## Task 3: Create Media Router - Endpoint Tests
+
+**Files:**
+- Modify: `tests/api/v1/test_media.py`
+- Modify: `app/api/v1/media.py`
+- Modify: `app/main.py`
+
+**Step 1: Write failing tests for endpoints**
+
+Add to `tests/api/v1/test_media.py`:
+
+```python
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from unittest.mock import patch, AsyncMock
+
+from app.config import ImageStatus
+from app.core.security import create_access_token
+from app.core.permissions import Permission
+from app.models.image import Images
+from app.models.user import Users
+from app.models.permissions import Perms, UserPerms
+
+
+class TestServeImageEndpoint:
+    """Tests for GET /images/{filename} endpoint."""
+
+    @pytest.fixture
+    async def public_image(self, db_session: AsyncSession):
+        """Create a public (ACTIVE) image."""
+        image = Images(
+            image_id=100,
+            filename="2026-01-02-100",
+            ext="png",
+            md5_hash="abc123public",
+            filesize=1000,
+            width=100,
+            height=100,
+            user_id=1,
+            status=ImageStatus.ACTIVE,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    @pytest.fixture
+    async def protected_image(self, db_session: AsyncSession):
+        """Create a protected (REVIEW) image."""
+        image = Images(
+            image_id=200,
+            filename="2026-01-02-200",
+            ext="png",
+            md5_hash="abc123protected",
+            filesize=1000,
+            width=100,
+            height=100,
+            user_id=1,  # Owned by testuser (user_id=1)
+            status=ImageStatus.REVIEW,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    async def test_invalid_filename_returns_404(self, client: AsyncClient):
+        """Invalid filename format returns 404."""
+        response = await client.get("/images/invalid.png")
+        assert response.status_code == 404
+
+    async def test_nonexistent_image_returns_404(self, client: AsyncClient):
+        """Non-existent image_id returns 404."""
+        response = await client.get("/images/2026-01-02-99999999.png")
+        assert response.status_code == 404
+
+    async def test_public_image_anonymous_returns_xaccel(self, client: AsyncClient, public_image: Images):
+        """Public image returns X-Accel-Redirect for anonymous user."""
+        response = await client.get(f"/images/2026-01-02-{public_image.image_id}.png")
+        assert response.status_code == 200
+        assert "X-Accel-Redirect" in response.headers
+        assert f"/internal/fullsize/{public_image.md5_hash}.png" in response.headers["X-Accel-Redirect"]
+
+    async def test_protected_image_anonymous_returns_404(self, client: AsyncClient, protected_image: Images):
+        """Protected image returns 404 for anonymous user (not 403 to hide existence)."""
+        response = await client.get(f"/images/2026-01-02-{protected_image.image_id}.png")
+        assert response.status_code == 404
+
+    async def test_protected_image_owner_returns_xaccel(
+        self, client: AsyncClient, protected_image: Images, db_session: AsyncSession
+    ):
+        """Protected image returns X-Accel-Redirect for owner."""
+        # Get the owner (user_id=1, created by conftest)
+        owner = await db_session.get(Users, 1)
+        token = create_access_token(owner.user_id)
+
+        response = await client.get(
+            f"/images/2026-01-02-{protected_image.image_id}.png",
+            cookies={"access_token": token},
+        )
+        assert response.status_code == 200
+        assert "X-Accel-Redirect" in response.headers
+
+    async def test_protected_image_non_owner_returns_404(
+        self, client: AsyncClient, protected_image: Images, db_session: AsyncSession
+    ):
+        """Protected image returns 404 for non-owner regular user."""
+        # Get user_id=2 (not the owner)
+        non_owner = await db_session.get(Users, 2)
+        token = create_access_token(non_owner.user_id)
+
+        response = await client.get(
+            f"/images/2026-01-02-{protected_image.image_id}.png",
+            cookies={"access_token": token},
+        )
+        assert response.status_code == 404
+
+    async def test_protected_image_moderator_returns_xaccel(
+        self, client: AsyncClient, protected_image: Images, db_session: AsyncSession
+    ):
+        """Protected image returns X-Accel-Redirect for moderator with IMAGE_EDIT."""
+        # Get user_id=2 and give them IMAGE_EDIT permission
+        moderator = await db_session.get(Users, 2)
+
+        # Create the permission in database
+        perm = Perms(perm_id=1, title=Permission.IMAGE_EDIT.value)
+        db_session.add(perm)
+        user_perm = UserPerms(user_id=moderator.user_id, perm_id=1, permvalue=1)
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        token = create_access_token(moderator.user_id)
+
+        response = await client.get(
+            f"/images/2026-01-02-{protected_image.image_id}.png",
+            cookies={"access_token": token},
+        )
+        assert response.status_code == 200
+        assert "X-Accel-Redirect" in response.headers
+
+
+class TestServeThumbnailEndpoint:
+    """Tests for GET /thumbs/{filename} endpoint."""
+
+    @pytest.fixture
+    async def public_image(self, db_session: AsyncSession):
+        """Create a public (ACTIVE) image."""
+        image = Images(
+            image_id=300,
+            filename="2026-01-02-300",
+            ext="jpeg",
+            md5_hash="thumb123public",
+            filesize=500,
+            width=250,
+            height=200,
+            user_id=1,
+            status=ImageStatus.ACTIVE,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    async def test_thumbnail_returns_xaccel_with_internal_thumbs_path(
+        self, client: AsyncClient, public_image: Images
+    ):
+        """Thumbnail endpoint returns X-Accel-Redirect with /internal/thumbs/ path."""
+        response = await client.get(f"/thumbs/2026-01-02-{public_image.image_id}.jpeg")
+        assert response.status_code == 200
+        assert "X-Accel-Redirect" in response.headers
+        # Thumbnails are always jpeg regardless of original format
+        assert f"/internal/thumbs/{public_image.md5_hash}.jpeg" in response.headers["X-Accel-Redirect"]
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/api/v1/test_media.py::TestServeImageEndpoint -v`
+Expected: FAIL - Endpoints not registered, 404 for all requests
+
+**Step 3: Implement endpoints and register router**
+
+Update `app/api/v1/media.py` - add endpoints:
+
+```python
+@router.get("/images/{filename}")
+async def serve_fullsize_image(
+    filename: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[Users | None, Depends(get_optional_current_user)],
+) -> Response:
+    """
+    Serve fullsize image with permission check.
+
+    Returns X-Accel-Redirect header for nginx to serve the actual file.
+    Authentication: Cookie-based (access_token).
+
+    Args:
+        filename: Image filename like "2026-01-02-1112196.png"
+        db: Database session
+        current_user: Authenticated user or None
+
+    Returns:
+        Response with X-Accel-Redirect header
+
+    Raises:
+        HTTPException 404: If image not found or user lacks permission
+    """
+    return await _serve_image(filename, "fullsize", db, current_user)
+
+
+@router.get("/thumbs/{filename}")
+async def serve_thumbnail(
+    filename: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[Users | None, Depends(get_optional_current_user)],
+) -> Response:
+    """
+    Serve thumbnail with permission check.
+
+    Returns X-Accel-Redirect header for nginx to serve the actual file.
+    Authentication: Cookie-based (access_token).
+
+    Note: Thumbnails are always JPEG format regardless of original image format.
+
+    Args:
+        filename: Image filename like "2026-01-02-1112196.jpeg"
+        db: Database session
+        current_user: Authenticated user or None
+
+    Returns:
+        Response with X-Accel-Redirect header
+
+    Raises:
+        HTTPException 404: If image not found or user lacks permission
+    """
+    return await _serve_image(filename, "thumbs", db, current_user)
+
+
+async def _serve_image(
+    filename: str,
+    image_type: str,  # "fullsize" or "thumbs"
+    db: AsyncSession,
+    current_user: Users | None,
+) -> Response:
+    """
+    Internal handler for serving images.
+
+    Args:
+        filename: The requested filename
+        image_type: Either "fullsize" or "thumbs"
+        db: Database session
+        current_user: Authenticated user or None
+
+    Returns:
+        Response with X-Accel-Redirect header
+
+    Raises:
+        HTTPException 404: If image not found or user lacks permission
+    """
+    # Parse image_id from filename
+    image_id = parse_image_id_from_filename(filename)
+    if image_id is None:
+        raise HTTPException(status_code=404)
+
+    # Fetch image from database
+    image = await db.get(Images, image_id)
+    if image is None:
+        raise HTTPException(status_code=404)
+
+    # Check visibility permission
+    if not await can_view_image_file(image, current_user, db):
+        # Return 404 (not 403) to avoid revealing existence of hidden images
+        raise HTTPException(status_code=404)
+
+    # Determine file extension for X-Accel-Redirect path
+    if image_type == "thumbs":
+        # Thumbnails are always JPEG
+        ext = "jpeg"
+    else:
+        ext = get_extension_from_filename(filename)
+
+    # Return X-Accel-Redirect for nginx to serve the file
+    internal_path = f"/internal/{image_type}/{image.md5_hash}.{ext}"
+    return Response(
+        status_code=200,
+        headers={"X-Accel-Redirect": internal_path},
+    )
+```
+
+Update `app/main.py` - add media router at root level (after the API router):
+
+```python
+# Add after line 133 (app.include_router(api_v1_router, prefix="/api/v1"))
+from app.api.v1.media import router as media_router  # noqa: E402
+
+# Mount media routes at root level (not under /api/v1)
+# These serve image files with permission checks via X-Accel-Redirect
+app.include_router(media_router)
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/api/v1/test_media.py -v`
+Expected: PASS (all tests)
+
+**Step 5: Commit**
+
+```bash
+git add app/api/v1/media.py app/main.py tests/api/v1/test_media.py
+git commit -m "feat: add media endpoints with X-Accel-Redirect and permission checks"
+```
+
+---
+
+## Task 4: Add Integration Test for Full Flow
+
+**Files:**
+- Modify: `tests/api/v1/test_media.py`
+
+**Step 1: Write integration test covering full visibility matrix**
+
+Add to `tests/api/v1/test_media.py`:
+
+```python
+class TestVisibilityMatrix:
+    """Integration tests for the complete visibility matrix."""
+
+    @pytest.fixture
+    async def images_by_status(self, db_session: AsyncSession):
+        """Create images with different statuses."""
+        statuses = {
+            "review": ImageStatus.REVIEW,
+            "inappropriate": ImageStatus.INAPPROPRIATE,
+            "repost": ImageStatus.REPOST,
+            "other": ImageStatus.OTHER,
+            "active": ImageStatus.ACTIVE,
+            "spoiler": ImageStatus.SPOILER,
+        }
+        images = {}
+        for name, status in statuses.items():
+            image = Images(
+                filename=f"2026-01-02-{400 + len(images)}",
+                ext="png",
+                md5_hash=f"matrix{name}hash",
+                filesize=1000,
+                width=100,
+                height=100,
+                user_id=1,  # Owned by testuser
+                status=status,
+            )
+            db_session.add(image)
+            await db_session.flush()
+            images[name] = image
+        await db_session.commit()
+        return images
+
+    async def test_anonymous_sees_public_statuses_only(
+        self, client: AsyncClient, images_by_status: dict
+    ):
+        """Anonymous users can only see REPOST, ACTIVE, SPOILER."""
+        public = ["repost", "active", "spoiler"]
+        protected = ["review", "inappropriate", "other"]
+
+        for name in public:
+            img = images_by_status[name]
+            response = await client.get(f"/images/2026-01-02-{img.image_id}.png")
+            assert response.status_code == 200, f"Expected 200 for {name}, got {response.status_code}"
+
+        for name in protected:
+            img = images_by_status[name]
+            response = await client.get(f"/images/2026-01-02-{img.image_id}.png")
+            assert response.status_code == 404, f"Expected 404 for {name}, got {response.status_code}"
+
+    async def test_owner_sees_all_statuses(
+        self, client: AsyncClient, images_by_status: dict, db_session: AsyncSession
+    ):
+        """Image owner can see all their images regardless of status."""
+        owner = await db_session.get(Users, 1)
+        token = create_access_token(owner.user_id)
+
+        for name, img in images_by_status.items():
+            response = await client.get(
+                f"/images/2026-01-02-{img.image_id}.png",
+                cookies={"access_token": token},
+            )
+            assert response.status_code == 200, f"Owner should see {name}, got {response.status_code}"
+```
+
+**Step 2: Run tests to verify they pass**
+
+Run: `uv run pytest tests/api/v1/test_media.py::TestVisibilityMatrix -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add tests/api/v1/test_media.py
+git commit -m "test: add visibility matrix integration tests"
+```
+
+---
+
+## Task 5: Run Full Test Suite and Lint
+
+**Step 1: Run all tests**
+
+Run: `uv run pytest tests/ -v --tb=short`
+Expected: PASS (all tests including new ones)
+
+**Step 2: Run linter**
+
+Run: `uv run ruff check app/services/image_visibility.py app/api/v1/media.py tests/unit/test_image_visibility.py tests/api/v1/test_media.py`
+Expected: No errors
+
+**Step 3: Run formatter**
+
+Run: `uv run ruff format app/services/image_visibility.py app/api/v1/media.py tests/unit/test_image_visibility.py tests/api/v1/test_media.py`
+
+**Step 4: Final commit if any formatting changes**
+
+```bash
+git add -A
+git commit -m "chore: format code with ruff"
+```
+
+---
+
+## Task 6: Document nginx Configuration
+
+**Files:**
+- Modify: `docs/plans/2026-01-02-image-visibility-protection-design.md` (already has nginx config)
+
+**Step 1: Verify design doc has nginx config**
+
+The design document already contains the nginx configuration. No additional changes needed, but the user should be reminded to:
+
+1. Update nginx config to proxy `/images/` and `/thumbs/` to FastAPI
+2. Add internal locations for X-Accel-Redirect
+3. Substitute `STORAGE_PATH` environment variable in the config
+
+**Step 2: Create a summary for the user**
+
+After implementation is complete, provide summary of what nginx changes are needed.
+
+---
+
+## Summary
+
+| Task | Description | Files |
+|------|-------------|-------|
+| 1 | Visibility service + unit tests | `app/services/image_visibility.py`, `tests/unit/test_image_visibility.py` |
+| 2 | Media router + parsing tests | `app/api/v1/media.py`, `tests/api/v1/test_media.py` |
+| 3 | Media endpoints + integration | `app/api/v1/media.py`, `app/main.py`, `tests/api/v1/test_media.py` |
+| 4 | Visibility matrix tests | `tests/api/v1/test_media.py` |
+| 5 | Full test suite + lint | - |
+| 6 | nginx config documentation | Design doc reference |
+
+**Total estimated commits:** 5-6

--- a/tests/api/v1/test_media.py
+++ b/tests/api/v1/test_media.py
@@ -121,7 +121,7 @@ class TestServeImageEndpoint:
         assert response.status_code == 200
         assert "X-Accel-Redirect" in response.headers
         assert (
-            f"/internal/fullsize/{public_image.md5_hash}.png"
+            f"/internal/fullsize/{public_image.filename}.png"
             in response.headers["X-Accel-Redirect"]
         )
 
@@ -232,7 +232,7 @@ class TestServeThumbnailEndpoint:
         assert response.status_code == 200
         assert "X-Accel-Redirect" in response.headers
         assert (
-            f"/internal/thumbs/{public_image.md5_hash}.jpeg" in response.headers["X-Accel-Redirect"]
+            f"/internal/thumbs/{public_image.filename}.jpeg" in response.headers["X-Accel-Redirect"]
         )
 
 
@@ -286,7 +286,7 @@ class TestServeMediumEndpoint:
         response = await client.get(f"/medium/2026-01-02-{image_with_medium.image_id}.png")
         assert response.status_code == 200
         assert "X-Accel-Redirect" in response.headers
-        assert f"/internal/medium/{image_with_medium.md5_hash}.png" in response.headers["X-Accel-Redirect"]
+        assert f"/internal/medium/{image_with_medium.filename}.png" in response.headers["X-Accel-Redirect"]
 
     async def test_medium_returns_404_when_variant_missing(
         self, client: AsyncClient, image_without_medium: Images
@@ -346,7 +346,7 @@ class TestServeLargeEndpoint:
         response = await client.get(f"/large/2026-01-02-{image_with_large.image_id}.jpeg")
         assert response.status_code == 200
         assert "X-Accel-Redirect" in response.headers
-        assert f"/internal/large/{image_with_large.md5_hash}.jpeg" in response.headers["X-Accel-Redirect"]
+        assert f"/internal/large/{image_with_large.filename}.jpeg" in response.headers["X-Accel-Redirect"]
 
     async def test_large_returns_404_when_variant_missing(
         self, client: AsyncClient, image_without_large: Images

--- a/tests/api/v1/test_media.py
+++ b/tests/api/v1/test_media.py
@@ -236,6 +236,126 @@ class TestServeThumbnailEndpoint:
         )
 
 
+class TestServeMediumEndpoint:
+    """Tests for GET /medium/{filename} endpoint."""
+
+    @pytest.fixture
+    async def image_with_medium(self, db_session: AsyncSession):
+        """Create a public image with medium variant available."""
+        image = Images(
+            image_id=400,
+            filename="2026-01-02-400",
+            ext="png",
+            md5_hash="medium123hash",
+            filesize=2000,
+            width=1920,
+            height=1080,
+            user_id=1,
+            status=ImageStatus.ACTIVE,
+            medium=1,  # Medium variant exists
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    @pytest.fixture
+    async def image_without_medium(self, db_session: AsyncSession):
+        """Create a public image without medium variant."""
+        image = Images(
+            image_id=401,
+            filename="2026-01-02-401",
+            ext="png",
+            md5_hash="nomedium123hash",
+            filesize=1000,
+            width=800,
+            height=600,
+            user_id=1,
+            status=ImageStatus.ACTIVE,
+            medium=0,  # No medium variant
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    async def test_medium_returns_xaccel_when_variant_exists(
+        self, client: AsyncClient, image_with_medium: Images
+    ):
+        """Medium endpoint returns X-Accel-Redirect when variant exists."""
+        response = await client.get(f"/medium/2026-01-02-{image_with_medium.image_id}.png")
+        assert response.status_code == 200
+        assert "X-Accel-Redirect" in response.headers
+        assert f"/internal/medium/{image_with_medium.md5_hash}.png" in response.headers["X-Accel-Redirect"]
+
+    async def test_medium_returns_404_when_variant_missing(
+        self, client: AsyncClient, image_without_medium: Images
+    ):
+        """Medium endpoint returns 404 when variant doesn't exist."""
+        response = await client.get(f"/medium/2026-01-02-{image_without_medium.image_id}.png")
+        assert response.status_code == 404
+
+
+class TestServeLargeEndpoint:
+    """Tests for GET /large/{filename} endpoint."""
+
+    @pytest.fixture
+    async def image_with_large(self, db_session: AsyncSession):
+        """Create a public image with large variant available."""
+        image = Images(
+            image_id=500,
+            filename="2026-01-02-500",
+            ext="jpeg",
+            md5_hash="large123hash",
+            filesize=5000,
+            width=4000,
+            height=3000,
+            user_id=1,
+            status=ImageStatus.ACTIVE,
+            large=1,  # Large variant exists
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    @pytest.fixture
+    async def image_without_large(self, db_session: AsyncSession):
+        """Create a public image without large variant."""
+        image = Images(
+            image_id=501,
+            filename="2026-01-02-501",
+            ext="jpeg",
+            md5_hash="nolarge123hash",
+            filesize=1000,
+            width=1200,
+            height=800,
+            user_id=1,
+            status=ImageStatus.ACTIVE,
+            large=0,  # No large variant
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    async def test_large_returns_xaccel_when_variant_exists(
+        self, client: AsyncClient, image_with_large: Images
+    ):
+        """Large endpoint returns X-Accel-Redirect when variant exists."""
+        response = await client.get(f"/large/2026-01-02-{image_with_large.image_id}.jpeg")
+        assert response.status_code == 200
+        assert "X-Accel-Redirect" in response.headers
+        assert f"/internal/large/{image_with_large.md5_hash}.jpeg" in response.headers["X-Accel-Redirect"]
+
+    async def test_large_returns_404_when_variant_missing(
+        self, client: AsyncClient, image_without_large: Images
+    ):
+        """Large endpoint returns 404 when variant doesn't exist."""
+        response = await client.get(f"/large/2026-01-02-{image_without_large.image_id}.jpeg")
+        assert response.status_code == 404
+
+
 class TestVisibilityMatrix:
     """Integration tests for the complete visibility matrix."""
 

--- a/tests/api/v1/test_media.py
+++ b/tests/api/v1/test_media.py
@@ -210,8 +210,7 @@ class TestServeThumbnailEndpoint:
         assert response.status_code == 200
         assert "X-Accel-Redirect" in response.headers
         assert (
-            f"/internal/thumbs/{public_image.md5_hash}.jpeg"
-            in response.headers["X-Accel-Redirect"]
+            f"/internal/thumbs/{public_image.md5_hash}.jpeg" in response.headers["X-Accel-Redirect"]
         )
 
 
@@ -257,12 +256,16 @@ class TestVisibilityMatrix:
         for name in public:
             img = images_by_status[name]
             response = await client.get(f"/images/2026-01-02-{img.image_id}.png")
-            assert response.status_code == 200, f"Expected 200 for {name}, got {response.status_code}"
+            assert response.status_code == 200, (
+                f"Expected 200 for {name}, got {response.status_code}"
+            )
 
         for name in protected:
             img = images_by_status[name]
             response = await client.get(f"/images/2026-01-02-{img.image_id}.png")
-            assert response.status_code == 404, f"Expected 404 for {name}, got {response.status_code}"
+            assert response.status_code == 404, (
+                f"Expected 404 for {name}, got {response.status_code}"
+            )
 
     async def test_owner_sees_all_statuses(
         self, client: AsyncClient, images_by_status: dict, db_session: AsyncSession
@@ -278,4 +281,6 @@ class TestVisibilityMatrix:
                 f"/images/2026-01-02-{img.image_id}.png",
                 cookies={"access_token": token},
             )
-            assert response.status_code == 200, f"Owner should see {name}, got {response.status_code}"
+            assert response.status_code == 200, (
+                f"Owner should see {name}, got {response.status_code}"
+            )

--- a/tests/api/v1/test_media.py
+++ b/tests/api/v1/test_media.py
@@ -1,6 +1,16 @@
 """Tests for media file serving endpoints."""
 
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.api.v1.media import get_extension_from_filename, parse_image_id_from_filename
+from app.config import ImageStatus
+from app.core.permissions import Permission
+from app.core.security import create_access_token
+from app.models.image import Images
+from app.models.permissions import Perms, UserPerms
+from app.models.user import Users
 
 
 class TestFilenameParsing:
@@ -50,3 +60,156 @@ class TestFilenameParsing:
         """Return empty string for filename without extension."""
         result = get_extension_from_filename("noextension")
         assert result == ""
+
+
+class TestServeImageEndpoint:
+    """Tests for GET /images/{filename} endpoint."""
+
+    @pytest.fixture
+    async def public_image(self, db_session: AsyncSession):
+        """Create a public (ACTIVE) image."""
+        image = Images(
+            image_id=100,
+            filename="2026-01-02-100",
+            ext="png",
+            md5_hash="abc123public",
+            filesize=1000,
+            width=100,
+            height=100,
+            user_id=1,
+            status=ImageStatus.ACTIVE,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    @pytest.fixture
+    async def protected_image(self, db_session: AsyncSession):
+        """Create a protected (REVIEW) image."""
+        image = Images(
+            image_id=200,
+            filename="2026-01-02-200",
+            ext="png",
+            md5_hash="abc123protected",
+            filesize=1000,
+            width=100,
+            height=100,
+            user_id=1,  # Owned by testuser (user_id=1)
+            status=ImageStatus.REVIEW,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    async def test_invalid_filename_returns_404(self, client: AsyncClient):
+        """Invalid filename format returns 404."""
+        response = await client.get("/images/invalid.png")
+        assert response.status_code == 404
+
+    async def test_nonexistent_image_returns_404(self, client: AsyncClient):
+        """Non-existent image_id returns 404."""
+        response = await client.get("/images/2026-01-02-99999999.png")
+        assert response.status_code == 404
+
+    async def test_public_image_anonymous_returns_xaccel(
+        self, client: AsyncClient, public_image: Images
+    ):
+        """Public image returns X-Accel-Redirect for anonymous user."""
+        response = await client.get(f"/images/2026-01-02-{public_image.image_id}.png")
+        assert response.status_code == 200
+        assert "X-Accel-Redirect" in response.headers
+        assert (
+            f"/internal/fullsize/{public_image.md5_hash}.png"
+            in response.headers["X-Accel-Redirect"]
+        )
+
+    async def test_protected_image_anonymous_returns_404(
+        self, client: AsyncClient, protected_image: Images
+    ):
+        """Protected image returns 404 for anonymous user (not 403 to hide existence)."""
+        response = await client.get(f"/images/2026-01-02-{protected_image.image_id}.png")
+        assert response.status_code == 404
+
+    async def test_protected_image_owner_returns_xaccel(
+        self, client: AsyncClient, protected_image: Images, db_session: AsyncSession
+    ):
+        """Protected image returns X-Accel-Redirect for owner."""
+        owner = await db_session.get(Users, 1)
+        owner.active = 1  # Must be active to authenticate
+        await db_session.commit()
+        token = create_access_token(owner.user_id)
+        response = await client.get(
+            f"/images/2026-01-02-{protected_image.image_id}.png",
+            cookies={"access_token": token},
+        )
+        assert response.status_code == 200
+        assert "X-Accel-Redirect" in response.headers
+
+    async def test_protected_image_non_owner_returns_404(
+        self, client: AsyncClient, protected_image: Images, db_session: AsyncSession
+    ):
+        """Protected image returns 404 for non-owner regular user."""
+        non_owner = await db_session.get(Users, 2)
+        token = create_access_token(non_owner.user_id)
+        response = await client.get(
+            f"/images/2026-01-02-{protected_image.image_id}.png",
+            cookies={"access_token": token},
+        )
+        assert response.status_code == 404
+
+    async def test_protected_image_moderator_returns_xaccel(
+        self, client: AsyncClient, protected_image: Images, db_session: AsyncSession
+    ):
+        """Protected image returns X-Accel-Redirect for moderator with IMAGE_EDIT."""
+        moderator = await db_session.get(Users, 2)
+        moderator.active = 1  # Must be active to authenticate
+        perm = Perms(perm_id=1, title=Permission.IMAGE_EDIT.value)
+        db_session.add(perm)
+        user_perm = UserPerms(user_id=moderator.user_id, perm_id=1, permvalue=1)
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        token = create_access_token(moderator.user_id)
+        response = await client.get(
+            f"/images/2026-01-02-{protected_image.image_id}.png",
+            cookies={"access_token": token},
+        )
+        assert response.status_code == 200
+        assert "X-Accel-Redirect" in response.headers
+
+
+class TestServeThumbnailEndpoint:
+    """Tests for GET /thumbs/{filename} endpoint."""
+
+    @pytest.fixture
+    async def public_image(self, db_session: AsyncSession):
+        """Create a public (ACTIVE) image."""
+        image = Images(
+            image_id=300,
+            filename="2026-01-02-300",
+            ext="jpeg",
+            md5_hash="thumb123public",
+            filesize=500,
+            width=250,
+            height=200,
+            user_id=1,
+            status=ImageStatus.ACTIVE,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    async def test_thumbnail_returns_xaccel_with_internal_thumbs_path(
+        self, client: AsyncClient, public_image: Images
+    ):
+        """Thumbnail endpoint returns X-Accel-Redirect with /internal/thumbs/ path."""
+        response = await client.get(f"/thumbs/2026-01-02-{public_image.image_id}.jpeg")
+        assert response.status_code == 200
+        assert "X-Accel-Redirect" in response.headers
+        assert (
+            f"/internal/thumbs/{public_image.md5_hash}.jpeg"
+            in response.headers["X-Accel-Redirect"]
+        )

--- a/tests/api/v1/test_media.py
+++ b/tests/api/v1/test_media.py
@@ -1,0 +1,52 @@
+"""Tests for media file serving endpoints."""
+
+from app.api.v1.media import get_extension_from_filename, parse_image_id_from_filename
+
+
+class TestFilenameParsing:
+    """Tests for filename parsing utilities."""
+
+    def test_parse_valid_filename(self):
+        """Parse image_id from valid filename like '2026-01-02-1112196.png'."""
+        result = parse_image_id_from_filename("2026-01-02-1112196.png")
+        assert result == 1112196
+
+    def test_parse_filename_with_jpeg(self):
+        """Parse image_id from jpeg filename."""
+        result = parse_image_id_from_filename("2025-12-31-999.jpeg")
+        assert result == 999
+
+    def test_parse_invalid_filename_no_id(self):
+        """Return None for filename without image_id."""
+        result = parse_image_id_from_filename("invalid.png")
+        assert result is None
+
+    def test_parse_invalid_filename_no_extension(self):
+        """Return None for filename without extension."""
+        result = parse_image_id_from_filename("2026-01-02-1112196")
+        assert result is None
+
+    def test_parse_invalid_filename_non_numeric_id(self):
+        """Return None for filename with non-numeric id."""
+        result = parse_image_id_from_filename("2026-01-02-abc.png")
+        assert result is None
+
+    def test_parse_empty_filename(self):
+        """Return None for empty filename."""
+        result = parse_image_id_from_filename("")
+        assert result is None
+
+    def test_get_extension_png(self):
+        """Get extension from png filename."""
+        result = get_extension_from_filename("2026-01-02-123.png")
+        assert result == "png"
+
+    def test_get_extension_jpeg(self):
+        """Get extension from jpeg filename."""
+        result = get_extension_from_filename("test.jpeg")
+        assert result == "jpeg"
+
+    def test_get_extension_none(self):
+        """Return empty string for filename without extension."""
+        result = get_extension_from_filename("noextension")
+        assert result == ""

--- a/tests/unit/test_image_visibility.py
+++ b/tests/unit/test_image_visibility.py
@@ -1,0 +1,178 @@
+"""Tests for image visibility service."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus
+from app.models.image import Images
+from app.models.user import Users
+from app.services.image_visibility import PUBLIC_IMAGE_STATUSES, can_view_image_file
+
+
+class TestPublicImageStatuses:
+    """Test the PUBLIC_IMAGE_STATUSES constant."""
+
+    def test_public_statuses_include_repost(self):
+        """REPOST (-1) should be publicly visible."""
+        assert ImageStatus.REPOST in PUBLIC_IMAGE_STATUSES
+
+    def test_public_statuses_include_active(self):
+        """ACTIVE (1) should be publicly visible."""
+        assert ImageStatus.ACTIVE in PUBLIC_IMAGE_STATUSES
+
+    def test_public_statuses_include_spoiler(self):
+        """SPOILER (2) should be publicly visible."""
+        assert ImageStatus.SPOILER in PUBLIC_IMAGE_STATUSES
+
+    def test_public_statuses_exclude_review(self):
+        """REVIEW (-4) should NOT be publicly visible."""
+        assert ImageStatus.REVIEW not in PUBLIC_IMAGE_STATUSES
+
+    def test_public_statuses_exclude_inappropriate(self):
+        """INAPPROPRIATE (-2) should NOT be publicly visible."""
+        assert ImageStatus.INAPPROPRIATE not in PUBLIC_IMAGE_STATUSES
+
+    def test_public_statuses_exclude_other(self):
+        """OTHER (0) should NOT be publicly visible."""
+        assert ImageStatus.OTHER not in PUBLIC_IMAGE_STATUSES
+
+
+class TestCanViewImageFile:
+    """Tests for can_view_image_file function."""
+
+    @pytest.fixture
+    def mock_image(self):
+        """Create a mock image with configurable status and user_id."""
+        image = Images(
+            image_id=1,
+            filename="test",
+            ext="png",
+            md5_hash="abc123",
+            filesize=1000,
+            width=100,
+            height=100,
+            user_id=10,
+            status=ImageStatus.ACTIVE,
+        )
+        return image
+
+    @pytest.fixture
+    def mock_user(self):
+        """Create a mock user."""
+        user = Users(
+            user_id=20,
+            username="testuser",
+            password="hash",
+            password_type="bcrypt",
+            salt="1234567890123456",
+            email="test@example.com",
+        )
+        return user
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock database session."""
+        return AsyncMock(spec=AsyncSession)
+
+    # === Public status tests ===
+
+    async def test_active_image_visible_to_anonymous(self, mock_image, mock_db):
+        """ACTIVE images are visible to anonymous users."""
+        mock_image.status = ImageStatus.ACTIVE
+        result = await can_view_image_file(mock_image, None, mock_db)
+        assert result is True
+
+    async def test_spoiler_image_visible_to_anonymous(self, mock_image, mock_db):
+        """SPOILER images are visible to anonymous users."""
+        mock_image.status = ImageStatus.SPOILER
+        result = await can_view_image_file(mock_image, None, mock_db)
+        assert result is True
+
+    async def test_repost_image_visible_to_anonymous(self, mock_image, mock_db):
+        """REPOST images are visible to anonymous users."""
+        mock_image.status = ImageStatus.REPOST
+        result = await can_view_image_file(mock_image, None, mock_db)
+        assert result is True
+
+    # === Protected status tests - anonymous ===
+
+    async def test_review_image_hidden_from_anonymous(self, mock_image, mock_db):
+        """REVIEW images are hidden from anonymous users."""
+        mock_image.status = ImageStatus.REVIEW
+        result = await can_view_image_file(mock_image, None, mock_db)
+        assert result is False
+
+    async def test_inappropriate_image_hidden_from_anonymous(self, mock_image, mock_db):
+        """INAPPROPRIATE images are hidden from anonymous users."""
+        mock_image.status = ImageStatus.INAPPROPRIATE
+        result = await can_view_image_file(mock_image, None, mock_db)
+        assert result is False
+
+    async def test_other_image_hidden_from_anonymous(self, mock_image, mock_db):
+        """OTHER images are hidden from anonymous users."""
+        mock_image.status = ImageStatus.OTHER
+        result = await can_view_image_file(mock_image, None, mock_db)
+        assert result is False
+
+    # === Protected status tests - non-owner regular user ===
+
+    async def test_review_image_hidden_from_non_owner(self, mock_image, mock_user, mock_db):
+        """REVIEW images are hidden from non-owner regular users."""
+        mock_image.status = ImageStatus.REVIEW
+        mock_image.user_id = 999  # Different from mock_user.user_id
+        with patch(
+            "app.services.image_visibility.has_any_permission", new_callable=AsyncMock
+        ) as mock_perm:
+            mock_perm.return_value = False
+            result = await can_view_image_file(mock_image, mock_user, mock_db)
+        assert result is False
+
+    # === Owner visibility tests ===
+
+    async def test_owner_can_view_review_image(self, mock_image, mock_user, mock_db):
+        """Owners can view their own REVIEW images."""
+        mock_image.status = ImageStatus.REVIEW
+        mock_image.user_id = mock_user.user_id
+        result = await can_view_image_file(mock_image, mock_user, mock_db)
+        assert result is True
+
+    async def test_owner_can_view_inappropriate_image(self, mock_image, mock_user, mock_db):
+        """Owners can view their own INAPPROPRIATE images."""
+        mock_image.status = ImageStatus.INAPPROPRIATE
+        mock_image.user_id = mock_user.user_id
+        result = await can_view_image_file(mock_image, mock_user, mock_db)
+        assert result is True
+
+    # === Moderator visibility tests ===
+
+    async def test_moderator_with_image_edit_can_view_review(self, mock_image, mock_user, mock_db):
+        """Users with IMAGE_EDIT permission can view REVIEW images."""
+        mock_image.status = ImageStatus.REVIEW
+        mock_image.user_id = 999  # Not the owner
+        with patch(
+            "app.services.image_visibility.has_any_permission", new_callable=AsyncMock
+        ) as mock_perm:
+            mock_perm.return_value = True
+            result = await can_view_image_file(mock_image, mock_user, mock_db)
+        assert result is True
+
+    async def test_permission_check_uses_correct_permissions(self, mock_image, mock_user, mock_db):
+        """Verify that IMAGE_EDIT and REVIEW_VIEW permissions are checked."""
+        mock_image.status = ImageStatus.REVIEW
+        mock_image.user_id = 999  # Not the owner
+        with patch(
+            "app.services.image_visibility.has_any_permission", new_callable=AsyncMock
+        ) as mock_perm:
+            mock_perm.return_value = False
+            await can_view_image_file(mock_image, mock_user, mock_db)
+            # Verify the correct permissions were checked
+            from app.core.permissions import Permission
+
+            mock_perm.assert_called_once()
+            call_args = mock_perm.call_args
+            assert call_args[0][1] == mock_user.user_id
+            permissions_arg = call_args[0][2]
+            assert Permission.IMAGE_EDIT in permissions_arg
+            assert Permission.REVIEW_VIEW in permissions_arg


### PR DESCRIPTION
## Summary

- Add permission-based image file protection using X-Accel-Redirect pattern
- Public statuses (REPOST, ACTIVE, SPOILER) visible to all users
- Protected statuses (REVIEW, INAPPROPRIATE, OTHER) only visible to image owner or users with IMAGE_EDIT/REVIEW_VIEW permission
- Returns 404 (not 403) for unauthorized access to hide existence of protected images
- Cookie-based authentication via access_token HTTPOnly cookie

## Files Changed

- `app/services/image_visibility.py` - Core visibility logic
- `app/api/v1/media.py` - Media serving endpoints with X-Accel-Redirect
- `app/main.py` - Router registration at root level
- `tests/unit/test_image_visibility.py` - 17 unit tests
- `tests/api/v1/test_media.py` - 20 API endpoint tests
- `docs/image-serving-nginx.md` - Updated nginx configuration docs

## Test Plan

- [x] Unit tests for visibility service (17 tests)
- [x] API tests for media endpoints (20 tests)
- [x] Visibility matrix integration tests
- [x] Tests for both IMAGE_EDIT and REVIEW_VIEW permissions
- [ ] Manual testing with nginx X-Accel-Redirect configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)