### PR TITLE
fix: add pool_recycle to prevent stale database connections

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -19,6 +19,7 @@ engine = create_async_engine(
     pool_size=settings.DB_POOL_SIZE,
     max_overflow=settings.DB_MAX_OVERFLOW,
     pool_pre_ping=True,  # Verify connections before using
+    pool_recycle=3600,  # Recycle connections every hour (MariaDB wait_timeout is 8 hours)
 )
 
 # Create async session factory


### PR DESCRIPTION
After extended idle periods (8+ hours), MariaDB closes inactive connections server-side via wait_timeout. The connection pool would then try to use these dead connections, causing 500 errors until fresh connections were established.

Adding pool_recycle=3600 proactively replaces connections every hour, well before MariaDB's 8-hour timeout, preventing this issue.