### PR TITLE
feat: add admin endpoint to list all suspensions

### DIFF
--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -306,3 +306,31 @@ class ImageStatusResponse(BaseModel):
     status_updated: UTCDatetimeOptional = None
 
     model_config = {"from_attributes": True}
+
+
+# ===== Admin Suspension List Schemas =====
+
+
+class AdminSuspensionItem(BaseModel):
+    """Schema for a suspension item in the admin list."""
+
+    suspension_id: int
+    user_id: int
+    username: str
+    action: str
+    is_active: bool
+    actioned_at: UTCDatetime
+    actioned_by_id: int | None
+    actioned_by_username: str | None
+    reason: str | None
+    suspended_until: UTCDatetimeOptional = None
+
+
+class AdminSuspensionListResponse(BaseModel):
+    """Response schema for listing all suspensions across users."""
+
+    items: list[AdminSuspensionItem]
+    total: int
+    page: int
+    per_page: int
+    active_count: int


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/admin/suspensions` endpoint for listing all suspension/warning records across users
- Add `AdminSuspensionItem` and `AdminSuspensionListResponse` schemas to OpenAPI
- Support filtering by `action_type` (warning/suspended) and `days_back`
- Include `is_active` calculation (checks expiry and reactivation status)
- Include `active_count` in response for dashboard stats

## Test plan
- [x] All 8 new tests pass for the endpoint
- [x] All 33 existing suspension tests still pass
- [x] mypy passes with no errors
- [x] OpenAPI schema includes new endpoint and schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)