### PR TITLE
fix: prevent race condition from nuking refresh token family

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -398,13 +398,56 @@ async def refresh_token(
 
     # SECURITY: Check if token was already used (potential theft!)
     if db_token.revoked:
-        # Token reuse detected! Revoke all tokens in this family
-        await db.execute(delete(RefreshTokens).where(RefreshTokens.family_id == db_token.family_id))  # type: ignore[arg-type]
-        await db.commit()
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Refresh token reuse detected. All sessions revoked for security.",
-        )
+        # Distinguish between race condition and actual theft:
+        # - Race condition: token revoked very recently AND child token exists
+        #   (concurrent requests during page load with expired access token)
+        # - Theft: token revoked long ago OR no child token exists
+        #   (attacker using stolen token)
+        is_race_condition = False
+
+        if db_token.revoked_at:
+            # Check if revoked within last 10 seconds
+            revoked_at_utc = db_token.revoked_at.replace(tzinfo=UTC)
+            time_since_revoked = datetime.now(UTC) - revoked_at_utc
+
+            if time_since_revoked.total_seconds() < 10:
+                # Check if a child token exists (legitimate refresh happened)
+                child_result = await db.execute(
+                    select(RefreshTokens).where(RefreshTokens.parent_token_id == db_token.id)  # type: ignore[arg-type]
+                )
+                child_exists = child_result.scalar_one_or_none() is not None
+
+                if child_exists:
+                    is_race_condition = True
+                    logger.info(
+                        "refresh_race_condition_detected",
+                        token_id=db_token.id,
+                        user_id=db_token.user_id,
+                        seconds_since_revoked=time_since_revoked.total_seconds(),
+                    )
+
+        if is_race_condition:
+            # Race condition from concurrent requests - just reject, don't nuke session
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token already refreshed",
+            )
+        else:
+            # Suspicious activity - could be theft. Nuke the entire token family.
+            logger.warning(
+                "refresh_token_reuse_detected",
+                token_id=db_token.id,
+                user_id=db_token.user_id,
+                family_id=db_token.family_id,
+            )
+            await db.execute(
+                delete(RefreshTokens).where(RefreshTokens.family_id == db_token.family_id)
+            )  # type: ignore[arg-type]
+            await db.commit()
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Refresh token reuse detected. All sessions revoked for security.",
+            )
 
     # Load user
     result_user = await db.execute(select(Users).where(Users.user_id == db_token.user_id))  # type: ignore[arg-type]

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -180,6 +180,118 @@ class TestRefresh:
         response = await client.post("/api/v1/auth/refresh")
         assert response.status_code == 401
 
+    async def test_refresh_race_condition_does_not_nuke_family(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that concurrent refresh requests don't nuke the token family.
+
+        Simulates a race condition where multiple requests try to refresh
+        simultaneously: the first one succeeds and revokes the old token,
+        then subsequent requests using the old token should get 401 but
+        NOT trigger the family deletion (since it was just revoked and
+        a child token exists).
+        """
+        # Create user and login
+        user = Users(
+            username="raceuser",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="race@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+
+        # Login to get initial token
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "raceuser", "password": "TestPassword123!"},
+        )
+        assert login_response.status_code == 200
+        original_refresh_token = login_response.cookies.get("refresh_token")
+        assert original_refresh_token is not None
+
+        # First refresh succeeds - this revokes the original token
+        refresh1_response = await client.post("/api/v1/auth/refresh")
+        assert refresh1_response.status_code == 200
+
+        # Get the new refresh token
+        new_refresh_token = refresh1_response.cookies.get("refresh_token")
+        assert new_refresh_token is not None
+        assert new_refresh_token != original_refresh_token
+
+        # Simulate concurrent request using the OLD token (race condition)
+        # Manually set the old token cookie
+        client.cookies.set("refresh_token", original_refresh_token)
+        refresh2_response = await client.post("/api/v1/auth/refresh")
+
+        # Should get 401 but with "already refreshed" message (not "reuse detected")
+        assert refresh2_response.status_code == 401
+        assert "already refreshed" in refresh2_response.json()["detail"].lower()
+
+        # The new token should still work - family was NOT nuked
+        client.cookies.set("refresh_token", new_refresh_token)
+        refresh3_response = await client.post("/api/v1/auth/refresh")
+        assert refresh3_response.status_code == 200
+
+    async def test_refresh_reuse_detection_nukes_family_after_grace_period(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that reuse detection still works for actual theft scenarios.
+
+        If a revoked token is used AFTER the grace period (10 seconds),
+        it should trigger family deletion as a security measure.
+        """
+        # Create user and login
+        user = Users(
+            username="theftuser",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="theft@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+
+        # Login to get initial token
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "theftuser", "password": "TestPassword123!"},
+        )
+        assert login_response.status_code == 200
+        original_refresh_token = login_response.cookies.get("refresh_token")
+
+        # First refresh succeeds
+        refresh1_response = await client.post("/api/v1/auth/refresh")
+        assert refresh1_response.status_code == 200
+        new_refresh_token = refresh1_response.cookies.get("refresh_token")
+
+        # Simulate theft scenario: manually set revoked_at to be older than grace period
+        result = await db_session.execute(
+            select(RefreshTokens).where(RefreshTokens.user_id == user.user_id)
+        )
+        tokens = result.scalars().all()
+
+        # Find the revoked token (original one) and backdate its revoked_at
+        for token in tokens:
+            if token.revoked:
+                token.revoked_at = datetime.now(UTC) - timedelta(seconds=15)
+        await db_session.commit()
+
+        # Try to use the old token - should trigger family nuke
+        client.cookies.set("refresh_token", original_refresh_token)
+        refresh2_response = await client.post("/api/v1/auth/refresh")
+
+        assert refresh2_response.status_code == 401
+        assert "reuse detected" in refresh2_response.json()["detail"].lower()
+
+        # The new token should also be invalid now - family was nuked
+        client.cookies.set("refresh_token", new_refresh_token)
+        refresh3_response = await client.post("/api/v1/auth/refresh")
+        assert refresh3_response.status_code == 401
+
 
 @pytest.mark.api
 class TestLogout:

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -262,11 +262,13 @@ class TestRefresh:
         )
         assert login_response.status_code == 200
         original_refresh_token = login_response.cookies.get("refresh_token")
+        assert original_refresh_token is not None
 
         # First refresh succeeds
         refresh1_response = await client.post("/api/v1/auth/refresh")
         assert refresh1_response.status_code == 200
         new_refresh_token = refresh1_response.cookies.get("refresh_token")
+        assert new_refresh_token is not None
 
         # Simulate theft scenario: manually set revoked_at to be older than grace period
         result = await db_session.execute(


### PR DESCRIPTION
When multiple concurrent requests hit a 401 and try to refresh simultaneously, the first succeeds (revoking the old token) while subsequent requests using the now-revoked token would trigger reuse detection and delete the entire token family, logging the user out.

Now distinguishes between race conditions and actual theft:
- Race condition: token revoked < 10s ago AND child token exists → Returns 401 "Token already refreshed" but preserves the session
- Theft: token revoked > 10s ago OR no child token exists → Deletes family as before (security measure)