### PR TITLE
feat: include replacement_id in image API responses

### DIFF
--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -88,6 +88,7 @@ class ImageResponse(ImageBase):
     num_ratings: int
     medium: int
     large: int
+    replacement_id: int | None = None  # Original image ID when this is a repost (status=-1)
 
     # Computed fields
     @computed_field  # type: ignore[prop-decorator]


### PR DESCRIPTION
## Summary

- Add `replacement_id` field to `ImageResponse` schema
- Frontend can now display which image a repost is duplicating (when `status=-1`)
- No performance impact - field is already loaded from database, just wasn't exposed

## Test plan

- [x] All tests pass (544 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)