### PR TITLE
Expose OpenAPI docs and add structured request logging

### DIFF
--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -88,9 +88,9 @@ def configure_logging() -> None:
     )
 
     # Reduce noise from third-party libraries
-    # Keep uvicorn.access at INFO to see request logs in development
-    if settings.ENVIRONMENT != "development":
-        logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+    # Suppress uvicorn access logs — structlog request_complete covers this with
+    # richer context (user_id, request_id, elapsed_ms)
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
     logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
 
 


### PR DESCRIPTION
## Summary
- Move OpenAPI docs (`/docs`, `/redoc`, `/openapi.json`) under `/api/` so they're accessible through the nginx reverse proxy
- Add structlog `request_complete` log line per request with `method`, `path`, `status_code`, `elapsed_ms`, `request_id`, and `user_id` (when authenticated)
- Suppress duplicate uvicorn access logs in all environments since structlog now provides richer request logging

## Test plan
- [x] All 964 tests pass
- [x] Verify `/api/docs` and `/api/redoc` load through nginx
- [x] Verify authenticated requests show `user_id` in logs
- [x] Verify unauthenticated requests omit `user_id`
- [x] Verify `elapsed_ms` appears in all request logs
- [x] Verify no duplicate uvicorn access log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)