### PR TITLE
feat: add tag_depth param and sort_by override for search

### DIFF
--- a/alembic/versions/12207ec6cc9b_add_tag_sort_indexes.py
+++ b/alembic/versions/12207ec6cc9b_add_tag_sort_indexes.py
@@ -1,0 +1,33 @@
+"""add tag sort indexes
+
+Revision ID: 12207ec6cc9b
+Revises: fa6353e5de42
+Create Date: 2026-02-03 22:24:07.331919
+
+"""
+from typing import Sequence
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '12207ec6cc9b'
+down_revision: str | Sequence[str] | None = 'fa6353e5de42'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add B-tree indexes on tags.usage_count and tags.title for sort performance.
+
+    The tags table has ~229K rows. Without these indexes, ORDER BY + LIMIT + OFFSET
+    on these columns causes a full filesort on every paginated request.
+    """
+    op.create_index('idx_tags_usage_count', 'tags', ['usage_count'], unique=False)
+    op.create_index('idx_tags_title', 'tags', ['title'], unique=False)
+
+
+def downgrade() -> None:
+    """Remove sort indexes from tags table."""
+    op.drop_index('idx_tags_title', table_name='tags')
+    op.drop_index('idx_tags_usage_count', table_name='tags')

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -56,3 +56,12 @@ class UserSortParams(BaseModel):
         "user_id", "username", "date_joined", "last_login", "image_posts", "posts", "favorites"
     ] = Field(default="user_id", description="Sort field")
     sort_order: SortOrder = Field(default="DESC", description="Sort order")
+
+
+class TagSortParams(BaseModel):
+    """Common sorting parameters for tag queries."""
+
+    sort_by: Literal["usage_count", "title", "date_added", "tag_id", "type"] = Field(
+        default="usage_count", description="Sort field"
+    )
+    sort_order: SortOrder = Field(default="DESC", description="Sort order")

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -61,7 +61,7 @@ class UserSortParams(BaseModel):
 class TagSortParams(BaseModel):
     """Common sorting parameters for tag queries."""
 
-    sort_by: Literal["usage_count", "title", "date_added", "tag_id", "type"] = Field(
-        default="usage_count", description="Sort field"
+    sort_by: Literal["usage_count", "title", "date_added", "tag_id", "type"] | None = Field(
+        default=None, description="Sort field (omit to use relevance when searching)"
     )
     sort_order: SortOrder = Field(default="DESC", description="Sort order")

--- a/app/models/tag.py
+++ b/app/models/tag.py
@@ -104,6 +104,8 @@ class Tags(TagBase, table=True):
         Index("fk_tags_inheritedfrom_id", "inheritedfrom_id"),
         Index("fk_tags_user_id", "user_id"),
         Index("type_alias", "type", "alias_of"),
+        Index("idx_tags_usage_count", "usage_count"),
+        Index("idx_tags_title", "title"),
     )
 
     # Primary key

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -133,6 +133,7 @@ class TagResponse(TagBase):
     alias_of: int | None = None
     alias_of_name: str | None = None
     is_alias: bool = False
+    usage_count: int = 0
 
     # NOTE: No normalization/escaping for title and desc.
     # These fields are stored as plain text (trimmed on input) and HTML escaping
@@ -158,7 +159,7 @@ class LinkedTag(BaseModel):
 class TagWithStats(TagResponse):
     """Schema for tag response with usage statistics"""
 
-    image_count: int
+    total_image_count: int
     is_alias: bool = False
     aliased_tag_id: int | None = None  # The actual tag this aliases (if is_alias=True)
     aliases: list[LinkedTag] = []  # Tags that are aliases of this tag

--- a/docs/plans/2026-02-03-tag-list-sorting-design.md
+++ b/docs/plans/2026-02-03-tag-list-sorting-design.md
@@ -1,0 +1,68 @@
+# Tag List: Add usage_count and Sorting Support
+
+## Summary
+
+Add `usage_count` to the tag list response and support `sort_by`/`sort_order` query parameters for the tag listing endpoint.
+
+## Changes
+
+### 1. Schema: Expose `usage_count` in `TagResponse`
+
+Add `usage_count: int = 0` to `TagResponse` in `app/schemas/tag.py`. The field already exists on the `Tags` model (maintained by a DB trigger on tag_links changes), so no query changes are needed -- `model_validate` picks it up automatically.
+
+### 2. Dependencies: Add `TagSortParams`
+
+Add to `app/api/dependencies.py`:
+
+```python
+class TagSortParams(BaseModel):
+    sort_by: Literal["usage_count", "title", "date_added", "tag_id", "type"] = Field(
+        default="usage_count", description="Sort field"
+    )
+    sort_order: SortOrder = Field(default="DESC", description="Sort order")
+```
+
+`date_added` maps to `tag_id` internally (PK is auto-increment chronological and indexed; `date_added` has no index).
+
+### 3. Endpoint: Use `TagSortParams` in `list_tags`
+
+In `app/api/v1/tags.py`, add `sorting: Annotated[TagSortParams, Depends()]` parameter.
+
+**With search:** Ignore `sort_by`/`sort_order`. Keep existing relevance-based ranking (exact match, fulltext relevance, usage_count, alphabetical).
+
+**Without search:** Replace hardcoded `usage_count DESC, date_added DESC` with:
+
+```python
+sort_column_map = {
+    "usage_count": Tags.usage_count,
+    "title": Tags.title,
+    "date_added": Tags.tag_id,
+    "tag_id": Tags.tag_id,
+    "type": Tags.type,
+}
+sort_column = sort_column_map[sorting.sort_by]
+sort_func = desc if sorting.sort_order == "DESC" else asc
+query = query.order_by(sort_func(sort_column))
+```
+
+### 4. Migration: Add indexes for sort columns
+
+The tags table has 229K rows. Without B-tree indexes on the sort columns, `ORDER BY + LIMIT + OFFSET` causes a full filesort on every paginated request.
+
+Add an Alembic migration with two indexes:
+
+- `idx_tags_usage_count` on `usage_count` (default sort field, currently unindexed)
+- `idx_tags_title` on `title` (B-tree for sorting; the existing `ft_tags_title` FULLTEXT index is only for search)
+
+`tag_id` already has the PK index. `type` can use the leading column of the existing `type_alias` composite index.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `app/schemas/tag.py` | Add `usage_count` field to `TagResponse` |
+| `app/api/dependencies.py` | Add `TagSortParams` class |
+| `app/api/v1/tags.py` | Add `sorting` dependency, use in no-search branch |
+| `app/models/tag.py` | Add index definitions for model consistency |
+| `alembic/versions/xxx_add_tag_sort_indexes.py` | Migration to add `idx_tags_usage_count` and `idx_tags_title` |
+| `tests/` | Tests for sorting params and usage_count in response |

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -505,8 +505,7 @@ class TestTagListSorting:
             db_session.add(tag)
         await db_session.commit()
 
-        response = await client.get("/api/v1/tags?sort_by=type&sort_order=ASC&search=sort type")
-        # search present = relevance used, so test without search
+        # Don't use search param here - search activates relevance sorting
         response = await client.get("/api/v1/tags?sort_by=type&sort_order=ASC")
         assert response.status_code == 200
         data = response.json()
@@ -544,17 +543,16 @@ class TestTagListSorting:
         response = await client.get("/api/v1/tags?sort_by=usage_count&sort_order=asc")
         assert response.status_code == 200
 
-    async def test_search_ignores_sort_params(
+    async def test_explicit_sort_by_overrides_search_relevance(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Test that search uses relevance ranking, ignoring sort_by/sort_order."""
+        """Test that explicit sort_by overrides relevance ranking during search."""
         tag1 = Tags(title="exact match test", type=TagType.THEME, usage_count=1)
         tag2 = Tags(title="test partial match", type=TagType.THEME, usage_count=999)
         db_session.add_all([tag1, tag2])
         await db_session.commit()
 
-        # Even with sort_by=usage_count ASC, search should use relevance
-        # The exact/prefix match should come first, not the lowest usage_count
+        # With explicit sort_by=usage_count ASC, should sort by usage_count, not relevance
         response = await client.get(
             "/api/v1/tags?search=ex&sort_by=usage_count&sort_order=ASC"
         )
@@ -562,7 +560,25 @@ class TestTagListSorting:
         data = response.json()
         matching = [t for t in data["tags"] if "match test" in t["title"]]
         if len(matching) >= 2:
-            # exact match test should be first (prefix match), regardless of sort_by
+            # Lowest usage_count first (sort_by overrides relevance)
+            assert matching[0]["usage_count"] <= matching[1]["usage_count"]
+
+    async def test_search_without_sort_by_uses_relevance(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that search without explicit sort_by uses relevance ranking."""
+        tag1 = Tags(title="exact match test", type=TagType.THEME, usage_count=1)
+        tag2 = Tags(title="test partial match", type=TagType.THEME, usage_count=999)
+        db_session.add_all([tag1, tag2])
+        await db_session.commit()
+
+        # No sort_by: search should use relevance (prefix match first)
+        response = await client.get("/api/v1/tags?search=ex")
+        assert response.status_code == 200
+        data = response.json()
+        matching = [t for t in data["tags"] if "match test" in t["title"]]
+        if len(matching) >= 2:
+            # exact match test should be first (prefix match)
             assert matching[0]["title"] == "exact match test"
 
     async def test_invalid_sort_by_rejected(self, client: AsyncClient):
@@ -1367,6 +1383,164 @@ class TestGetTag:
         alias_titles = {a["title"] for a in data["aliases"]}
         assert alias_titles == {"Alias A", "Alias B"}
 
+    async def test_total_image_count_anonymous_excludes_non_public(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Anonymous users should only see public-status images in total_image_count."""
+        from app.config import ImageStatus
+
+        tag = Tags(title="Count Test Tag", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.flush()
+
+        # Create images with various statuses
+        statuses = [
+            ImageStatus.ACTIVE,    # public
+            ImageStatus.ACTIVE,    # public
+            ImageStatus.SPOILER,   # public
+            ImageStatus.REPOST,    # public
+            ImageStatus.OTHER,     # non-public (status=0)
+            ImageStatus.INAPPROPRIATE,  # non-public (status=-2)
+        ]
+        for i, status_val in enumerate(statuses):
+            img_data = sample_image_data.copy()
+            img_data.update({
+                "filename": f"count-test-{i}",
+                "md5_hash": f"counttest{i:018d}",
+                "status": status_val,
+            })
+            img = Images(**img_data)
+            db_session.add(img)
+            await db_session.flush()
+            db_session.add(TagLinks(tag_id=tag.tag_id, image_id=img.image_id))
+
+        await db_session.commit()
+
+        # Anonymous request - should only count public statuses (ACTIVE, SPOILER, REPOST)
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_image_count"] == 4  # 2 ACTIVE + 1 SPOILER + 1 REPOST
+
+    async def test_total_image_count_show_all_images_sees_all(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """User with show_all_images=1 should see all images in total_image_count."""
+        from app.config import ImageStatus
+        from app.core.security import create_access_token
+
+        user = Users(
+            username="showall_user",
+            email="showall@test.com",
+            password=get_password_hash("Password123!"),
+            password_type="bcrypt",
+            salt="",
+            show_all_images=1,
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        tag = Tags(title="Show All Count Tag", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.flush()
+
+        statuses = [
+            ImageStatus.ACTIVE,
+            ImageStatus.SPOILER,
+            ImageStatus.OTHER,
+            ImageStatus.INAPPROPRIATE,
+        ]
+        for i, status_val in enumerate(statuses):
+            img_data = sample_image_data.copy()
+            img_data.update({
+                "filename": f"showall-test-{i}",
+                "md5_hash": f"showalltest{i:015d}",
+                "status": status_val,
+            })
+            img = Images(**img_data)
+            db_session.add(img)
+            await db_session.flush()
+            db_session.add(TagLinks(tag_id=tag.tag_id, image_id=img.image_id))
+
+        await db_session.commit()
+
+        token = create_access_token(user.user_id)
+        response = await client.get(
+            f"/api/v1/tags/{tag.tag_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_image_count"] == 4  # All statuses visible
+
+    async def test_total_image_count_show_all_images_0_excludes_non_public(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """User with show_all_images=0 sees public images + own non-public images."""
+        from app.config import ImageStatus
+        from app.core.security import create_access_token
+
+        user = Users(
+            username="noshowuser",
+            email="noshow@test.com",
+            password=get_password_hash("Password123!"),
+            password_type="bcrypt",
+            salt="",
+            show_all_images=0,
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        tag = Tags(title="No Show All Count Tag", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.flush()
+
+        # Other user's images (various statuses)
+        statuses = [
+            ImageStatus.ACTIVE,
+            ImageStatus.SPOILER,
+            ImageStatus.OTHER,
+            ImageStatus.INAPPROPRIATE,
+        ]
+        for i, status_val in enumerate(statuses):
+            img_data = sample_image_data.copy()
+            img_data.update({
+                "filename": f"noshow-test-{i}",
+                "md5_hash": f"noshowtest{i:015d}",
+                "status": status_val,
+            })
+            img = Images(**img_data)
+            db_session.add(img)
+            await db_session.flush()
+            db_session.add(TagLinks(tag_id=tag.tag_id, image_id=img.image_id))
+
+        # User's own non-public image (should be counted)
+        own_img_data = sample_image_data.copy()
+        own_img_data.update({
+            "filename": "noshow-own",
+            "md5_hash": "noshowown" + "0" * 16,
+            "status": ImageStatus.OTHER,
+            "user_id": user.user_id,
+        })
+        own_img = Images(**own_img_data)
+        db_session.add(own_img)
+        await db_session.flush()
+        db_session.add(TagLinks(tag_id=tag.tag_id, image_id=own_img.image_id))
+
+        await db_session.commit()
+
+        token = create_access_token(user.user_id)
+        response = await client.get(
+            f"/api/v1/tags/{tag.tag_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        # 2 public (ACTIVE + SPOILER) + 1 own non-public = 3
+        assert data["total_image_count"] == 3
+
 
 @pytest.mark.api
 class TestGetImagesByTag:
@@ -1409,6 +1583,94 @@ class TestGetImagesByTag:
         """Test getting images for non-existent tag."""
         response = await client.get("/api/v1/tags/999999/images")
         assert response.status_code == 404
+
+    async def test_get_images_by_tag_with_depth_0(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """tag_depth=0 should only return images tagged with the exact tag, not children."""
+        # Create parent tag
+        parent = Tags(title="clothing", desc="Parent", type=TagType.THEME)
+        db_session.add(parent)
+        await db_session.commit()
+        await db_session.refresh(parent)
+
+        # Create child tag
+        child = Tags(
+            title="dress",
+            desc="Child of clothing",
+            type=TagType.THEME,
+            inheritedfrom_id=parent.tag_id,
+        )
+        db_session.add(child)
+        await db_session.commit()
+        await db_session.refresh(child)
+
+        # Image tagged with parent directly
+        image1_data = sample_image_data.copy()
+        image1_data["filename"] = "parent-img"
+        image1_data["md5_hash"] = "a" * 32
+        image1 = Images(**image1_data)
+        db_session.add(image1)
+        await db_session.flush()
+
+        # Image tagged with child only
+        image2_data = sample_image_data.copy()
+        image2_data["filename"] = "child-img"
+        image2_data["md5_hash"] = "b" * 32
+        image2 = Images(**image2_data)
+        db_session.add(image2)
+        await db_session.flush()
+
+        tag_link1 = TagLinks(tag_id=parent.tag_id, image_id=image1.image_id)
+        tag_link2 = TagLinks(tag_id=child.tag_id, image_id=image2.image_id)
+        db_session.add_all([tag_link1, tag_link2])
+        await db_session.commit()
+
+        # tag_depth=0: only exact tag, no children
+        response = await client.get(
+            f"/api/v1/tags/{parent.tag_id}/images?tag_depth=0"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["images"][0]["image_id"] == image1.image_id
+
+    async def test_get_images_by_tag_default_depth(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """No tag_depth should return full hierarchy (default behavior)."""
+        # Create parent → child hierarchy
+        parent = Tags(title="clothing", desc="Parent", type=TagType.THEME)
+        db_session.add(parent)
+        await db_session.commit()
+        await db_session.refresh(parent)
+
+        child = Tags(
+            title="dress",
+            type=TagType.THEME,
+            inheritedfrom_id=parent.tag_id,
+        )
+        db_session.add(child)
+        await db_session.commit()
+        await db_session.refresh(child)
+
+        # Image tagged with child only
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.flush()
+
+        tag_link = TagLinks(tag_id=child.tag_id, image_id=image.image_id)
+        db_session.add(tag_link)
+        await db_session.commit()
+
+        # No tag_depth: full hierarchy, should find child-tagged image
+        response = await client.get(f"/api/v1/tags/{parent.tag_id}/images")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["images"][0]["image_id"] == image.image_id
 
 
 @pytest.mark.api


### PR DESCRIPTION
## Summary
- Add `tag_depth` query parameter to `/images` and `/tags/{id}/images` to control tag hierarchy depth (0=exact only, 1=direct children, etc., omit for full hierarchy)
- Explicit `sort_by` now overrides search relevance ranking in tag list endpoint — omitting `sort_by` preserves the existing relevance behavior
- `total_image_count` in `get_tag` now respects visibility rules (public images + user's own images), matching `list_images` behavior

## Test plan
- [x] `TestTagDepthFiltering` — 4 tests for depth control in image search
- [x] `TestGetImagesByTag` — 2 tests for depth control in tag image listing
- [x] `TestTagListSorting` — updated tests for sort_by override behavior
- [x] `TestGetTag` visibility tests — 3 tests for total_image_count filtering
- [x] Full regression: 95 tag tests + 68 image tests, 0 failures
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)