### PR TITLE
feat: bookmark navigation support

### DIFF
--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -232,3 +232,18 @@ class ImageStatsResponse(BaseModel):
     total_images: int
     total_favorites: int
     average_rating: float
+
+
+class BookmarkPageResponse(BaseModel):
+    """Schema for bookmark page calculation response.
+
+    Returns the page number where the user's bookmark appears based on
+    their sort preferences and visibility settings.
+    """
+
+    page: int | None = Field(
+        description="Page number (1-indexed) where bookmark appears, "
+        "or null if bookmark is not visible under user's settings"
+    )
+    image_id: int = Field(description="The bookmarked image ID")
+    images_per_page: int = Field(description="User's images_per_page setting")

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -53,6 +53,9 @@ class UserUpdate(BaseModel):
     sorting_pref_order: str | None = None  # ASC or DESC
     images_per_page: int | None = None  # 1-100
 
+    # Navigation
+    bookmark: int | None = None  # Bookmarked image_id
+
     @field_validator("location", "website", "interests", "user_title", "gender")
     @classmethod
     def sanitize_text_fields(cls, v: str | None) -> str | None:
@@ -194,6 +197,9 @@ class UserPrivateResponse(UserResponse):
     sorting_pref: str  # ImageSortBy enum value (e.g., "image_id", "favorites")
     sorting_pref_order: str  # "ASC" or "DESC"
     images_per_page: int  # 1-100
+
+    # Navigation
+    bookmark: int | None  # Bookmarked image_id (for "continue where I left off")
 
     @field_validator("email_verified", mode="before")
     @classmethod

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -119,6 +119,14 @@ class UserUpdate(BaseModel):
             raise ValueError("images_per_page must be between 1 and 100")
         return v
 
+    @field_validator("bookmark")
+    @classmethod
+    def validate_bookmark(cls, v: int | None) -> int | None:
+        """Validate bookmark is a positive integer when set"""
+        if v is not None and v < 1:
+            raise ValueError("bookmark must be a positive integer")
+        return v
+
     @field_validator("timezone")
     @classmethod
     def validate_timezone(cls, v: str | None) -> str | None:

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -2164,9 +2164,10 @@ class TestBookmarkPage:
 
         assert data["image_id"] == images[10].image_id
         assert data["images_per_page"] == 10
-        # images[10] is 15th from end (24,23,22,21,20,19,18,17,16,15,[14],...)
-        # In DESC order: position = 14 (0-indexed)
-        # Page = ceil((14+1)/10) = ceil(1.5) = 2
+        # Array has 25 images: images[0]..images[24], where higher index = higher image_id
+        # When sorted DESC by image_id: images[24] is position 0, images[23] is position 1, etc.
+        # images[10] is at position 14 (because 24 - 10 = 14)
+        # Page = ceil((14 + 1) / 10) = ceil(1.5) = 2
         assert data["page"] == 2
 
     async def test_bookmark_not_visible_returns_null_page(


### PR DESCRIPTION
## Summary
- Expose `bookmark` field in `UserPrivateResponse` (GET/PATCH /users/me)
- Add `bookmark` to `UserUpdate` schema to allow setting via API
- Add `GET /api/v1/images/bookmark/page` endpoint

## Bookmark Page Endpoint
Returns the page number where the user's bookmark appears based on their:
- `sorting_pref` and `sorting_pref_order`
- `show_all_images` setting
- `images_per_page` setting

Response:
```json
{
  "page": 42,
  "image_id": 12345,
  "images_per_page": 15
}
```

Frontend can redirect to: `/images?page=42#i12345`

## Test plan
- [ ] Verify bookmark field appears in GET /users/me response
- [ ] Verify bookmark can be set via PATCH /users/me
- [ ] Verify GET /images/bookmark/page returns correct page number
- [ ] Verify page calculation respects user's sort preferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)