### PR TITLE
feat: add optional reason field to image reviews

### DIFF
--- a/alembic/versions/3d5cbb8566ab_add_reason_to_image_reviews.py
+++ b/alembic/versions/3d5cbb8566ab_add_reason_to_image_reviews.py
@@ -1,0 +1,31 @@
+"""add reason to image_reviews
+
+Revision ID: 3d5cbb8566ab
+Revises: 81cdaeb0ff13
+Create Date: 2026-02-22 19:04:17.634719
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3d5cbb8566ab'
+down_revision: str | Sequence[str] | None = '81cdaeb0ff13'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "image_reviews",
+        sa.Column("reason", sa.String(1000), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("image_reviews", "reason")

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -1796,6 +1796,7 @@ async def create_review(
         deadline=deadline,
         status=ReviewStatus.OPEN,
         outcome=ReviewOutcome.PENDING,
+        reason=review_data.reason,
     )
     db.add(review)
     await db.flush()
@@ -1806,7 +1807,11 @@ async def create_review(
         action_type=AdminActionType.REVIEW_START,
         review_id=review.review_id,
         image_id=image_id,
-        details={"previous_status": previous_status, "deadline_days": deadline_days},
+        details={
+            "previous_status": previous_status,
+            "deadline_days": deadline_days,
+            "reason": review_data.reason,
+        },
     )
     db.add(action)
 

--- a/app/models/image_review.py
+++ b/app/models/image_review.py
@@ -48,6 +48,9 @@ class ImageReviewBase(SQLModel):
     # Whether the deadline has been extended
     extension_used: int = Field(default=0)
 
+    # Optional reason for starting the review (for direct reviews without a report)
+    reason: str | None = Field(default=None, max_length=1000)
+
     # Admin who closed the review early (NULL = automatic/deadline close)
     closed_by: int | None = Field(default=None)
 

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -170,6 +170,14 @@ class ReviewCreate(BaseModel):
         None, max_length=1000, description="Optional reason for starting the review"
     )
 
+    @field_validator("reason")
+    @classmethod
+    def sanitize_reason(cls, v: str | None) -> str | None:
+        """Sanitize review reason."""
+        if v is None:
+            return v
+        return v.strip() or None
+
 
 class ReviewVoteRequest(BaseModel):
     """Schema for casting a vote on a review."""

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -166,6 +166,9 @@ class ReviewCreate(BaseModel):
     deadline_days: int | None = Field(
         None, ge=1, le=30, description="Days until voting deadline (default: 7)"
     )
+    reason: str | None = Field(
+        None, max_length=1000, description="Optional reason for starting the review"
+    )
 
 
 class ReviewVoteRequest(BaseModel):
@@ -229,6 +232,7 @@ class ReviewResponse(BaseModel):
     source_report_category: int | None = None
     source_report_category_label: str | None = None
     source_report_reason: str | None = None
+    reason: str | None = None
     initiated_by: int | None
     initiated_by_username: str | None = None
     closed_by: int | None = None


### PR DESCRIPTION
## Summary
- Add nullable `reason` column (`VARCHAR(1000)`) to `image_reviews` table
- Accept optional `reason` in `POST /admin/images/{id}/review` and include it in responses
- Include reason in admin audit trail details

## Context
Direct reviews (not escalated from reports) had no way to explain why the review was started. Report-escalated reviews inherit `reason_text` from the report, but direct reviews had no equivalent.

## Test plan
- [x] Create review with reason — stored and returned
- [x] Create review without reason — null, still optional
- [x] Reason appears in review detail response
- [x] All 29 review tests pass
- [x] Full suite (1107 tests) passes
- [x] mypy clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)