### PR TITLE
feat: track who closed reviews and reviewed reports

### DIFF
--- a/alembic/versions/81cdaeb0ff13_add_closed_by_to_image_reviews.py
+++ b/alembic/versions/81cdaeb0ff13_add_closed_by_to_image_reviews.py
@@ -63,6 +63,6 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Remove closed_by column."""
-    op.drop_index("fk_image_reviews_closed_by", table_name="image_reviews")
     op.drop_constraint("fk_image_reviews_closed_by", "image_reviews", type_="foreignkey")
+    op.drop_index("fk_image_reviews_closed_by", table_name="image_reviews")
     op.drop_column("image_reviews", "closed_by")

--- a/alembic/versions/81cdaeb0ff13_add_closed_by_to_image_reviews.py
+++ b/alembic/versions/81cdaeb0ff13_add_closed_by_to_image_reviews.py
@@ -1,0 +1,68 @@
+"""add closed_by to image_reviews
+
+Tracks which admin closed a review early. NULL means automatic (deadline job).
+Backfills from admin_actions where action_type=5 (REVIEW_CLOSE) and user_id IS NOT NULL.
+
+Revision ID: 81cdaeb0ff13
+Revises: 9682bf315db3
+Create Date: 2026-02-21 17:51:42.422076
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.mysql import INTEGER
+
+
+# revision identifiers, used by Alembic.
+revision: str = '81cdaeb0ff13'
+down_revision: str | Sequence[str] | None = '9682bf315db3'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add closed_by column, FK, index, and backfill from admin_actions."""
+    # Add column
+    op.add_column(
+        "image_reviews",
+        sa.Column("closed_by", INTEGER(unsigned=True), nullable=True),
+    )
+
+    # Add FK constraint
+    op.create_foreign_key(
+        "fk_image_reviews_closed_by",
+        "image_reviews",
+        "users",
+        ["closed_by"],
+        ["user_id"],
+        ondelete="SET NULL",
+        onupdate="CASCADE",
+    )
+
+    # Add index
+    op.create_index(
+        "fk_image_reviews_closed_by",
+        "image_reviews",
+        ["closed_by"],
+    )
+
+    # Backfill from admin_actions: action_type=5 is REVIEW_CLOSE
+    op.execute(
+        """
+        UPDATE image_reviews ir
+        INNER JOIN admin_actions aa
+            ON aa.review_id = ir.review_id
+            AND aa.action_type = 5
+            AND aa.user_id IS NOT NULL
+        SET ir.closed_by = aa.user_id
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove closed_by column."""
+    op.drop_index("fk_image_reviews_closed_by", table_name="image_reviews")
+    op.drop_constraint("fk_image_reviews_closed_by", "image_reviews", type_="foreignkey")
+    op.drop_column("image_reviews", "closed_by")

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -888,7 +888,7 @@ async def list_reports(
             ReviewedByUser.username.label("reviewed_by_username"),  # type: ignore[attr-defined]
         )
         query = query.join(Users, Users.user_id == ImageReports.user_id)
-        query = query.outerjoin(ReviewedByUser, ReviewedByUser.user_id == ImageReports.reviewed_by)  # type: ignore[arg-type]
+        query = query.outerjoin(ReviewedByUser, ReviewedByUser.user_id == ImageReports.reviewed_by)
         if status_filter is not None:
             query = query.where(ImageReports.status == status_filter)
         if category is not None:
@@ -1604,7 +1604,7 @@ async def list_reviews(
         )
         .outerjoin(Users, ImageReviews.initiated_by == Users.user_id)
         .outerjoin(ImageReports, ImageReviews.source_report_id == ImageReports.report_id)
-        .outerjoin(ClosedByUser, ImageReviews.closed_by == ClosedByUser.user_id)  # type: ignore[arg-type]
+        .outerjoin(ClosedByUser, ImageReviews.closed_by == ClosedByUser.user_id)
     )
 
     if status_filter is not None:
@@ -1681,7 +1681,7 @@ async def get_review(
         )
         .outerjoin(Users, ImageReviews.initiated_by == Users.user_id)
         .outerjoin(ImageReports, ImageReviews.source_report_id == ImageReports.report_id)
-        .outerjoin(ClosedByUser, ImageReviews.closed_by == ClosedByUser.user_id)  # type: ignore[arg-type]
+        .outerjoin(ClosedByUser, ImageReviews.closed_by == ClosedByUser.user_id)
         .where(ImageReviews.review_id == review_id)
     )
     row = result.one_or_none()
@@ -1695,7 +1695,7 @@ async def get_review(
     VoteUser = aliased(Users)
     votes_result = await db.execute(
         select(ReviewVotes, VoteUser.username)  # type: ignore[call-overload]
-        .outerjoin(VoteUser, ReviewVotes.user_id == VoteUser.user_id)  # type: ignore[arg-type]
+        .outerjoin(VoteUser, ReviewVotes.user_id == VoteUser.user_id)
         .where(ReviewVotes.review_id == review_id)
         .order_by(ReviewVotes.created_at)
     )

--- a/app/models/image_review.py
+++ b/app/models/image_review.py
@@ -48,6 +48,9 @@ class ImageReviewBase(SQLModel):
     # Whether the deadline has been extended
     extension_used: int = Field(default=0)
 
+    # Admin who closed the review early (NULL = automatic/deadline close)
+    closed_by: int | None = Field(default=None)
+
 
 class ImageReviews(ImageReviewBase, table=True):
     """
@@ -74,6 +77,7 @@ class ImageReviews(ImageReviewBase, table=True):
         Index("fk_image_reviews_image_id", "image_id"),
         Index("fk_image_reviews_source_report_id", "source_report_id"),
         Index("fk_image_reviews_initiated_by", "initiated_by"),
+        Index("fk_image_reviews_closed_by", "closed_by"),
         Index("idx_image_reviews_status", "status"),
         Index("idx_image_reviews_deadline", "deadline"),
     )
@@ -102,6 +106,16 @@ class ImageReviews(ImageReviewBase, table=True):
 
     # Admin who started the review
     initiated_by: int | None = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("users.user_id", ondelete="SET NULL", onupdate="CASCADE"),
+            nullable=True,
+        ),
+    )
+
+    # Admin who closed the review early (overrides base with FK)
+    closed_by: int | None = Field(
         default=None,
         sa_column=Column(
             Integer,

--- a/app/schemas/comment_report.py
+++ b/app/schemas/comment_report.py
@@ -55,6 +55,7 @@ class CommentReportResponse(BaseModel):
     status_label: str | None = None
     created_at: UTCDatetime
     reviewed_by: int | None = None
+    reviewed_by_username: str | None = None
     reviewed_at: UTCDatetimeOptional = None
     admin_notes: str | None = None
 

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -97,6 +97,7 @@ class ReportResponse(BaseModel):
     status_label: str | None = None
     created_at: UTCDatetime
     reviewed_by: int | None
+    reviewed_by_username: str | None = None
     reviewed_at: UTCDatetimeOptional = None
     admin_notes: str | None = None
     suggested_tags: list[TagSuggestion] | None = None

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -230,6 +230,8 @@ class ReviewResponse(BaseModel):
     source_report_reason: str | None = None
     initiated_by: int | None
     initiated_by_username: str | None = None
+    closed_by: int | None = None
+    closed_by_username: str | None = None
     review_type: int
     review_type_label: str | None = None
     deadline: UTCDatetime

--- a/tests/api/v1/test_daily_upload_limit.py
+++ b/tests/api/v1/test_daily_upload_limit.py
@@ -1,6 +1,6 @@
 """API tests for daily upload limit: uploads_remaining_today and 429 enforcement."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -41,7 +41,7 @@ def _make_image(user_id: int, suffix: str) -> Images:
         user_id=user_id,
         status=1,
         locked=0,
-        date_added=datetime.now(),
+        date_added=datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0, tzinfo=None),
     )
 
 


### PR DESCRIPTION
## Summary
- Add `closed_by` field to reviews to track which admin closed a review early (NULL = automatic/deadline close), with migration that backfills from `admin_actions`
- Add `closed_by_username` to review API responses (list + detail)
- Add `reviewed_by_username` to image report and comment report API responses

## Test plan
- [x] Existing report tests pass (75 passing)
- [x] New tests for `closed_by` on close, null when automatic, and presence in list endpoint
- [x] Verify frontend displays reviewer/closer usernames correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)