### PR TITLE
feat: expose miscmeta field and add image edit endpoint

### DIFF
--- a/app/models/image.py
+++ b/app/models/image.py
@@ -98,6 +98,7 @@ class ImageBase(SQLModel):
 
     # Metadata
     caption: str = Field(default="", max_length=35)
+    miscmeta: str | None = Field(default=None, max_length=255)
 
     # Status
     status: int = Field(
@@ -143,7 +144,7 @@ class Images(ImageBase, table=True):
     - ip: Privacy-sensitive tracking
     - status_user_id, status_updated, last_post: Internal moderation
     - medium, large: image variant booleans
-    - total_pixels, miscmeta: Internal metadata
+    - total_pixels: Internal metadata
     - replacement_id: Internal reference
     """
 
@@ -222,7 +223,6 @@ class Images(ImageBase, table=True):
 
     # Internal metadata
     total_pixels: Decimal | None = Field(default=None)
-    miscmeta: str | None = Field(default=None, max_length=255)
     replacement_id: int | None = Field(default=None, foreign_key="images.image_id")
 
     # Relationships - Example implementation

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -51,17 +51,10 @@ class ImageCreate(ImageBase):
 
 
 class ImageUpdate(BaseModel):
-    """Schema for updating an image - all fields optional"""
+    """Schema for updating image metadata — all fields optional."""
 
-    filename: str | None = None
-    ext: str | None = None
-    original_filename: str | None = None
-    md5_hash: str | None = None
-    filesize: int | None = None
-    width: int | None = None
-    height: int | None = None
     caption: str | None = None
-    rating: float | None = None
+    miscmeta: str | None = None
 
     @field_validator("caption")
     @classmethod

--- a/tests/api/v1/test_image_edit.py
+++ b/tests/api/v1/test_image_edit.py
@@ -1,0 +1,252 @@
+"""Tests for PATCH /api/v1/images/{image_id} endpoint."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, get_password_hash
+from app.models.image import Images
+from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
+from app.models.user import Users
+
+
+async def create_user(
+    db_session: AsyncSession,
+    username: str = "edituser",
+    email: str = "edit@example.com",
+    admin: int = 0,
+) -> Users:
+    """Create a user for testing."""
+    user = Users(
+        username=username,
+        password=get_password_hash("TestPassword123!"),
+        password_type="bcrypt",
+        salt="saltsalt12345678",
+        email=email,
+        active=1,
+        admin=admin,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+async def create_image(
+    db_session: AsyncSession,
+    user_id: int,
+    caption: str = "original caption",
+    miscmeta: str | None = None,
+) -> Images:
+    """Create a test image."""
+    image = Images(
+        filename="test-edit-001",
+        ext="jpg",
+        original_filename="test.jpg",
+        md5_hash="abcdef1234567890abcdef1234567890",
+        filesize=100000,
+        width=800,
+        height=600,
+        caption=caption,
+        miscmeta=miscmeta,
+        user_id=user_id,
+        status=1,
+    )
+    db_session.add(image)
+    await db_session.commit()
+    await db_session.refresh(image)
+    return image
+
+
+async def grant_permission(db_session: AsyncSession, user_id: int, perm_title: str):
+    """Grant a permission to a user via a group."""
+    result = await db_session.execute(select(Perms).where(Perms.title == perm_title))
+    perm = result.scalar_one_or_none()
+    if not perm:
+        perm = Perms(title=perm_title, desc=f"Test permission {perm_title}")
+        db_session.add(perm)
+        await db_session.flush()
+
+    result = await db_session.execute(
+        select(Groups).where(Groups.title == "edit_test_group")
+    )
+    group = result.scalar_one_or_none()
+    if not group:
+        group = Groups(title="edit_test_group", desc="Image edit test group")
+        db_session.add(group)
+        await db_session.flush()
+
+    result = await db_session.execute(
+        select(GroupPerms).where(
+            GroupPerms.group_id == group.group_id, GroupPerms.perm_id == perm.perm_id
+        )
+    )
+    if not result.scalar_one_or_none():
+        group_perm = GroupPerms(group_id=group.group_id, perm_id=perm.perm_id, permvalue=1)
+        db_session.add(group_perm)
+        await db_session.flush()
+
+    result = await db_session.execute(
+        select(UserGroups).where(
+            UserGroups.user_id == user_id, UserGroups.group_id == group.group_id
+        )
+    )
+    if not result.scalar_one_or_none():
+        user_group = UserGroups(user_id=user_id, group_id=group.group_id)
+        db_session.add(user_group)
+
+    await db_session.commit()
+
+
+def auth_header(user: Users) -> dict[str, str]:
+    """Create an Authorization header for a user."""
+    token = create_access_token(user.user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestImageEdit:
+    """Tests for PATCH /api/v1/images/{image_id}."""
+
+    @pytest.mark.asyncio
+    async def test_owner_can_update_caption(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Image owner can update their image's caption."""
+        owner = await create_user(db_session)
+        image = await create_image(db_session, owner.user_id)
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"caption": "new caption"},
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 200
+        assert response.json()["caption"] == "new caption"
+
+    @pytest.mark.asyncio
+    async def test_owner_can_update_miscmeta(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Image owner can update their image's miscmeta."""
+        owner = await create_user(db_session)
+        image = await create_image(db_session, owner.user_id)
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"miscmeta": "pixiv: 99999"},
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 200
+        assert response.json()["miscmeta"] == "pixiv: 99999"
+
+    @pytest.mark.asyncio
+    async def test_non_owner_without_permission_gets_403(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Non-owner without IMAGE_EDIT_META permission cannot edit."""
+        owner = await create_user(db_session, username="owner", email="owner@test.com")
+        other = await create_user(db_session, username="other", email="other@test.com")
+        image = await create_image(db_session, owner.user_id)
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"caption": "hacked"},
+            headers=auth_header(other),
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_user_with_image_edit_meta_permission_can_edit(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """User with IMAGE_EDIT_META permission can edit any image."""
+        owner = await create_user(db_session, username="owner2", email="owner2@test.com")
+        mod = await create_user(db_session, username="mod", email="mod@test.com")
+        image = await create_image(db_session, owner.user_id, caption="before")
+
+        await grant_permission(db_session, mod.user_id, "image_edit_meta")
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"caption": "mod edited"},
+            headers=auth_header(mod),
+        )
+
+        assert response.status_code == 200
+        assert response.json()["caption"] == "mod edited"
+
+    @pytest.mark.asyncio
+    async def test_admin_can_edit_any_image(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Admin users can edit any image."""
+        owner = await create_user(db_session, username="owner3", email="owner3@test.com")
+        admin = await create_user(
+            db_session, username="admin", email="admin@test.com", admin=1
+        )
+        image = await create_image(db_session, owner.user_id, caption="before")
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"caption": "admin edited"},
+            headers=auth_header(admin),
+        )
+
+        assert response.status_code == 200
+        assert response.json()["caption"] == "admin edited"
+
+    @pytest.mark.asyncio
+    async def test_empty_update_returns_400(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Empty update body (no fields set) returns 400."""
+        owner = await create_user(db_session)
+        image = await create_image(db_session, owner.user_id)
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={},
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_image_not_found_returns_404(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Editing a nonexistent image returns 404."""
+        user = await create_user(db_session)
+
+        response = await client.patch(
+            "/api/v1/images/999999",
+            json={"caption": "ghost"},
+            headers=auth_header(user),
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_partial_update_only_changes_provided_fields(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Setting caption does not clear miscmeta, and vice versa."""
+        owner = await create_user(db_session)
+        image = await create_image(
+            db_session, owner.user_id, caption="keep me", miscmeta="keep me too"
+        )
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"caption": "changed"},
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["caption"] == "changed"
+        assert data["miscmeta"] == "keep me too"

--- a/tests/unit/test_image_response_groups.py
+++ b/tests/unit/test_image_response_groups.py
@@ -26,6 +26,7 @@ def _create_mock_image(
     mock_image.width = 100
     mock_image.height = 100
     mock_image.caption = "Test"
+    mock_image.miscmeta = None
     mock_image.rating = 0.0
     mock_image.user_id = user_id
     mock_image.date_added = datetime.now()

--- a/tests/unit/test_miscmeta.py
+++ b/tests/unit/test_miscmeta.py
@@ -1,0 +1,40 @@
+"""Tests for miscmeta field exposure in models and schemas."""
+
+from app.models.image import ImageBase
+from app.schemas.image import ImageUpdate
+
+
+class TestMiscmetaInImageBase:
+    """miscmeta should be a public field on ImageBase (and thus on all response schemas)."""
+
+    def test_miscmeta_is_a_field_on_image_base(self):
+        """ImageBase should include miscmeta as a field."""
+        assert "miscmeta" in ImageBase.model_fields
+
+    def test_miscmeta_defaults_to_none(self):
+        """miscmeta should default to None when not provided."""
+        image = ImageBase(ext="jpg")
+        assert image.miscmeta is None
+
+    def test_miscmeta_accepts_string_value(self):
+        """miscmeta should accept a string value."""
+        image = ImageBase(ext="jpg", miscmeta="pixiv: 12345")
+        assert image.miscmeta == "pixiv: 12345"
+
+
+class TestMiscmetaInImageUpdate:
+    """ImageUpdate schema should accept miscmeta for editing."""
+
+    def test_image_update_accepts_miscmeta(self):
+        """ImageUpdate should have miscmeta as an optional field."""
+        assert "miscmeta" in ImageUpdate.model_fields
+
+    def test_image_update_miscmeta_defaults_to_none(self):
+        """miscmeta should default to None (not included in update) when not provided."""
+        update = ImageUpdate()
+        assert update.miscmeta is None
+
+    def test_image_update_with_miscmeta_value(self):
+        """ImageUpdate should accept a miscmeta string."""
+        update = ImageUpdate(miscmeta="some metadata")
+        assert update.miscmeta == "some metadata"


### PR DESCRIPTION
## Summary
- Moves `miscmeta` from internal-only `Images` model to public `ImageBase`, exposing it in all image API responses
- Adds `miscmeta` as an optional parameter to the upload endpoint (`POST /api/v1/images/upload`)
- Creates new `PATCH /api/v1/images/{image_id}` endpoint for editing `caption` and `miscmeta` on existing images
- Trims `ImageUpdate` schema to only user-editable fields (was exposing internal fields like filename, md5_hash, etc.)

### Permission model for PATCH endpoint
- Image owner can edit their own images
- Admin users can edit any image
- Users with `IMAGE_EDIT_META` permission can edit any image

Matches the legacy PHP permission model from `/image/edit/index.php`.

## Test plan
- [x] Unit tests for `miscmeta` on `ImageBase` and `ImageUpdate` schemas (`tests/unit/test_miscmeta.py`)
- [x] Upload test for `miscmeta` parameter (`tests/api/v1/test_upload.py`)
- [x] 8 integration tests for PATCH endpoint (`tests/api/v1/test_image_edit.py`): owner edit, permission edit, admin edit, 403/404/400, partial update
- [x] Full test suite: 951 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)