### PR TITLE
security: remove refresh token from response body

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -151,7 +151,7 @@ def _set_auth_cookies(response: Response, access_token: str, refresh_token: str)
         key="refresh_token",
         value=refresh_token,
         httponly=True,  # Prevent JavaScript access (XSS protection)
-        secure=settings.ENVIRONMENT == "production",  # HTTPS only in production
+        secure=settings.ENVIRONMENT != "development",  # HTTPS everywhere except development
         samesite="strict",  # CSRF protection
         max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,  # seconds
     )
@@ -161,7 +161,7 @@ def _set_auth_cookies(response: Response, access_token: str, refresh_token: str)
         key="access_token",
         value=access_token,
         httponly=True,  # Prevent JavaScript access (XSS protection)
-        secure=settings.ENVIRONMENT == "production",  # HTTPS only in production
+        secure=settings.ENVIRONMENT != "development",  # HTTPS everywhere except development
         samesite="strict",  # CSRF protection
         max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # Match JWT expiration
     )
@@ -179,7 +179,7 @@ def _clear_auth_cookies(response: Response) -> None:
         key="refresh_token",
         path="/",
         httponly=True,
-        secure=settings.ENVIRONMENT == "production",
+        secure=settings.ENVIRONMENT != "development",
         samesite="strict",
     )
 
@@ -188,7 +188,7 @@ def _clear_auth_cookies(response: Response) -> None:
         key="access_token",
         path="/",
         httponly=True,
-        secure=settings.ENVIRONMENT == "production",
+        secure=settings.ENVIRONMENT != "development",
         samesite="strict",
     )
 
@@ -347,7 +347,6 @@ async def login(
         access_token=access_token,
         token_type="bearer",
         expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
-        refresh_token=refresh_token,
     )
 
 
@@ -509,7 +508,6 @@ async def refresh_token(
         access_token=access_token,
         token_type="bearer",
         expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
-        refresh_token=new_refresh_token,
     )
 
 

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -25,10 +25,6 @@ class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
     expires_in: int = Field(..., description="Access token expiration time in seconds from now")
-    refresh_token: str | None = Field(
-        default=None,
-        description="Refresh token (included for SSR cookie forwarding, also set in HTTPOnly cookie)",
-    )
 
 
 class RefreshRequest(BaseModel):

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -55,6 +55,9 @@ class TestLogin:
         # Check that refresh token cookie is set
         assert "refresh_token" in response.cookies
 
+        # Security: refresh token must NOT be in response body (HTTPOnly cookie only)
+        assert "refresh_token" not in data
+
     async def test_login_wrong_password(self, client: AsyncClient, db_session: AsyncSession):
         """Test login with incorrect password."""
         user = Users(
@@ -174,6 +177,10 @@ class TestRefresh:
         data = refresh_response.json()
         assert "access_token" in data
         assert data["token_type"] == "bearer"
+
+        # Security: refresh token must NOT be in response body (HTTPOnly cookie only)
+        assert "refresh_token" not in data
+        assert "refresh_token" in refresh_response.cookies
 
     async def test_refresh_without_token(self, client: AsyncClient):
         """Test refresh without a refresh token cookie."""


### PR DESCRIPTION
## Summary
- Remove `refresh_token` field from `TokenResponse` schema so the token is only delivered via HTTPOnly cookie, closing an XSS vector where an attacker could read the 30-day token from the JSON body
- Align cookie `Secure` flag logic with the frontend (`!= "development"` instead of `== "production"`) so non-production HTTPS environments get secure cookies

## Files changed
- `app/schemas/auth.py` — removed `refresh_token` field from `TokenResponse`
- `app/api/v1/auth.py` — removed `refresh_token` kwarg from both login and refresh endpoints; updated `Secure` flag condition in `_set_auth_cookies` and `_clear_auth_cookies`
- `tests/api/v1/test_auth.py` — added assertions confirming refresh token is absent from response body but present in cookies

## Test plan
- [x] `uv run pytest tests/api/v1/test_auth.py -x -v` — all 23 auth tests pass
- [x] `uv run pytest tests/ -x` — full suite (964 tests) passes
- [ ] Verify frontend SSR cookie forwarding works end-to-end in test environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)