### PR TITLE
feat: add DELETE /images/{image_id} endpoint for permanent image deletion

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -529,8 +529,9 @@ async def delete_image(
                 "image_file_delete_failed", image_id=image_id, path=str(file_path), error=str(e)
             )
 
-    # Delete database record (CASCADE will remove tag_links, favorites, ratings, etc.)
-    await db.delete(image)
+    # Delete database record using raw SQL to let database handle CASCADE
+    # (ORM delete tries to manage relationships in Python, causing issues with composite PKs)
+    await db.execute(delete(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
     await db.commit()
 
     logger.info(

--- a/app/config.py
+++ b/app/config.py
@@ -220,6 +220,7 @@ class AdminActionType:
     REVIEW_EXTEND = 6
     IMAGE_STATUS_CHANGE = 7
     COMMENT_DELETE = 8
+    IMAGE_DELETE = 9
 
 
 class TagType:

--- a/app/core/permissions.py
+++ b/app/core/permissions.py
@@ -90,7 +90,7 @@ _PERMISSION_DESCRIPTIONS: dict["Permission", str] = {
     Permission.TAG_DELETE: "Delete tags",
     # Image management
     Permission.IMAGE_EDIT_META: "Edit image metadata",
-    Permission.IMAGE_EDIT: "Deactivate or delete images",
+    Permission.IMAGE_EDIT: "Deactivate images (soft delete, reversible)",
     Permission.IMAGE_DELETE: "Permanently delete images from database and disk",
     Permission.IMAGE_MARK_REPOST: "Mark images as reposts",
     Permission.IMAGE_TAG_ADD: "Add tags to images",

--- a/app/core/permissions.py
+++ b/app/core/permissions.py
@@ -47,6 +47,7 @@ class Permission(str, Enum):
     # Image management
     IMAGE_EDIT_META = "image_edit_meta"
     IMAGE_EDIT = "image_edit"
+    IMAGE_DELETE = "image_delete"
     IMAGE_MARK_REPOST = "image_mark_repost"
     IMAGE_TAG_ADD = "image_tag_add"
     IMAGE_TAG_REMOVE = "image_tag_remove"
@@ -90,6 +91,7 @@ _PERMISSION_DESCRIPTIONS: dict["Permission", str] = {
     # Image management
     Permission.IMAGE_EDIT_META: "Edit image metadata",
     Permission.IMAGE_EDIT: "Deactivate or delete images",
+    Permission.IMAGE_DELETE: "Permanently delete images from database and disk",
     Permission.IMAGE_MARK_REPOST: "Mark images as reposts",
     Permission.IMAGE_TAG_ADD: "Add tags to images",
     Permission.IMAGE_TAG_REMOVE: "Remove tags from images",

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -355,7 +355,7 @@ class TestPermissionEnum:
     def test_permission_has_description(self):
         """Each permission should have a human-readable description."""
         assert Permission.TAG_CREATE.description == "Create new tags"
-        assert Permission.IMAGE_EDIT.description == "Deactivate or delete images"
+        assert Permission.IMAGE_EDIT.description == "Deactivate images (soft delete, reversible)"
         assert Permission.USER_BAN.description == "Ban users and IPs"
 
     def test_all_permissions_have_descriptions(self):


### PR DESCRIPTION
## Summary

- Add `DELETE /api/v1/images/{image_id}` endpoint for permanent image deletion
- New `IMAGE_DELETE` permission required to use the endpoint
- Logs deletion to `admin_actions` table with reason and metadata for audit trail
- Removes image from IQDB similarity index
- Deletes all files from disk (fullsize, thumbnails, medium, large variants)
- Database CASCADE handles related records (tags, favorites, ratings, comments, reports)

## Changes

- `app/api/v1/images.py` - DELETE endpoint with permission check
- `app/core/permissions.py` - New `IMAGE_DELETE` permission
- `app/config.py` - New `AdminActionType.IMAGE_DELETE = 9`
- `app/services/iqdb.py` - New `remove_from_iqdb()` function
- `alembic/versions/79e1a49d9e90_update_perms.py` - Fix migration to properly grant permission and clean up deprecated perms

## Test plan

- [x] Verify 403 returned without IMAGE_DELETE permission
- [x] Verify 422 returned without reason parameter
- [x] Verify successful deletion removes files and database record
- [x] Verify admin_actions audit log is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)