### PR TITLE
feat: add usage_count to LinkedTag for sortable relationships

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -696,7 +696,7 @@ async def get_tag(
                 Tags.tag_id == CharacterSourceLinks.source_tag_id,
             )
             .where(CharacterSourceLinks.character_tag_id == tag_id)
-            .order_by(Tags.usage_count.desc(), Tags.title)  # type: ignore[union-attr]
+            .order_by(Tags.usage_count.desc(), Tags.title)  # type: ignore[attr-defined]
         )
         sources = [
             {"tag_id": row[0], "title": row[1], "type": row[2], "usage_count": row[3]}
@@ -713,7 +713,7 @@ async def get_tag(
                 Tags.tag_id == CharacterSourceLinks.character_tag_id,
             )
             .where(CharacterSourceLinks.source_tag_id == tag_id)
-            .order_by(Tags.usage_count.desc(), Tags.title)  # type: ignore[union-attr]
+            .order_by(Tags.usage_count.desc(), Tags.title)  # type: ignore[attr-defined]
         )
         characters = [
             {"tag_id": row[0], "title": row[1], "type": row[2], "usage_count": row[3]}

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -696,7 +696,7 @@ async def get_tag(
                 Tags.tag_id == CharacterSourceLinks.source_tag_id,
             )
             .where(CharacterSourceLinks.character_tag_id == tag_id)
-            .order_by(Tags.usage_count.desc(), Tags.title)  # type: ignore[attr-defined]
+            .order_by(desc(Tags.usage_count), Tags.title)  # type: ignore[arg-type]
         )
         sources = [
             {"tag_id": row[0], "title": row[1], "type": row[2], "usage_count": row[3]}
@@ -713,7 +713,7 @@ async def get_tag(
                 Tags.tag_id == CharacterSourceLinks.character_tag_id,
             )
             .where(CharacterSourceLinks.source_tag_id == tag_id)
-            .order_by(Tags.usage_count.desc(), Tags.title)  # type: ignore[attr-defined]
+            .order_by(desc(Tags.usage_count), Tags.title)  # type: ignore[arg-type]
         )
         characters = [
             {"tag_id": row[0], "title": row[1], "type": row[2], "usage_count": row[3]}

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -673,11 +673,14 @@ async def get_tag(
     # Fetch tags that are aliases of this tag (use resolved_tag_id for consistency
     # with image_count/child_count - when viewing an alias, show all sibling aliases)
     aliases_result = await db.execute(
-        select(Tags.tag_id, Tags.title, Tags.type)  # type: ignore[call-overload]
+        select(Tags.tag_id, Tags.title, Tags.type, Tags.usage_count)  # type: ignore[call-overload]
         .where(Tags.alias_of == resolved_tag_id)
         .order_by(Tags.title)
     )
-    aliases = [{"tag_id": row[0], "title": row[1], "type": row[2]} for row in aliases_result.all()]
+    aliases = [
+        {"tag_id": row[0], "title": row[1], "type": row[2], "usage_count": row[3]}
+        for row in aliases_result.all()
+    ]
 
     # Fetch linked sources/characters based on tag type
     sources: list[dict[str, Any]] = []
@@ -685,32 +688,36 @@ async def get_tag(
 
     if tag.type == TagType.CHARACTER:
         # Get all sources linked to this character
+        # Sorted by usage_count descending with title as tiebreaker
         sources_result = await db.execute(
-            select(Tags.tag_id, Tags.title, Tags.type)  # type: ignore[call-overload]
+            select(Tags.tag_id, Tags.title, Tags.type, Tags.usage_count)  # type: ignore[call-overload]
             .join(
                 CharacterSourceLinks,
                 Tags.tag_id == CharacterSourceLinks.source_tag_id,
             )
             .where(CharacterSourceLinks.character_tag_id == tag_id)
-            .order_by(Tags.title)
+            .order_by(Tags.usage_count.desc(), Tags.title)  # type: ignore[union-attr]
         )
         sources = [
-            {"tag_id": row[0], "title": row[1], "type": row[2]} for row in sources_result.all()
+            {"tag_id": row[0], "title": row[1], "type": row[2], "usage_count": row[3]}
+            for row in sources_result.all()
         ]
 
     elif tag.type == TagType.SOURCE:
         # Get all characters linked to this source
+        # Sorted by usage_count descending with title as tiebreaker
         characters_result = await db.execute(
-            select(Tags.tag_id, Tags.title, Tags.type)  # type: ignore[call-overload]
+            select(Tags.tag_id, Tags.title, Tags.type, Tags.usage_count)  # type: ignore[call-overload]
             .join(
                 CharacterSourceLinks,
                 Tags.tag_id == CharacterSourceLinks.character_tag_id,
             )
             .where(CharacterSourceLinks.source_tag_id == tag_id)
-            .order_by(Tags.title)
+            .order_by(Tags.usage_count.desc(), Tags.title)  # type: ignore[union-attr]
         )
         characters = [
-            {"tag_id": row[0], "title": row[1], "type": row[2]} for row in characters_result.all()
+            {"tag_id": row[0], "title": row[1], "type": row[2], "usage_count": row[3]}
+            for row in characters_result.all()
         ]
 
     return TagWithStats(

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -152,6 +152,7 @@ class LinkedTag(BaseModel):
     tag_id: int
     title: str | None
     type: int
+    usage_count: int = 0  # Optional with default for backward compat
 
 
 class TagWithStats(TagResponse):

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -152,7 +152,7 @@ class LinkedTag(BaseModel):
     tag_id: int
     title: str | None
     type: int
-    usage_count: int = 0  # Optional with default for backward compat
+    usage_count: int | None = None  # Nullable: None means usage count not loaded
 
 
 class TagWithStats(TagResponse):

--- a/tests/api/v1/test_character_source_links.py
+++ b/tests/api/v1/test_character_source_links.py
@@ -999,11 +999,14 @@ class TestLinkedTagUsageCount:
         assert response.status_code == 200
         data = response.json()
 
-        # Verify aliases have usage_count field
+        # Verify aliases have usage_count field with correct values
+        # Aliases are sorted alphabetically by title, so Alias A comes first
         assert "aliases" in data
         assert len(data["aliases"]) == 2
-        for alias in data["aliases"]:
-            assert "usage_count" in alias
+        assert data["aliases"][0]["title"] == "Alias A"
+        assert data["aliases"][0]["usage_count"] == 150
+        assert data["aliases"][1]["title"] == "Alias B"
+        assert data["aliases"][1]["usage_count"] == 25
 
     async def test_characters_sorted_by_usage_count_with_title_tiebreaker(
         self,

--- a/tests/api/v1/test_character_source_links.py
+++ b/tests/api/v1/test_character_source_links.py
@@ -872,3 +872,171 @@ class TestCharacterSourceLinkCascade:
             select(CharacterSourceLinks).where(CharacterSourceLinks.id == link_id)
         )
         assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.api
+class TestLinkedTagUsageCount:
+    """Tests for usage_count field in LinkedTag responses."""
+
+    async def test_source_tag_characters_include_usage_count(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        source_tag: Tags,
+    ):
+        """Test that characters linked to a source tag include usage_count."""
+        # Create two character tags with different usage counts
+        char1 = Tags(title="Character A", type=TagType.CHARACTER, usage_count=100)
+        char2 = Tags(title="Character B", type=TagType.CHARACTER, usage_count=50)
+        db_session.add_all([char1, char2])
+        await db_session.commit()
+        await db_session.refresh(char1)
+        await db_session.refresh(char2)
+
+        # Create links
+        link1 = CharacterSourceLinks(
+            character_tag_id=char1.tag_id,
+            source_tag_id=source_tag.tag_id,
+        )
+        link2 = CharacterSourceLinks(
+            character_tag_id=char2.tag_id,
+            source_tag_id=source_tag.tag_id,
+        )
+        db_session.add_all([link1, link2])
+        await db_session.commit()
+
+        # Get source tag detail
+        response = await client.get(f"/api/v1/tags/{source_tag.tag_id}")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify characters have usage_count field
+        assert "characters" in data
+        assert len(data["characters"]) == 2
+        for char in data["characters"]:
+            assert "usage_count" in char
+
+        # Verify sorted by usage_count descending (char1 should be first with 100)
+        assert data["characters"][0]["usage_count"] == 100
+        assert data["characters"][0]["title"] == "Character A"
+        assert data["characters"][1]["usage_count"] == 50
+        assert data["characters"][1]["title"] == "Character B"
+
+    async def test_character_tag_sources_include_usage_count(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        character_tag: Tags,
+    ):
+        """Test that sources linked to a character tag include usage_count."""
+        # Create two source tags with different usage counts
+        source1 = Tags(title="Source A", type=TagType.SOURCE, usage_count=200)
+        source2 = Tags(title="Source B", type=TagType.SOURCE, usage_count=75)
+        db_session.add_all([source1, source2])
+        await db_session.commit()
+        await db_session.refresh(source1)
+        await db_session.refresh(source2)
+
+        # Create links
+        link1 = CharacterSourceLinks(
+            character_tag_id=character_tag.tag_id,
+            source_tag_id=source1.tag_id,
+        )
+        link2 = CharacterSourceLinks(
+            character_tag_id=character_tag.tag_id,
+            source_tag_id=source2.tag_id,
+        )
+        db_session.add_all([link1, link2])
+        await db_session.commit()
+
+        # Get character tag detail
+        response = await client.get(f"/api/v1/tags/{character_tag.tag_id}")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify sources have usage_count field
+        assert "sources" in data
+        assert len(data["sources"]) == 2
+        for source in data["sources"]:
+            assert "usage_count" in source
+
+        # Verify sorted by usage_count descending (source1 should be first with 200)
+        assert data["sources"][0]["usage_count"] == 200
+        assert data["sources"][0]["title"] == "Source A"
+        assert data["sources"][1]["usage_count"] == 75
+        assert data["sources"][1]["title"] == "Source B"
+
+    async def test_aliases_include_usage_count(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ):
+        """Test that alias tags include usage_count."""
+        # Create a main tag
+        main_tag = Tags(title="Main Tag", type=TagType.THEME, usage_count=500)
+        db_session.add(main_tag)
+        await db_session.commit()
+        await db_session.refresh(main_tag)
+
+        # Create alias tags with different usage counts
+        alias1 = Tags(
+            title="Alias A",
+            type=TagType.THEME,
+            usage_count=150,
+            alias_of=main_tag.tag_id,
+        )
+        alias2 = Tags(
+            title="Alias B",
+            type=TagType.THEME,
+            usage_count=25,
+            alias_of=main_tag.tag_id,
+        )
+        db_session.add_all([alias1, alias2])
+        await db_session.commit()
+
+        # Get main tag detail
+        response = await client.get(f"/api/v1/tags/{main_tag.tag_id}")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify aliases have usage_count field
+        assert "aliases" in data
+        assert len(data["aliases"]) == 2
+        for alias in data["aliases"]:
+            assert "usage_count" in alias
+
+    async def test_characters_sorted_by_usage_count_with_title_tiebreaker(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        source_tag: Tags,
+    ):
+        """Test that characters with same usage_count are sorted by title."""
+        # Create characters with same usage count
+        char_b = Tags(title="Character B", type=TagType.CHARACTER, usage_count=100)
+        char_a = Tags(title="Character A", type=TagType.CHARACTER, usage_count=100)
+        db_session.add_all([char_b, char_a])
+        await db_session.commit()
+        await db_session.refresh(char_a)
+        await db_session.refresh(char_b)
+
+        # Create links
+        link1 = CharacterSourceLinks(
+            character_tag_id=char_a.tag_id,
+            source_tag_id=source_tag.tag_id,
+        )
+        link2 = CharacterSourceLinks(
+            character_tag_id=char_b.tag_id,
+            source_tag_id=source_tag.tag_id,
+        )
+        db_session.add_all([link1, link2])
+        await db_session.commit()
+
+        # Get source tag detail
+        response = await client.get(f"/api/v1/tags/{source_tag.tag_id}")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Same usage_count, should be sorted alphabetically by title
+        assert data["characters"][0]["title"] == "Character A"
+        assert data["characters"][1]["title"] == "Character B"


### PR DESCRIPTION
## Summary
- Add `usage_count` field to `LinkedTag` schema for sources, characters, and aliases in tag detail endpoint
- Sort linked sources/characters by `usage_count DESC, title` (most popular first, alphabetical tiebreaker)
- Enables frontend to display most-used related tags first

## Changes
- `app/schemas/tag.py`: Add `usage_count: int = 0` to `LinkedTag` (backward compatible default)
- `app/api/v1/tags.py`: Update queries to select `usage_count` and sort by it
- `tests/api/v1/test_character_source_links.py`: Add 4 tests for new behavior

## Performance Impact
Minimal - adds one integer from same row (no extra I/O), sorts small filtered result sets in memory.

## Test plan
- [x] Run new tests: `uv run pytest tests/api/v1/test_character_source_links.py::TestLinkedTagUsageCount -v`
- [x] Run all character source link tests (31 passed)
- [x] Run all tag tests (78 passed)
- [x] Run audit log tests (17 passed)

🤖 Generated with [Claude Code](https://claude.ai/code)