### PR TITLE
feat: restrict maximgperday field to admin-only updates

### DIFF
--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ValidationError
 
 from app.schemas.base import UTCDatetime, UTCDatetimeOptional
 from app.schemas.image import ImageBase, ImageResponse
-from app.schemas.user import UserResponse
+from app.schemas.user import UserResponse, UserUpdate
 
 
 @pytest.mark.unit
@@ -260,3 +260,35 @@ class TestUTCDatetimeSerialization:
         # Both datetime fields should have Z suffix
         assert '"2026-01-11T12:00:00Z"' in json_data
         assert '"2026-01-11T16:30:00Z"' in json_data
+
+
+@pytest.mark.unit
+class TestUserUpdateSchema:
+    """Tests for UserUpdate schema validation."""
+
+    def test_maximgperday_valid(self):
+        """Test maximgperday accepts valid positive integer."""
+        update = UserUpdate(maximgperday=50)
+        assert update.maximgperday == 50
+
+    def test_maximgperday_rejects_zero(self):
+        """Test maximgperday rejects zero."""
+        with pytest.raises(ValidationError) as exc_info:
+            UserUpdate(maximgperday=0)
+        assert "maximgperday must be a positive integer" in str(exc_info.value)
+
+    def test_maximgperday_rejects_negative(self):
+        """Test maximgperday rejects negative values."""
+        with pytest.raises(ValidationError) as exc_info:
+            UserUpdate(maximgperday=-5)
+        assert "maximgperday must be a positive integer" in str(exc_info.value)
+
+    def test_maximgperday_none_allowed(self):
+        """Test maximgperday allows None (field not being updated)."""
+        update = UserUpdate(maximgperday=None)
+        assert update.maximgperday is None
+
+    def test_maximgperday_omitted(self):
+        """Test maximgperday defaults to None when omitted."""
+        update = UserUpdate(location="Tokyo")
+        assert update.maximgperday is None


### PR DESCRIPTION
## Summary
- Add admin-only restriction for updating `maximgperday` (daily upload limit), matching the existing pattern for `user_title`
- Only users with `USER_EDIT_PROFILE` permission can modify the field
- Field visibility is conditional: hidden from anonymous/other users, visible to self and admins

## Test plan
- [x] Regular users cannot update their own `maximgperday` via `/users/me` (403)
- [x] Regular users cannot update their own `maximgperday` via `/users/{id}` (403)
- [x] Users with `USER_EDIT_PROFILE` permission can update their own `maximgperday`
- [x] Users with `USER_EDIT_PROFILE` permission can update other users' `maximgperday`
- [x] `maximgperday` is hidden from anonymous users viewing profiles
- [x] `maximgperday` is hidden from other regular users viewing profiles
- [x] `maximgperday` is visible when viewing own profile
- [x] `maximgperday` is visible to admins viewing any profile
- [x] Schema validation rejects zero/negative values

🤖 Generated with [Claude Code](https://claude.ai/code)