### PR TITLE
feat: add GET /images/{image_id}/similar endpoint

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -59,6 +59,8 @@ from app.schemas.image import (
     ImageTagItem,
     ImageTagsResponse,
     ImageUploadResponse,
+    SimilarImageResult,
+    SimilarImagesResponse,
 )
 from app.schemas.report import ReportCreate, ReportResponse, SkippedTagsInfo, TagSuggestion
 from app.schemas.user import UserListResponse, UserResponse
@@ -700,6 +702,75 @@ async def get_image_favorites(
         per_page=pagination.per_page,
         users=[UserResponse.model_validate(user) for user in users],
     )
+
+
+@router.get("/{image_id}/similar", response_model=SimilarImagesResponse)
+async def get_similar_images(
+    image_id: int,
+    threshold: Annotated[
+        float | None, Query(description="Minimum similarity score (0-100)", ge=0, le=100)
+    ] = None,
+    db: AsyncSession = Depends(get_db),
+) -> SimilarImagesResponse:
+    """
+    Find images similar to the specified image using IQDB.
+
+    Queries the IQDB similarity index using the image's thumbnail and returns
+    matching images ordered by similarity score (highest first).
+
+    The query image itself is excluded from results.
+    """
+    # Get the image to find its thumbnail path
+    result = await db.execute(
+        select(Images).where(Images.image_id == image_id)  # type: ignore[arg-type]
+    )
+    image = result.scalar_one_or_none()
+
+    if not image:
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    # Construct thumbnail path
+    thumb_path = FilePath(settings.STORAGE_PATH) / "thumbs" / f"{image.filename}.webp"
+
+    if not thumb_path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail="Image thumbnail not found - cannot perform similarity search",
+        )
+
+    # Query IQDB for similar images (threshold is 0-100 scale)
+    similar_results = await check_iqdb_similarity(thumb_path, db, threshold=threshold)
+
+    # Filter out the query image itself
+    similar_results = [r for r in similar_results if r["image_id"] != image_id]
+
+    if not similar_results:
+        return SimilarImagesResponse(query_image_id=image_id, similar_images=[])
+
+    # Get full image details for similar images
+    similar_ids = [r["image_id"] for r in similar_results]
+
+    images_result = await db.execute(
+        select(Images)
+        .options(
+            selectinload(Images.user).load_only(  # type: ignore[arg-type]
+                Users.user_id, Users.username, Users.avatar
+            )
+        )
+        .where(Images.image_id.in_(similar_ids))  # type: ignore[arg-type]
+    )
+    images = {img.image_id: img for img in images_result.scalars().all()}
+
+    # Build response with similarity scores, ordered by score descending
+    similar_images = []
+    for r in sorted(similar_results, key=lambda x: x["score"], reverse=True):
+        img = images.get(r["image_id"])
+        if img:
+            img_data = ImageResponse.model_validate(img).model_dump()
+            img_data["similarity_score"] = r["score"]
+            similar_images.append(SimilarImageResult(**img_data))
+
+    return SimilarImagesResponse(query_image_id=image_id, similar_images=similar_images)
 
 
 @router.get("/bookmark/me", response_model=ImageResponse)

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -262,3 +262,21 @@ class BookmarkPageResponse(BaseModel):
     )
     image_id: int = Field(description="The bookmarked image ID")
     images_per_page: int = Field(description="User's images_per_page setting")
+
+
+class SimilarImageResult(ImageResponse):
+    """Schema for a similar image result from IQDB.
+
+    Extends ImageResponse with similarity score.
+    """
+
+    similarity_score: float = Field(description="Similarity score from IQDB (0-100)")
+
+
+class SimilarImagesResponse(BaseModel):
+    """Schema for similar images search response."""
+
+    query_image_id: int = Field(description="The image ID that was searched")
+    similar_images: list[SimilarImageResult] = Field(
+        description="List of similar images ordered by similarity score (highest first)"
+    )

--- a/app/services/iqdb.py
+++ b/app/services/iqdb.py
@@ -59,8 +59,9 @@ async def check_iqdb_similarity(
         results = response.json()
 
         # Filter by threshold and return
+        # Note: IQDB uses "post_id" as the key for image IDs
         similar_images = [
-            {"image_id": result["image_id"], "score": result["score"]}
+            {"image_id": result["post_id"], "score": result["score"]}
             for result in results
             if result.get("score", 0) >= threshold
         ]

--- a/tests/api/v1/test_similar_images.py
+++ b/tests/api/v1/test_similar_images.py
@@ -1,0 +1,248 @@
+"""Tests for the similar images endpoint."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+class TestSimilarImages:
+    """Tests for GET /images/{image_id}/similar endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_similar_images_not_found(self, client: AsyncClient):
+        """Returns 404 for non-existent image."""
+        response = await client.get("/api/v1/images/999999999/similar")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Image not found"
+
+    @pytest.mark.asyncio
+    async def test_similar_images_no_thumbnail(
+        self, client: AsyncClient, test_image, db_session
+    ):
+        """Returns 404 if thumbnail doesn't exist."""
+        # The test_image fixture creates a DB record but no actual file
+        with patch("app.api.v1.images.FilePath.exists", return_value=False):
+            response = await client.get(f"/api/v1/images/{test_image.image_id}/similar")
+
+        assert response.status_code == 404
+        assert "thumbnail not found" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_similar_images_empty_results(
+        self, client: AsyncClient, test_image, db_session
+    ):
+        """Returns empty list when IQDB finds no similar images."""
+        with (
+            patch("app.api.v1.images.FilePath.exists", return_value=True),
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            response = await client.get(f"/api/v1/images/{test_image.image_id}/similar")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["query_image_id"] == test_image.image_id
+        assert data["similar_images"] == []
+
+    @pytest.mark.asyncio
+    async def test_similar_images_excludes_query_image(
+        self, client: AsyncClient, test_image, db_session
+    ):
+        """Query image itself is excluded from results."""
+        # IQDB returns the query image with high score
+        iqdb_response = [
+            {"image_id": test_image.image_id, "score": 98.5},
+        ]
+
+        with (
+            patch("app.api.v1.images.FilePath.exists", return_value=True),
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=iqdb_response,
+            ),
+        ):
+            response = await client.get(f"/api/v1/images/{test_image.image_id}/similar")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["similar_images"] == []
+
+    @pytest.mark.asyncio
+    async def test_similar_images_returns_matches(
+        self, client: AsyncClient, test_image, another_test_image, db_session
+    ):
+        """Returns similar images with scores when IQDB finds matches."""
+        # IQDB returns another image as similar
+        iqdb_response = [
+            {"image_id": test_image.image_id, "score": 98.5},  # Query image (excluded)
+            {"image_id": another_test_image.image_id, "score": 85.3},
+        ]
+
+        with (
+            patch("app.api.v1.images.FilePath.exists", return_value=True),
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=iqdb_response,
+            ),
+        ):
+            response = await client.get(f"/api/v1/images/{test_image.image_id}/similar")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["query_image_id"] == test_image.image_id
+        assert len(data["similar_images"]) == 1
+        assert data["similar_images"][0]["image_id"] == another_test_image.image_id
+        assert data["similar_images"][0]["similarity_score"] == 85.3
+
+    @pytest.mark.asyncio
+    async def test_similar_images_ordered_by_score(
+        self, client: AsyncClient, test_image, test_images_batch, db_session
+    ):
+        """Results are ordered by similarity score descending."""
+        # Create IQDB response with multiple images in non-sorted order
+        batch_ids = [img.image_id for img in test_images_batch[:3]]
+        iqdb_response = [
+            {"image_id": batch_ids[0], "score": 70.0},
+            {"image_id": batch_ids[1], "score": 90.0},
+            {"image_id": batch_ids[2], "score": 80.0},
+        ]
+
+        with (
+            patch("app.api.v1.images.FilePath.exists", return_value=True),
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=iqdb_response,
+            ),
+        ):
+            response = await client.get(f"/api/v1/images/{test_image.image_id}/similar")
+
+        assert response.status_code == 200
+        data = response.json()
+        scores = [img["similarity_score"] for img in data["similar_images"]]
+        assert scores == [90.0, 80.0, 70.0]
+
+    @pytest.mark.asyncio
+    async def test_similar_images_threshold_parameter(
+        self, client: AsyncClient, test_image, db_session
+    ):
+        """Threshold parameter is passed to IQDB service."""
+        with (
+            patch("app.api.v1.images.FilePath.exists", return_value=True),
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_iqdb,
+        ):
+            response = await client.get(
+                f"/api/v1/images/{test_image.image_id}/similar?threshold=75"
+            )
+
+        assert response.status_code == 200
+        mock_iqdb.assert_called_once()
+        # Check threshold was passed (third positional arg or keyword arg)
+        call_kwargs = mock_iqdb.call_args
+        assert call_kwargs.kwargs.get("threshold") == 75
+
+
+class TestIQDBService:
+    """Unit tests for the IQDB service functions."""
+
+    @pytest.mark.asyncio
+    async def test_check_iqdb_similarity_success(self, db_session):
+        """check_iqdb_similarity returns filtered results on success."""
+        from app.services.iqdb import check_iqdb_similarity
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"post_id": 123, "score": 95.0},
+            {"post_id": 456, "score": 85.0},
+            {"post_id": 789, "score": 50.0},  # Below threshold of 80
+        ]
+
+        with (
+            patch("app.services.iqdb.open", create=True),
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            # Pass explicit threshold to test filtering
+            result = await check_iqdb_similarity(
+                Path("/fake/path.jpg"), db_session, threshold=80
+            )
+
+        # Threshold is 80, so only first two should be returned
+        assert len(result) == 2
+        assert result[0]["image_id"] == 123
+        assert result[0]["score"] == 95.0
+        assert result[1]["image_id"] == 456
+
+    @pytest.mark.asyncio
+    async def test_check_iqdb_similarity_unavailable(self, db_session):
+        """Returns empty list when IQDB is unavailable."""
+        from app.services.iqdb import check_iqdb_similarity
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+
+        with (
+            patch("app.services.iqdb.open", create=True),
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            result = await check_iqdb_similarity(Path("/fake/path.jpg"), db_session)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_check_iqdb_similarity_timeout(self, db_session):
+        """Returns empty list on timeout."""
+        from app.services.iqdb import check_iqdb_similarity
+        from pathlib import Path
+        import httpx
+
+        with (
+            patch("app.services.iqdb.open", create=True),
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            result = await check_iqdb_similarity(Path("/fake/path.jpg"), db_session)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_check_iqdb_similarity_file_not_found(self, db_session):
+        """Returns empty list when image file doesn't exist."""
+        from app.services.iqdb import check_iqdb_similarity
+        from pathlib import Path
+
+        result = await check_iqdb_similarity(
+            Path("/nonexistent/path/image.jpg"), db_session
+        )
+        assert result == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -528,6 +528,61 @@ async def test_image(db_session: AsyncSession, test_user):
 
 
 @pytest.fixture
+async def another_test_image(db_session: AsyncSession, test_user):
+    """Create a second test image for tests that need multiple images."""
+    from app.models.image import Images
+
+    image = Images(
+        filename="test-image-002",
+        ext="jpg",
+        original_filename="test2.jpg",
+        md5_hash="e41d8cd98f00b204e9800998ecf8427f",
+        filesize=234567,
+        width=1280,
+        height=720,
+        caption="Second test image from fixture",
+        rating=0.0,
+        user_id=test_user.user_id,
+        status=1,
+        locked=False,
+    )
+    db_session.add(image)
+    await db_session.commit()
+    await db_session.refresh(image)
+    return image
+
+
+@pytest.fixture
+async def test_images_batch(db_session: AsyncSession, test_user):
+    """Create a batch of test images for tests that need multiple images."""
+    from app.models.image import Images
+
+    images = []
+    for i in range(5):
+        image = Images(
+            filename=f"test-batch-image-{i:03d}",
+            ext="jpg",
+            original_filename=f"batch{i}.jpg",
+            md5_hash=f"{i:032x}",  # 32-char hex string
+            filesize=100000 + i * 1000,
+            width=800,
+            height=600,
+            caption=f"Batch test image {i}",
+            rating=0.0,
+            user_id=test_user.user_id,
+            status=1,
+            locked=False,
+        )
+        db_session.add(image)
+        images.append(image)
+
+    await db_session.commit()
+    for img in images:
+        await db_session.refresh(img)
+    return images
+
+
+@pytest.fixture
 async def test_tag(db_session: AsyncSession):
     """
     Create a test tag in the database.


### PR DESCRIPTION
## Summary

Adds a new endpoint to find visually similar images using IQDB (Image Query Database).

**Endpoint:** `GET /api/v1/images/{image_id}/similar`

## Features

- Queries IQDB using the image's thumbnail
- Returns similar images with full metadata + similarity score
- Optional `threshold` parameter (0-100 scale, default from settings)
- Query image is excluded from results
- Results ordered by similarity score (highest first)

## Response Schema

```json
{
  "query_image_id": 1111520,
  "similar_images": [
    {
      "image_id": 1234567,
      "similarity_score": 95.5,
      "filename": "...",
      "url": "...",
      "thumbnail_url": "...",
      // ... all ImageResponse fields
    }
  ]
}
```

## Bug Fix

Also fixes the IQDB service to use the correct field name (`post_id` instead of `image_id`) when parsing IQDB responses.

## Test Plan

- [x] All existing image tests pass (60 passed)
- [x] Manual testing with real IQDB instance
- [x] Endpoint returns 404 for non-existent image
- [x] Endpoint returns 404 if thumbnail missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)