### PR TITLE
feat: threaded PM chat API endpoints

### DIFF
--- a/alembic/versions/b50f77d51a12_add_thread_id_to_privmsgs.py
+++ b/alembic/versions/b50f77d51a12_add_thread_id_to_privmsgs.py
@@ -1,0 +1,74 @@
+"""add thread_id to privmsgs
+
+Revision ID: b50f77d51a12
+Revises: 92f9d7890c30
+Create Date: 2026-03-01 15:19:53.515328
+
+"""
+import uuid
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = 'b50f77d51a12'
+down_revision: str | Sequence[str] | None = '92f9d7890c30'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add thread_id column and backport existing messages into threads."""
+    # 1. Add nullable thread_id column
+    op.add_column("privmsgs", sa.Column("thread_id", sa.String(36), nullable=True))
+
+    # 2. Backport existing messages into threads
+    conn = op.get_bind()
+
+    rows = conn.execute(text("""
+        SELECT privmsg_id, subject, from_user_id, to_user_id
+        FROM privmsgs
+        ORDER BY date ASC
+    """)).fetchall()
+
+    # Group by (normalized_subject, sorted user pair)
+    threads: dict[tuple, str] = {}
+    for privmsg_id, subject, from_uid, to_uid in rows:
+        normalized = subject or ""
+        while normalized.startswith("Re: ") or normalized.startswith("Re:"):
+            if normalized.startswith("Re: "):
+                normalized = normalized[4:]
+            elif normalized.startswith("Re:"):
+                normalized = normalized[3:]
+        normalized = normalized.strip().lower()
+
+        user_pair = tuple(sorted([from_uid, to_uid]))
+        key = (normalized, user_pair)
+
+        if key not in threads:
+            threads[key] = str(uuid.uuid4())
+
+        conn.execute(
+            text("UPDATE privmsgs SET thread_id = :tid WHERE privmsg_id = :pid"),
+            {"tid": threads[key], "pid": privmsg_id},
+        )
+
+    # 3. Assign unique thread_id to any remaining NULL rows
+    remaining = conn.execute(text("SELECT privmsg_id FROM privmsgs WHERE thread_id IS NULL")).fetchall()
+    for (privmsg_id,) in remaining:
+        conn.execute(
+            text("UPDATE privmsgs SET thread_id = :tid WHERE privmsg_id = :pid"),
+            {"tid": str(uuid.uuid4()), "pid": privmsg_id},
+        )
+
+    # 4. Make column NOT NULL and add index
+    op.alter_column("privmsgs", "thread_id", nullable=False, existing_type=sa.String(36))
+    op.create_index("ix_privmsgs_thread_id", "privmsgs", ["thread_id"])
+
+
+def downgrade() -> None:
+    """Remove thread_id column."""
+    op.drop_index("ix_privmsgs_thread_id", table_name="privmsgs")
+    op.drop_column("privmsgs", "thread_id")

--- a/alembic/versions/b50f77d51a12_add_thread_id_to_privmsgs.py
+++ b/alembic/versions/b50f77d51a12_add_thread_id_to_privmsgs.py
@@ -5,6 +5,7 @@ Revises: 92f9d7890c30
 Create Date: 2026-03-01 15:19:53.515328
 
 """
+import re
 import uuid
 from typing import Sequence
 
@@ -36,12 +37,7 @@ def upgrade() -> None:
     # Group by (normalized_subject, sorted user pair)
     threads: dict[tuple, str] = {}
     for privmsg_id, subject, from_uid, to_uid in rows:
-        normalized = subject or ""
-        while normalized.startswith("Re: ") or normalized.startswith("Re:"):
-            if normalized.startswith("Re: "):
-                normalized = normalized[4:]
-            elif normalized.startswith("Re:"):
-                normalized = normalized[3:]
+        normalized = re.sub(r'^(Re:\s*)+', '', subject or '', flags=re.IGNORECASE)
         normalized = normalized.strip().lower()
 
         user_pair = tuple(sorted([from_uid, to_uid]))

--- a/app/models/privmsg.py
+++ b/app/models/privmsg.py
@@ -37,6 +37,9 @@ class PrivmsgBase(SQLModel):
     from_user_id: int
     to_user_id: int
 
+    # Thread grouping
+    thread_id: str | None = Field(default=None, max_length=36)
+
     # Public timestamp
     date: datetime
 
@@ -77,6 +80,7 @@ class Privmsgs(PrivmsgBase, table=True):
         ),
         Index("fk_privmsgs_from_user_id", "from_user_id"),
         Index("fk_privmsgs_to_user_id", "to_user_id"),
+        Index("ix_privmsgs_thread_id", "thread_id"),
     )
 
     # Primary key
@@ -90,6 +94,8 @@ class Privmsgs(PrivmsgBase, table=True):
     viewed: int = Field(default=0)
     from_del: int = Field(default=0)
     to_del: int = Field(default=0)
+
+    thread_id: str | None = Field(default=None, max_length=36, index=True)
 
     # Public timestamp
     date: datetime = Field(

--- a/app/models/privmsg.py
+++ b/app/models/privmsg.py
@@ -95,8 +95,6 @@ class Privmsgs(PrivmsgBase, table=True):
     from_del: int = Field(default=0)
     to_del: int = Field(default=0)
 
-    thread_id: str | None = Field(default=None, max_length=36)
-
     # Public timestamp
     date: datetime = Field(
         default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}

--- a/app/models/privmsg.py
+++ b/app/models/privmsg.py
@@ -95,7 +95,7 @@ class Privmsgs(PrivmsgBase, table=True):
     from_del: int = Field(default=0)
     to_del: int = Field(default=0)
 
-    thread_id: str | None = Field(default=None, max_length=36, index=True)
+    thread_id: str | None = Field(default=None, max_length=36)
 
     # Public timestamp
     date: datetime = Field(

--- a/app/schemas/privmsg.py
+++ b/app/schemas/privmsg.py
@@ -14,6 +14,7 @@ class PrivmsgCreate(BaseModel):
     to_user_id: int
     subject: str
     message: str
+    thread_id: str | None = None
 
     @field_validator("subject")
     @classmethod
@@ -77,3 +78,27 @@ class PrivmsgMessages(BaseModel):
     page: int
     per_page: int
     messages: list[PrivmsgMessage]
+
+
+class ThreadSummary(BaseModel):
+    """Schema for a conversation thread summary in the inbox."""
+
+    thread_id: str
+    subject: str
+    other_user_id: int
+    other_username: str | None = None
+    other_avatar_url: str | None = None
+    other_groups: list[str] = []
+    latest_message_preview: str
+    latest_message_date: str
+    unread_count: int
+    message_count: int
+
+
+class ThreadList(BaseModel):
+    """Schema for paginated thread list."""
+
+    total: int
+    page: int
+    per_page: int
+    threads: list[ThreadSummary]

--- a/tests/api/v1/test_privmsg_threads.py
+++ b/tests/api/v1/test_privmsg_threads.py
@@ -1,0 +1,174 @@
+"""Tests for privmsg thread endpoints."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import get_password_hash
+from app.models.privmsg import Privmsgs
+from app.models.user import Users
+
+
+async def create_user(db: AsyncSession, username: str, **kwargs) -> Users:
+    """Helper to create a test user."""
+    user = Users(
+        username=username,
+        password=get_password_hash("TestPassword123!"),
+        password_type="bcrypt",
+        salt="",
+        email=f"{username}@example.com",
+        active=1,
+        **kwargs,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def login(client: AsyncClient, username: str) -> str:
+    """Helper to login and return access token."""
+    response = await client.post(
+        "/api/v1/auth/login",
+        json={"username": username, "password": "TestPassword123!"},
+    )
+    assert response.status_code == 200
+    return response.json()["access_token"]
+
+
+@pytest.mark.api
+class TestGetThreads:
+    """Tests for GET /api/v1/privmsgs/threads endpoint."""
+
+    async def test_list_threads(self, client: AsyncClient, db_session: AsyncSession):
+        """Test listing conversation threads."""
+        user_a = await create_user(db_session, "thread_a")
+        user_b = await create_user(db_session, "thread_b")
+
+        thread_id = str(uuid.uuid4())
+        now = datetime.now(UTC)
+
+        for i in range(2):
+            msg = Privmsgs(
+                from_user_id=user_a.user_id if i == 0 else user_b.user_id,
+                to_user_id=user_b.user_id if i == 0 else user_a.user_id,
+                subject="Hello" if i == 0 else "Re: Hello",
+                text=f"Message {i}",
+                thread_id=thread_id,
+                date=now + timedelta(minutes=i),
+                viewed=1 if i == 0 else 0,
+            )
+            db_session.add(msg)
+        await db_session.commit()
+
+        token = await login(client, "thread_a")
+        response = await client.get(
+            "/api/v1/privmsgs/threads",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] >= 1
+
+        thread = next(t for t in data["threads"] if t["thread_id"] == thread_id)
+        assert thread["subject"] == "Hello"
+        assert thread["other_user_id"] == user_b.user_id
+        assert thread["other_username"] == "thread_b"
+        assert thread["unread_count"] == 1
+        assert thread["message_count"] == 2
+
+    async def test_list_threads_unauthenticated(self, client: AsyncClient):
+        """Test listing threads without authentication."""
+        response = await client.get("/api/v1/privmsgs/threads")
+        assert response.status_code == 401
+
+    async def test_list_threads_filter_unread(self, client: AsyncClient, db_session: AsyncSession):
+        """Test filtering threads to only unread."""
+        user_a = await create_user(db_session, "unread_a")
+        user_b = await create_user(db_session, "unread_b")
+        user_c = await create_user(db_session, "unread_c")
+
+        now = datetime.now(UTC)
+
+        t1 = str(uuid.uuid4())
+        msg1 = Privmsgs(
+            from_user_id=user_b.user_id, to_user_id=user_a.user_id,
+            subject="Read thread", text="Hi", thread_id=t1, date=now, viewed=1,
+        )
+        db_session.add(msg1)
+
+        t2 = str(uuid.uuid4())
+        msg2 = Privmsgs(
+            from_user_id=user_c.user_id, to_user_id=user_a.user_id,
+            subject="Unread thread", text="Hey", thread_id=t2, date=now, viewed=0,
+        )
+        db_session.add(msg2)
+        await db_session.commit()
+
+        token = await login(client, "unread_a")
+        response = await client.get(
+            "/api/v1/privmsgs/threads?filter=unread",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        thread_ids = [t["thread_id"] for t in data["threads"]]
+        assert t2 in thread_ids
+        assert t1 not in thread_ids
+
+    async def test_threads_exclude_left_conversations(self, client: AsyncClient, db_session: AsyncSession):
+        """Test that left (soft-deleted) conversations don't appear."""
+        user_a = await create_user(db_session, "left_a")
+        user_b = await create_user(db_session, "left_b")
+
+        thread_id = str(uuid.uuid4())
+        msg = Privmsgs(
+            from_user_id=user_b.user_id, to_user_id=user_a.user_id,
+            subject="Left thread", text="Bye", thread_id=thread_id,
+            to_del=1,
+        )
+        db_session.add(msg)
+        await db_session.commit()
+
+        token = await login(client, "left_a")
+        response = await client.get(
+            "/api/v1/privmsgs/threads",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        thread_ids = [t["thread_id"] for t in response.json()["threads"]]
+        assert thread_id not in thread_ids
+
+    async def test_threads_sorted_by_latest_message(self, client: AsyncClient, db_session: AsyncSession):
+        """Test threads are sorted by most recent message date."""
+        user_a = await create_user(db_session, "sort_a")
+        user_b = await create_user(db_session, "sort_b")
+        user_c = await create_user(db_session, "sort_c")
+
+        now = datetime.now(UTC)
+
+        t1 = str(uuid.uuid4())
+        db_session.add(Privmsgs(
+            from_user_id=user_b.user_id, to_user_id=user_a.user_id,
+            subject="Old", text="Old msg", thread_id=t1, date=now - timedelta(hours=1),
+        ))
+
+        t2 = str(uuid.uuid4())
+        db_session.add(Privmsgs(
+            from_user_id=user_c.user_id, to_user_id=user_a.user_id,
+            subject="New", text="New msg", thread_id=t2, date=now,
+        ))
+        await db_session.commit()
+
+        token = await login(client, "sort_a")
+        response = await client.get(
+            "/api/v1/privmsgs/threads",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        threads = response.json()["threads"]
+        thread_ids = [t["thread_id"] for t in threads]
+        assert thread_ids.index(t2) < thread_ids.index(t1)

--- a/tests/unit/test_privmsg_schemas.py
+++ b/tests/unit/test_privmsg_schemas.py
@@ -1,0 +1,34 @@
+"""Tests for privmsg thread schemas."""
+
+from app.schemas.privmsg import PrivmsgCreate, ThreadSummary
+
+
+class TestPrivmsgCreate:
+    def test_thread_id_optional(self):
+        """PrivmsgCreate should accept optional thread_id."""
+        msg = PrivmsgCreate(to_user_id=1, subject="Hello", message="World")
+        assert msg.thread_id is None
+
+    def test_thread_id_provided(self):
+        """PrivmsgCreate should accept thread_id when provided."""
+        msg = PrivmsgCreate(to_user_id=1, subject="Hello", message="World", thread_id="abc-123")
+        assert msg.thread_id == "abc-123"
+
+
+class TestThreadSummary:
+    def test_thread_summary_fields(self):
+        """ThreadSummary should contain all required fields."""
+        summary = ThreadSummary(
+            thread_id="abc-123",
+            subject="Hello",
+            other_user_id=2,
+            other_username="bob",
+            other_avatar_url=None,
+            other_groups=["mods"],
+            latest_message_preview="Hi there...",
+            latest_message_date="2026-01-01T00:00:00",
+            unread_count=3,
+            message_count=5,
+        )
+        assert summary.thread_id == "abc-123"
+        assert summary.unread_count == 3


### PR DESCRIPTION
## Summary

- Add `thread_id` column to privmsgs with migration that backports existing messages into conversation threads
- Add thread-based API endpoints for listing, viewing, and leaving conversations
- Enhance POST /privmsgs to support thread_id with automatic del-flag reset on reply

## Changes

### Migration
- `alembic/versions/b50f77d51a12_add_thread_id_to_privmsgs.py` — adds `thread_id` column, backfills by grouping messages on normalized subject + user pair using case-insensitive Re: stripping

### Endpoints
- **GET `/privmsgs/threads`** — paginated conversation list with unread counts, message counts, latest preview, other-user metadata; supports `?filter=unread`
- **GET `/privmsgs/threads/{thread_id}`** — all messages in a thread (marks unread as viewed)
- **DELETE `/privmsgs/threads/{thread_id}`** — leave a conversation (soft-delete; hard-delete when both parties leave)
- **POST `/privmsgs`** — now accepts optional `thread_id`; resets recipient del-flags on reply so thread reappears

### Model/Schema
- `thread_id` field added to Privmsg model and PrivmsgCreate schema
- New `ThreadSummary` and `ThreadList` response schemas

No existing endpoints were removed or broken. The migration has a proper downgrade path.

## Test plan

- [x] Run `alembic upgrade head` — thread_id column added, existing messages grouped
- [x] GET /privmsgs/threads — returns conversation list with correct metadata
- [x] GET /privmsgs/threads/{id} — returns messages in order, marks as read
- [x] POST /privmsgs with thread_id — reply appears in thread
- [x] DELETE /privmsgs/threads/{id} — conversation removed from inbox
- [x] `alembic downgrade -1` — thread_id column cleanly removed
- [x] Existing endpoints (received, sent, individual) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)