### PR TITLE
fix: explicit sort_by overrides search relevance in tag list

### DIFF
--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -61,7 +61,7 @@ class UserSortParams(BaseModel):
 class TagSortParams(BaseModel):
     """Common sorting parameters for tag queries."""
 
-    sort_by: Literal["usage_count", "title", "date_added", "tag_id", "type"] = Field(
-        default="usage_count", description="Sort field"
+    sort_by: Literal["usage_count", "title", "date_added", "tag_id", "type"] | None = Field(
+        default=None, description="Sort field (omit to use relevance when searching)"
     )
     sort_order: SortOrder = Field(default="DESC", description="Sort order")


### PR DESCRIPTION
## Summary
- When `sort_by` is explicitly provided in `/tags` queries, it now overrides search relevance ranking
- Omitting `sort_by` preserves existing relevance-based sorting for search results
- `TagSortParams.sort_by` defaults to `None` instead of `"usage_count"` to distinguish explicit from default

## Test plan
- [x] `test_explicit_sort_by_overrides_search_relevance` — verifies sort_by takes precedence over relevance
- [x] `test_search_without_sort_by_uses_relevance` — verifies default search still uses relevance ranking
- [x] Full `TestTagListSorting` suite: 12 passed
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)