### PR TITLE
feat: enforce daily upload limit and expose uploads remaining

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1717,9 +1717,9 @@ async def upload_image(
         content_type=file.content_type,
     )
 
-    # Check upload rate limit (skip for admins/moderators)
+    # Check upload rate limit and daily limit (skip for admins/moderators)
     if not current_user.admin:
-        await check_upload_rate_limit(current_user.id, db)
+        await check_upload_rate_limit(current_user.id, db, maximgperday=current_user.maximgperday)
 
     # Get client IP address for logging
     client_ip = _get_client_ip(request)

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1717,7 +1717,7 @@ async def upload_image(
         content_type=file.content_type,
     )
 
-    # Check upload rate limit and daily limit (skip for admins/moderators)
+    # Check upload rate limit and daily limit (skip for admins)
     if not current_user.admin:
         await check_upload_rate_limit(current_user.id, db, maximgperday=current_user.maximgperday)
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -207,6 +207,9 @@ class UserPrivateResponse(UserResponse):
     # Navigation
     bookmark: int | None  # Bookmarked image_id (for "continue where I left off")
 
+    # Computed at request time
+    uploads_remaining_today: int = 0  # How many more images the user can upload today
+
     @field_validator("email_verified", mode="before")
     @classmethod
     def convert_email_verified_to_bool(cls, v: int | bool) -> bool:

--- a/tests/api/v1/test_daily_upload_limit.py
+++ b/tests/api/v1/test_daily_upload_limit.py
@@ -1,0 +1,115 @@
+"""API tests for daily upload limit: uploads_remaining_today and 429 enforcement."""
+
+from datetime import datetime
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token
+from app.models.image import Images
+from app.models.user import Users
+
+
+def _make_user(**overrides) -> Users:
+    """Create a Users instance with sensible defaults."""
+    defaults = dict(
+        password="hashed_password_here",
+        password_type="bcrypt",
+        salt="saltsalt12345678",
+        active=1,
+        email_verified=True,
+        maximgperday=15,
+    )
+    defaults.update(overrides)
+    return Users(**defaults)
+
+
+def _make_image(user_id: int, suffix: str) -> Images:
+    """Create an Images instance with today's date."""
+    return Images(
+        filename=f"daily-{suffix}",
+        ext="jpg",
+        original_filename=f"daily-{suffix}.jpg",
+        md5_hash=f"dailyhash-{suffix}",
+        filesize=1000,
+        width=100,
+        height=100,
+        user_id=user_id,
+        status=1,
+        locked=0,
+        date_added=datetime.now(),
+    )
+
+
+@pytest.mark.api
+class TestUploadsRemainingToday:
+    """Tests for uploads_remaining_today in /users/me."""
+
+    async def test_full_remaining_when_no_uploads(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """User with no uploads today should see full remaining count."""
+        user = _make_user(username="remainfull", email="remainfull@example.com")
+        db_session.add(user)
+        await db_session.commit()
+
+        token = create_access_token(user.user_id)
+        response = await client.get(
+            "/api/v1/users/me",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["uploads_remaining_today"] == 15
+
+    async def test_decrements_after_uploads(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """uploads_remaining_today should decrease with each upload."""
+        user = _make_user(
+            username="remaindecr", email="remaindecr@example.com", maximgperday=10
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Add 3 images today
+        for i in range(3):
+            db_session.add(_make_image(user.user_id, f"decr-{i}"))
+        await db_session.commit()
+
+        token = create_access_token(user.user_id)
+        response = await client.get(
+            "/api/v1/users/me",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        assert response.json()["uploads_remaining_today"] == 7  # 10 - 3
+
+    async def test_floors_at_zero(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """uploads_remaining_today should never go negative."""
+        user = _make_user(
+            username="remainzero", email="remainzero@example.com", maximgperday=2
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Add 5 images (more than limit)
+        for i in range(5):
+            db_session.add(_make_image(user.user_id, f"zero-{i}"))
+        await db_session.commit()
+
+        token = create_access_token(user.user_id)
+        response = await client.get(
+            "/api/v1/users/me",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        assert response.json()["uploads_remaining_today"] == 0

--- a/tests/unit/test_daily_upload_limit.py
+++ b/tests/unit/test_daily_upload_limit.py
@@ -1,0 +1,224 @@
+"""Tests for daily upload limit helpers and enforcement."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.image import Images
+from app.models.user import Users
+from app.services.upload import check_upload_rate_limit, get_uploads_today
+
+
+@pytest.mark.unit
+class TestGetUploadsToday:
+    """Tests for get_uploads_today helper."""
+
+    async def test_returns_zero_when_no_uploads(self, db_session: AsyncSession):
+        """User with no uploads today should return 0."""
+        user = Users(
+            username="nouploader",
+            password="hashed",
+            password_type="bcrypt",
+            salt="saltsalt12345678",
+            email="nouploader@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        count = await get_uploads_today(user.user_id, db_session)
+        assert count == 0
+
+    async def test_counts_todays_uploads(self, db_session: AsyncSession):
+        """Should count images uploaded today."""
+        user = Users(
+            username="dayuploader",
+            password="hashed",
+            password_type="bcrypt",
+            salt="saltsalt12345678",
+            email="dayuploader@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Add 3 images with today's date
+        for i in range(3):
+            img = Images(
+                filename=f"test-{i}",
+                ext="jpg",
+                original_filename=f"test-{i}.jpg",
+                md5_hash=f"hash{i}daily",
+                filesize=1000,
+                width=100,
+                height=100,
+                user_id=user.user_id,
+                status=1,
+                locked=0,
+                date_added=datetime.now(),
+            )
+            db_session.add(img)
+        await db_session.commit()
+
+        count = await get_uploads_today(user.user_id, db_session)
+        assert count == 3
+
+    async def test_excludes_other_users_uploads(self, db_session: AsyncSession):
+        """Should only count the specified user's uploads."""
+        user1 = Users(
+            username="dayuser1",
+            password="hashed",
+            password_type="bcrypt",
+            salt="saltsalt12345678",
+            email="dayuser1@example.com",
+            active=1,
+        )
+        user2 = Users(
+            username="dayuser2",
+            password="hashed",
+            password_type="bcrypt",
+            salt="saltsalt12345678",
+            email="dayuser2@example.com",
+            active=1,
+        )
+        db_session.add_all([user1, user2])
+        await db_session.commit()
+        await db_session.refresh(user1)
+        await db_session.refresh(user2)
+
+        # user1 uploads 2, user2 uploads 1
+        for i in range(2):
+            db_session.add(
+                Images(
+                    filename=f"u1-{i}",
+                    ext="jpg",
+                    original_filename=f"u1-{i}.jpg",
+                    md5_hash=f"u1hash{i}daily",
+                    filesize=1000,
+                    width=100,
+                    height=100,
+                    user_id=user1.user_id,
+                    status=1,
+                    locked=0,
+                    date_added=datetime.now(),
+                )
+            )
+        db_session.add(
+            Images(
+                filename="u2-0",
+                ext="jpg",
+                original_filename="u2-0.jpg",
+                md5_hash="u2hash0daily",
+                filesize=1000,
+                width=100,
+                height=100,
+                user_id=user2.user_id,
+                status=1,
+                locked=0,
+                date_added=datetime.now(),
+            )
+        )
+        await db_session.commit()
+
+        assert await get_uploads_today(user1.user_id, db_session) == 2
+        assert await get_uploads_today(user2.user_id, db_session) == 1
+
+
+def _make_image(user_id: int, suffix: str) -> Images:
+    """Create an Images instance with today's date but far enough back to avoid rate limit."""
+    # Use 1 hour ago so it's still "today" but won't trigger per-upload rate limit
+    earlier_today = datetime.now() - timedelta(hours=1)
+    return Images(
+        filename=f"limit-{suffix}",
+        ext="jpg",
+        original_filename=f"limit-{suffix}.jpg",
+        md5_hash=f"limithash-{suffix}",
+        filesize=1000,
+        width=100,
+        height=100,
+        user_id=user_id,
+        status=1,
+        locked=0,
+        date_added=earlier_today,
+    )
+
+
+@pytest.mark.unit
+class TestDailyLimitEnforcement:
+    """Tests for daily limit enforcement in check_upload_rate_limit."""
+
+    async def test_allows_upload_under_limit(self, db_session: AsyncSession):
+        """Should not raise when uploads are under the daily limit."""
+        user = Users(
+            username="underlimit",
+            password="hashed",
+            password_type="bcrypt",
+            salt="saltsalt12345678",
+            email="underlimit@example.com",
+            active=1,
+            maximgperday=5,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Add 2 images (under limit of 5)
+        for i in range(2):
+            db_session.add(_make_image(user.user_id, f"under-{i}"))
+        await db_session.commit()
+
+        # Should not raise
+        await check_upload_rate_limit(user.user_id, db_session, maximgperday=5)
+
+    async def test_blocks_upload_at_limit(self, db_session: AsyncSession):
+        """Should raise 429 when daily limit is reached."""
+        user = Users(
+            username="atlimit",
+            password="hashed",
+            password_type="bcrypt",
+            salt="saltsalt12345678",
+            email="atlimit@example.com",
+            active=1,
+            maximgperday=3,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Add exactly 3 images (at limit)
+        for i in range(3):
+            db_session.add(_make_image(user.user_id, f"at-{i}"))
+        await db_session.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check_upload_rate_limit(user.user_id, db_session, maximgperday=3)
+        assert exc_info.value.status_code == 429
+        assert "daily upload limit" in exc_info.value.detail.lower()
+
+    async def test_blocks_upload_over_limit(self, db_session: AsyncSession):
+        """Should raise 429 when over daily limit."""
+        user = Users(
+            username="overlimit",
+            password="hashed",
+            password_type="bcrypt",
+            salt="saltsalt12345678",
+            email="overlimit@example.com",
+            active=1,
+            maximgperday=2,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Add 5 images (over limit of 2)
+        for i in range(5):
+            db_session.add(_make_image(user.user_id, f"over-{i}"))
+        await db_session.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check_upload_rate_limit(user.user_id, db_session, maximgperday=2)
+        assert exc_info.value.status_code == 429


### PR DESCRIPTION
## Summary
- Add `get_uploads_today()` shared helper that counts a user's uploads since start of today
- Enforce `maximgperday` in `check_upload_rate_limit()` — returns 429 when limit reached
- Add `uploads_remaining_today` field to `UserPrivateResponse`, calculated in `/users/me`
- Admins bypass the daily limit (consistent with existing rate limit bypass)

## Test plan
- [x] Unit tests for `get_uploads_today()` (zero uploads, counts correctly, excludes other users)
- [x] Unit tests for daily limit enforcement (under limit passes, at/over limit returns 429)
- [x] API tests for `/users/me` (full remaining, decrements after uploads, floors at zero)
- [x] Full test suite passes (1063/1063)

🤖 Generated with [Claude Code](https://claude.com/claude-code)