### PR TITLE
feat: include date_added in tag list response

### DIFF
--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -131,6 +131,7 @@ class TagResponse(TagBase):
     """Schema for tag response - what API returns"""
 
     tag_id: int
+    date_added: UTCDatetime | None = None
     alias_of: int | None = None
     alias_of_name: str | None = None
     is_alias: bool = False


### PR DESCRIPTION
## Summary
- Add `date_added` to `TagResponse` schema so the `/tags` list endpoint returns tag creation dates
- Sorting by `date_added` was already supported via `?sort_by=date_added` but the field wasn't included in responses

## Test plan
- [x] All 99 tag tests pass
- [x] Verified `date_added` appears in `/api/v1/tags` response
- [x] Verified `?sort_by=date_added&sort_order=desc` returns newest tags first

🤖 Generated with [Claude Code](https://claude.com/claude-code)