### PR TITLE
fix: resolve Python 3.14 runtime compat issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 # Set working directory
 WORKDIR /app
 
+# aiomysql calls getpass.getuser() at import time; Python 3.13+ raises OSError
+# when running as a numeric UID without a /etc/passwd entry
+ENV USER=app
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     gcc \

--- a/app/tasks/worker.py
+++ b/app/tasks/worker.py
@@ -4,7 +4,16 @@ ARQ worker configuration and job definitions.
 Run worker with: uv run arq app.tasks.worker.WorkerSettings
 """
 
+import asyncio
 from typing import Any
+
+# arq's Worker.__init__ calls asyncio.get_event_loop() which raises RuntimeError
+# in Python 3.14 when no event loop exists. Ensure one is available before arq runs.
+# https://github.com/python-arq/arq/issues/144
+try:
+    asyncio.get_event_loop()
+except RuntimeError:
+    asyncio.set_event_loop(asyncio.new_event_loop())
 
 from arq.connections import RedisSettings
 from arq.cron import cron

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,8 +74,6 @@ services:
       - IQDB_HOST=iqdb
       # Prevent Python from writing pyc files and __pycache__ dirs
       - PYTHONDONTWRITEBYTECODE=1
-      # Required for aiomysql: getpass.getuser() needs a username (Python 3.13+ raises OSError without one)
-      - USER=app
     volumes:
       # Mount only necessary directories, excluding .venv to prevent conflicts
       - ./app:/app/app
@@ -154,8 +152,6 @@ services:
       - IQDB_HOST=iqdb
       # Prevent Python from writing pyc files
       - PYTHONDONTWRITEBYTECODE=1
-      # Required for aiomysql: getpass.getuser() needs a username (Python 3.13+ raises OSError without one)
-      - USER=app
     volumes:
       # Mount only necessary directories, excluding .venv to prevent conflicts
       - ./app:/app/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
       - IQDB_HOST=iqdb
       # Prevent Python from writing pyc files and __pycache__ dirs
       - PYTHONDONTWRITEBYTECODE=1
+      # Required for aiomysql: getpass.getuser() needs a username (Python 3.13+ raises OSError without one)
+      - USER=app
     volumes:
       # Mount only necessary directories, excluding .venv to prevent conflicts
       - ./app:/app/app
@@ -152,6 +154,8 @@ services:
       - IQDB_HOST=iqdb
       # Prevent Python from writing pyc files
       - PYTHONDONTWRITEBYTECODE=1
+      # Required for aiomysql: getpass.getuser() needs a username (Python 3.13+ raises OSError without one)
+      - USER=app
     volumes:
       # Mount only necessary directories, excluding .venv to prevent conflicts
       - ./app:/app/app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "structlog>=24.1.0",
     "python-json-logger>=2.0.7",
     # Task queue
-    "arq>=0.26.0", # Task queue for background jobs
+    "arq>=0.27.0", # Task queue for background jobs
     # "python-magic>=0.4.27",  # File type detection - for validating image uploads
     # "slowapi>=0.1.9",  # Rate limiting - for API throttling
     # "python-multipart>=0.0.20",  # Multipart form data - needed for image uploads

--- a/uv.lock
+++ b/uv.lock
@@ -69,15 +69,15 @@ wheels = [
 
 [[package]]
 name = "arq"
-version = "0.26.3"
+version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "redis", extra = ["hiredis"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/65/5add7049297a449d1453e26a8d5924f0d5440b3876edc9e80d5dc621f16d/arq-0.26.3.tar.gz", hash = "sha256:362063ea3c726562fb69c723d5b8ee80827fdefda782a8547da5be3d380ac4b1", size = 291111, upload-time = "2025-01-06T22:44:49.771Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/f9/0f1df9a39b36fc4df590a5f2fca010e6bc8ba2635b75f0368f41722ef24e/arq-0.27.0.tar.gz", hash = "sha256:302a16e78396923fbff0f542fee0e04c731cc549195d18d039be3cc1a3431106", size = 415951, upload-time = "2026-02-02T14:38:21.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/b3/a24a183c628da633b7cafd1759b14aaf47958de82ba6bcae9f1c2898781d/arq-0.26.3-py3-none-any.whl", hash = "sha256:9f4b78149a58c9dc4b88454861a254b7c4e7a159f2c973c89b548288b77e9005", size = 25968, upload-time = "2025-01-06T22:44:45.771Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/89/e28a3a82da9b3d5ccacf143013b8911501c3593cf976b14b34711766fd4c/arq-0.27.0-py3-none-any.whl", hash = "sha256:4ca085671520472e45f09f5c37a1495097e5c4a79faaf18efcb9a759f8917f87", size = 26026, upload-time = "2026-02-02T14:38:19.375Z" },
 ]
 
 [[package]]
@@ -1395,7 +1395,7 @@ requires-dist = [
     { name = "aiomysql", specifier = ">=0.2.0" },
     { name = "aiosmtplib", specifier = ">=5.0.0" },
     { name = "alembic", specifier = ">=1.13.0" },
-    { name = "arq", specifier = ">=0.26.0" },
+    { name = "arq", specifier = ">=0.27.0" },
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0,<=0.122.0" },
     { name = "httpx", specifier = ">=0.27.0" },


### PR DESCRIPTION
## Summary
Follow-up to #128. Fixes two runtime issues discovered when running Docker containers on Python 3.14:

- **aiomysql `getpass.getuser()` crash**: Python 3.13+ raises `OSError` (instead of `KeyError`) when UID has no `/etc/passwd` entry. aiomysql calls this at import time. Fixed by setting `USER=app` env var in Docker containers.
- **arq `asyncio.get_event_loop()` crash**: Python 3.14 raises `RuntimeError` when no event loop exists. arq's `Worker.__init__` calls this unconditionally. Fixed with a module-level workaround in `worker.py`. ([arq issue #144](https://github.com/python-arq/arq/issues/144))
- **arq bumped 0.26.0 → 0.27.0** (latest, adds Python 3.13 support)

## Test plan
- [x] Unit tests pass (53/53) on Python 3.14.2
- [x] Docker containers (`api` + `arq-worker`) start and stay healthy
- [x] API smoke test: `curl localhost:8000/api/v1/images/1111520` returns valid JSON
- [x] arq-worker registers all 7 job functions successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)