### PR TITLE
feat: add SMTP_STARTTLS config for localhost email support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,12 +50,17 @@ STORAGE_PATH=/shuushuu/images
 # S3_SECRET_KEY=your-secret-key
 
 # Email Configuration (optional)
+# Common configurations:
+#   - Port 587 + STARTTLS (default): SMTP_TLS=false, SMTP_STARTTLS=true
+#   - Port 465 + implicit TLS: SMTP_TLS=true, SMTP_STARTTLS=false
+#   - Localhost (no encryption): SMTP_TLS=false, SMTP_STARTTLS=false
+# Note: SMTP_TLS and SMTP_STARTTLS are mutually exclusive
 # SMTP_HOST=smtp.example.com
 # SMTP_PORT=587
 # SMTP_USER=your-email@example.com
 # SMTP_PASSWORD=your-email-password
-# SMTP_TLS=true                    # Use implicit TLS (port 465)
-# SMTP_STARTTLS=true               # Use STARTTLS (port 587). Set both to false for localhost
+# SMTP_TLS=false
+# SMTP_STARTTLS=true
 # SMTP_FROM_EMAIL=noreply@e-shuushuu.net
 # SMTP_FROM_NAME=Shuushuu
 

--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,10 @@ STORAGE_PATH=/shuushuu/images
 # SMTP_PORT=587
 # SMTP_USER=your-email@example.com
 # SMTP_PASSWORD=your-email-password
+# SMTP_TLS=true                    # Use implicit TLS (port 465)
+# SMTP_STARTTLS=true               # Use STARTTLS (port 587). Set both to false for localhost
 # SMTP_FROM_EMAIL=noreply@e-shuushuu.net
+# SMTP_FROM_NAME=Shuushuu
 
 # Frontend URL (for email verification links, etc.)
 FRONTEND_URL=https://test.shuushuu.com

--- a/app/config.py
+++ b/app/config.py
@@ -113,7 +113,8 @@ class Settings(BaseSettings):
     SMTP_PORT: int = Field(default=587, description="SMTP server port")
     SMTP_USER: str = Field(default="user", description="SMTP username")
     SMTP_PASSWORD: str = Field(default="password", description="SMTP password")
-    SMTP_TLS: bool = Field(default=True, description="Use TLS for SMTP")
+    SMTP_TLS: bool = Field(default=True, description="Use implicit TLS (port 465)")
+    SMTP_STARTTLS: bool = Field(default=True, description="Use STARTTLS (port 587)")
     SMTP_FROM_EMAIL: str = Field(default="noreply@e-shuushuu.net", description="From email address")
     SMTP_FROM_NAME: str = Field(default="Shuushuu", description="From name")
 

--- a/app/services/email.py
+++ b/app/services/email.py
@@ -60,9 +60,10 @@ async def send_email(
                 message,
                 hostname=settings.SMTP_HOST,
                 port=settings.SMTP_PORT,
-                username=settings.SMTP_USER,
-                password=settings.SMTP_PASSWORD,
+                username=settings.SMTP_USER or None,
+                password=settings.SMTP_PASSWORD or None,
                 use_tls=settings.SMTP_TLS,
+                start_tls=settings.SMTP_STARTTLS,
                 timeout=30,
             )
             logger.info(

--- a/tests/unit/test_email_retry.py
+++ b/tests/unit/test_email_retry.py
@@ -1,6 +1,6 @@
 """Tests for email service retry logic and SMTP configuration."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from aiosmtplib.errors import (
@@ -270,7 +270,8 @@ class TestSmtpConfigValidation:
                 SMTP_STARTTLS=True,
             )
 
-        assert "mutually exclusive" in str(exc_info.value).lower()
+        errors = exc_info.value.errors()
+        assert any("mutually exclusive" in err.get("msg", "").lower() for err in errors)
 
     def test_smtp_tls_only_valid(self):
         """Test that SMTP_TLS=True with SMTP_STARTTLS=False is valid."""


### PR DESCRIPTION
## Summary

- Add separate `SMTP_STARTTLS` setting to control STARTTLS behavior independently from implicit TLS
- Enables using local Postfix on port 25 without TLS/STARTTLS for self-hosted email sending
- Handle empty `SMTP_USER`/`SMTP_PASSWORD` for unauthenticated local relay

## Changes

- `app/config.py`: Add `SMTP_STARTTLS` setting (default: `true`)
- `app/services/email.py`: Pass `start_tls` parameter to aiosmtplib, convert empty credentials to `None`
- `.env.example`: Document new settings

## Usage

For localhost Postfix (no auth, no TLS):
```env
SMTP_HOST=localhost
SMTP_PORT=25
SMTP_USER=
SMTP_PASSWORD=
SMTP_TLS=false
SMTP_STARTTLS=false
```

For external SMTP with STARTTLS (port 587):
```env
SMTP_HOST=smtp.example.com
SMTP_PORT=587
SMTP_TLS=false
SMTP_STARTTLS=true
```

## Test plan

- [x] Tested sending email via local Postfix with DKIM signing
- [x] Verified SPF, DKIM, DMARC all pass on received email

🤖 Generated with [Claude Code](https://claude.com/claude-code)