### PR TITLE
feat: allow free-form text input for user gender field

### DIFF
--- a/alembic/versions/c97f6ff5c0f5_expand_gender_field_to_varchar_50.py
+++ b/alembic/versions/c97f6ff5c0f5_expand_gender_field_to_varchar_50.py
@@ -1,0 +1,40 @@
+"""expand gender field to varchar 50
+
+Revision ID: c97f6ff5c0f5
+Revises: e66f8043bc60
+Create Date: 2026-01-03 21:54:12.612086
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c97f6ff5c0f5'
+down_revision: str | Sequence[str] | None = 'e66f8043bc60'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Expand gender field from VARCHAR(1) to VARCHAR(50) for free-form input."""
+    op.alter_column(
+        "users",
+        "gender",
+        type_=sa.String(50),
+        existing_type=sa.String(1),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    """Revert gender field back to VARCHAR(1)."""
+    op.alter_column(
+        "users",
+        "gender",
+        type_=sa.String(1),
+        existing_type=sa.String(50),
+        existing_nullable=False,
+    )

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -39,7 +39,7 @@ class UserBase(SQLModel):
 
     # Avatar
     avatar: str = Field(default="", max_length=255)
-    gender: str = Field(default="", max_length=1)
+    gender: str = Field(default="", max_length=50)
 
     # Public stats
     posts: int = Field(default=0)

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -53,7 +53,7 @@ class UserUpdate(BaseModel):
     sorting_pref_order: str | None = None  # ASC or DESC
     images_per_page: int | None = None  # 1-100
 
-    @field_validator("location", "website", "interests", "user_title")
+    @field_validator("location", "website", "interests", "user_title", "gender")
     @classmethod
     def sanitize_text_fields(cls, v: str | None) -> str | None:
         """
@@ -68,10 +68,10 @@ class UserUpdate(BaseModel):
 
     @field_validator("gender")
     @classmethod
-    def validate_gender(cls, v: str | None) -> str | None:
-        """Validate gender is one of the allowed values"""
-        if v is not None and v not in ["", "M", "F", "O"]:
-            raise ValueError("Gender must be 'M', 'F', 'O', or empty")
+    def validate_gender_length(cls, v: str | None) -> str | None:
+        """Validate gender is within max length (50 chars)."""
+        if v is not None and len(v) > 50:
+            raise ValueError("Gender must be 50 characters or less")
         return v
 
     @field_validator("email_pm_pref", "show_all_images", "spoiler_warning_pref", "thumb_layout")


### PR DESCRIPTION
## Summary
- Replace enum restriction (M/F/O) with free-form text input up to 50 characters
- Allows users to self-describe their gender identity
- Includes database migration to expand column from VARCHAR(1) to VARCHAR(50)

## Test plan
- [x] Tests pass for free-form gender values (e.g., "Non-binary", "Prefer not to say")
- [x] Empty string still accepted
- [x] Max length validation at 50 characters
- [x] All 66 existing user tests pass
- [ ] Run `alembic upgrade head` in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)