### PR TITLE
feat: restrict tag names to ASCII-only characters

### DIFF
--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -16,27 +16,9 @@ TAG_NAME_MIN_LENGTH = 2
 TAG_NAME_MAX_LENGTH = 150
 
 # Regex pattern for allowed characters in tag names:
-# - Latin letters (a-z, A-Z)
-# - Digits (0-9)
-# - CJK Unified Ideographs (U+4E00-9FFF) and Extension A (U+3400-4DBF)
-# - Hiragana (U+3040-309F)
-# - Katakana (U+30A0-30FF)
-# - Hangul Syllables (U+AC00-D7AF) and Jamo (U+1100-11FF)
-# - Basic punctuation: space, hyphen, period, apostrophe, colon, parentheses,
-#   exclamation, question mark, ampersand, forward slash, comma, underscore
-TAG_NAME_PATTERN = re.compile(
-    r"^["
-    r"a-zA-Z"  # Latin letters
-    r"0-9"  # Digits
-    r"\u4E00-\u9FFF"  # CJK Unified Ideographs
-    r"\u3400-\u4DBF"  # CJK Extension A
-    r"\u3040-\u309F"  # Hiragana
-    r"\u30A0-\u30FF"  # Katakana
-    r"\uAC00-\uD7AF"  # Hangul Syllables
-    r"\u1100-\u11FF"  # Hangul Jamo
-    r" \-\.\'\:\(\)\!\?\&\/\,\_"  # Allowed punctuation
-    r"]+$"
-)
+# All printable ASCII (U+0020 through U+007E) except backtick (`).
+# Tags cannot start with ! or -.
+TAG_NAME_PATTERN = re.compile(r"^(?![!\-])[\x20-\x5F\x61-\x7E]+$")
 
 
 def validate_tag_name(title: str) -> str:
@@ -47,7 +29,7 @@ def validate_tag_name(title: str) -> str:
     - Minimum length: 2 characters
     - Maximum length: 150 characters
     - Consecutive spaces normalized to single space
-    - Only allowed characters (Latin, digits, CJK, kana, hangul, basic punctuation)
+    - Only printable ASCII characters (no backticks, cannot start with ! or -)
 
     Args:
         title: The tag name to validate
@@ -76,7 +58,8 @@ def validate_tag_name(title: str) -> str:
     if not TAG_NAME_PATTERN.match(title):
         raise ValueError(
             "Tag name contains invalid characters. "
-            "Only letters, numbers, CJK characters, and basic punctuation are allowed."
+            "Only printable ASCII characters are allowed (no backticks). "
+            "Tag names cannot start with ! or -."
         )
 
     return title

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -4158,6 +4158,108 @@ class TestTagNameValidation:
         # The title should be normalized
         assert response.json()["title"] == "School Uniform"
 
+    async def test_reject_leading_bang_or_dash(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that tags starting with ! or - are rejected."""
+        perm = Perms(title="tag_create", desc="Create tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        admin = Users(
+            username="tagleadingadmin",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="tagleadingadmin@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        user_perm = UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1)
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "tagleadingadmin", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Tags starting with ! should be rejected
+        response = await client.post(
+            "/api/v1/tags",
+            json={"title": "!foo", "type": TagType.THEME},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 422
+
+        # Tags starting with - should be rejected
+        response = await client.post(
+            "/api/v1/tags",
+            json={"title": "-foo", "type": TagType.THEME},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 422
+
+        # ! and - are fine in non-leading positions
+        response = await client.post(
+            "/api/v1/tags",
+            json={"title": "foo-bar", "type": TagType.THEME},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+
+        response = await client.post(
+            "/api/v1/tags",
+            json={"title": "foo!", "type": TagType.THEME},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+
+    async def test_reject_backtick_in_tag_name(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that backtick character is rejected."""
+        perm = Perms(title="tag_create", desc="Create tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        admin = Users(
+            username="tagbacktickadmin",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="tagbacktickadmin@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        user_perm = UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1)
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "tagbacktickadmin", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        response = await client.post(
+            "/api/v1/tags",
+            json={"title": "foo`bar", "type": TagType.THEME},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 422
+
     async def test_tag_update_validation(
         self, client: AsyncClient, db_session: AsyncSession
     ):

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -3695,10 +3695,10 @@ class TestTagNameValidation:
         assert response.status_code == 200
         assert response.json()["title"] == "School Uniform"
 
-    async def test_valid_cjk_tag_name(
+    async def test_reject_cjk_tag_name(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Test that CJK characters (Japanese kanji, Chinese) are allowed."""
+        """Test that CJK characters (Japanese kanji, Chinese) are rejected."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)
         await db_session.commit()
@@ -3727,19 +3727,18 @@ class TestTagNameValidation:
         )
         access_token = login_response.json()["access_token"]
 
-        # Create tag with Japanese kanji
+        # CJK characters are not allowed (ASCII-only)
         response = await client.post(
             "/api/v1/tags",
             json={"title": "桜木花道", "type": TagType.CHARACTER},
             headers={"Authorization": f"Bearer {access_token}"},
         )
-        assert response.status_code == 200
-        assert response.json()["title"] == "桜木花道"
+        assert response.status_code == 422
 
-    async def test_valid_hiragana_katakana_tag_name(
+    async def test_reject_hiragana_katakana_tag_name(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Test that Hiragana and Katakana are allowed."""
+        """Test that Hiragana and Katakana are rejected."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)
         await db_session.commit()
@@ -3768,26 +3767,26 @@ class TestTagNameValidation:
         )
         access_token = login_response.json()["access_token"]
 
-        # Create tag with hiragana
+        # Hiragana not allowed (ASCII-only)
         response = await client.post(
             "/api/v1/tags",
             json={"title": "ひらがな", "type": TagType.CHARACTER},
             headers={"Authorization": f"Bearer {access_token}"},
         )
-        assert response.status_code == 200
+        assert response.status_code == 422
 
-        # Create tag with katakana (different word to avoid collation conflicts)
+        # Katakana not allowed (ASCII-only)
         response = await client.post(
             "/api/v1/tags",
             json={"title": "カタカナ", "type": TagType.CHARACTER},
             headers={"Authorization": f"Bearer {access_token}"},
         )
-        assert response.status_code == 200
+        assert response.status_code == 422
 
-    async def test_valid_korean_tag_name(
+    async def test_reject_korean_tag_name(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Test that Korean Hangul is allowed."""
+        """Test that Korean Hangul is rejected."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)
         await db_session.commit()
@@ -3816,13 +3815,13 @@ class TestTagNameValidation:
         )
         access_token = login_response.json()["access_token"]
 
-        # Create tag with Korean
+        # Korean not allowed (ASCII-only)
         response = await client.post(
             "/api/v1/tags",
             json={"title": "한글태그", "type": TagType.CHARACTER},
             headers={"Authorization": f"Bearer {access_token}"},
         )
-        assert response.status_code == 200
+        assert response.status_code == 422
 
     async def test_valid_punctuation_in_tag_name(
         self, client: AsyncClient, db_session: AsyncSession


### PR DESCRIPTION
## Summary
- Simplifies `TAG_NAME_PATTERN` from complex unicode ranges (CJK, kana, hangul + punctuation list) to all printable ASCII (U+0020–U+007E) except backtick
- Tags cannot start with `!` or `-`
- Follows danbooru convention of romanized tag names
- Updates 3 tests from expecting unicode acceptance (200) to rejection (422)

## Context
Audited existing tags: ~1,593 contain non-ASCII characters (CJK, accented Latin, decorative symbols, etc.). Since we romanize Asian character names, ASCII-only is sufficient. Existing tags with non-ASCII characters remain in the database but new tags must be ASCII-only.

## Test plan
- [x] `test_reject_cjk_tag_name` - CJK characters return 422
- [x] `test_reject_hiragana_katakana_tag_name` - Hiragana/Katakana return 422
- [x] `test_reject_korean_tag_name` - Korean Hangul returns 422
- [x] All 108 tag API tests pass
- [x] All 311 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)