### PR TITLE
fix: reject tag rename to duplicate (title, type)

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1085,7 +1085,7 @@ async def update_tag(
     new_type = update_data.get("type", tag.type)
     if new_title != tag.title or new_type != tag.type:
         existing_result = await db.execute(
-            select(Tags).where(Tags.title == new_title).where(Tags.type == new_type)
+            select(Tags).where(Tags.title == new_title).where(Tags.type == new_type)  # type: ignore[arg-type]
         )
         if existing_result.scalar_one_or_none():
             raise HTTPException(status_code=409, detail="Tag already exists")

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1080,6 +1080,16 @@ async def update_tag(
 
     update_data = tag_data.model_dump(exclude_unset=True)
 
+    # Check for duplicate (title, type) combination
+    new_title = update_data.get("title", tag.title)
+    new_type = update_data.get("type", tag.type)
+    if new_title != tag.title or new_type != tag.type:
+        existing_result = await db.execute(
+            select(Tags).where(Tags.title == new_title).where(Tags.type == new_type)
+        )
+        if existing_result.scalar_one_or_none():
+            raise HTTPException(status_code=409, detail="Tag already exists")
+
     # Validate inheritedfrom_id and alias fields if present
     inheritedfrom_id = update_data.get("inheritedfrom_id")
     if inheritedfrom_id is not None:

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -1958,6 +1958,61 @@ class TestUpdateTag:
         )
         assert response.status_code == 403
 
+    async def test_update_tag_rejects_duplicate_title_and_type(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that renaming a tag to a (title, type) that already exists returns 409."""
+        # Create TAG_UPDATE permission
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Create admin user
+        admin = Users(
+            username="admindupeupdate",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="admindupeupdate@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        # Grant TAG_UPDATE permission
+        user_perm = UserPerms(
+            user_id=admin.user_id,
+            perm_id=perm.perm_id,
+            permvalue=1,
+        )
+        db_session.add(user_perm)
+
+        # Create two tags with different titles but same type
+        existing_tag = Tags(title="existing tag", desc="", type=TagType.THEME)
+        tag_to_rename = Tags(title="rename me", desc="", type=TagType.THEME)
+        db_session.add_all([existing_tag, tag_to_rename])
+        await db_session.commit()
+        await db_session.refresh(tag_to_rename)
+
+        # Login as admin
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "admindupeupdate", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Try to rename tag to existing (title, type) combo
+        response = await client.put(
+            f"/api/v1/tags/{tag_to_rename.tag_id}",
+            json={"title": "existing tag", "type": TagType.THEME},
+        headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 409
+        assert "already exists" in response.json()["detail"].lower()
+
 
 @pytest.mark.api
 class TestDeleteTag:

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -2008,7 +2008,7 @@ class TestUpdateTag:
         response = await client.put(
             f"/api/v1/tags/{tag_to_rename.tag_id}",
             json={"title": "existing tag", "type": TagType.THEME},
-        headers={"Authorization": f"Bearer {access_token}"},
+            headers={"Authorization": f"Bearer {access_token}"},
         )
         assert response.status_code == 409
         assert "already exists" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary
- The `update_tag` endpoint allowed renaming a tag to a `(title, type)` combination that already existed in the database, unlike `create_tag` which returned 409
- Added the same duplicate check to `update_tag` — returns 409 Conflict when the new `(title, type)` already exists
- Only checks when title or type is actually changing, so no-op updates still work

## Test plan
- [x] New test: `test_update_tag_rejects_duplicate_title_and_type` — verifies 409 on duplicate
- [x] Existing `test_update_tag_as_admin` — still passes (legitimate renames work)
- [x] Existing `test_update_tag_as_non_admin` — still passes (auth unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)