### PR TITLE
feat: add similarity search by image upload

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -195,8 +195,11 @@ async def check_similar_by_upload(
         thumb_path = FilePath(temp_dir) / "thumbs" / "temp-0.webp"
 
         if not thumb_path.exists():
-            logger.warning("check_similar_thumbnail_failed", user_id=current_user.user_id)
-            return SimilarImagesUploadResponse(similar_images=[])
+            logger.warning("check_similar_thumbnail_failed", user_id=current_user.id)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to generate thumbnail for similarity check",
+            )
 
         # Query IQDB
         similar_results = await check_iqdb_similarity(thumb_path, db, threshold=threshold)

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -151,7 +151,7 @@ async def check_similar_by_upload(
     file: Annotated[UploadFile, File(description="Image file to check for similarity")],
     current_user: Annotated[Users, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    redis_client: Annotated[redis.Redis, Depends(get_redis)],
+    redis_client: Annotated[redis.Redis, Depends(get_redis)],  # type: ignore[type-arg]
     threshold: Annotated[
         float | None, Query(description="Minimum similarity score (0-100)", ge=0, le=100)
     ] = None,
@@ -161,7 +161,7 @@ async def check_similar_by_upload(
     Accepts a temporary image upload, queries IQDB for similar matches,
     and returns results. The uploaded image is not stored permanently.
     """
-    await check_similarity_rate_limit(current_user.user_id, redis_client)
+    await check_similarity_rate_limit(current_user.id, redis_client)
 
     temp_dir = tempfile.mkdtemp()
     try:

--- a/app/config.py
+++ b/app/config.py
@@ -100,6 +100,7 @@ class Settings(BaseSettings):
     UPLOAD_DELAY_SECONDS: int = 30
     SEARCH_DELAY_SECONDS: int = 2
     MAX_SEARCH_TAGS: int = 5
+    SIMILARITY_CHECK_RATE_LIMIT: int = 5  # Max similarity checks per user per minute
     REGISTRATION_RATE_LIMIT: int = Field(
         default=5, description="Max registrations per IP per window"
     )

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -275,6 +275,18 @@ class SimilarImagesResponse(BaseModel):
     )
 
 
+class SimilarImagesUploadResponse(BaseModel):
+    """Schema for similarity check by upload response.
+
+    Unlike SimilarImagesResponse, has no query_image_id since the
+    uploaded image is not stored in the database.
+    """
+
+    similar_images: list[SimilarImageResult] = Field(
+        description="List of similar images ordered by similarity score (highest first)"
+    )
+
+
 class ImageUploadSimilarResponse(BaseModel):
     """Schema for 409 response when similar images are found during upload.
 

--- a/app/services/rate_limit.py
+++ b/app/services/rate_limit.py
@@ -58,3 +58,63 @@ async def check_registration_rate_limit(ip_address: str, redis_client: redis.Red
         count=count + 1,
         limit=settings.REGISTRATION_RATE_LIMIT,
     )
+
+
+async def check_similarity_rate_limit(user_id: int, redis_client: redis.Redis) -> None:  # type: ignore[type-arg]
+    """
+    Enforce similarity check rate limit per user.
+
+    Limit: 5 checks per user per 60 seconds (configurable via SIMILARITY_CHECK_RATE_LIMIT).
+
+    Uses Redis for fast lookups and automatic expiration.
+    Gracefully degrades if Redis is unavailable (allows the request).
+
+    Args:
+        user_id: ID of the user making the request
+        redis_client: Redis client instance
+
+    Raises:
+        HTTPException: 429 if rate limit exceeded
+    """
+    try:
+        key = f"similarity_check_rate:{user_id}"
+
+        # Get current count
+        count_bytes = await redis_client.get(key)
+        count = int(count_bytes) if count_bytes else 0
+
+        if count >= settings.SIMILARITY_CHECK_RATE_LIMIT:
+            logger.warning(
+                "similarity_check_rate_limit_exceeded",
+                user_id=user_id,
+                count=count,
+                limit=settings.SIMILARITY_CHECK_RATE_LIMIT,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many similarity checks. Please try again in 60 seconds.",
+                headers={"Retry-After": "60"},
+            )
+
+        # Increment counter with expiration
+        pipe = redis_client.pipeline()
+        pipe.incr(key)
+        if count == 0:
+            # First check from this user in this window - set expiration
+            pipe.expire(key, 60)
+        await pipe.execute()
+
+        logger.debug(
+            "similarity_check_rate_check",
+            user_id=user_id,
+            count=count + 1,
+            limit=settings.SIMILARITY_CHECK_RATE_LIMIT,
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        logger.warning(
+            "similarity_check_rate_limit_redis_error",
+            user_id=user_id,
+            exc_info=True,
+        )

--- a/tests/api/v1/test_check_similar.py
+++ b/tests/api/v1/test_check_similar.py
@@ -1,0 +1,188 @@
+"""Tests for POST /api/v1/images/check-similar endpoint."""
+
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token
+from app.models.user import Users
+from app.schemas.image import SimilarImageResult
+
+
+@pytest.fixture
+async def verified_user(db_session: AsyncSession) -> Users:
+    """Create a verified user for testing."""
+    user = Users(
+        username="checker",
+        password="hashed_password_here",
+        password_type="bcrypt",
+        salt="saltsalt12345678",
+        email="checker@example.com",
+        active=1,
+        email_verified=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+async def auth_client(client: AsyncClient, verified_user: Users) -> AsyncClient:
+    """Authenticated client."""
+    access_token = create_access_token(verified_user.id)
+    client.headers.update({"Authorization": f"Bearer {access_token}"})
+    return client
+
+
+def _fake_image_bytes() -> bytes:
+    """Create a minimal valid JPEG for tests."""
+    from PIL import Image
+
+    img = Image.new("RGB", (100, 100), color="red")
+    buf = BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _make_similar_result(image_id: int, score: float) -> SimilarImageResult:
+    """Build a SimilarImageResult for test assertions."""
+    return SimilarImageResult(
+        image_id=image_id,
+        filename=f"2025-01-01-{image_id}",
+        ext="jpg",
+        md5_hash="fakehash",
+        filesize=1000,
+        width=100,
+        height=100,
+        rating=0.0,
+        user_id=1,
+        date_added="2025-01-01T00:00:00",
+        status=1,
+        locked=0,
+        posts=0,
+        favorites=0,
+        bayesian_rating=0.0,
+        num_ratings=0,
+        medium=0,
+        large=0,
+        similarity_score=score,
+    )
+
+
+@pytest.mark.api
+class TestCheckSimilar:
+    """Tests for the check-similar endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_returns_similar_images(self, auth_client: AsyncClient):
+        """Successful similarity check returns hydrated results."""
+        hydrated = [
+            _make_similar_result(42, 95.5),
+            _make_similar_result(99, 80.0),
+        ]
+
+        with (
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=[
+                    {"image_id": 42, "score": 95.5},
+                    {"image_id": 99, "score": 80.0},
+                ],
+            ),
+            patch(
+                "app.api.v1.images._hydrate_similar_images",
+                new_callable=AsyncMock,
+                return_value=hydrated,
+            ),
+            patch("app.api.v1.images.validate_image_file"),
+            patch("app.api.v1.images.create_thumbnail"),
+            patch(
+                "app.api.v1.images.check_similarity_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch("pathlib.Path.exists", return_value=True),
+        ):
+            response = await auth_client.post(
+                "/api/v1/images/check-similar",
+                files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "similar_images" in data
+        assert len(data["similar_images"]) == 2
+        assert data["similar_images"][0]["image_id"] == 42
+        assert data["similar_images"][0]["similarity_score"] == 95.5
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_matches(self, auth_client: AsyncClient):
+        """Returns empty list when IQDB finds no similar images."""
+        with (
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("app.api.v1.images.validate_image_file"),
+            patch("app.api.v1.images.create_thumbnail"),
+            patch(
+                "app.api.v1.images.check_similarity_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch("pathlib.Path.exists", return_value=True),
+        ):
+            response = await auth_client.post(
+                "/api/v1/images/check-similar",
+                files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["similar_images"] == []
+
+    @pytest.mark.asyncio
+    async def test_requires_authentication(self, client: AsyncClient):
+        """Unauthenticated request returns 401."""
+        response = await client.post(
+            "/api/v1/images/check-similar",
+            files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_image_file(self, auth_client: AsyncClient):
+        """Non-image file returns 400."""
+        with patch(
+            "app.api.v1.images.check_similarity_rate_limit",
+            new_callable=AsyncMock,
+        ):
+            response = await auth_client.post(
+                "/api/v1/images/check-similar",
+                files={"file": ("test.txt", b"not an image", "text/plain")},
+            )
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_returns_429(self, auth_client: AsyncClient):
+        """Rate-limited request returns 429."""
+        from fastapi import HTTPException
+
+        with patch(
+            "app.api.v1.images.check_similarity_rate_limit",
+            new_callable=AsyncMock,
+            side_effect=HTTPException(
+                status_code=429,
+                detail="Too many requests",
+                headers={"Retry-After": "60"},
+            ),
+        ):
+            response = await auth_client.post(
+                "/api/v1/images/check-similar",
+                files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+            )
+        assert response.status_code == 429

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -1,0 +1,98 @@
+"""Tests for similarity check rate limiting."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+from app.services.rate_limit import check_similarity_rate_limit
+
+
+@pytest.fixture
+def mock_redis():
+    """Create a mock Redis client with pipeline support.
+
+    pipeline() is synchronous, as are pipeline methods (incr, expire).
+    Only pipeline.execute() is async.
+    """
+    client = AsyncMock()
+    mock_pipe = MagicMock()
+    mock_pipe.execute = AsyncMock(return_value=[])
+    # pipeline() is synchronous in redis.asyncio, so use MagicMock
+    client.pipeline = MagicMock(return_value=mock_pipe)
+    return client
+
+
+@pytest.mark.unit
+class TestCheckSimilarityRateLimit:
+    """Tests for check_similarity_rate_limit."""
+
+    async def test_allows_request_under_limit(self, mock_redis):
+        """First request (count=None) should be allowed."""
+        mock_redis.get.return_value = None
+
+        # Should not raise
+        await check_similarity_rate_limit(user_id=1, redis_client=mock_redis)
+
+    async def test_allows_request_at_limit_minus_one(self, mock_redis):
+        """Request at count=4 (limit-1) should be allowed."""
+        mock_redis.get.return_value = b"4"
+
+        # Should not raise
+        await check_similarity_rate_limit(user_id=1, redis_client=mock_redis)
+
+    async def test_rejects_request_at_limit(self, mock_redis):
+        """Request at count=5 (limit) should raise 429 with Retry-After header."""
+        mock_redis.get.return_value = b"5"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check_similarity_rate_limit(user_id=1, redis_client=mock_redis)
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.headers["Retry-After"] == "60"
+
+    async def test_rejects_request_over_limit(self, mock_redis):
+        """Request at count=10 (over limit) should raise 429."""
+        mock_redis.get.return_value = b"10"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check_similarity_rate_limit(user_id=1, redis_client=mock_redis)
+
+        assert exc_info.value.status_code == 429
+
+    async def test_sets_expiry_on_first_request(self, mock_redis):
+        """First request (count=None) should set 60s expiry on the key."""
+        mock_redis.get.return_value = None
+        mock_pipe = mock_redis.pipeline.return_value
+
+        await check_similarity_rate_limit(user_id=1, redis_client=mock_redis)
+
+        mock_pipe.expire.assert_called_once()
+        args = mock_pipe.expire.call_args[0]
+        # First arg is the key, second is the TTL (60 seconds)
+        assert args[1] == 60
+
+    async def test_does_not_set_expiry_on_subsequent_requests(self, mock_redis):
+        """Subsequent requests (count > 0) should not set expiry."""
+        mock_redis.get.return_value = b"2"
+        mock_pipe = mock_redis.pipeline.return_value
+
+        await check_similarity_rate_limit(user_id=1, redis_client=mock_redis)
+
+        mock_pipe.expire.assert_not_called()
+
+    async def test_uses_correct_redis_key(self, mock_redis):
+        """Should use key 'similarity_check_rate:{user_id}'."""
+        mock_redis.get.return_value = None
+
+        await check_similarity_rate_limit(user_id=42, redis_client=mock_redis)
+
+        mock_redis.get.assert_called_once_with("similarity_check_rate:42")
+
+    async def test_allows_request_when_redis_unavailable(self, mock_redis):
+        """Should allow request (not raise) when Redis is down."""
+        mock_redis.get.side_effect = RedisConnectionError("Connection refused")
+
+        # Should not raise - graceful degradation
+        await check_similarity_rate_limit(user_id=1, redis_client=mock_redis)


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/images/check-similar` endpoint that accepts a temporary image upload, queries IQDB for similar matches, and returns hydrated results without persisting the uploaded image
- Requires authentication; rate-limited to 5 requests/minute per user via Redis
- Validates uploaded file is a real image, generates a temp thumbnail for IQDB query, cleans up temp files in a finally block

## Details

- New `SimilarImagesUploadResponse` schema (like `SimilarImagesResponse` but without `query_image_id`)
- New `check_similarity_rate_limit` service with Redis fixed-window counter and graceful degradation
- New `SIMILARITY_CHECK_RATE_LIMIT` config setting (default: 5)
- 8 unit tests for the rate limiter, 5 API tests for the endpoint

## Test plan

- [x] Unit tests for rate limiter (8 tests covering limits, expiry, Redis failure)
- [x] API tests for endpoint (auth required, similar images returned, empty results, invalid file, rate limiting)
- [x] Full test suite passes (1104 passed, 9 skipped)
- [x] Manual smoke test with real IQDB instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)