### PR TITLE
fix: allow taggers to dismiss TAG_SUGGESTIONS reports

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -1203,17 +1203,35 @@ async def delete_comment_via_report(
 async def dismiss_report(
     report_id: Annotated[int, Path(description="Report ID")],
     current_user: Annotated[Users, Depends(get_current_user)],
-    _: Annotated[None, Depends(require_permission(Permission.REPORT_MANAGE))],
     request_data: ReportDismissRequest | None = None,
     db: AsyncSession = Depends(get_db),
+    redis_client: redis.Redis = Depends(get_redis),  # type: ignore[type-arg]
 ) -> MessageResponse:
     """
     Dismiss a report without taking action on the image.
 
     Optionally include admin_notes to document why the report was dismissed.
 
-    Requires REPORT_MANAGE permission.
+    Requires REPORT_MANAGE permission, or TAG_SUGGESTION_APPLY for TAG_SUGGESTIONS reports.
     """
+    from app.core.permissions import has_permission
+
+    has_report_manage = await has_permission(
+        db,
+        current_user.user_id,  # type: ignore[arg-type]
+        Permission.REPORT_MANAGE,
+        redis_client,
+    )
+    has_tag_suggestion_apply = await has_permission(
+        db,
+        current_user.user_id,  # type: ignore[arg-type]
+        Permission.TAG_SUGGESTION_APPLY,
+        redis_client,
+    )
+
+    if not has_report_manage and not has_tag_suggestion_apply:
+        raise HTTPException(status_code=403, detail="Permission denied")
+
     result = await db.execute(
         select(ImageReports).where(ImageReports.report_id == report_id)  # type: ignore[arg-type]
     )
@@ -1224,6 +1242,10 @@ async def dismiss_report(
 
     if report.status != ReportStatus.PENDING:
         raise HTTPException(status_code=400, detail="Report has already been processed")
+
+    # Taggers can only dismiss TAG_SUGGESTIONS reports
+    if not has_report_manage and report.category != ReportCategory.TAG_SUGGESTIONS:
+        raise HTTPException(status_code=403, detail="Permission denied")
 
     # Mark all tag suggestions as rejected
     suggestions_result = await db.execute(

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -915,10 +915,10 @@ class TestReportPermissionDenials:
 
         assert response.status_code == 403
 
-    async def test_tagger_cannot_dismiss_report(
+    async def test_tagger_can_dismiss_tag_suggestion_report(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Test user with only TAG_SUGGESTION_APPLY cannot dismiss reports."""
+        """Test user with TAG_SUGGESTION_APPLY can dismiss TAG_SUGGESTIONS reports."""
         tagger, password = await create_auth_user(db_session, username="tagger_dismiss1")
         await grant_permission(db_session, tagger.user_id, "tag_suggestion_apply")
         image = await create_test_image(db_session, tagger.user_id)
@@ -928,6 +928,32 @@ class TestReportPermissionDenials:
             image_id=image.image_id,
             user_id=tagger.user_id,
             category=4,  # TAG_SUGGESTIONS
+            status=ReportStatus.PENDING,
+        )
+        db_session.add(report)
+        await db_session.commit()
+
+        response = await client.post(
+            f"/api/v1/admin/reports/{report.report_id}/dismiss",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Report dismissed successfully"
+
+    async def test_tagger_cannot_dismiss_non_tag_suggestion_report(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test user with only TAG_SUGGESTION_APPLY cannot dismiss non-TAG_SUGGESTIONS reports."""
+        tagger, password = await create_auth_user(db_session, username="tagger_dismiss2")
+        await grant_permission(db_session, tagger.user_id, "tag_suggestion_apply")
+        image = await create_test_image(db_session, tagger.user_id)
+        token = await login_user(client, tagger.username, password)
+
+        report = ImageReports(
+            image_id=image.image_id,
+            user_id=tagger.user_id,
+            category=1,  # REPOST
             status=ReportStatus.PENDING,
         )
         db_session.add(report)


### PR DESCRIPTION
## Summary
- Taggers (`TAG_SUGGESTION_APPLY`) could see tag suggestion reports but had no way to handle ones with only a reason text and no tag suggestions — the apply endpoint returns 400 and dismiss required `REPORT_MANAGE`
- The dismiss endpoint now accepts `TAG_SUGGESTION_APPLY` for TAG_SUGGESTIONS reports specifically, using the same manual permission check pattern as the apply-tag-suggestions endpoint
- Taggers are still denied from dismissing any other report category (REPOST, INAPPROPRIATE, etc.)

## Test plan
- [x] `test_tagger_can_dismiss_tag_suggestion_report` — verifies taggers can dismiss TAG_SUGGESTIONS reports (200)
- [x] `test_tagger_cannot_dismiss_non_tag_suggestion_report` — verifies taggers cannot dismiss other categories (403)
- [x] All 51 existing report tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)