### PR TITLE
feat: allow image owners to mark their images as spoiler or repost

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -937,7 +937,7 @@ async def update_image(
 
         previous_status = image.status
         image.status = new_status
-        image.status_user_id = current_user.user_id
+        image.status_user_id = current_user.id
         image.status_updated = datetime.now(UTC)
 
         # Log to status history
@@ -945,7 +945,7 @@ async def update_image(
             image_id=image_id,
             old_status=previous_status,
             new_status=new_status,
-            user_id=current_user.user_id,
+            user_id=current_user.id,
         )
         db.add(history)
 
@@ -958,6 +958,7 @@ async def update_image(
     # Recalculate ratings for the original image after repost migration
     if new_status == ImageStatus.REPOST and replacement_id:
         await recalculate_image_ratings(db, replacement_id)
+        await db.commit()
 
     # Re-fetch with relationships for response
     result = await db.execute(

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -838,14 +838,21 @@ async def update_image(
     from app.services.repost import migrate_repost_data
 
     update_fields = image_data.model_dump(exclude_unset=True)
-    if not update_fields:
+    new_status = update_fields.pop("status", None)
+    replacement_id = update_fields.pop("replacement_id", None)
+
+    # replacement_id is only valid with status=REPOST
+    if replacement_id is not None and new_status != ImageStatus.REPOST:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="replacement_id is only valid when marking as repost",
+        )
+
+    if not update_fields and new_status is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No fields to update",
         )
-
-    new_status = update_fields.pop("status", None)
-    replacement_id = update_fields.pop("replacement_id", None)
 
     # Fetch image
     result = await db.execute(
@@ -915,7 +922,7 @@ async def update_image(
                     detail="An image cannot be a repost of itself",
                 )
             original_result = await db.execute(
-                select(Images).where(Images.image_id == replacement_id)  # type: ignore[arg-type]
+                select(Images).where(Images.image_id == replacement_id)
             )
             if not original_result.scalar_one_or_none():
                 raise HTTPException(
@@ -924,6 +931,9 @@ async def update_image(
                 )
             image.replacement_id = replacement_id
             await migrate_repost_data(image_id, replacement_id, db)
+        else:
+            # Clear replacement_id when not a repost
+            image.replacement_id = None
 
         previous_status = image.status
         image.status = new_status
@@ -944,6 +954,10 @@ async def update_image(
         setattr(image, field, value)
 
     await db.commit()
+
+    # Recalculate ratings for the original image after repost migration
+    if new_status == ImageStatus.REPOST and replacement_id:
+        await recalculate_image_ratings(db, replacement_id)
 
     # Re-fetch with relationships for response
     result = await db.execute(

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -6,7 +6,7 @@ import math
 import random
 import shutil
 import tempfile
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path as FilePath
 from typing import Annotated
@@ -823,19 +823,29 @@ async def update_image(
     redis_client: redis.Redis = Depends(get_redis),  # type: ignore[type-arg]
 ) -> ImageDetailedResponse:
     """
-    Update image metadata (caption, miscmeta).
+    Update image metadata (caption, miscmeta) and/or owner status.
 
-    Can be used by:
+    Metadata can be updated by:
     - The image owner
     - Admin users
     - Users with IMAGE_EDIT_META permission
+
+    Status can be set to SPOILER (2) or REPOST (-1) by:
+    - The image owner (only when image is ACTIVE and not locked)
+
+    Repost requires replacement_id (the original image ID).
     """
+    from app.services.repost import migrate_repost_data
+
     update_fields = image_data.model_dump(exclude_unset=True)
     if not update_fields:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No fields to update",
         )
+
+    new_status = update_fields.pop("status", None)
+    replacement_id = update_fields.pop("replacement_id", None)
 
     # Fetch image
     result = await db.execute(
@@ -855,12 +865,81 @@ async def update_image(
             db, current_user.id, Permission.IMAGE_EDIT_META, redis_client
         )
 
-    if not is_owner and not is_admin and not has_edit_permission:
+    # Metadata fields require owner, admin, or IMAGE_EDIT_META
+    if update_fields and not is_owner and not is_admin and not has_edit_permission:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not authorized to edit this image",
         )
 
+    # Status changes require ownership
+    if new_status is not None:
+        if not is_owner:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not authorized to change this image's status",
+            )
+
+        # Owners can only set SPOILER or REPOST
+        allowed_statuses = {ImageStatus.SPOILER, ImageStatus.REPOST}
+        if new_status not in allowed_statuses:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Owners can only mark images as spoiler or repost",
+            )
+
+        # Image must be ACTIVE
+        if image.status != ImageStatus.ACTIVE:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Only active images can have their status changed",
+            )
+
+        # Image must not be locked
+        if image.locked:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Locked images cannot have their status changed",
+            )
+
+        # Handle repost validation
+        if new_status == ImageStatus.REPOST:
+            if replacement_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="replacement_id is required when marking as repost",
+                )
+            if replacement_id == image_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="An image cannot be a repost of itself",
+                )
+            original_result = await db.execute(
+                select(Images).where(Images.image_id == replacement_id)  # type: ignore[arg-type]
+            )
+            if not original_result.scalar_one_or_none():
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Original image not found",
+                )
+            image.replacement_id = replacement_id
+            await migrate_repost_data(image_id, replacement_id, db)
+
+        previous_status = image.status
+        image.status = new_status
+        image.status_user_id = current_user.user_id
+        image.status_updated = datetime.now(UTC)
+
+        # Log to status history
+        history = ImageStatusHistory(
+            image_id=image_id,
+            old_status=previous_status,
+            new_status=new_status,
+            user_id=current_user.user_id,
+        )
+        db.add(history)
+
+    # Apply metadata updates
     for field, value in update_fields.items():
         setattr(image, field, value)
 

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -51,10 +51,12 @@ class ImageCreate(ImageBase):
 
 
 class ImageUpdate(BaseModel):
-    """Schema for updating image metadata — all fields optional."""
+    """Schema for updating image metadata and owner status — all fields optional."""
 
     caption: str | None = None
     miscmeta: str | None = None
+    status: int | None = None
+    replacement_id: int | None = None
 
     @field_validator("caption")
     @classmethod

--- a/tests/api/v1/test_image_edit.py
+++ b/tests/api/v1/test_image_edit.py
@@ -282,7 +282,7 @@ class TestImageOwnerStatusChange:
         repost = await create_image(
             db_session, owner.user_id, caption="repost img",
         )
-        # Need a unique md5 hash for the second image
+        # Use a different md5 hash for the second image to keep test data distinct
         repost.md5_hash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         await db_session.commit()
 

--- a/tests/api/v1/test_image_edit.py
+++ b/tests/api/v1/test_image_edit.py
@@ -250,3 +250,199 @@ class TestImageEdit:
         data = response.json()
         assert data["caption"] == "changed"
         assert data["miscmeta"] == "keep me too"
+
+
+class TestImageOwnerStatusChange:
+    """Tests for owner setting their own image status to spoiler or repost."""
+
+    @pytest.mark.asyncio
+    async def test_owner_can_mark_active_image_as_spoiler(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Owner can set their ACTIVE image to SPOILER status."""
+        owner = await create_user(db_session, username="spoiler1", email="sp1@test.com")
+        image = await create_image(db_session, owner.user_id)
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"status": 2},  # SPOILER
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == 2
+
+    @pytest.mark.asyncio
+    async def test_owner_can_mark_active_image_as_repost(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Owner can set their ACTIVE image to REPOST status with replacement_id."""
+        owner = await create_user(db_session, username="repost1", email="rp1@test.com")
+        original = await create_image(db_session, owner.user_id)
+        repost = await create_image(
+            db_session, owner.user_id, caption="repost img",
+        )
+        # Need a unique md5 hash for the second image
+        repost.md5_hash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        await db_session.commit()
+
+        response = await client.patch(
+            f"/api/v1/images/{repost.image_id}",
+            json={"status": -1, "replacement_id": original.image_id},  # REPOST
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == -1
+        assert data["replacement_id"] == original.image_id
+
+    @pytest.mark.asyncio
+    async def test_owner_cannot_mark_non_active_image(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Owner cannot change status of a non-ACTIVE image."""
+        owner = await create_user(db_session, username="nonactive1", email="na1@test.com")
+        image = await create_image(db_session, owner.user_id)
+        image.status = 2  # Already SPOILER
+        await db_session.commit()
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"status": -1, "replacement_id": 999},
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 400
+        assert "active" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_owner_cannot_set_disallowed_status(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Owner cannot set status to values other than SPOILER or REPOST."""
+        owner = await create_user(db_session, username="badstatus1", email="bs1@test.com")
+        image = await create_image(db_session, owner.user_id)
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"status": -2},  # INAPPROPRIATE — not allowed for owners
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_repost_requires_replacement_id(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Marking as repost without replacement_id fails."""
+        owner = await create_user(db_session, username="norepl1", email="nr1@test.com")
+        image = await create_image(db_session, owner.user_id)
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"status": -1},  # REPOST without replacement_id
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 400
+        assert "replacement_id" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_repost_of_self_fails(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Cannot mark an image as a repost of itself."""
+        owner = await create_user(db_session, username="selfr1", email="sr1@test.com")
+        image = await create_image(db_session, owner.user_id)
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"status": -1, "replacement_id": image.image_id},
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 400
+        assert "itself" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_repost_with_nonexistent_replacement_fails(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Marking as repost with nonexistent replacement_id fails."""
+        owner = await create_user(db_session, username="badrepl1", email="br1@test.com")
+        image = await create_image(db_session, owner.user_id)
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"status": -1, "replacement_id": 999999},
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 404
+        assert "original" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_non_owner_cannot_set_status(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Non-owner without admin/permissions cannot change image status."""
+        owner = await create_user(db_session, username="statusown1", email="so1@test.com")
+        other = await create_user(db_session, username="statusoth1", email="so2@test.com")
+        image = await create_image(db_session, owner.user_id)
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"status": 2},  # SPOILER
+            headers=auth_header(other),
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_locked_image_cannot_have_status_changed_by_owner(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Owner cannot change status of a locked image."""
+        owner = await create_user(db_session, username="locked1", email="lk1@test.com")
+        image = await create_image(db_session, owner.user_id)
+        image.locked = 1
+        await db_session.commit()
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"status": 2},  # SPOILER
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 400
+        assert "locked" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_status_change_creates_history_entry(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Status change by owner creates an ImageStatusHistory entry."""
+        from app.models.image_status_history import ImageStatusHistory
+
+        owner = await create_user(db_session, username="hist1", email="h1@test.com")
+        image = await create_image(db_session, owner.user_id)
+
+        response = await client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"status": 2},  # SPOILER
+            headers=auth_header(owner),
+        )
+
+        assert response.status_code == 200
+
+        result = await db_session.execute(
+            select(ImageStatusHistory).where(
+                ImageStatusHistory.image_id == image.image_id
+            )
+        )
+        history = result.scalar_one()
+        assert history.old_status == 1  # ACTIVE
+        assert history.new_status == 2  # SPOILER
+        assert history.user_id == owner.user_id


### PR DESCRIPTION
## Summary
- Ports PHP functionality where image owners could set their own images to spoiler or repost status
- Extends `PATCH /api/v1/images/{id}` to accept `status` and `replacement_id` fields
- Owners can only set SPOILER (2) or REPOST (-1), only on ACTIVE images, only when not locked
- Repost requires valid `replacement_id` and triggers favorites/ratings/tags migration to the original
- Creates `ImageStatusHistory` entry for audit trail

## Test plan
- [x] `test_owner_can_mark_active_image_as_spoiler` — owner sets ACTIVE → SPOILER (200)
- [x] `test_owner_can_mark_active_image_as_repost` — owner sets ACTIVE → REPOST with replacement_id (200)
- [x] `test_owner_cannot_mark_non_active_image` — non-ACTIVE image rejected (400)
- [x] `test_owner_cannot_set_disallowed_status` — INAPPROPRIATE etc. rejected (403)
- [x] `test_repost_requires_replacement_id` — missing replacement_id rejected (400)
- [x] `test_repost_of_self_fails` — self-referencing repost rejected (400)
- [x] `test_repost_with_nonexistent_replacement_fails` — bad replacement_id rejected (404)
- [x] `test_non_owner_cannot_set_status` — non-owner rejected (403)
- [x] `test_locked_image_cannot_have_status_changed_by_owner` — locked image rejected (400)
- [x] `test_status_change_creates_history_entry` — ImageStatusHistory logged correctly
- [x] All 98 existing image tests + 23 admin image tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)