### PR TITLE
feat: prevent alias tags from being parents and vice versa

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -223,6 +223,68 @@ async def get_tag_hierarchy(db: AsyncSession, tag_id: int, max_depth: int = 10) 
     return [row[0] for row in result.fetchall()]
 
 
+async def validate_tag_relationships(
+    db: AsyncSession,
+    *,
+    tag_id: int | None,
+    inheritedfrom_id: int | None,
+    alias_of: int | None,
+) -> None:
+    """Validate parent/alias tag constraints.
+
+    Checks:
+    1. Parent tag exists and is not an alias
+    2. Alias tag exists
+    3. Tag being aliased has no children (update only, when tag_id is set)
+
+    Raises HTTPException(400) on validation failure.
+    """
+    if inheritedfrom_id:
+        parent_result = await db.execute(select(Tags).where(Tags.tag_id == inheritedfrom_id))
+        parent_tag = parent_result.scalar_one_or_none()
+        if not parent_tag:
+            raise HTTPException(status_code=400, detail="Parent tag does not exist")
+        if parent_tag.alias_of is not None:
+            # Look up the canonical tag for a helpful error message
+            canonical_result = await db.execute(
+                select(Tags).where(Tags.tag_id == parent_tag.alias_of)
+            )
+            canonical_tag = canonical_result.scalar_one_or_none()
+            canonical_name = canonical_tag.title if canonical_tag else "unknown"
+            canonical_id = parent_tag.alias_of
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Cannot use alias tag as parent. "
+                    f"Tag '{parent_tag.title}' (id: {inheritedfrom_id}) is an alias of "
+                    f"'{canonical_name}' (id: {canonical_id}). "
+                    f"Use the canonical tag as parent instead."
+                ),
+            )
+
+    if alias_of:
+        alias_result = await db.execute(select(Tags).where(Tags.tag_id == alias_of))
+        if not alias_result.scalar_one_or_none():
+            raise HTTPException(status_code=400, detail="Alias tag does not exist")
+
+    if alias_of and tag_id is not None:
+        # Check if this tag has children
+        children_result = await db.execute(
+            select(Tags.tag_id, Tags.title).where(Tags.inheritedfrom_id == tag_id)
+        )
+        children = children_result.all()
+        if children:
+            child_list = ", ".join(f"'{title}' (id: {cid})" for cid, title in children)
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Cannot make a tag with children into an alias. "
+                    f"{len(children)} tag(s) inherit from this tag: {child_list}. "
+                    f"Reassign or remove child tags first."
+                ),
+            )
+
+
 @router.get("/", response_model=TagListResponse, include_in_schema=False)
 @router.get("", response_model=TagListResponse)
 async def list_tags(
@@ -1027,21 +1089,13 @@ async def create_tag(
     if existing_tag_result.scalar_one_or_none():
         raise HTTPException(status_code=409, detail="Tag already exists")
 
-    # if inherited_from is set, ensure that tag exists
-    if tag_data.inheritedfrom_id:
-        parent_tag_result = await db.execute(
-            select(Tags).where(Tags.tag_id == tag_data.inheritedfrom_id)  # type: ignore[arg-type]
-        )
-        if not parent_tag_result.scalar_one_or_none():
-            raise HTTPException(status_code=400, detail="Parent tag does not exist")
-
-    # if alias is set, ensure that tag exists
-    if tag_data.alias_of:
-        alias_tag_result = await db.execute(
-            select(Tags).where(Tags.tag_id == tag_data.alias_of)  # type: ignore[arg-type]
-        )
-        if not alias_tag_result.scalar_one_or_none():
-            raise HTTPException(status_code=400, detail="Alias tag does not exist")
+    # Validate parent and alias tag relationships
+    await validate_tag_relationships(
+        db,
+        tag_id=None,
+        inheritedfrom_id=tag_data.inheritedfrom_id,
+        alias_of=tag_data.alias_of,
+    )
 
     new_tag = Tags(
         title=tag_data.title,
@@ -1096,22 +1150,15 @@ async def update_tag(
 
     # Validate inheritedfrom_id and alias fields if present
     inheritedfrom_id = update_data.get("inheritedfrom_id")
-    if inheritedfrom_id is not None:
-        parent_result = await db.execute(select(Tags).where(Tags.tag_id == inheritedfrom_id))
-        parent_tag = parent_result.scalar_one_or_none()
-        if not parent_tag:
-            raise HTTPException(
-                status_code=400, detail=f"Parent tag with id {inheritedfrom_id} does not exist"
-            )
-
     alias_id = update_data.get("alias_of")
-    if alias_id is not None:
-        alias_result = await db.execute(select(Tags).where(Tags.tag_id == alias_id))
-        alias_tag = alias_result.scalar_one_or_none()
-        if not alias_tag:
-            raise HTTPException(
-                status_code=400, detail=f"Alias of tag with id {alias_id} does not exist"
-            )
+
+    # Validate parent and alias tag relationships
+    await validate_tag_relationships(
+        db,
+        tag_id=tag_id,
+        inheritedfrom_id=inheritedfrom_id,
+        alias_of=alias_id,
+    )
 
     # Update fields
     for key, value in update_data.items():

--- a/scripts/audit_alias_parent_violations.py
+++ b/scripts/audit_alias_parent_violations.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Audit script: find tags where an alias tag is used as a parent.
+
+Reports two types of violations:
+1. Tags whose parent (inheritedfrom_id) is an alias tag
+2. Tags that are aliases AND have children inheriting from them
+
+Usage: uv run python scripts/audit_alias_parent_violations.py
+"""
+
+import asyncio
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.config import settings
+from app.models.tag import Tags
+
+
+async def audit() -> None:
+    engine = create_async_engine(settings.DATABASE_URL, echo=False)
+    async_session = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False, future=True
+    )
+
+    async with async_session() as db:
+        # Violation 1: Tags whose parent is an alias
+        parent_alias = Tags.__table__.alias("parent")
+        result = await db.execute(
+            select(
+                Tags.tag_id,
+                Tags.title,
+                Tags.inheritedfrom_id,
+                parent_alias.c.title.label("parent_title"),
+                parent_alias.c.alias_of.label("parent_alias_of"),
+            )
+            .join(parent_alias, Tags.inheritedfrom_id == parent_alias.c.tag_id)
+            .where(parent_alias.c.alias_of.isnot(None))
+        )
+        alias_parents = result.all()
+
+        if alias_parents:
+            print(f"\n=== Violation 1: {len(alias_parents)} tag(s) with alias parent ===")
+            for row in alias_parents:
+                print(
+                    f"  Tag '{row.title}' (id: {row.tag_id}) "
+                    f"has parent '{row.parent_title}' (id: {row.inheritedfrom_id}) "
+                    f"which is alias of tag id {row.parent_alias_of}"
+                )
+        else:
+            print("\n=== Violation 1: No tags with alias parents ===")
+
+        # Violation 2: Tags that are aliases AND have children
+        child_alias = Tags.__table__.alias("child")
+        result = await db.execute(
+            select(Tags.tag_id, Tags.title, Tags.alias_of)
+            .where(Tags.alias_of.isnot(None))
+            .where(
+                Tags.tag_id.in_(
+                    select(child_alias.c.inheritedfrom_id).where(
+                        child_alias.c.inheritedfrom_id.isnot(None)
+                    )
+                )
+            )
+        )
+        alias_with_children = result.all()
+
+        if alias_with_children:
+            print(
+                f"\n=== Violation 2: {len(alias_with_children)} alias tag(s) that are parents ==="
+            )
+            for row in alias_with_children:
+                children_result = await db.execute(
+                    select(Tags.tag_id, Tags.title).where(Tags.inheritedfrom_id == row.tag_id)
+                )
+                children = children_result.all()
+                child_list = ", ".join(f"'{t}' (id: {i})" for i, t in children)
+                print(
+                    f"  Tag '{row.title}' (id: {row.tag_id}) "
+                    f"is alias of tag id {row.alias_of} "
+                    f"but has children: {child_list}"
+                )
+        else:
+            print("\n=== Violation 2: No alias tags with children ===")
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(audit())


### PR DESCRIPTION
## Summary

- Add `validate_tag_relationships()` shared validation function to enforce two new constraints:
  - **Cannot use an alias tag as parent** — error message suggests the canonical tag by name and ID
  - **Cannot make a tag with children into an alias** — error message lists child tags that need reassigning first
- Both constraints enforced on `create_tag` and `update_tag` endpoints
- Add audit script (`scripts/audit_alias_parent_violations.py`) — found 5 existing violations to fix manually

## Existing violations (fix with SQL)

```sql
UPDATE tags SET inheritedfrom_id = 1246 WHERE tag_id = 11876;
UPDATE tags SET inheritedfrom_id = 17981 WHERE tag_id = 57448;
UPDATE tags SET inheritedfrom_id = 79588 WHERE tag_id = 113318;
UPDATE tags SET inheritedfrom_id = 146965 WHERE tag_id = 142624;
UPDATE tags SET inheritedfrom_id = 611 WHERE tag_id = 219990;
```

## Test plan

- [x] Create tag with alias as parent → 400 with canonical tag suggestion
- [x] Update tag to set alias as parent → 400 with canonical tag suggestion
- [x] Make parent tag (with children) into alias → 400 with child list
- [x] Create tag with canonical parent → 200 (happy path)
- [x] Make childless tag into alias → 200 (happy path)
- [x] All 106 tag tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)