### PR TITLE
fix: resolve asyncio.run() failure in ARQ variant job, enable pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,11 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        exclude: ^docker-compose(\.\w+)?\.ya?ml$
+      - id: check-yaml
+        name: check-docker-compose-yaml
         args: [--unsafe]
+        files: ^docker-compose(\.\w+)?\.ya?ml$
       - id: check-added-large-files
         args: [--maxkb=1000]
       # - id: check-json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        args: [--unsafe]
       - id: check-added-large-files
         args: [--maxkb=1000]
       # - id: check-json

--- a/app/services/image_processing.py
+++ b/app/services/image_processing.py
@@ -28,23 +28,16 @@ async def _update_image_variant_field(image_id: int, field: str, value: int) -> 
         image_id: Image ID to update
         field: Field name ('medium' or 'large')
         value: Value to set (0 or 1)
-    """
-    try:
-        from app.models.image import Images
 
-        async with get_async_session() as db:
-            stmt = update(Images).where(Images.image_id == image_id).values(**{field: value})  # type: ignore[arg-type]
-            await db.execute(stmt)
-            await db.commit()
-    except Exception as e:
-        logger.error(
-            "failed_to_update_variant_field",
-            image_id=image_id,
-            field=field,
-            value=value,
-            error=str(e),
-            error_type=type(e).__name__,
-        )
+    Raises:
+        Exception: Propagates DB errors so the caller (ARQ job) can retry.
+    """
+    from app.models.image import Images
+
+    async with get_async_session() as db:
+        stmt = update(Images).where(Images.image_id == image_id).values(**{field: value})  # type: ignore[arg-type]
+        await db.execute(stmt)
+        await db.commit()
 
 
 def _create_variant(

--- a/app/services/image_processing.py
+++ b/app/services/image_processing.py
@@ -332,7 +332,7 @@ def create_thumbnail(source_path: FilePath, image_id: int, ext: str, storage_pat
 
 def create_medium_variant(
     source_path: FilePath, image_id: int, ext: str, storage_path: str, width: int, height: int
-) -> bool:
+) -> bool | None:
     """Create medium-size variant if image is larger than MEDIUM_EDGE.
 
     Args:
@@ -344,7 +344,8 @@ def create_medium_variant(
         height: Original image height
 
     Returns:
-        True if medium variant was created, False otherwise
+        True if variant was created and kept, False if not needed,
+        None if variant was deleted (larger than original) and DB needs updating.
     """
     return _create_variant(
         source_path=source_path,
@@ -360,7 +361,7 @@ def create_medium_variant(
 
 def create_large_variant(
     source_path: FilePath, image_id: int, ext: str, storage_path: str, width: int, height: int
-) -> bool:
+) -> bool | None:
     """Create large-size variant if image is larger than LARGE_EDGE.
 
     Args:
@@ -372,7 +373,8 @@ def create_large_variant(
         height: Original image height
 
     Returns:
-        True if large variant was created, False otherwise
+        True if variant was created and kept, False if not needed,
+        None if variant was deleted (larger than original) and DB needs updating.
     """
     return _create_variant(
         source_path=source_path,

--- a/app/services/image_processing.py
+++ b/app/services/image_processing.py
@@ -2,7 +2,6 @@
 Image processing utilities for validation, dimension extraction, and thumbnail generation.
 """
 
-import asyncio
 import hashlib
 from datetime import datetime
 from pathlib import Path as FilePath
@@ -57,7 +56,7 @@ def _create_variant(
     height: int,
     size_threshold: int,
     variant_type: str,
-) -> bool:
+) -> bool | None:
     """Create an image variant (medium or large) with size validation.
 
     Args:
@@ -71,7 +70,8 @@ def _create_variant(
         variant_type: Type of variant ('medium' or 'large')
 
     Returns:
-        True if variant was created and kept, False otherwise
+        True if variant was created and kept, False if not needed,
+        None if variant was deleted (larger than original) and DB needs updating.
     """
     # Check if image exceeds threshold
     if width <= size_threshold and height <= size_threshold:
@@ -136,12 +136,8 @@ def _create_variant(
                     original_file_size=original_file_size,
                     variant_file_size=variant_file_size,
                 )
-                # Update database to reflect that variant doesn't exist
-                # Note: asyncio.run() is safe here because this function runs in ARQ worker's
-                # thread pool where no event loop exists. asyncio.run() creates a new
-                # event loop in the thread for this async DB operation.
-                asyncio.run(_update_image_variant_field(image_id, variant_type, 0))
-                return False
+                # Signal caller to update DB (caller is async and can await)
+                return None
 
             logger.info(
                 f"{variant_type}_variant_generated",


### PR DESCRIPTION
## Summary
- **Fix ARQ variant DB update bug**: `_create_variant` (sync) was calling `asyncio.run()` to update the DB when a generated variant was larger than the original and got deleted. This fails silently inside ARQ's already-running event loop. Moved the DB update to the async caller (`create_variant_job`) which can properly `await` it.
- **Enable pre-commit hooks**: Added `--unsafe` flag to `check-yaml` hook to support Docker Compose's `!override` YAML tag. Hooks are now installable via `uv run pre-commit install`.

## Test plan
- [x] Upload an image where the medium/large variant would be larger than the original (e.g. a small PNG near the threshold) and verify the DB flag is correctly set to 0
- [x] Run `uv run pre-commit run --all-files` and confirm all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)