### PR TITLE
feat: migrate external links when setting tag alias

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1318,7 +1318,7 @@ async def update_tag(
 
         # Migrate external links from alias to canonical tag
         existing_urls_result = await db.execute(
-            select(TagExternalLinks.url).where(TagExternalLinks.tag_id == canonical_id)
+            select(TagExternalLinks.url).where(TagExternalLinks.tag_id == canonical_id)  # type: ignore[call-overload]
         )
         existing_urls = {row[0] for row in existing_urls_result}
 
@@ -1327,7 +1327,7 @@ async def update_tag(
             await db.execute(
                 delete(TagExternalLinks).where(
                     TagExternalLinks.tag_id == tag_id,  # type: ignore[arg-type]
-                    TagExternalLinks.url.in_(existing_urls),  # type: ignore[union-attr]
+                    TagExternalLinks.url.in_(existing_urls),  # type: ignore[attr-defined]
                 )
             )
 

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -266,6 +266,11 @@ async def validate_tag_relationships(
             )
 
     if alias_of is not None:
+        if tag_id is not None and alias_of == tag_id:
+            raise HTTPException(
+                status_code=400,
+                detail="A tag cannot be an alias of itself",
+            )
         alias_result = await db.execute(select(Tags).where(Tags.tag_id == alias_of))  # type: ignore[arg-type]
         if not alias_result.scalar_one_or_none():
             raise HTTPException(


### PR DESCRIPTION
## Summary
- When a tag is aliased, its external links (artist sites, social media URLs) are now migrated to the canonical tag
- Duplicate URLs are deleted to avoid unique constraint violations, matching the existing tag_links migration pattern

## Test plan
- [x] Test that all external links move from alias to canonical tag
- [x] Test conflict handling when both tags share the same URL
- [x] Existing alias migration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)