### PR TITLE
feat: add production deployment configuration for e-shuushuu.net

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ env/
 .env
 .env.local
 .env.*.local
+.env.prod
 *.pem
 *.key
 *.crt

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,150 @@
+# Production override - HTTPS with Let's Encrypt
+# Usage: docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.prod up -d
+
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "5"
+
+services:
+  # Disable local services not needed in production
+  mariadb:
+    profiles: [disabled]
+
+  adminer:
+    profiles: [disabled]
+
+  redis-commander:
+    profiles: [disabled]
+
+  redis:
+    container_name: shuushuu-redis-prod
+    logging: *default-logging
+
+  frontend:
+    build:
+      context: ../shuushuu-frontend
+      dockerfile: Dockerfile
+      args:
+        - PUBLIC_ENVIRONMENT=production
+        - PUBLIC_API_URL=http://nginx:8080
+        - PUBLIC_DEBUG=false
+        - PUBLIC_TURNSTILE_SITE_KEY=${TURNSTILE_SITE_KEY}
+    container_name: shuushuu-frontend-prod
+    environment:
+      - PUBLIC_ENVIRONMENT=production
+      - PUBLIC_API_URL=http://nginx:8080
+      - STORAGE_PATH=${STORAGE_PATH}
+      - NODE_OPTIONS=--max-old-space-size=4096
+    depends_on:
+      - api
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - default
+    logging: *default-logging
+
+  nginx:
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./docker/nginx/frontend-production.conf.template:/etc/nginx/conf.d/frontend.conf.template:ro
+      - ./docker/certbot/conf:/etc/letsencrypt:ro
+      - ./docker/certbot/www:/var/www/certbot:ro
+    environment:
+      - NGINX_HOST=${DOMAIN}
+      - NGINX_PORT=443
+    depends_on:
+      frontend:
+        condition: service_healthy
+    restart: unless-stopped
+    logging: *default-logging
+
+  api:
+    container_name: shuushuu-api-prod
+    command: uv run --no-project uvicorn app.main:app --host 0.0.0.0 --port 8000
+    ports: []
+    env_file: .env.prod
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=redis://redis:6379/0
+      - ARQ_REDIS_URL=redis://redis:6379/1
+      - IQDB_HOST=iqdb
+      - PYTHONDONTWRITEBYTECODE=1
+    volumes:
+      - ${STORAGE_PATH:-/shuushuu/images}:${STORAGE_PATH:-/shuushuu/images}
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: always
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    logging: *default-logging
+
+  arq-worker:
+    container_name: shuushuu-arq-worker-prod
+    env_file: .env.prod
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=redis://redis:6379/0
+      - ARQ_REDIS_URL=redis://redis:6379/1
+      - IQDB_HOST=iqdb
+      - PYTHONDONTWRITEBYTECODE=1
+    volumes:
+      - ${STORAGE_PATH:-/shuushuu/images}:${STORAGE_PATH:-/shuushuu/images}
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: always
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    logging: *default-logging
+
+  iqdb:
+    container_name: shuushuu-iqdb-prod
+    logging: *default-logging
+
+  certbot:
+    image: certbot/certbot:latest
+    container_name: shuushuu-certbot-prod
+    volumes:
+      - ./docker/certbot/conf:/etc/letsencrypt
+      - ./docker/certbot/www:/var/www/certbot
+    command: >
+      sh -c "
+      if [ -d /etc/letsencrypt/live ]; then
+        echo 'Certificates found. Starting renewal loop...'
+        while :; do
+          certbot renew --webroot -w /var/www/certbot --quiet || echo 'Renewal check completed'
+          sleep 12h
+        done
+      else
+        echo 'No certificates found in /etc/letsencrypt/live'
+        echo 'To generate certificates, run:'
+        echo '  docker compose -f docker-compose.yml -f docker-compose.prod.yml run --rm certbot certonly --webroot -w /var/www/certbot -d e-shuushuu.net'
+        echo 'Then restart the services.'
+        sleep infinity
+      fi
+      "
+    depends_on:
+      - nginx
+    logging: *default-logging
+
+volumes:
+  # Override generic volume names with prod-specific names for data isolation
+  mariadb_data:
+    name: mariadb_data_prod
+    driver: local
+  redis_data:
+    name: redis_data_prod
+    driver: local
+  iqdb_data:
+    name: iqdb_data_prod
+    driver: local

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,6 +23,7 @@ services:
     logging: *default-logging
 
   frontend:
+    # NOTE: Expects shuushuu-frontend repo at ../shuushuu-frontend (sibling directory)
     build:
       context: ../shuushuu-frontend
       dockerfile: Dockerfile
@@ -135,6 +136,7 @@ services:
       "
     depends_on:
       - nginx
+    restart: unless-stopped
     logging: *default-logging
 
 volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,6 +20,7 @@ services:
 
   redis:
     container_name: shuushuu-redis-prod
+    ports: []  # Internal only in production
     logging: *default-logging
 
   frontend:
@@ -81,9 +82,9 @@ services:
       - PYTHONDONTWRITEBYTECODE=1
     volumes:
       - ${STORAGE_PATH:-/shuushuu/images}:${STORAGE_PATH:-/shuushuu/images}
+    # List form replaces base depends_on entirely (removes mariadb dependency)
     depends_on:
-      redis:
-        condition: service_healthy
+      - redis
     restart: always
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -100,9 +101,9 @@ services:
       - PYTHONDONTWRITEBYTECODE=1
     volumes:
       - ${STORAGE_PATH:-/shuushuu/images}:${STORAGE_PATH:-/shuushuu/images}
+    # List form replaces base depends_on entirely (removes mariadb dependency)
     depends_on:
-      redis:
-        condition: service_healthy
+      - redis
     restart: always
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -110,6 +111,7 @@ services:
 
   iqdb:
     container_name: shuushuu-iqdb-prod
+    ports: []  # Internal only in production
     logging: *default-logging
 
   certbot:

--- a/scripts/create_prod_symlinks.sh
+++ b/scripts/create_prod_symlinks.sh
@@ -56,7 +56,12 @@ create_link() {
         if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$src" ]; then
             return
         fi
-        # Remove existing file/symlink at destination before creating
+        # Refuse to overwrite real files (only replace symlinks)
+        if [ -e "$dst" ] && [ ! -L "$dst" ]; then
+            echo "  WARNING: Skipping $dst — real file exists (not a symlink). Use rm manually if intended." >&2
+            return
+        fi
+        # Remove existing symlink at destination before creating
         rm -f "$dst"
         ln -s "$src" "$dst"
     fi

--- a/scripts/create_prod_symlinks.sh
+++ b/scripts/create_prod_symlinks.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create production symlink tree for image files
+# Links the new directory structure to existing PHP site image files
+#
+# Usage:
+#   SRC_BASE=/path/to/php/images ./scripts/create_prod_symlinks.sh           # Dry-run (preview)
+#   SRC_BASE=/path/to/php/images ./scripts/create_prod_symlinks.sh --apply   # Create symlinks
+#
+# Environment variables:
+#   SRC_BASE   - (required) Path to the PHP site's fullsize image directory
+#   DEST_BASE  - (optional) Destination directory, defaults to /shuushuu/images
+
+DEST_BASE="${DEST_BASE:-/shuushuu/images}"
+DRY_RUN=1
+
+if [ "${1:-}" = "--apply" ]; then
+    DRY_RUN=0
+fi
+
+# Validate SRC_BASE is set and exists
+if [ -z "${SRC_BASE:-}" ]; then
+    echo "ERROR: SRC_BASE must be set to the PHP site's image directory" >&2
+    echo "Usage: SRC_BASE=/path/to/images $0 [--apply]" >&2
+    exit 1
+fi
+
+if [ ! -d "$SRC_BASE" ]; then
+    echo "ERROR: SRC_BASE directory does not exist: $SRC_BASE" >&2
+    exit 1
+fi
+
+echo "=== Production Image Symlink Creator ==="
+echo "Source:      $SRC_BASE"
+echo "Destination: $DEST_BASE"
+echo "Mode:        $([ "$DRY_RUN" -eq 1 ] && echo 'DRY RUN (use --apply to create symlinks)' || echo 'APPLY')"
+echo ""
+
+# Create destination directories
+dirs=(fullsize medium large avatars banners)
+if [ "$DRY_RUN" -eq 0 ]; then
+    for dir in "${dirs[@]}"; do
+        mkdir -p "$DEST_BASE/$dir"
+    done
+fi
+
+# Helper: create a symlink (or print what would be done in dry-run mode)
+# Arguments: $1 = source file (absolute path), $2 = destination symlink path
+create_link() {
+    local src="$1" dst="$2"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "  LINK: $dst -> $src"
+    else
+        # Skip if symlink already exists and points to the same target
+        if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$src" ]; then
+            return
+        fi
+        # Remove existing file/symlink at destination before creating
+        rm -f "$dst"
+        ln -s "$src" "$dst"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# 1) Fullsize: all image files excluding medium, large, and thumb variants
+# ---------------------------------------------------------------------------
+echo "--- Fullsize ---"
+fullsize_count=0
+
+# Process main directory (non-recursive for the top level, but find handles it)
+while IFS= read -r -d '' f; do
+    base=$(basename "$f")
+    create_link "$f" "$DEST_BASE/fullsize/$base"
+    fullsize_count=$((fullsize_count + 1))
+done < <(find "$SRC_BASE" -maxdepth 1 -type f \
+    \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.gif' -o -iname '*.webp' \) \
+    ! -iname '*medium*' ! -iname '*large*' ! -iname '*thumb*' \
+    -print0)
+
+# Flatten deactivated subdirectory into fullsize (if it exists)
+if [ -d "$SRC_BASE/deactivated" ]; then
+    echo "  (including deactivated/ images)"
+    while IFS= read -r -d '' f; do
+        base=$(basename "$f")
+        create_link "$f" "$DEST_BASE/fullsize/$base"
+        fullsize_count=$((fullsize_count + 1))
+    done < <(find "$SRC_BASE/deactivated" -type f \
+        \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.gif' -o -iname '*.webp' \) \
+        ! -iname '*medium*' ! -iname '*large*' ! -iname '*thumb*' \
+        -print0)
+fi
+
+echo "  Count: $fullsize_count"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 2) Medium: files with 'medium' in the name, strip -medium suffix
+# ---------------------------------------------------------------------------
+echo "--- Medium ---"
+medium_count=0
+
+while IFS= read -r -d '' f; do
+    base=$(basename "$f")
+    # Strip -medium from the filename, e.g. 123-medium.jpg -> 123.jpg
+    newname=$(echo "$base" | sed -E 's/-medium([.][^.]+)$/\1/I')
+    create_link "$f" "$DEST_BASE/medium/$newname"
+    medium_count=$((medium_count + 1))
+done < <(find "$SRC_BASE" -type f -iname '*medium*' \
+    \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.gif' -o -iname '*.webp' \) \
+    -print0)
+
+echo "  Count: $medium_count"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 3) Large: files with 'large' in the name, strip -large suffix
+# ---------------------------------------------------------------------------
+echo "--- Large ---"
+large_count=0
+
+while IFS= read -r -d '' f; do
+    base=$(basename "$f")
+    # Strip -large from the filename, e.g. 123-large.jpg -> 123.jpg
+    newname=$(echo "$base" | sed -E 's/-large([.][^.]+)$/\1/I')
+    create_link "$f" "$DEST_BASE/large/$newname"
+    large_count=$((large_count + 1))
+done < <(find "$SRC_BASE" -type f -iname '*large*' \
+    \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.gif' -o -iname '*.webp' \) \
+    -print0)
+
+echo "  Count: $large_count"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 4) Avatars: symlink avatar files if the directory exists
+# ---------------------------------------------------------------------------
+echo "--- Avatars ---"
+avatar_count=0
+
+if [ -d "$SRC_BASE/avatars" ]; then
+    while IFS= read -r -d '' f; do
+        base=$(basename "$f")
+        create_link "$f" "$DEST_BASE/avatars/$base"
+        avatar_count=$((avatar_count + 1))
+    done < <(find "$SRC_BASE/avatars" -type f \
+        \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.gif' -o -iname '*.webp' \) \
+        -print0)
+    echo "  Count: $avatar_count"
+else
+    echo "  (skipped - $SRC_BASE/avatars does not exist)"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# 5) Banners: symlink banner files if the directory exists
+# ---------------------------------------------------------------------------
+echo "--- Banners ---"
+banner_count=0
+
+if [ -d "$SRC_BASE/banners" ]; then
+    while IFS= read -r -d '' f; do
+        base=$(basename "$f")
+        create_link "$f" "$DEST_BASE/banners/$base"
+        banner_count=$((banner_count + 1))
+    done < <(find "$SRC_BASE/banners" -type f \
+        \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.gif' -o -iname '*.webp' \) \
+        -print0)
+    echo "  Count: $banner_count"
+else
+    echo "  (skipped - $SRC_BASE/banners does not exist)"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Note: Thumbs are skipped — thumbnails are generated as WebP on demand.
+# ---------------------------------------------------------------------------
+
+# Summary
+total=$((fullsize_count + medium_count + large_count + avatar_count + banner_count))
+echo "=== Summary ==="
+echo "  Fullsize: $fullsize_count"
+echo "  Medium:   $medium_count"
+echo "  Large:    $large_count"
+echo "  Avatars:  $avatar_count"
+echo "  Banners:  $banner_count"
+echo "  Total:    $total"
+echo ""
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo "DRY RUN complete. Re-run with --apply to create symlinks."
+else
+    echo "Symlinks created successfully."
+fi


### PR DESCRIPTION
## Summary

- Add `docker-compose.prod.yml` — production Docker Compose overlay that removes local mariadb/adminer/redis-commander, adds frontend + certbot, configures json-file log rotation (50MB x 5 per service), and connects to a remote MariaDB server
- Add production Makefile targets (`make prod-up`, `make prod-down`, `make prod-logs`, etc.)
- Add `scripts/create_prod_symlinks.sh` — builds the image directory structure with symlinks to existing PHP site files (dry-run by default, `--apply` to execute)
- Add design doc and implementation plan under `docs/plans/`
- Add `.env.prod` to `.gitignore`

## Test plan

- [ ] Verify `docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.prod config` parses without errors (after filling in `.env.prod` placeholders)
- [ ] Verify `make help` shows the new Production section
- [ ] Verify `scripts/create_prod_symlinks.sh` exits with helpful error when `SRC_BASE` is not set
- [ ] Verify dry-run mode lists expected symlinks without creating them
- [ ] Verify `--apply` mode creates correct symlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)