### PR TITLE
feat: IQDB duplicate detection during image upload

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -81,6 +81,7 @@ from app.schemas.image import (
     ImageTagItem,
     ImageTagsResponse,
     ImageUploadResponse,
+    ImageUploadSimilarResponse,
     SimilarImageResult,
     SimilarImagesResponse,
 )
@@ -106,6 +107,34 @@ def _get_client_ip(request: Request) -> str:
         # X-Forwarded-For can contain multiple IPs, first one is the client
         return forwarded.split(",")[0].strip()
     return request.client.host if request.client else "0.0.0.0"
+
+
+async def _hydrate_similar_images(
+    iqdb_results: list[dict[str, int | float]],
+    db: AsyncSession,
+) -> list[SimilarImageResult]:
+    """Fetch full image data for IQDB results and build SimilarImageResult list."""
+    similar_ids = [r["image_id"] for r in iqdb_results]
+    images_result = await db.execute(
+        select(Images)
+        .options(
+            selectinload(Images.user).load_only(Users.user_id, Users.username, Users.avatar)  # type: ignore[arg-type]
+        )
+        .where(Images.image_id.in_(similar_ids))  # type: ignore[union-attr]
+    )
+    images_by_id: dict[int, Images] = {
+        img.image_id: img  # type: ignore[misc]
+        for img in images_result.scalars().all()
+    }
+
+    similar: list[SimilarImageResult] = []
+    for r in sorted(iqdb_results, key=lambda x: x["score"], reverse=True):
+        img = images_by_id.get(int(r["image_id"]))
+        if img:
+            img_data = ImageResponse.model_validate(img).model_dump()
+            img_data["similarity_score"] = r["score"]
+            similar.append(SimilarImageResult(**img_data))
+    return similar
 
 
 @router.get("/", response_model=ImageDetailedListResponse, include_in_schema=False)
@@ -1046,30 +1075,7 @@ async def get_similar_images(
     if not similar_results:
         return SimilarImagesResponse(query_image_id=image_id, similar_images=[])
 
-    # Get full image details for similar images
-    similar_ids = [r["image_id"] for r in similar_results]
-
-    images_result = await db.execute(
-        select(Images)
-        .options(
-            selectinload(Images.user).load_only(Users.user_id, Users.username, Users.avatar)  # type: ignore[arg-type]
-        )
-        .where(Images.image_id.in_(similar_ids))  # type: ignore[union-attr]
-    )
-    images: dict[int, Images] = {
-        img.image_id: img  # type: ignore[misc]
-        for img in images_result.scalars().all()
-    }
-
-    # Build response with similarity scores, ordered by score descending
-    similar_images = []
-    for r in sorted(similar_results, key=lambda x: x["score"], reverse=True):
-        img = images.get(int(r["image_id"]))
-        if img:
-            img_data = ImageResponse.model_validate(img).model_dump()
-            img_data["similarity_score"] = r["score"]
-            similar_images.append(SimilarImageResult(**img_data))
-
+    similar_images = await _hydrate_similar_images(similar_results, db)
     return SimilarImagesResponse(query_image_id=image_id, similar_images=similar_images)
 
 
@@ -1547,15 +1553,23 @@ async def unfavorite_image(
     }
 
 
-@router.post("/upload", response_model=ImageUploadResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/upload",
+    response_model=ImageUploadResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={409: {"model": ImageUploadSimilarResponse, "description": "Similar images found"}},
+)
 async def upload_image(
     request: Request,
     current_user: VerifiedUser,
     file: Annotated[UploadFile, File(description="Image file to upload")],
     caption: Annotated[str, Form(max_length=35)] = "",
     tag_ids: Annotated[str, Form(description="Comma-separated tag IDs (e.g., '1,2,3')")] = "",
+    confirm_similar: Annotated[
+        bool, Form(description="Set to true to bypass IQDB similarity check")
+    ] = False,
     db: AsyncSession = Depends(get_db),
-) -> ImageUploadResponse:
+) -> ImageUploadResponse | JSONResponse:
     """
     Upload a new image with metadata and tags.
 
@@ -1658,16 +1672,25 @@ async def upload_image(
         date_prefix = datetime.now().strftime("%Y-%m-%d")
         filename = f"{date_prefix}-{image_id}"  # Store without extension
 
-        # Check IQDB for similar images (runs in main thread, ~100-300ms)
-        # Uses the main uploaded file for similarity check
-        similar_images = await check_iqdb_similarity(file_path, db)
-
-        # TODO: If similar_images has high-scoring matches:
-        # - Show them to user for confirmation (return 409 with list of matches)
-        # - Allow user to confirm upload anyway (add skip_similarity_check param)
-        # - Example: if similar_images and not skip_similarity_check:
-        #     raise HTTPException(409, {"matches": similar_images, "message": "Similar images found"})
-        # For now, we just check but don't block the upload
+        # Check IQDB for near-duplicate images unless user confirmed
+        if not confirm_similar:
+            iqdb_results = await check_iqdb_similarity(
+                file_path, db, threshold=settings.IQDB_UPLOAD_THRESHOLD
+            )
+            if iqdb_results:
+                # Hydrate IQDB results with full image data
+                similar = await _hydrate_similar_images(iqdb_results, db)
+                # Clean up temp record and file before returning 409
+                await db.rollback()
+                if file_path and file_path.exists():
+                    file_path.unlink()
+                return JSONResponse(
+                    status_code=status.HTTP_409_CONFLICT,
+                    content=ImageUploadSimilarResponse(
+                        message="Similar images found. Please confirm to proceed with upload.",
+                        similar_images=similar,
+                    ).model_dump(mode="json"),
+                )
 
         # Determine if medium/large variants should be created
         has_medium = 1 if (width > settings.MEDIUM_EDGE or height > settings.MEDIUM_EDGE) else 0

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1581,16 +1581,20 @@ async def upload_image(
     3. Check for duplicate (MD5 hash)
     4. Save image to storage (filename: YYYY-MM-DD-{image_id}.{ext})
     5. Extract image dimensions
-    6. Update image record with metadata
-    7. Link tags to image
-    8. Schedule thumbnail generation (background)
-    9. Return created image details
+    6. Check IQDB for near-duplicate images (unless confirm_similar=true)
+       - If matches found (>= IQDB_UPLOAD_THRESHOLD), return 409 with similar images
+       - Frontend displays matches for user confirmation, then retries with confirm_similar=true
+    7. Update image record with metadata
+    8. Link tags to image
+    9. Schedule thumbnail generation (background)
+    10. Return created image details
 
     Security:
     - Requires authentication
     - Validates file is actually an image using PIL (prevents malicious uploads)
     - Validates file type, size, and extension
     - Prevents duplicate images (MD5 check)
+    - Detects near-duplicate images via IQDB similarity (409 with confirmation flow)
 
     Filename Format:
     - Main image: YYYY-MM-DD-{image_id}.{ext} (e.g., 2025-11-15-1111881.jpeg)

--- a/app/config.py
+++ b/app/config.py
@@ -93,6 +93,7 @@ class Settings(BaseSettings):
     IQDB_HOST: str = "localhost"
     IQDB_PORT: int = 5588
     IQDB_SIMILARITY_THRESHOLD: float = 50.0
+    IQDB_UPLOAD_THRESHOLD: float = 90.0
 
     # Rate Limiting
     RATE_LIMIT_PER_MINUTE: int = 60

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -280,3 +280,14 @@ class SimilarImagesResponse(BaseModel):
     similar_images: list[SimilarImageResult] = Field(
         description="List of similar images ordered by similarity score (highest first)"
     )
+
+
+class ImageUploadSimilarResponse(BaseModel):
+    """Schema for 409 response when similar images are found during upload.
+
+    Returned when IQDB detects near-duplicate images above IQDB_UPLOAD_THRESHOLD.
+    Frontend should display these to the user for confirmation before retrying.
+    """
+
+    message: str
+    similar_images: list[SimilarImageResult]

--- a/tests/api/v1/test_similar_images.py
+++ b/tests/api/v1/test_similar_images.py
@@ -246,3 +246,27 @@ class TestIQDBService:
             Path("/nonexistent/path/image.jpg"), db_session
         )
         assert result == []
+
+
+class TestIQDBUploadThreshold:
+    """Tests for IQDB upload duplicate detection threshold."""
+
+    def test_upload_threshold_filters_high_similarity(self):
+        """IQDB_UPLOAD_THRESHOLD filters results to near-duplicates only."""
+        from app.config import settings
+
+        # Simulate IQDB results at various similarity levels
+        all_results = [
+            {"image_id": 1, "score": 95.0},  # Above upload threshold
+            {"image_id": 2, "score": 91.0},  # Above upload threshold
+            {"image_id": 3, "score": 85.0},  # Below upload threshold
+            {"image_id": 4, "score": 60.0},  # Below upload threshold
+        ]
+
+        # Filter using the upload threshold (same logic as upload handler)
+        upload_duplicates = [
+            r for r in all_results if r["score"] >= settings.IQDB_UPLOAD_THRESHOLD
+        ]
+
+        assert len(upload_duplicates) == 2
+        assert all(r["score"] >= 90.0 for r in upload_duplicates)

--- a/tests/api/v1/test_similar_images.py
+++ b/tests/api/v1/test_similar_images.py
@@ -249,24 +249,12 @@ class TestIQDBService:
 
 
 class TestIQDBUploadThreshold:
-    """Tests for IQDB upload duplicate detection threshold."""
+    """Tests configuration for IQDB upload duplicate detection threshold."""
 
-    def test_upload_threshold_filters_high_similarity(self):
-        """IQDB_UPLOAD_THRESHOLD filters results to near-duplicates only."""
+    def test_upload_threshold_config_for_near_duplicates(self):
+        """IQDB_UPLOAD_THRESHOLD is configured for near-duplicate detection."""
         from app.config import settings
 
-        # Simulate IQDB results at various similarity levels
-        all_results = [
-            {"image_id": 1, "score": 95.0},  # Above upload threshold
-            {"image_id": 2, "score": 91.0},  # Above upload threshold
-            {"image_id": 3, "score": 85.0},  # Below upload threshold
-            {"image_id": 4, "score": 60.0},  # Below upload threshold
-        ]
-
-        # Filter using the upload threshold (same logic as upload handler)
-        upload_duplicates = [
-            r for r in all_results if r["score"] >= settings.IQDB_UPLOAD_THRESHOLD
-        ]
-
-        assert len(upload_duplicates) == 2
-        assert all(r["score"] >= 90.0 for r in upload_duplicates)
+        # The upload duplicate detection should only treat very similar matches
+        # as duplicates, so the threshold must be high (e.g., >= 90).
+        assert settings.IQDB_UPLOAD_THRESHOLD >= 90.0

--- a/tests/api/v1/test_upload.py
+++ b/tests/api/v1/test_upload.py
@@ -1,0 +1,178 @@
+"""Tests for image upload IQDB duplicate detection."""
+
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token
+from app.models.user import Users
+from app.schemas.image import SimilarImageResult
+
+
+@pytest.fixture
+async def verified_user(db_session: AsyncSession) -> Users:
+    """Create a verified user for upload testing."""
+    user = Users(
+        username="uploader",
+        password="hashed_password_here",
+        password_type="bcrypt",
+        salt="saltsalt12345678",
+        email="uploader@example.com",
+        active=1,
+        email_verified=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+async def upload_client(client: AsyncClient, verified_user: Users) -> AsyncClient:
+    """Authenticated client with a verified user."""
+    access_token = create_access_token(verified_user.id)
+    client.headers.update({"Authorization": f"Bearer {access_token}"})
+    return client
+
+
+def _fake_image_bytes() -> bytes:
+    """Create a minimal valid JPEG for upload tests."""
+    from PIL import Image
+
+    img = Image.new("RGB", (100, 100), color="red")
+    buf = BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _make_similar_result(image_id: int, score: float) -> SimilarImageResult:
+    """Build a SimilarImageResult for test assertions."""
+    return SimilarImageResult(
+        image_id=image_id,
+        filename=f"2025-01-01-{image_id}",
+        ext="jpg",
+        md5_hash="fakehash",
+        filesize=1000,
+        width=100,
+        height=100,
+        rating=0.0,
+        user_id=1,
+        date_added="2025-01-01T00:00:00",
+        status=1,
+        locked=0,
+        posts=0,
+        favorites=0,
+        bayesian_rating=0.0,
+        num_ratings=0,
+        medium=0,
+        large=0,
+        similarity_score=score,
+    )
+
+
+def _mock_save_uploaded_image(md5: str = "abc123unique"):
+    """Create an AsyncMock for save_uploaded_image that returns a fake path."""
+    fake_path = Path("/tmp/fake-upload.jpg")
+
+    async def _save(file, storage_path, image_id):
+        # Create the fake file so cleanup code doesn't error
+        fake_path.touch()
+        return fake_path, "jpg", md5
+
+    return patch("app.api.v1.images.save_uploaded_image", side_effect=_save)
+
+
+class TestUploadIQDBDuplicateDetection:
+    """Tests for IQDB near-duplicate detection during upload."""
+
+    @pytest.mark.asyncio
+    async def test_upload_returns_409_when_similar_images_found(
+        self, upload_client: AsyncClient, verified_user: Users
+    ):
+        """Upload returns 409 with similar images when IQDB finds near-duplicates."""
+        hydrated = [
+            _make_similar_result(42, 95.5),
+            _make_similar_result(99, 91.0),
+        ]
+
+        with (
+            _mock_save_uploaded_image(),
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=[{"image_id": 42, "score": 95.5}, {"image_id": 99, "score": 91.0}],
+            ),
+            patch(
+                "app.api.v1.images._hydrate_similar_images",
+                new_callable=AsyncMock,
+                return_value=hydrated,
+            ),
+            patch("app.api.v1.images.get_image_dimensions", return_value=(100, 100)),
+            patch("app.api.v1.images.enqueue_job", new_callable=AsyncMock),
+        ):
+            response = await upload_client.post(
+                "/api/v1/images/upload",
+                files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+                data={"tag_ids": "", "caption": ""},
+            )
+
+        assert response.status_code == 409
+        data = response.json()
+        assert "similar_images" in data
+        assert len(data["similar_images"]) == 2
+        assert data["similar_images"][0]["image_id"] == 42
+        assert data["similar_images"][0]["similarity_score"] == 95.5
+        assert data["similar_images"][1]["image_id"] == 99
+        assert data["similar_images"][1]["similarity_score"] == 91.0
+
+    @pytest.mark.asyncio
+    async def test_upload_succeeds_with_confirm_similar(
+        self, upload_client: AsyncClient, verified_user: Users
+    ):
+        """Upload succeeds when confirm_similar=true, skipping IQDB check."""
+        mock_iqdb = AsyncMock(return_value=[])
+
+        with (
+            _mock_save_uploaded_image("abc123unique2"),
+            patch("app.api.v1.images.check_iqdb_similarity", mock_iqdb),
+            patch("app.api.v1.images.get_image_dimensions", return_value=(100, 100)),
+            patch("app.api.v1.images.enqueue_job", new_callable=AsyncMock),
+        ):
+            response = await upload_client.post(
+                "/api/v1/images/upload",
+                files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+                data={"tag_ids": "", "caption": "", "confirm_similar": "true"},
+            )
+
+        assert response.status_code == 201
+        # IQDB should not have been called
+        mock_iqdb.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upload_succeeds_when_no_iqdb_matches(
+        self, upload_client: AsyncClient, verified_user: Users
+    ):
+        """Upload succeeds normally when IQDB finds no near-duplicates."""
+        with (
+            _mock_save_uploaded_image("abc123unique3"),
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("app.api.v1.images.get_image_dimensions", return_value=(100, 100)),
+            patch("app.api.v1.images.enqueue_job", new_callable=AsyncMock),
+        ):
+            response = await upload_client.post(
+                "/api/v1/images/upload",
+                files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+                data={"tag_ids": "", "caption": ""},
+            )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert "similar_images" not in data

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,6 +1,20 @@
 """Tests for config constants."""
 
-from app.config import TagAuditActionType
+from app.config import Settings, TagAuditActionType
+
+
+class TestIQDBConfig:
+    """Tests for IQDB configuration settings."""
+
+    def test_iqdb_upload_threshold_default(self) -> None:
+        """IQDB upload threshold defaults to 90.0."""
+        s = Settings()
+        assert s.IQDB_UPLOAD_THRESHOLD == 90.0
+
+    def test_iqdb_upload_threshold_higher_than_similarity(self) -> None:
+        """Upload threshold should be higher than general similarity threshold."""
+        s = Settings()
+        assert s.IQDB_UPLOAD_THRESHOLD > s.IQDB_SIMILARITY_THRESHOLD
 
 
 class TestTagAuditActionType:

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -13,7 +13,6 @@ from app.schemas.base import UTCDatetime, UTCDatetimeOptional
 from app.schemas.image import (
     ImageBase,
     ImageResponse,
-    ImageUploadResponse,
     ImageUploadSimilarResponse,
     SimilarImageResult,
 )


### PR DESCRIPTION
## Summary
- Adds IQDB near-duplicate detection to the upload flow with a 90% similarity threshold (`IQDB_UPLOAD_THRESHOLD`)
- Returns 409 with `ImageUploadSimilarResponse` (typed `SimilarImageResult[]`) when matches are found, giving the frontend full image data to display for user confirmation
- Adds `confirm_similar` form parameter to bypass the check on retry
- Declares the 409 response in the OpenAPI spec so generated types include it
- Refactors similar image hydration into shared `_hydrate_similar_images` helper (used by both upload and `/similar` endpoints)

## Test plan
- [x] Upload with IQDB matches returns 409 with similar images
- [x] Upload with `confirm_similar=true` skips IQDB and returns 201
- [x] Upload with no IQDB matches returns 201 without `similar_images`
- [x] Schema tests for `ImageUploadSimilarResponse` with `SimilarImageResult`
- [x] Config tests for `IQDB_UPLOAD_THRESHOLD` default and relationship to `IQDB_SIMILARITY_THRESHOLD`
- [x] Existing `/similar` endpoint tests still pass after refactor
- [x] Full suite: 936 passed, 0 failures
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)