### PR TITLE
fix: tag search finds hyphenated terms

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -326,25 +326,28 @@ async def list_tags(
             # Additionally, strip special fulltext boolean operators from terms to prevent
             # unexpected behavior (e.g., "C++" becoming "+C++*" with extra operators).
             search_terms = search.split()
-            # Sanitize terms first, then filter by stopwords and token validity.
-            # Order matters: we need to check stopwords and tokens AFTER sanitization.
-            # e.g., "+the+" becomes "the" (a stopword), and "C++" becomes "C" (too short).
+            # Sanitize and tokenize terms to match MySQL/MariaDB fulltext behavior.
+            # First strip boolean operators, then split on word delimiters (hyphens,
+            # periods, etc.) the same way MySQL does. This ensures "deep-blue" becomes
+            # tokens ["deep", "blue"] matching how the indexed data is tokenized.
             #
-            # IMPORTANT: We check _has_valid_fulltext_tokens() to handle cases like "C.C."
-            # where the overall length >= 3, but MySQL tokenizes it into "C", "C" which
-            # are both below the minimum token size. Such terms should fall back to LIKE.
+            # Filter out stopwords and tokens below minimum size to prevent query
+            # failures (required stopwords cause the entire BOOLEAN MODE query to fail).
             valid_terms = []
             for term in search_terms:
-                sanitized = _sanitize_fulltext_term(term)
-                if not sanitized:
-                    continue
-                if sanitized.lower() in FULLTEXT_STOPWORDS:
-                    continue
-                # Check both overall length AND whether MySQL will produce valid tokens
-                if len(sanitized) >= FULLTEXT_MIN_TOKEN_SIZE and _has_valid_fulltext_tokens(
-                    sanitized
-                ):
-                    valid_terms.append(sanitized)
+                # Tokenize FIRST (split on delimiters like -, ., etc.) to match
+                # how MySQL tokenizes indexed data, THEN sanitize each token
+                # (strip boolean operators). Order matters: "-" is both a delimiter
+                # and a boolean operator, so tokenizing first preserves the split.
+                tokens = _get_fulltext_tokens(term)
+                for token in tokens:
+                    sanitized = _sanitize_fulltext_term(token)
+                    if not sanitized:
+                        continue
+                    if sanitized.lower() in FULLTEXT_STOPWORDS:
+                        continue
+                    if len(sanitized) >= FULLTEXT_MIN_TOKEN_SIZE:
+                        valid_terms.append(sanitized)
 
             if valid_terms:
                 # Build fulltext query with valid terms only

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -326,10 +326,11 @@ async def list_tags(
             # Additionally, strip special fulltext boolean operators from terms to prevent
             # unexpected behavior (e.g., "C++" becoming "+C++*" with extra operators).
             search_terms = search.split()
-            # Sanitize and tokenize terms to match MySQL/MariaDB fulltext behavior.
-            # First strip boolean operators, then split on word delimiters (hyphens,
-            # periods, etc.) the same way MySQL does. This ensures "deep-blue" becomes
-            # tokens ["deep", "blue"] matching how the indexed data is tokenized.
+            # Tokenize and sanitize terms to match MySQL/MariaDB fulltext behavior.
+            # First split on word delimiters (hyphens, periods, etc.) the same way
+            # MySQL does, then strip boolean operators from each token. This ensures
+            # "deep-blue" becomes tokens ["deep", "blue"] matching how the indexed
+            # data is tokenized.
             #
             # Filter out stopwords and tokens below minimum size to prevent query
             # failures (required stopwords cause the entire BOOLEAN MODE query to fail).


### PR DESCRIPTION
## Summary
- Searching for "deep-blue" failed to find tags like "Deep-Blue Series" because the search term tokenizer stripped hyphens before splitting on word delimiters, producing "deepblue" instead of ["deep", "blue"]
- Fixed by tokenizing first (matching MySQL/MariaDB fulltext behavior), then sanitizing each token
- This also fixes similar issues with other delimiter characters (periods, underscores, etc.) in search queries

## Test plan
- [x] New test: `test_search_tags_with_hyphens` — "deep-blue" finds "Deep-Blue Series"
- [x] Existing: `test_search_tags` — "school" still finds "school uniform"
- [x] Existing: `test_search_tags_with_periods` — "C.C." still falls back to LIKE correctly
- [x] Verified on dev API: `curl "localhost:8000/api/v1/tags?search=deep-blue"` returns 5 results including "Deep-Blue Series"

🤖 Generated with [Claude Code](https://claude.com/claude-code)