### PR TITLE
feat: add aliases list to tag detail endpoint

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -670,10 +670,11 @@ async def get_tag(
     )
     links = links_result.scalars().all()
 
-    # Fetch tags that are aliases of this tag
+    # Fetch tags that are aliases of this tag (use resolved_tag_id for consistency
+    # with image_count/child_count - when viewing an alias, show all sibling aliases)
     aliases_result = await db.execute(
         select(Tags.tag_id, Tags.title, Tags.type)  # type: ignore[call-overload]
-        .where(Tags.alias_of == tag_id)
+        .where(Tags.alias_of == resolved_tag_id)
         .order_by(Tags.title)
     )
     aliases = [{"tag_id": row[0], "title": row[1], "type": row[2]} for row in aliases_result.all()]

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -670,6 +670,14 @@ async def get_tag(
     )
     links = links_result.scalars().all()
 
+    # Fetch tags that are aliases of this tag
+    aliases_result = await db.execute(
+        select(Tags.tag_id, Tags.title, Tags.type)  # type: ignore[call-overload]
+        .where(Tags.alias_of == tag_id)
+        .order_by(Tags.title)
+    )
+    aliases = [{"tag_id": row[0], "title": row[1], "type": row[2]} for row in aliases_result.all()]
+
     # Fetch linked sources/characters based on tag type
     sources: list[dict[str, Any]] = []
     characters: list[dict[str, Any]] = []
@@ -712,6 +720,7 @@ async def get_tag(
         image_count=image_count or 0,
         is_alias=is_alias,
         aliased_tag_id=aliased_tag_id,
+        aliases=aliases,
         parent_tag_id=parent_tag_id,
         child_count=child_count or 0,
         created_by=created_by,

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -160,6 +160,7 @@ class TagWithStats(TagResponse):
     image_count: int
     is_alias: bool = False
     aliased_tag_id: int | None = None  # The actual tag this aliases (if is_alias=True)
+    aliases: list[LinkedTag] = []  # Tags that are aliases of this tag
     parent_tag_id: int | None = None  # The parent tag in hierarchy (inheritedfrom_id)
     child_count: int = 0  # Number of child tags that inherit from this tag
     created_by: UserSummary | None = None  # User who created the tag


### PR DESCRIPTION
## Summary
- Added `aliases` field to `TagWithStats` response showing tags that redirect to this tag
- Complements existing `is_alias`/`aliased_tag_id` which show if a tag IS an alias

## Example response
```json
{
  "tag_id": 205578,
  "title": "Nijisanji",
  "is_alias": false,
  "aliased_tag_id": null,
  "aliases": [
    {"tag_id": 216995, "title": "Aiba Uiha Channel", "type": 2},
    {"tag_id": 208845, "title": "Aizono Manami (Channel)", "type": 2}
  ]
}
```

## Performance
- Uses existing `fk_tags_alias` index on `tags.alias_of`
- Negligible impact - simple indexed lookup returning typically 0-5 results

## Test plan
- [x] Verified endpoint returns aliases for tag with 53 aliases (Nijisanji)
- [x] Verified empty array for tags without aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)