### PR TITLE
feat: add locked field support to image moderation endpoint

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -741,10 +741,10 @@ async def change_image_status(
         image_id=image_id,
         details={
             "previous_status": previous_status,
-            "new_status": status_data.status,
+            "new_status": image.status,
             "previous_locked": previous_locked,
             "new_locked": image.locked,
-            "replacement_id": status_data.replacement_id,
+            "replacement_id": image.replacement_id,
         },
     )
     db.add(action)

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -678,9 +678,10 @@ async def change_image_status(
     db: AsyncSession = Depends(get_db),
 ) -> ImageStatusResponse:
     """
-    Change an image's status directly.
+    Change an image's status and/or locked state.
 
     Use this for quick moderation actions without creating a report.
+    Can update status, locked, or both in a single request.
 
     Requires IMAGE_EDIT permission.
     """
@@ -694,37 +695,44 @@ async def change_image_status(
         raise HTTPException(status_code=404, detail="Image not found")
 
     previous_status = image.status
+    previous_locked = image.locked
 
-    # Handle repost status
-    if status_data.status == ImageStatus.REPOST:
-        if status_data.replacement_id is None:
-            raise HTTPException(
-                status_code=400,
-                detail="replacement_id is required when marking as repost",
+    # Handle status change if provided
+    if status_data.status is not None:
+        # Handle repost status
+        if status_data.status == ImageStatus.REPOST:
+            if status_data.replacement_id is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="replacement_id is required when marking as repost",
+                )
+            if status_data.replacement_id == image_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail="An image cannot be a repost of itself",
+                )
+            # Verify original image exists
+            original_result = await db.execute(
+                select(Images).where(Images.image_id == status_data.replacement_id)  # type: ignore[arg-type]
             )
-        if status_data.replacement_id == image_id:
-            raise HTTPException(
-                status_code=400,
-                detail="An image cannot be a repost of itself",
-            )
-        # Verify original image exists
-        original_result = await db.execute(
-            select(Images).where(Images.image_id == status_data.replacement_id)  # type: ignore[arg-type]
-        )
-        if not original_result.scalar_one_or_none():
-            raise HTTPException(
-                status_code=404,
-                detail="Original image not found",
-            )
-        image.replacement_id = status_data.replacement_id
-    else:
-        # Clear replacement_id when not a repost
-        image.replacement_id = None
+            if not original_result.scalar_one_or_none():
+                raise HTTPException(
+                    status_code=404,
+                    detail="Original image not found",
+                )
+            image.replacement_id = status_data.replacement_id
+        else:
+            # Clear replacement_id when not a repost
+            image.replacement_id = None
 
-    # Update image status
-    image.status = status_data.status
-    image.status_user_id = current_user.user_id
-    image.status_updated = datetime.now(UTC)
+        # Update image status
+        image.status = status_data.status
+        image.status_user_id = current_user.user_id
+        image.status_updated = datetime.now(UTC)
+
+    # Handle locked change if provided
+    if status_data.locked is not None:
+        image.locked = 1 if status_data.locked else 0
 
     # Log admin action
     action = AdminActions(
@@ -734,6 +742,8 @@ async def change_image_status(
         details={
             "previous_status": previous_status,
             "new_status": status_data.status,
+            "previous_locked": previous_locked,
+            "new_locked": image.locked,
             "replacement_id": status_data.replacement_id,
         },
     )

--- a/app/api/v1/comments.py
+++ b/app/api/v1/comments.py
@@ -370,6 +370,7 @@ async def create_comment(
     **Errors:**
     - 400: Empty comment text or invalid parent_comment_id
     - 401: Not authenticated
+    - 403: Comments are locked on the image
     - 404: Image or parent comment not found
     """
     # Validate image exists
@@ -379,6 +380,13 @@ async def create_comment(
     image = image_result.scalar_one_or_none()
     if not image:
         raise HTTPException(status_code=404, detail="Image not found")
+
+    # Check if image is locked
+    if image.locked:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Comments are locked on this image",
+        )
 
     # Validate parent_comment_id if provided
     if body.parent_comment_id is not None:

--- a/tests/api/v1/test_admin_images.py
+++ b/tests/api/v1/test_admin_images.py
@@ -573,6 +573,10 @@ class TestImageLocked:
         assert action.details is not None
         assert action.details.get("previous_locked") == 0
         assert action.details.get("new_locked") == 1
+        # Verify status fields are recorded even when only locked changes
+        assert action.details.get("previous_status") == ImageStatus.ACTIVE
+        assert action.details.get("new_status") == ImageStatus.ACTIVE
+        assert action.details.get("replacement_id") is None
 
     async def test_must_provide_status_or_locked(
         self, client: AsyncClient, db_session: AsyncSession


### PR DESCRIPTION
## Summary
Extend `PATCH /admin/images/{image_id}` to support locking/unlocking comments on images.

## Changes
- Add optional `locked: bool` field to `ImageStatusUpdate` schema
- Make `status` optional (require at least one of `status` or `locked`)
- Include `locked` in `ImageStatusResponse`
- Log locked changes in audit trail

## Usage
```bash
# Lock comments only
PATCH /api/v1/admin/images/{id}
{"locked": true}

# Change status and lock together
PATCH /api/v1/admin/images/{id}
{"status": 2, "locked": true}
```

## Test plan
- [x] 6 new tests for locked functionality
- [x] All 17 image admin tests pass
- [x] mypy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)