### PR TITLE
fix: tag search fails for terms containing underscores

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -112,7 +112,7 @@ FULLTEXT_SPECIAL_CHARS = frozenset('+-~*"()><@')
 #
 # These split terms into separate tokens, which may result in tokens too short for fulltext.
 # e.g., "C.C." becomes ["C", "C"] which are both below min token size.
-FULLTEXT_WORD_DELIMITERS = frozenset(" \n\t;:!?.'\"`()[]{}|&/\\,-_=~")
+FULLTEXT_WORD_DELIMITERS = frozenset(" \n\t;:!?.'\"`()[]{}|&/\\,-=~")
 
 # Pre-computed translation table for efficient delimiter replacement (used by str.translate)
 _DELIMITER_TRANS_TABLE = str.maketrans(dict.fromkeys(FULLTEXT_WORD_DELIMITERS, " "))


### PR DESCRIPTION
## Summary
- Remove `_` from `FULLTEXT_WORD_DELIMITERS` in `app/api/v1/tags.py` to match MySQL/MariaDB InnoDB FULLTEXT tokenization, which treats underscore as a word character
- Fixes searches like `yano_0o0` which were incorrectly split into `["yano", "0o0"]`, producing a FULLTEXT query that matched nothing

## Test plan
- [x] Added `test_search_term_with_underscores` — creates tag `Yano (yano_0o0)`, searches `yano_0o0`, asserts it's found
- [x] All 100 existing tag tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)