### PR TITLE
feat: add user profile settings to PATCH /me endpoint

### DIFF
--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -418,6 +418,12 @@ async def _update_user_profile(
     # Update only provided fields
     update_data = user_data.model_dump(exclude_unset=True)
 
+    # Handle timezone conversion (string to Decimal)
+    if "timezone" in update_data:
+        from decimal import Decimal
+
+        update_data["timezone"] = Decimal(update_data["timezone"])
+
     # Handle password separately with validation and hashing
     if "password" in update_data:
         password = update_data.pop("password")

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -753,6 +753,13 @@ class TestUpdateUserProfile:
         )
         assert response.status_code == 422
 
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={"timezone": "-13.00"},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 422
+
     async def test_update_display_preferences_via_me(
         self, client: AsyncClient, db_session: AsyncSession
     ):

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -652,6 +652,107 @@ class TestUpdateUserProfile:
         await db_session.refresh(user)
         assert user.email_pm_pref == 1
 
+    async def test_update_user_settings_via_me(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that PATCH /api/v1/users/me accepts and returns user settings."""
+        from decimal import Decimal
+
+        # Create user with default settings
+        user = Users(
+            username="settingstest",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="settingstest@example.com",
+            active=1,
+            show_all_images=0,
+            spoiler_warning_pref=1,
+            timezone=Decimal("0.00"),
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Login
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "settingstest", "password": "TestPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Update all settings
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={
+                "show_all_images": 1,
+                "spoiler_warning_pref": 0,
+                "timezone": "-5.00",
+            },
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify response includes updated settings
+        assert data.get("show_all_images") == 1
+        assert data.get("spoiler_warning_pref") == 0
+        assert Decimal(data.get("timezone")) == Decimal("-5")
+
+        # Verify persisted in DB
+        await db_session.refresh(user)
+        assert user.show_all_images == 1
+        assert user.spoiler_warning_pref == 0
+        assert user.timezone == Decimal("-5")
+
+    async def test_update_user_settings_validation(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that user settings have proper validation."""
+        # Create user
+        user = Users(
+            username="settingsvalidation",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="settingsvalidation@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Login
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "settingsvalidation", "password": "TestPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Test invalid show_all_images (must be 0 or 1)
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={"show_all_images": 2},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 422
+
+        # Test invalid spoiler_warning_pref (must be 0 or 1)
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={"spoiler_warning_pref": -1},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 422
+
+        # Test invalid timezone (must be between -12 and 14)
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={"timezone": "15.00"},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 422
+
     async def test_update_other_user_profile_forbidden(
         self, client: AsyncClient, db_session: AsyncSession
     ):


### PR DESCRIPTION
## Summary

- Add support for updating user settings via `PATCH /api/v1/users/me`
- Settings are returned in the `UserPrivateResponse` when fetching profile
- All settings have proper validation

## New Fields

| Field | Type | Validation |
|-------|------|------------|
| `show_all_images` | int | 0 or 1 |
| `spoiler_warning_pref` | int | 0 or 1 |
| `timezone` | string | UTC offset -12 to +14 |
| `thumb_layout` | int | 0 (list) or 1 (grid) |
| `sorting_pref` | string | ImageSortBy enum values |
| `sorting_pref_order` | string | ASC or DESC |
| `images_per_page` | int | 1-100 |

## Test plan

- [x] Tests for updating user settings (show_all_images, spoiler_warning_pref, timezone)
- [x] Tests for updating display preferences (thumb_layout, sorting_pref, sorting_pref_order, images_per_page)
- [x] Validation tests for all fields
- [x] All 62 user tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)