### PR TITLE
feat: optimize thumbnails with WebP, sRGB conversion, and sharpening

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1109,7 +1109,7 @@ async def upload_image(
 
         # Add to IQDB index AFTER thumbnail is created
         # Use defer to ensure thumbnail completes first (simple approach)
-        thumb_path = FilePath(settings.STORAGE_PATH) / "thumbs" / f"{date_prefix}-{image_id}.jpeg"
+        thumb_path = FilePath(settings.STORAGE_PATH) / "thumbs" / f"{date_prefix}-{image_id}.webp"
         await enqueue_job(
             "add_to_iqdb_job",
             image_id=image_id,

--- a/app/api/v1/media.py
+++ b/app/api/v1/media.py
@@ -89,7 +89,7 @@ async def serve_thumbnail(
     """
     Serve thumbnail with permission check.
     Returns X-Accel-Redirect header for nginx to serve the actual file.
-    Note: Thumbnails are always JPEG format.
+    Note: Thumbnails are always WebP format.
     """
     return await _serve_image(filename, "thumbs", db, current_user)
 
@@ -145,9 +145,9 @@ async def _serve_image(
     if image_type == "large" and not image.large:
         raise HTTPException(status_code=404)
 
-    # Use database extension for fullsize/medium/large, always jpeg for thumbnails
+    # Use database extension for fullsize/medium/large, always webp for thumbnails
     if image_type == "thumbs":
-        ext = "jpeg"
+        ext = "webp"
     else:
         ext = image.ext
 

--- a/app/config.py
+++ b/app/config.py
@@ -77,11 +77,11 @@ class Settings(BaseSettings):
 
     # Image Processing
     MAX_IMAGE_SIZE: int = 32 * 1024 * 1024  # 32MB
-    MAX_THUMB_WIDTH: int = 250
-    MAX_THUMB_HEIGHT: int = 200
+    MAX_THUMB_WIDTH: int = 500  # Thumbnail longest edge (WebP format)
+    MAX_THUMB_HEIGHT: int = 500
     MEDIUM_EDGE: int = 1280
     LARGE_EDGE: int = 2048
-    THUMBNAIL_QUALITY: int = 80
+    THUMBNAIL_QUALITY: int = 75  # WebP quality (75 is sweet spot for thumbnails)
     LARGE_QUALITY: int = 90
 
     # Avatar Settings

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -101,7 +101,7 @@ class ImageResponse(ImageBase):
     @property
     def thumbnail_url(self) -> str:
         """Generate thumbnail URL (protected path with permission check)"""
-        return f"{settings.IMAGE_BASE_URL}/thumbs/{self.filename}.jpeg"
+        return f"{settings.IMAGE_BASE_URL}/thumbs/{self.filename}.webp"
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/app/services/image_processing.py
+++ b/app/services/image_processing.py
@@ -243,7 +243,11 @@ def _convert_to_srgb(img: Image.Image) -> Image.Image:
         icc_profile = img.info.get("icc_profile")
         if icc_profile:
             input_profile = ImageCms.ImageCmsProfile(ImageCms.getOpenProfile(icc_profile))
-            img = ImageCms.profileToProfile(img, input_profile, _srgb_profile, outputMode="RGB")  # type: ignore[assignment]
+            # Preserve grayscale mode; only force RGB for non-grayscale images
+            if img.mode == "L":
+                img = ImageCms.profileToProfile(img, input_profile, _srgb_profile)  # type: ignore[assignment]
+            else:
+                img = ImageCms.profileToProfile(img, input_profile, _srgb_profile, outputMode="RGB")  # type: ignore[assignment]
     except (PyCMSError, OSError, TypeError):
         # If color profile conversion fails, just ensure RGB mode
         if img.mode not in ("RGB", "L"):

--- a/app/services/image_processing.py
+++ b/app/services/image_processing.py
@@ -8,7 +8,8 @@ from datetime import datetime
 from pathlib import Path as FilePath
 
 from fastapi import HTTPException, UploadFile, status
-from PIL import Image
+from PIL import Image, ImageCms, ImageFilter
+from PIL.ImageCms import PyCMSError
 from sqlalchemy import update
 
 from app.config import settings
@@ -16,6 +17,9 @@ from app.core.database import get_async_session
 from app.core.logging import bind_context, get_logger
 
 logger = get_logger(__name__)
+
+# Load sRGB profile for color space conversion
+_srgb_profile = ImageCms.createProfile("sRGB")
 
 
 async def _update_image_variant_field(image_id: int, field: str, value: int) -> None:
@@ -92,6 +96,9 @@ def _create_variant(
         with Image.open(source_path) as img:
             original_size = img.size
 
+            # Convert to sRGB for consistent web display
+            img = _convert_to_srgb(img)
+
             # Convert RGBA to RGB for JPEG compatibility
             if img.mode in ("RGBA", "LA") and ext.lower() in ("jpg", "jpeg"):
                 background = Image.new("RGB", img.size, (255, 255, 255))
@@ -112,7 +119,7 @@ def _create_variant(
             elif ext.lower() == "webp":
                 save_kwargs["quality"] = settings.LARGE_QUALITY
 
-            img.save(variant_path, **save_kwargs)
+            img.save(variant_path, **save_kwargs)  # type: ignore[arg-type]
 
             # Check file sizes - delete variant if it's not smaller than original
             original_file_size = source_path.stat().st_size
@@ -223,13 +230,36 @@ def validate_image_file(
         ) from e
 
 
+def _convert_to_srgb(img: Image.Image) -> Image.Image:
+    """Convert image to sRGB color space if it has an embedded ICC profile.
+
+    Args:
+        img: PIL Image object
+
+    Returns:
+        Image converted to sRGB, or original if no profile/conversion fails
+    """
+    try:
+        icc_profile = img.info.get("icc_profile")
+        if icc_profile:
+            input_profile = ImageCms.ImageCmsProfile(ImageCms.getOpenProfile(icc_profile))
+            img = ImageCms.profileToProfile(img, input_profile, _srgb_profile, outputMode="RGB")  # type: ignore[assignment]
+    except (PyCMSError, OSError, TypeError):
+        # If color profile conversion fails, just ensure RGB mode
+        if img.mode not in ("RGB", "L"):
+            img = img.convert("RGB")
+    return img
+
+
 def create_thumbnail(source_path: FilePath, image_id: int, ext: str, storage_path: str) -> None:
     """Create thumbnail for uploaded image (ARQ task).
 
     Called by create_thumbnail_job in app/tasks/image_jobs.py.
-    Generates thumbnail using settings from config:
-    - MAX_THUMB_WIDTH and MAX_THUMB_HEIGHT define max dimensions
-    - THUMBNAIL_QUALITY defines JPEG/WebP compression quality
+    Generates WebP thumbnail optimized for modern web display:
+    - MAX_THUMB_WIDTH/MAX_THUMB_HEIGHT define max dimensions (500px recommended)
+    - THUMBNAIL_QUALITY defines WebP compression quality (75 recommended)
+    - Converts to sRGB for consistent color display
+    - Applies gentle sharpening to restore detail after downscaling
     - Maintains aspect ratio
     """
     # Bind context for this ARQ task
@@ -242,19 +272,24 @@ def create_thumbnail(source_path: FilePath, image_id: int, ext: str, storage_pat
         thumbs_dir = FilePath(storage_path) / "thumbs"
         thumbs_dir.mkdir(parents=True, exist_ok=True)
 
-        # Generate thumbnail filename (we always store thumbnails as JPEG)
+        # Generate thumbnail filename (WebP format for better compression)
         # Extract date prefix from source filename (assumes format: {date_prefix}-{image_id}.{ext})
-        # Split from right to get everything before the image_id
         date_prefix = source_path.stem.rsplit("-", 1)[0]
-        thumb_filename = f"{date_prefix}-{image_id}.jpeg"
+        thumb_filename = f"{date_prefix}-{image_id}.webp"
         thumb_path = thumbs_dir / thumb_filename
 
         # Open image and create thumbnail
         with Image.open(source_path) as img:
             original_size = img.size
 
-            # Ensure image is RGB for JPEG output
-            if img.mode not in ("RGB", "L"):
+            # Convert to sRGB for consistent web display
+            img = _convert_to_srgb(img)
+
+            # Ensure image is RGB (handle grayscale, palette, RGBA)
+            if img.mode == "RGBA":
+                # Preserve alpha for WebP (it supports transparency)
+                pass
+            elif img.mode not in ("RGB", "L"):
                 img = img.convert("RGB")
 
             # Calculate thumbnail size maintaining aspect ratio
@@ -263,13 +298,20 @@ def create_thumbnail(source_path: FilePath, image_id: int, ext: str, storage_pat
                 Image.Resampling.LANCZOS,  # High-quality downsampling
             )
 
-            # Save thumbnail with quality setting
-            save_kwargs = {}
-            # Save thumbnail as JPEG regardless of original extension
-            save_kwargs["quality"] = settings.THUMBNAIL_QUALITY
-            save_kwargs["optimize"] = True
+            # Apply subtle sharpening to restore detail lost during downscaling
+            # UnsharpMask(radius, percent, threshold)
+            # - radius: blur radius (1.0 is subtle)
+            # - percent: strength (50 = gentle)
+            # - threshold: minimum brightness change to sharpen (3 avoids noise)
+            img = img.filter(ImageFilter.UnsharpMask(radius=1.0, percent=50, threshold=3))
 
-            img.save(thumb_path, format="JPEG", **save_kwargs)
+            # Save thumbnail as WebP with quality setting
+            img.save(
+                thumb_path,
+                format="WEBP",
+                quality=settings.THUMBNAIL_QUALITY,
+                method=4,  # Compression method 0-6 (4 is good balance of speed/size)
+            )
 
             logger.info(
                 "thumbnail_generated",

--- a/scripts/generate_thumbnails.py
+++ b/scripts/generate_thumbnails.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""
+Generate thumbnails for existing images in the database.
+
+Optimized for processing large volumes (1M+ images) with:
+- Multiprocessing for parallel thumbnail generation
+- Streaming database fetches to minimize memory usage
+- Progress tracking with ETA
+- Resumable via --missing-only flag
+
+Usage:
+    # Generate thumbnails for specific image IDs
+    uv run python scripts/generate_thumbnails.py 123 456 789
+
+    # Generate thumbnails for all images (uses all CPU cores)
+    uv run python scripts/generate_thumbnails.py --all
+
+    # Control parallelism (default: number of CPU cores)
+    uv run python scripts/generate_thumbnails.py --all --workers 8
+
+    # Only process images missing thumbnails (resumable)
+    uv run python scripts/generate_thumbnails.py --all --missing-only
+
+    # Dry run to see what would be done
+    uv run python scripts/generate_thumbnails.py --all --dry-run
+
+    # Run in background and log output to file
+    nohup uv run python scripts/generate_thumbnails.py --all --missing-only --workers 6 > thumb_gen.log 2>&1 &
+
+    # Monitor progress
+    tail -f thumb_gen.log | grep "Progress:"
+
+    # Stop gracefully (allows current work to finish)
+    pkill -TERM -f "generate_thumbnails.py"
+"""
+
+import argparse
+import multiprocessing
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Iterator
+
+# Add parent directory to path so we can import app modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def get_source_path(filename: str, ext: str, storage_path: str) -> Path:
+    """Construct the fullsize image path from image metadata."""
+    return Path(storage_path) / "fullsize" / f"{filename}.{ext}"
+
+
+def get_thumbnail_path(filename: str, storage_path: str) -> Path:
+    """Construct the thumbnail path from image metadata."""
+    return Path(storage_path) / "thumbs" / f"{filename}.webp"
+
+
+def process_thumbnail_worker(args: tuple[int, str, str, str, bool, bool]) -> tuple[int, bool, str]:
+    """Worker function for multiprocessing.
+
+    Args:
+        args: Tuple of (image_id, filename, ext, storage_path, dry_run, missing_only)
+
+    Returns:
+        Tuple of (image_id, success, message)
+    """
+    image_id, filename, ext, storage_path, dry_run, missing_only = args
+
+    source_path = get_source_path(filename, ext, storage_path)
+    thumb_path = get_thumbnail_path(filename, storage_path)
+
+    # Check if source exists
+    if not source_path.exists():
+        return image_id, False, f"Source not found: {source_path}"
+
+    # Check if thumbnail already exists
+    if missing_only and thumb_path.exists():
+        return image_id, True, "skipped"
+
+    if dry_run:
+        return image_id, True, "would create"
+
+    # Generate the thumbnail - import here to avoid issues with multiprocessing
+    try:
+        from app.services.image_processing import create_thumbnail
+
+        create_thumbnail(
+            source_path=source_path,
+            image_id=image_id,
+            ext=ext,
+            storage_path=storage_path,
+        )
+
+        # Verify thumbnail was created
+        if thumb_path.exists():
+            size = thumb_path.stat().st_size
+            return image_id, True, f"created ({size:,} bytes)"
+        else:
+            return image_id, False, "creation failed"
+
+    except Exception as e:
+        return image_id, False, f"error: {e}"
+
+
+def get_images_streaming(
+    image_ids: list[int] | None = None,
+    all_images: bool = False,
+    batch_size: int = 10000,
+) -> Iterator[tuple[int, str, str]]:
+    """Stream images from database in batches to minimize memory usage.
+
+    Yields:
+        Tuples of (image_id, filename, ext)
+    """
+    # Import here to avoid issues at module load time
+    import asyncio
+
+    from sqlalchemy import select, func
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.config import settings
+    from app.models import Images
+
+    async def _fetch_images() -> list[tuple[int, str, str]]:
+        engine = create_async_engine(settings.DATABASE_URL, echo=False)
+
+        async with engine.connect() as conn:
+            if image_ids:
+                # Fetch specific images
+                result = await conn.execute(
+                    select(Images.image_id, Images.filename, Images.ext)  # type: ignore[call-overload]
+                    .where(Images.image_id.in_(image_ids))  # type: ignore[union-attr]
+                    .order_by(Images.image_id)
+                )
+                return [(r[0], r[1], r[2]) for r in result.fetchall()]
+
+            elif all_images:
+                # Stream all images in batches using keyset pagination (newest first)
+                all_results: list[tuple[int, str, str]] = []
+                last_id = 2**31  # Start high, work backwards
+
+                while True:
+                    result = await conn.execute(
+                        select(Images.image_id, Images.filename, Images.ext)  # type: ignore[call-overload]
+                        .where(Images.status == 1)  # type: ignore[arg-type]
+                        .where(Images.image_id < last_id)  # type: ignore[arg-type,operator]
+                        .order_by(Images.image_id.desc())  # type: ignore[union-attr]
+                        .limit(batch_size)
+                    )
+                    batch = result.fetchall()
+
+                    if not batch:
+                        break
+
+                    for row in batch:
+                        all_results.append((row[0], row[1], row[2]))
+
+                    last_id = batch[-1][0]
+
+                return all_results
+
+        return []
+
+    # Run async function and yield results
+    results = asyncio.run(_fetch_images())
+    yield from results
+
+
+def get_image_count(all_images: bool = False, image_ids: list[int] | None = None) -> int:
+    """Get total count of images to process."""
+    if image_ids:
+        return len(image_ids)
+
+    import asyncio
+
+    from sqlalchemy import select, func
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.config import settings
+    from app.models import Images
+
+    async def _count() -> int:
+        engine = create_async_engine(settings.DATABASE_URL, echo=False)
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                select(func.count()).select_from(Images).where(Images.status == 1)  # type: ignore[arg-type]
+            )
+            return result.scalar() or 0
+
+    return asyncio.run(_count())
+
+
+def format_time(seconds: float) -> str:
+    """Format seconds into human-readable time."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    elif seconds < 3600:
+        return f"{seconds / 60:.1f}m"
+    else:
+        return f"{seconds / 3600:.1f}h"
+
+
+def generate_thumbnails(
+    image_ids: list[int] | None = None,
+    all_images: bool = False,
+    dry_run: bool = False,
+    missing_only: bool = False,
+    workers: int | None = None,
+) -> None:
+    """Main function to generate thumbnails with parallel processing."""
+
+    from app.config import settings
+
+    # Determine worker count
+    if workers is None:
+        workers = os.cpu_count() or 4
+
+    print("=" * 80)
+    print("Thumbnail Generation Script (Parallel)")
+    print("=" * 80)
+    print(f"Storage Path: {settings.STORAGE_PATH}")
+    print(f"Workers: {workers}")
+    print(f"Dry Run: {dry_run}")
+    print(f"Missing Only: {missing_only}")
+    print("=" * 80)
+
+    # Get total count first
+    print("\nCounting images...")
+    total_images = get_image_count(all_images=all_images, image_ids=image_ids)
+    print(f"Found {total_images:,} images to process")
+
+    if total_images == 0:
+        print("No images to process. Exiting.")
+        return
+
+    if dry_run:
+        print("\n[DRY RUN MODE - No changes will be made]\n")
+
+    # Prepare work items
+    print("\nFetching image metadata...")
+    work_items = [
+        (image_id, filename, ext, settings.STORAGE_PATH, dry_run, missing_only)
+        for image_id, filename, ext in get_images_streaming(
+            image_ids=image_ids, all_images=all_images
+        )
+    ]
+
+    print(f"Loaded {len(work_items):,} work items")
+    print("\nProcessing images...")
+    print("-" * 80)
+
+    success_count = 0
+    error_count = 0
+    skipped_count = 0
+    processed = 0
+    start_time = time.time()
+    last_report_time = start_time
+
+    # Process with multiprocessing pool using imap for memory efficiency
+    # imap processes items lazily instead of submitting all 1M+ at once
+    with multiprocessing.Pool(processes=workers) as pool:
+        # Use imap_unordered for better performance (order doesn't matter)
+        for image_id, success, message in pool.imap_unordered(
+            process_thumbnail_worker, work_items, chunksize=100
+        ):
+            processed += 1
+
+            if success:
+                if "skipped" in message:
+                    skipped_count += 1
+                else:
+                    success_count += 1
+            else:
+                error_count += 1
+                print(f"  ERROR Image {image_id}: {message}", flush=True)
+
+            # Progress report every 5 seconds
+            current_time = time.time()
+            if current_time - last_report_time >= 5:
+                elapsed = current_time - start_time
+                rate = processed / elapsed if elapsed > 0 else 0
+                remaining = (total_images - processed) / rate if rate > 0 else 0
+                pct = processed / total_images * 100
+
+                print(
+                    f"Progress: {processed:,}/{total_images:,} ({pct:.1f}%) | "
+                    f"Rate: {rate:.1f}/s | "
+                    f"ETA: {format_time(remaining)} | "
+                    f"OK: {success_count:,} Skip: {skipped_count:,} Err: {error_count:,}",
+                    flush=True,
+                )
+                last_report_time = current_time
+
+    # Final summary
+    elapsed = time.time() - start_time
+    rate = processed / elapsed if elapsed > 0 else 0
+
+    print("-" * 80)
+    print("\n" + "=" * 80)
+    print("SUMMARY")
+    print("=" * 80)
+    print(f"Total images processed: {total_images:,}")
+    print(f"Successfully generated: {success_count:,}")
+    print(f"Skipped (already exist): {skipped_count:,}")
+    print(f"Errors:                 {error_count:,}")
+    print(f"Time elapsed:           {format_time(elapsed)}")
+    print(f"Average rate:           {rate:.1f} images/sec")
+
+    if dry_run:
+        print("\n[DRY RUN - no changes were made]")
+    else:
+        print("\nThumbnail generation complete!")
+
+    print("=" * 80)
+
+    # Exit with error code if there were errors
+    if error_count > 0:
+        sys.exit(1)
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Generate thumbnails for existing images in the database",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Generate thumbnails for specific images
+  uv run python scripts/generate_thumbnails.py 123 456 789
+
+  # Generate thumbnails for all images (uses all CPU cores)
+  uv run python scripts/generate_thumbnails.py --all
+
+  # Control parallelism
+  uv run python scripts/generate_thumbnails.py --all --workers 8
+
+  # Generate thumbnails only for images missing them (resumable)
+  uv run python scripts/generate_thumbnails.py --all --missing-only
+
+  # Dry run to see what would be done
+  uv run python scripts/generate_thumbnails.py --all --dry-run
+        """,
+    )
+
+    parser.add_argument(
+        "image_ids",
+        nargs="*",
+        type=int,
+        help="Specific image IDs to generate thumbnails for",
+    )
+
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_images",
+        help="Generate thumbnails for all active images in the database",
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes",
+    )
+
+    parser.add_argument(
+        "--missing-only",
+        action="store_true",
+        help="Only generate thumbnails for images that don't have one",
+    )
+
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=None,
+        help=f"Number of parallel workers (default: {os.cpu_count() or 4} CPU cores)",
+    )
+
+    args = parser.parse_args()
+
+    # Validate arguments
+    if not args.image_ids and not args.all_images:
+        parser.error("Must specify either image IDs or --all flag")
+
+    if args.image_ids and args.all_images:
+        parser.error("Cannot specify both image IDs and --all flag")
+
+    try:
+        generate_thumbnails(
+            image_ids=args.image_ids if args.image_ids else None,
+            all_images=args.all_images,
+            dry_run=args.dry_run,
+            missing_only=args.missing_only,
+            workers=args.workers,
+        )
+    except KeyboardInterrupt:
+        print("\n\nInterrupted by user. Exiting...")
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    # Required for multiprocessing on some platforms
+    multiprocessing.freeze_support()
+    main()

--- a/tests/api/v1/test_media.py
+++ b/tests/api/v1/test_media.py
@@ -228,11 +228,11 @@ class TestServeThumbnailEndpoint:
         self, client: AsyncClient, public_image: Images
     ):
         """Thumbnail endpoint returns X-Accel-Redirect with /internal/thumbs/ path."""
-        response = await client.get(f"/thumbs/2026-01-02-{public_image.image_id}.jpeg")
+        response = await client.get(f"/thumbs/2026-01-02-{public_image.image_id}.webp")
         assert response.status_code == 200
         assert "X-Accel-Redirect" in response.headers
         assert (
-            f"/internal/thumbs/{public_image.filename}.jpeg" in response.headers["X-Accel-Redirect"]
+            f"/internal/thumbs/{public_image.filename}.webp" in response.headers["X-Accel-Redirect"]
         )
 
 


### PR DESCRIPTION
## Summary

- Switch thumbnails from JPEG to WebP format (25-35% smaller files)
- Increase thumbnail size from 250px to 500px longest edge for better quality
- Add sRGB color space conversion for consistent color display across devices
- Apply subtle unsharp mask sharpening to restore detail lost during downscaling
- Add sRGB conversion to medium/large variant generation
- Add `scripts/generate_thumbnails.py` for bulk thumbnail regeneration with multiprocessing

## Test plan

- [x] Upload new image and verify thumbnail is WebP format
- [x] Verify thumbnail displays correctly in browser
- [x] Test `scripts/generate_thumbnails.py --dry-run` on a few images
- [x] Verify nginx serves WebP thumbnails with correct Content-Type
- [x] Check that protected thumbnails still require authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)