### PR TITLE
feat: rating stats, unread PM count, avatar path fix

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -85,7 +85,7 @@ class Settings(BaseSettings):
     LARGE_QUALITY: int = 90
 
     # Avatar Settings
-    AVATAR_STORAGE_PATH: str = "/shuushuu/avatars"
+    AVATAR_STORAGE_PATH: str = ""  # Derived from STORAGE_PATH if not set
     MAX_AVATAR_SIZE: int = 1 * 1024 * 1024  # 1MB max upload size
     MAX_AVATAR_DIMENSION: int = 200  # Max width/height after resize
 
@@ -186,6 +186,12 @@ class Settings(BaseSettings):
     def set_default_banner_base_url(self) -> Settings:
         if not self.BANNER_BASE_URL:
             self.BANNER_BASE_URL = f"{self.IMAGE_BASE_URL}/images/banners"
+        return self
+
+    @model_validator(mode="after")
+    def set_default_avatar_storage_path(self) -> Settings:
+        if not self.AVATAR_STORAGE_PATH:
+            self.AVATAR_STORAGE_PATH = f"{self.STORAGE_PATH}/avatars"
         return self
 
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -189,6 +189,7 @@ class UserPrivateResponse(UserResponse):
     permissions: list[
         str
     ] = []  # List of permission strings (e.g., ["image_tag_add", "tag_create"])
+    unread_pm_count: int = 0  # Number of unread private messages
 
     # Override maximgperday from UserResponse - always include for self
     maximgperday: int  # Max images allowed to upload per day


### PR DESCRIPTION
## Summary
- **Rating endpoint**: `rate_image` now returns `average_rating`, `bayesian_rating`, and `num_ratings` for immediate frontend UI updates. Global rating stats cached in Redis (5min TTL) to avoid full table scans on the 900k-row `image_ratings` table.
- **Unread PM count**: `GET /users/me` now includes `unread_pm_count` so the frontend can show a notification badge without a separate API call.
- **Avatar storage fix**: `AVATAR_STORAGE_PATH` now derives from `STORAGE_PATH` when not explicitly set, fixing `PermissionError` on avatar upload in Docker environments where the hardcoded default path wasn't mounted.

## Test plan
- [x] Rate an image and verify the response includes computed stats
- [x] Re-rate and confirm stats update
- [x] Check `GET /users/me` returns `unread_pm_count` (0 with no PMs, correct count with mixed read/unread/deleted)
- [x] Upload an avatar and verify no 500 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)