### PR TITLE
fix: required timestamps in schemas + permission updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ dump.rdb
 shuu-php/
 .worktrees/
 
-# Local project instructions (not shared)
+# Local project instructions
+AGENTS.md
 CLAUDE.md
 .github/copilot-instructions.md

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, computed_field, field_validator
 
 from app.config import TagType, settings
 from app.models.image import ImageBase
-from app.schemas.base import UTCDatetimeOptional
+from app.schemas.base import UTCDatetime
 from app.schemas.common import UserSummary
 
 # Sort order for tags in image responses: artist → source → character → theme
@@ -88,7 +88,7 @@ class ImageResponse(ImageBase):
     image_id: int
     user_id: int
     user: UserSummary | None = None  # Embedded user data (optional, loaded with selectinload)
-    date_added: UTCDatetimeOptional = None
+    date_added: UTCDatetime
     locked: int
     posts: int
     favorites: int

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -11,7 +11,7 @@ These schemas handle:
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.config import ReportCategory
-from app.schemas.base import UTCDatetimeOptional
+from app.schemas.base import UTCDatetime, UTCDatetimeOptional
 
 # ===== Tag Suggestion Schemas =====
 
@@ -94,7 +94,7 @@ class ReportResponse(BaseModel):
     reason_text: str | None
     status: int
     status_label: str | None = None
-    created_at: UTCDatetimeOptional = None
+    created_at: UTCDatetime
     reviewed_by: int | None
     reviewed_at: UTCDatetimeOptional = None
     admin_notes: str | None = None
@@ -198,7 +198,7 @@ class VoteResponse(BaseModel):
     vote: int | None
     vote_label: str | None = None
     comment: str | None
-    created_at: UTCDatetimeOptional = None
+    created_at: UTCDatetime
 
     model_config = {"from_attributes": True}
 
@@ -221,13 +221,13 @@ class ReviewResponse(BaseModel):
     initiated_by_username: str | None = None
     review_type: int
     review_type_label: str | None = None
-    deadline: UTCDatetimeOptional = None
+    deadline: UTCDatetime
     extension_used: int
     status: int
     status_label: str | None = None
     outcome: int
     outcome_label: str | None = None
-    created_at: UTCDatetimeOptional = None
+    created_at: UTCDatetime
     closed_at: UTCDatetimeOptional = None
     # Vote summary (populated by endpoint)
     vote_count: int = 0

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -130,7 +130,7 @@ class UserResponse(UserBase):
     """Schema for user response - what API returns"""
 
     user_id: int
-    date_joined: UTCDatetimeOptional = None
+    date_joined: UTCDatetime
     last_login: UTCDatetimeOptional = None
     active: bool
     admin: bool

--- a/tests/unit/test_review_system.py
+++ b/tests/unit/test_review_system.py
@@ -4,6 +4,8 @@ Unit tests for the image reporting and review system.
 Tests status constants, model defaults, and validation.
 """
 
+from datetime import datetime
+
 from app.config import (
     AdminActionType,
     ImageStatus,
@@ -173,7 +175,7 @@ class TestSchemaValidation:
             category=2,  # Inappropriate
             reason_text=None,
             status=0,  # Pending
-            created_at=None,
+            created_at=datetime(2026, 1, 1, 0, 0, 0),
             reviewed_by=None,
             reviewed_at=None,
         )
@@ -190,11 +192,11 @@ class TestSchemaValidation:
             source_report_id=None,
             initiated_by=1,
             review_type=1,  # Appropriateness
-            deadline=None,
+            deadline=datetime(2026, 1, 8, 0, 0, 0),
             extension_used=0,
             status=0,  # Open
             outcome=0,  # Pending
-            created_at=None,
+            created_at=datetime(2026, 1, 1, 0, 0, 0),
             closed_at=None,
         )
         assert response.review_type_label == "Appropriateness"
@@ -212,7 +214,7 @@ class TestSchemaValidation:
             user_id=1,
             vote=1,
             comment=None,
-            created_at=None,
+            created_at=datetime(2026, 1, 1, 0, 0, 0),
         )
         assert response.vote_label == "Keep"
 
@@ -223,6 +225,6 @@ class TestSchemaValidation:
             user_id=2,
             vote=0,
             comment=None,
-            created_at=None,
+            created_at=datetime(2026, 1, 1, 0, 0, 0),
         )
         assert response.vote_label == "Remove"

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -112,6 +112,7 @@ class TestUserSchemas:
             "posts": 0,
             "favorites": 0,
             "image_posts": 0,
+            "date_joined": datetime(2026, 1, 1, 0, 0, 0),
             "interests": None,
             "location": None,
             "website": None,
@@ -133,6 +134,7 @@ class TestUserSchemas:
             "posts": 0,
             "favorites": 0,
             "image_posts": 0,
+            "date_joined": datetime(2026, 1, 1, 0, 0, 0),
             "interests": "",
             "location": "",
             "website": "",
@@ -155,6 +157,7 @@ class TestUserSchemas:
             "posts": 0,
             "favorites": 0,
             "image_posts": 0,
+            "date_joined": datetime(2026, 1, 1, 0, 0, 0),
             "interests": "Plain text with no entities",
             "location": "Simple Location",
             "website": "https://example.com/path",
@@ -176,6 +179,7 @@ class TestUserSchemas:
             "posts": 0,
             "favorites": 0,
             "image_posts": 0,
+            "date_joined": datetime(2026, 1, 1, 0, 0, 0),
         }
         user = UserResponse(**data)
         assert user.active is True
@@ -191,6 +195,7 @@ class TestUserSchemas:
             "posts": 0,
             "favorites": 0,
             "image_posts": 0,
+            "date_joined": datetime(2026, 1, 1, 0, 0, 0),
         }
         user = UserResponse(**data)
         assert user.active is False


### PR DESCRIPTION
## Summary
- Make server-defaulted timestamps required in response schemas (gives frontend accurate TypeScript types)
- Add `tag_suggestion_apply` permission for taggers to apply tag suggestions
- Rename groups for consistency (image taggers → Taggers, admins → Admins, mods → Mods)
- Grant tagging/messaging permissions to appropriate groups
- Add AGENTS.md to gitignore

## Test Plan
- [x] All existing tests pass
- [x] Verify frontend TypeScript types no longer show timestamps as nullable

🤖 Generated with [Claude Code](https://claude.com/claude-code)