### PR TITLE
feat: redirect legacy /image/{id} URLs to /images/{id}

### DIFF
--- a/docker/nginx/frontend-production.conf.template
+++ b/docker/nginx/frontend-production.conf.template
@@ -177,6 +177,11 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # Legacy PHP URL redirects (e-shuushuu.net/image/827934/ → /images/827934)
+    location ~ "^/image/([0-9]+)/?$" {
+        return 301 /images/$1;
+    }
+
     # Frontend - proxy to SvelteKit SSR server (production build in Docker)
     location / {
         proxy_pass http://frontend:3000;


### PR DESCRIPTION
## Summary
- Adds nginx redirect from legacy PHP URL pattern `/image/{id}/` to new `/images/{id}`
- Ensures existing e-shuushuu.net links continue to work after migration from PHP
- Uses 301 permanent redirect so search engines update their indexes

## Test plan
- [ ] Verify `/image/827934/` redirects to `/images/827934`
- [ ] Verify `/image/827934` (no trailing slash) also redirects
- [ ] Verify existing `/images/` routes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)