### PR TITLE
feat: migrate favorites, ratings, and tags on repost

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -103,6 +103,7 @@ from app.schemas.report import (
     UnifiedReportListResponse,
     VoteResponse,
 )
+from app.services.rating import schedule_rating_recalculation
 from app.services.repost import migrate_repost_data
 
 router = APIRouter(prefix="/admin", tags=["admin"])
@@ -784,8 +785,6 @@ async def change_image_status(
 
     # Schedule rating recalculation for original image after repost migration
     if status_data.status == ImageStatus.REPOST and status_data.replacement_id:
-        from app.services.rating import schedule_rating_recalculation
-
         await schedule_rating_recalculation(status_data.replacement_id)
 
     return ImageStatusResponse.model_validate(image)

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -103,6 +103,7 @@ from app.schemas.report import (
     UnifiedReportListResponse,
     VoteResponse,
 )
+from app.services.repost import migrate_repost_data
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -710,6 +711,8 @@ async def change_image_status(
     previous_status = image.status
     previous_locked = image.locked
 
+    migration_result: dict[str, int] = {}
+
     # Handle status change if provided
     if status_data.status is not None:
         # Handle repost status
@@ -734,6 +737,9 @@ async def change_image_status(
                     detail="Original image not found",
                 )
             image.replacement_id = status_data.replacement_id
+
+            # Migrate favorites, ratings, and tags to the original image
+            migration_result = await migrate_repost_data(image_id, status_data.replacement_id, db)
         else:
             # Clear replacement_id when not a repost
             image.replacement_id = None
@@ -768,12 +774,19 @@ async def change_image_status(
             "previous_locked": previous_locked,
             "new_locked": image.locked,
             "replacement_id": image.replacement_id,
+            **migration_result,
         },
     )
     db.add(action)
 
     await db.commit()
     await db.refresh(image)
+
+    # Schedule rating recalculation for original image after repost migration
+    if status_data.status == ImageStatus.REPOST and status_data.replacement_id:
+        from app.services.rating import schedule_rating_recalculation
+
+        await schedule_rating_recalculation(status_data.replacement_id)
 
     return ImageStatusResponse.model_validate(image)
 

--- a/app/services/repost.py
+++ b/app/services/repost.py
@@ -42,7 +42,7 @@ async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession
     await db.execute(
         text(
             "INSERT IGNORE INTO favorites (user_id, image_id, fav_date) "
-            "SELECT user_id, :original_id, NOW() FROM favorites "
+            "SELECT user_id, :original_id, fav_date FROM favorites "
             "WHERE image_id = :repost_id"
         ),
         {"original_id": original_id, "repost_id": repost_id},
@@ -86,8 +86,8 @@ async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession
 
     await db.execute(
         text(
-            "INSERT IGNORE INTO image_ratings (user_id, image_id, rating) "
-            "SELECT user_id, :original_id, rating FROM image_ratings "
+            "INSERT IGNORE INTO image_ratings (user_id, image_id, rating, date) "
+            "SELECT user_id, :original_id, rating, date FROM image_ratings "
             "WHERE image_id = :repost_id"
         ),
         {"original_id": original_id, "repost_id": repost_id},

--- a/app/services/repost.py
+++ b/app/services/repost.py
@@ -1,0 +1,158 @@
+"""
+Repost data migration service.
+
+When an image is marked as a repost, migrates favorites, ratings, and tags
+from the repost to the original image, then cleans up the repost.
+"""
+
+from sqlalchemy import delete, func, select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.favorite import Favorites
+from app.models.image import Images
+from app.models.image_rating import ImageRatings
+from app.models.tag_link import TagLinks
+
+
+async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession) -> dict[str, int]:
+    """
+    Migrate favorites, ratings, and tags from a repost to the original image.
+
+    Uses INSERT IGNORE to handle duplicates: if a user already favorited/rated
+    the original, the repost's record is silently discarded.
+
+    Args:
+        repost_id: Image ID of the repost being marked
+        original_id: Image ID of the original (replacement) image
+        db: Database session (caller manages transaction)
+
+    Returns:
+        Dict with counts: favorites_moved, ratings_moved, tags_moved
+    """
+    # --- Favorites ---
+    before_fav = await db.execute(
+        select(func.count())
+        .select_from(Favorites)
+        .where(
+            Favorites.image_id == original_id  # type: ignore[arg-type]
+        )
+    )
+    fav_count_before = before_fav.scalar() or 0
+
+    await db.execute(
+        text(
+            "INSERT IGNORE INTO favorites (user_id, image_id, fav_date) "
+            "SELECT user_id, :original_id, NOW() FROM favorites "
+            "WHERE image_id = :repost_id"
+        ),
+        {"original_id": original_id, "repost_id": repost_id},
+    )
+
+    after_fav = await db.execute(
+        select(func.count())
+        .select_from(Favorites)
+        .where(
+            Favorites.image_id == original_id  # type: ignore[arg-type]
+        )
+    )
+    fav_count_after = after_fav.scalar() or 0
+    favorites_moved = fav_count_after - fav_count_before
+
+    await db.execute(
+        delete(Favorites).where(Favorites.image_id == repost_id)  # type: ignore[arg-type]
+    )
+
+    # Update favorites counts on both images
+    await db.execute(
+        update(Images)
+        .where(Images.image_id == original_id)  # type: ignore[arg-type]
+        .values(favorites=fav_count_after)
+    )
+    await db.execute(
+        update(Images)
+        .where(Images.image_id == repost_id)  # type: ignore[arg-type]
+        .values(favorites=0)
+    )
+
+    # --- Ratings ---
+    before_rat = await db.execute(
+        select(func.count())
+        .select_from(ImageRatings)
+        .where(
+            ImageRatings.image_id == original_id  # type: ignore[arg-type]
+        )
+    )
+    rat_count_before = before_rat.scalar() or 0
+
+    await db.execute(
+        text(
+            "INSERT IGNORE INTO image_ratings (user_id, image_id, rating) "
+            "SELECT user_id, :original_id, rating FROM image_ratings "
+            "WHERE image_id = :repost_id"
+        ),
+        {"original_id": original_id, "repost_id": repost_id},
+    )
+
+    after_rat = await db.execute(
+        select(func.count())
+        .select_from(ImageRatings)
+        .where(
+            ImageRatings.image_id == original_id  # type: ignore[arg-type]
+        )
+    )
+    rat_count_after = after_rat.scalar() or 0
+    ratings_moved = rat_count_after - rat_count_before
+
+    await db.execute(
+        delete(ImageRatings).where(
+            ImageRatings.image_id == repost_id  # type: ignore[arg-type]
+        )
+    )
+
+    # Reset repost rating fields
+    await db.execute(
+        update(Images)
+        .where(Images.image_id == repost_id)  # type: ignore[arg-type]
+        .values(num_ratings=0, rating=0, bayesian_rating=0)
+    )
+
+    # --- Tags ---
+    before_tag = await db.execute(
+        select(func.count())
+        .select_from(TagLinks)
+        .where(
+            TagLinks.image_id == original_id  # type: ignore[arg-type]
+        )
+    )
+    tag_count_before = before_tag.scalar() or 0
+
+    await db.execute(
+        text(
+            "INSERT IGNORE INTO tag_links (tag_id, image_id, date_linked, user_id) "
+            "SELECT tag_id, :original_id, date_linked, user_id FROM tag_links "
+            "WHERE image_id = :repost_id"
+        ),
+        {"original_id": original_id, "repost_id": repost_id},
+    )
+
+    after_tag = await db.execute(
+        select(func.count())
+        .select_from(TagLinks)
+        .where(
+            TagLinks.image_id == original_id  # type: ignore[arg-type]
+        )
+    )
+    tag_count_after = after_tag.scalar() or 0
+    tags_moved = tag_count_after - tag_count_before
+
+    await db.execute(
+        delete(TagLinks).where(
+            TagLinks.image_id == repost_id  # type: ignore[arg-type]
+        )
+    )
+
+    return {
+        "favorites_moved": favorites_moved,
+        "ratings_moved": ratings_moved,
+        "tags_moved": tags_moved,
+    }

--- a/tests/unit/test_repost_cleanup.py
+++ b/tests/unit/test_repost_cleanup.py
@@ -1,7 +1,5 @@
 """Tests for repost data migration service."""
 
-from datetime import UTC, datetime
-
 import pytest
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/tests/unit/test_repost_cleanup.py
+++ b/tests/unit/test_repost_cleanup.py
@@ -1,0 +1,268 @@
+"""Tests for repost data migration service."""
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.favorite import Favorites
+from app.models.image import Images
+from app.models.image_rating import ImageRatings
+from app.models.tag import Tags
+from app.models.tag_link import TagLinks
+from app.models.user import Users
+from app.services.repost import migrate_repost_data
+
+
+async def _create_user(db: AsyncSession, username: str) -> Users:
+    user = Users(
+        username=username,
+        password="hashed",
+        password_type="bcrypt",
+        salt="saltsalt12345678",
+        email=f"{username}@example.com",
+        active=1,
+    )
+    db.add(user)
+    await db.flush()
+    await db.refresh(user)
+    return user
+
+
+async def _create_image(db: AsyncSession, user_id: int, md5_suffix: str) -> Images:
+    img = Images(
+        user_id=user_id,
+        filename=f"img-{md5_suffix}",
+        ext="jpg",
+        original_filename=f"img-{md5_suffix}.jpg",
+        md5_hash=f"{md5_suffix:0<32}",
+        filesize=1000,
+        width=100,
+        height=100,
+        status=1,
+        locked=0,
+    )
+    db.add(img)
+    await db.flush()
+    await db.refresh(img)
+    return img
+
+
+async def _create_tag(db: AsyncSession, title: str) -> Tags:
+    tag = Tags(title=title, type=1)
+    db.add(tag)
+    await db.flush()
+    await db.refresh(tag)
+    return tag
+
+
+@pytest.mark.unit
+class TestMigrateRepostData:
+    """Tests for migrate_repost_data service function."""
+
+    async def test_migrates_favorites(self, db_session: AsyncSession):
+        """Favorites on the repost should move to the original."""
+        user = await _create_user(db_session, "favuser")
+        original = await _create_image(db_session, user.user_id, "orig1")
+        repost = await _create_image(db_session, user.user_id, "repo1")
+
+        db_session.add(Favorites(user_id=user.user_id, image_id=repost.image_id))
+        await db_session.flush()
+
+        result = await migrate_repost_data(repost.image_id, original.image_id, db_session)
+
+        assert result["favorites_moved"] == 1
+
+        # Favorite now on original
+        fav_count = await db_session.execute(
+            select(func.count()).select_from(Favorites).where(
+                Favorites.image_id == original.image_id
+            )
+        )
+        assert fav_count.scalar() == 1
+
+        # No favorites on repost
+        fav_count = await db_session.execute(
+            select(func.count()).select_from(Favorites).where(
+                Favorites.image_id == repost.image_id
+            )
+        )
+        assert fav_count.scalar() == 0
+
+    async def test_migrates_ratings(self, db_session: AsyncSession):
+        """Ratings on the repost should move to the original."""
+        user = await _create_user(db_session, "rateuser")
+        original = await _create_image(db_session, user.user_id, "orig2")
+        repost = await _create_image(db_session, user.user_id, "repo2")
+
+        db_session.add(ImageRatings(user_id=user.user_id, image_id=repost.image_id, rating=8))
+        await db_session.flush()
+
+        result = await migrate_repost_data(repost.image_id, original.image_id, db_session)
+
+        assert result["ratings_moved"] == 1
+
+        # Rating now on original
+        rating_count = await db_session.execute(
+            select(func.count()).select_from(ImageRatings).where(
+                ImageRatings.image_id == original.image_id
+            )
+        )
+        assert rating_count.scalar() == 1
+
+        # No ratings on repost
+        rating_count = await db_session.execute(
+            select(func.count()).select_from(ImageRatings).where(
+                ImageRatings.image_id == repost.image_id
+            )
+        )
+        assert rating_count.scalar() == 0
+
+    async def test_migrates_tags(self, db_session: AsyncSession):
+        """Tag links on the repost should move to the original."""
+        user = await _create_user(db_session, "taguser")
+        original = await _create_image(db_session, user.user_id, "orig3")
+        repost = await _create_image(db_session, user.user_id, "repo3")
+        tag = await _create_tag(db_session, "test tag")
+
+        db_session.add(TagLinks(
+            tag_id=tag.tag_id, image_id=repost.image_id, user_id=user.user_id
+        ))
+        await db_session.flush()
+
+        result = await migrate_repost_data(repost.image_id, original.image_id, db_session)
+
+        assert result["tags_moved"] == 1
+
+        # Tag link now on original
+        tag_count = await db_session.execute(
+            select(func.count()).select_from(TagLinks).where(
+                TagLinks.image_id == original.image_id
+            )
+        )
+        assert tag_count.scalar() == 1
+
+        # No tag links on repost
+        tag_count = await db_session.execute(
+            select(func.count()).select_from(TagLinks).where(
+                TagLinks.image_id == repost.image_id
+            )
+        )
+        assert tag_count.scalar() == 0
+
+    async def test_skips_duplicate_favorites(self, db_session: AsyncSession):
+        """If user already favorited the original, repost favorite is discarded."""
+        user = await _create_user(db_session, "dupfavuser")
+        original = await _create_image(db_session, user.user_id, "orig4")
+        repost = await _create_image(db_session, user.user_id, "repo4")
+
+        db_session.add(Favorites(user_id=user.user_id, image_id=original.image_id))
+        db_session.add(Favorites(user_id=user.user_id, image_id=repost.image_id))
+        await db_session.flush()
+
+        result = await migrate_repost_data(repost.image_id, original.image_id, db_session)
+
+        assert result["favorites_moved"] == 0
+
+        fav_count = await db_session.execute(
+            select(func.count()).select_from(Favorites).where(
+                Favorites.image_id == original.image_id
+            )
+        )
+        assert fav_count.scalar() == 1
+
+    async def test_skips_duplicate_ratings(self, db_session: AsyncSession):
+        """If user already rated the original, repost rating is discarded."""
+        user = await _create_user(db_session, "duprateuser")
+        original = await _create_image(db_session, user.user_id, "orig5")
+        repost = await _create_image(db_session, user.user_id, "repo5")
+
+        db_session.add(ImageRatings(user_id=user.user_id, image_id=original.image_id, rating=9))
+        db_session.add(ImageRatings(user_id=user.user_id, image_id=repost.image_id, rating=7))
+        await db_session.flush()
+
+        result = await migrate_repost_data(repost.image_id, original.image_id, db_session)
+
+        assert result["ratings_moved"] == 0
+
+        rating = await db_session.execute(
+            select(ImageRatings.rating).where(
+                ImageRatings.image_id == original.image_id,
+                ImageRatings.user_id == user.user_id,
+            )
+        )
+        assert rating.scalar() == 9
+
+    async def test_skips_duplicate_tags(self, db_session: AsyncSession):
+        """If tag already linked to original, repost tag link is discarded."""
+        user = await _create_user(db_session, "duptaguser")
+        original = await _create_image(db_session, user.user_id, "orig6")
+        repost = await _create_image(db_session, user.user_id, "repo6")
+        tag = await _create_tag(db_session, "duptag")
+
+        db_session.add(TagLinks(tag_id=tag.tag_id, image_id=original.image_id, user_id=user.user_id))
+        db_session.add(TagLinks(tag_id=tag.tag_id, image_id=repost.image_id, user_id=user.user_id))
+        await db_session.flush()
+
+        result = await migrate_repost_data(repost.image_id, original.image_id, db_session)
+
+        assert result["tags_moved"] == 0
+
+        tag_count = await db_session.execute(
+            select(func.count()).select_from(TagLinks).where(
+                TagLinks.image_id == original.image_id
+            )
+        )
+        assert tag_count.scalar() == 1
+
+    async def test_resets_repost_image_counters(self, db_session: AsyncSession):
+        """Repost image should have favorites=0 and rating fields reset."""
+        user = await _create_user(db_session, "resetuser")
+        original = await _create_image(db_session, user.user_id, "orig7")
+        repost = await _create_image(db_session, user.user_id, "repo7")
+
+        repost.favorites = 3
+        repost.num_ratings = 2
+        repost.rating = 7.5
+        repost.bayesian_rating = 6.8
+        db_session.add(Favorites(user_id=user.user_id, image_id=repost.image_id))
+        db_session.add(ImageRatings(user_id=user.user_id, image_id=repost.image_id, rating=8))
+        await db_session.flush()
+
+        await migrate_repost_data(repost.image_id, original.image_id, db_session)
+
+        await db_session.refresh(repost)
+        assert repost.favorites == 0
+        assert repost.num_ratings == 0
+        assert repost.rating == 0
+        assert repost.bayesian_rating == 0
+
+    async def test_updates_original_favorites_count(self, db_session: AsyncSession):
+        """Original image favorites count should reflect migrated favorites."""
+        user1 = await _create_user(db_session, "favcount1")
+        user2 = await _create_user(db_session, "favcount2")
+        original = await _create_image(db_session, user1.user_id, "orig8")
+        repost = await _create_image(db_session, user1.user_id, "repo8")
+
+        db_session.add(Favorites(user_id=user1.user_id, image_id=original.image_id))
+        db_session.add(Favorites(user_id=user2.user_id, image_id=repost.image_id))
+        original.favorites = 1
+        await db_session.flush()
+
+        await migrate_repost_data(repost.image_id, original.image_id, db_session)
+
+        await db_session.refresh(original)
+        assert original.favorites == 2
+
+    async def test_no_data_returns_zero_counts(self, db_session: AsyncSession):
+        """When repost has no favorites/ratings/tags, counts should be 0."""
+        user = await _create_user(db_session, "emptyuser")
+        original = await _create_image(db_session, user.user_id, "orig9")
+        repost = await _create_image(db_session, user.user_id, "repo9")
+
+        result = await migrate_repost_data(repost.image_id, original.image_id, db_session)
+
+        assert result["favorites_moved"] == 0
+        assert result["ratings_moved"] == 0
+        assert result["tags_moved"] == 0


### PR DESCRIPTION
## Summary
- Add `migrate_repost_data` service that migrates favorites, ratings, and tags from a repost to the original image when marking as repost
- Uses `INSERT IGNORE` for atomic duplicate handling — if a user already favorited/rated/tagged the original, the duplicate is silently discarded
- Cleans up the repost: deletes favorites/ratings/tags and resets counters
- Updates original image's favorites count and schedules background rating recalculation
- Migration summary (counts moved) logged in admin action audit trail

Matches the legacy PHP behavior but goes further — PHP left data on the repost, this fully cleans it up.

## Test plan
- [x] 9 unit tests for `migrate_repost_data` service (favorites, ratings, tags, duplicate handling, counter resets)
- [x] 1 API integration test verifying end-to-end migration through the endpoint
- [x] All 18 existing admin image tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)