### PR TITLE
fix: add --no-dry-run support to migration scripts

### DIFF
--- a/scripts/convert_bbcode_to_markdown.py
+++ b/scripts/convert_bbcode_to_markdown.py
@@ -223,7 +223,7 @@ async def main(dry_run: bool = False, batch_size: int = 1000, auto_confirm: bool
 
         if dry_run:
             print("\n⚠️  This was a DRY RUN - no changes were made")
-            print("Run without --dry-run to apply changes")
+            print("Run with --no-dry-run to apply changes")
 
 
 if __name__ == "__main__":
@@ -231,7 +231,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Preview changes without committing to database",
+        default=True,
+        help="Preview changes without committing to database (default: True)",
+    )
+    parser.add_argument(
+        "--no-dry-run",
+        dest="dry_run",
+        action="store_false",
+        help="Apply changes to database",
     )
     parser.add_argument(
         "--batch-size",

--- a/scripts/migrate_legacy_db.py
+++ b/scripts/migrate_legacy_db.py
@@ -73,6 +73,7 @@ MIGRATION_STEPS = [
         "name": "backfill_tag_usage_counts",
         "script": "backfill_tag_usage_counts.py",
         "description": "Backfill tag usage counts from tag_links table",
+        "skip_standard_flags": True,  # Script has no CLI args (idempotent operation)
     },
     {
         "number": 5,

--- a/scripts/normalize_db_text.py
+++ b/scripts/normalize_db_text.py
@@ -345,7 +345,7 @@ async def main(dry_run: bool = False, batch_size: int = 1000, auto_confirm: bool
 
         if dry_run:
             print("\n⚠️  This was a DRY RUN - no changes were made")
-            print("Run without --dry-run to apply changes")
+            print("Run with --no-dry-run to apply changes")
 
 
 if __name__ == "__main__":
@@ -353,7 +353,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Preview changes without committing to database",
+        default=True,
+        help="Preview changes without committing to database (default: True)",
+    )
+    parser.add_argument(
+        "--no-dry-run",
+        dest="dry_run",
+        action="store_false",
+        help="Apply changes to database",
     )
     parser.add_argument(
         "--batch-size",


### PR DESCRIPTION
## Summary
- Add `--no-dry-run` flag to `convert_bbcode_to_markdown.py` and `normalize_db_text.py` to match the pattern in `migrate_quoted_comments.py`
- Mark `backfill_tag_usage_counts` with `skip_standard_flags` in the orchestrator since it has no CLI args
- Default changed to `dry_run=True` for safety when running scripts standalone

`migrate_legacy_db.py` passes `--no-dry-run` to sub-scripts in live mode, but two scripts didn't accept that flag (would crash with an argparse error), and one had no args at all.

## Test plan
- [x] Verified `--help` output for both updated scripts shows `--no-dry-run`
- [x] Run `migrate_legacy_db.py --dry-run` end-to-end to confirm no argparse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)