### PR TITLE
feat: auto-close reviews when vote margin reaches threshold

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -105,6 +105,7 @@ from app.schemas.report import (
 )
 from app.services.rating import schedule_rating_recalculation
 from app.services.repost import migrate_repost_data
+from app.services.review_jobs import check_early_close
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -1906,6 +1907,11 @@ async def vote_on_review(
     db.add(action)
 
     await db.commit()
+
+    # Check if vote margin triggers early close
+    await check_early_close(db, review)
+    await db.commit()
+
     await db.refresh(vote)
 
     response = VoteResponse.model_validate(vote)

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -1906,12 +1906,12 @@ async def vote_on_review(
     )
     db.add(action)
 
-    await db.commit()
+    await db.flush()
 
     # Check if vote margin triggers early close
     await check_early_close(db, review)
-    await db.commit()
 
+    await db.commit()
     await db.refresh(vote)
 
     response = VoteResponse.model_validate(vote)

--- a/app/config.py
+++ b/app/config.py
@@ -136,6 +136,7 @@ class Settings(BaseSettings):
     REVIEW_DEADLINE_DAYS: int = 7  # Default deadline for review voting
     REVIEW_EXTENSION_DAYS: int = 3  # Extension period when deadline expires without quorum
     REVIEW_QUORUM: int = 3  # Minimum votes required for a decision
+    REVIEW_EARLY_CLOSE_MARGIN: int = 3  # Vote margin to auto-close before deadline
 
     # Frontend URL (for email links, verification links, etc.)
     # Development: http://localhost:5173 (Vite dev server) or http://localhost:3000 (via nginx)

--- a/app/config.py
+++ b/app/config.py
@@ -136,7 +136,9 @@ class Settings(BaseSettings):
     REVIEW_DEADLINE_DAYS: int = 7  # Default deadline for review voting
     REVIEW_EXTENSION_DAYS: int = 3  # Extension period when deadline expires without quorum
     REVIEW_QUORUM: int = 3  # Minimum votes required for a decision
-    REVIEW_EARLY_CLOSE_MARGIN: int = 3  # Vote margin to auto-close before deadline
+    REVIEW_EARLY_CLOSE_MARGIN: int = Field(
+        default=3, ge=1
+    )  # Vote margin to auto-close before deadline
 
     # Frontend URL (for email links, verification links, etc.)
     # Development: http://localhost:5173 (Vite dev server) or http://localhost:3000 (via nginx)

--- a/app/services/review_jobs.py
+++ b/app/services/review_jobs.py
@@ -260,6 +260,33 @@ async def _extend_review(db: AsyncSession, review: ImageReviews) -> None:
     )
 
 
+async def check_early_close(db: AsyncSession, review: ImageReviews) -> bool:
+    """
+    Check if a review should be closed early based on vote margin.
+
+    Called after each vote is cast. If one side leads by at least
+    REVIEW_EARLY_CLOSE_MARGIN votes, the review is closed immediately.
+
+    Args:
+        db: Database session
+        review: The review to check
+
+    Returns:
+        True if the review was closed, False otherwise
+    """
+    vote_counts = await _get_vote_counts(db, review.review_id)  # type: ignore[arg-type]
+    keep_votes = vote_counts.get(1, 0)
+    remove_votes = vote_counts.get(0, 0)
+    margin = abs(keep_votes - remove_votes)
+
+    if margin < settings.REVIEW_EARLY_CLOSE_MARGIN:
+        return False
+
+    outcome = ReviewOutcome.KEEP if keep_votes > remove_votes else ReviewOutcome.REMOVE
+    await _close_review(db, review, outcome, "early_close_margin")
+    return True
+
+
 async def prune_admin_actions(
     db: AsyncSession,
     retention_years: int = 2,

--- a/app/services/review_jobs.py
+++ b/app/services/review_jobs.py
@@ -274,11 +274,19 @@ async def check_early_close(db: AsyncSession, review: ImageReviews) -> bool:
     Returns:
         True if the review was closed, False otherwise
     """
+    # Re-read review to guard against concurrent close by another request/job
+    await db.refresh(review)
+    if review.status != ReviewStatus.OPEN:
+        return False
+
     vote_counts = await _get_vote_counts(db, review.review_id)  # type: ignore[arg-type]
     keep_votes = vote_counts.get(1, 0)
     remove_votes = vote_counts.get(0, 0)
-    margin = abs(keep_votes - remove_votes)
 
+    if keep_votes == remove_votes:
+        return False
+
+    margin = abs(keep_votes - remove_votes)
     if margin < settings.REVIEW_EARLY_CLOSE_MARGIN:
         return False
 

--- a/tests/api/v1/test_reviews.py
+++ b/tests/api/v1/test_reviews.py
@@ -448,6 +448,142 @@ class TestReviewVote:
         assert data["vote"] == 0
         assert data["review_id"] == review2.review_id
 
+    async def test_vote_triggers_early_close_keep(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that voting triggers early close when margin is reached (keep)."""
+        # Create 3 voters with review_vote permission
+        voters = []
+        for i in range(3):
+            user, pw = await create_auth_user(
+                db_session, username=f"voter{i}", email=f"voter{i}@example.com", admin=True
+            )
+            await grant_permission(db_session, user.user_id, "review_vote")
+            token = await login_user(client, user.username, pw)
+            voters.append((user, token))
+
+        image = await create_test_image(db_session, voters[0][0].user_id)
+        image.status = ImageStatus.REVIEW
+        review = ImageReviews(
+            image_id=image.image_id,
+            initiated_by=voters[0][0].user_id,
+            deadline=datetime.now(UTC) + timedelta(days=7),
+            status=ReviewStatus.OPEN,
+        )
+        db_session.add(review)
+        await db_session.commit()
+        await db_session.refresh(review)
+
+        # First 2 votes: should NOT close yet (margin=2, need 3)
+        for i in range(2):
+            response = await client.post(
+                f"/api/v1/admin/reviews/{review.review_id}/vote",
+                json={"vote": 1},
+                headers={"Authorization": f"Bearer {voters[i][1]}"},
+            )
+            assert response.status_code == 200
+
+        await db_session.refresh(review)
+        assert review.status == ReviewStatus.OPEN
+
+        # 3rd vote: should trigger early close (margin=3)
+        response = await client.post(
+            f"/api/v1/admin/reviews/{review.review_id}/vote",
+            json={"vote": 1},
+            headers={"Authorization": f"Bearer {voters[2][1]}"},
+        )
+        assert response.status_code == 200
+
+        await db_session.refresh(review)
+        await db_session.refresh(image)
+        assert review.status == ReviewStatus.CLOSED
+        assert review.outcome == ReviewOutcome.KEEP
+        assert image.status == ImageStatus.ACTIVE
+
+    async def test_vote_triggers_early_close_remove(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that voting triggers early close when margin is reached (remove)."""
+        voters = []
+        for i in range(3):
+            user, pw = await create_auth_user(
+                db_session, username=f"remvoter{i}", email=f"remvoter{i}@example.com", admin=True
+            )
+            await grant_permission(db_session, user.user_id, "review_vote")
+            token = await login_user(client, user.username, pw)
+            voters.append((user, token))
+
+        image = await create_test_image(db_session, voters[0][0].user_id)
+        image.status = ImageStatus.REVIEW
+        review = ImageReviews(
+            image_id=image.image_id,
+            initiated_by=voters[0][0].user_id,
+            deadline=datetime.now(UTC) + timedelta(days=7),
+            status=ReviewStatus.OPEN,
+        )
+        db_session.add(review)
+        await db_session.commit()
+        await db_session.refresh(review)
+
+        # 3 remove votes
+        for i in range(3):
+            await client.post(
+                f"/api/v1/admin/reviews/{review.review_id}/vote",
+                json={"vote": 0},
+                headers={"Authorization": f"Bearer {voters[i][1]}"},
+            )
+
+        await db_session.refresh(review)
+        await db_session.refresh(image)
+        assert review.status == ReviewStatus.CLOSED
+        assert review.outcome == ReviewOutcome.REMOVE
+        assert image.status == ImageStatus.INAPPROPRIATE
+
+    async def test_vote_no_early_close_when_margin_not_met(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Test that voting does NOT trigger early close when margin is insufficient."""
+        voters = []
+        for i in range(3):
+            user, pw = await create_auth_user(
+                db_session, username=f"mixvoter{i}", email=f"mixvoter{i}@example.com", admin=True
+            )
+            await grant_permission(db_session, user.user_id, "review_vote")
+            token = await login_user(client, user.username, pw)
+            voters.append((user, token))
+
+        image = await create_test_image(db_session, voters[0][0].user_id)
+        image.status = ImageStatus.REVIEW
+        review = ImageReviews(
+            image_id=image.image_id,
+            initiated_by=voters[0][0].user_id,
+            deadline=datetime.now(UTC) + timedelta(days=7),
+            status=ReviewStatus.OPEN,
+        )
+        db_session.add(review)
+        await db_session.commit()
+        await db_session.refresh(review)
+
+        # 2 keep, 1 remove -> margin=1, not enough
+        await client.post(
+            f"/api/v1/admin/reviews/{review.review_id}/vote",
+            json={"vote": 1},
+            headers={"Authorization": f"Bearer {voters[0][1]}"},
+        )
+        await client.post(
+            f"/api/v1/admin/reviews/{review.review_id}/vote",
+            json={"vote": 1},
+            headers={"Authorization": f"Bearer {voters[1][1]}"},
+        )
+        await client.post(
+            f"/api/v1/admin/reviews/{review.review_id}/vote",
+            json={"vote": 0},
+            headers={"Authorization": f"Bearer {voters[2][1]}"},
+        )
+
+        await db_session.refresh(review)
+        assert review.status == ReviewStatus.OPEN
+
     async def test_vote_on_closed_review_fails(
         self, client: AsyncClient, db_session: AsyncSession
     ):

--- a/tests/unit/test_review_deadline_job.py
+++ b/tests/unit/test_review_deadline_job.py
@@ -22,6 +22,7 @@ from app.models.review_vote import ReviewVotes
 from app.models.user import Users
 from app.services.review_jobs import (
     _get_vote_counts,
+    check_early_close,
     check_review_deadlines,
     prune_admin_actions,
 )
@@ -487,3 +488,132 @@ class TestHelperFunctions:
 
         assert counts.get(1, 0) == 0
         assert counts.get(0, 0) == 0
+
+
+@pytest.mark.asyncio
+class TestEarlyClose:
+    """Tests for early close when vote margin is reached."""
+
+    async def test_early_close_keep_margin_met(self, db_session: AsyncSession):
+        """3 keep, 0 remove (margin=3) -> close with outcome=KEEP."""
+        image = await create_test_image(db_session)
+        review = await create_test_review(
+            db_session, image.image_id, deadline_offset_days=7  # Not expired
+        )
+        await add_votes(db_session, review.review_id, keep_count=3, remove_count=0)  # type: ignore[arg-type]
+
+        closed = await check_early_close(db_session, review)
+        await db_session.commit()
+
+        await db_session.refresh(review)
+        await db_session.refresh(image)
+
+        assert closed is True
+        assert review.status == ReviewStatus.CLOSED
+        assert review.outcome == ReviewOutcome.KEEP
+        assert image.status == ImageStatus.ACTIVE
+
+    async def test_early_close_remove_margin_met(self, db_session: AsyncSession):
+        """0 keep, 3 remove (margin=3) -> close with outcome=REMOVE."""
+        image = await create_test_image(db_session)
+        review = await create_test_review(
+            db_session, image.image_id, deadline_offset_days=7
+        )
+        await add_votes(db_session, review.review_id, keep_count=0, remove_count=3)  # type: ignore[arg-type]
+
+        closed = await check_early_close(db_session, review)
+        await db_session.commit()
+
+        await db_session.refresh(review)
+        await db_session.refresh(image)
+
+        assert closed is True
+        assert review.status == ReviewStatus.CLOSED
+        assert review.outcome == ReviewOutcome.REMOVE
+        assert image.status == ImageStatus.INAPPROPRIATE
+
+    async def test_early_close_margin_not_met(self, db_session: AsyncSession):
+        """2 keep, 1 remove (margin=1, needs 3) -> stays open."""
+        image = await create_test_image(db_session)
+        review = await create_test_review(
+            db_session, image.image_id, deadline_offset_days=7
+        )
+        await add_votes(db_session, review.review_id, keep_count=2, remove_count=1)  # type: ignore[arg-type]
+
+        closed = await check_early_close(db_session, review)
+
+        await db_session.refresh(review)
+
+        assert closed is False
+        assert review.status == ReviewStatus.OPEN
+
+    async def test_early_close_tie(self, db_session: AsyncSession):
+        """3 keep, 3 remove (margin=0) -> stays open."""
+        image = await create_test_image(db_session)
+        review = await create_test_review(
+            db_session, image.image_id, deadline_offset_days=7
+        )
+        await add_votes(db_session, review.review_id, keep_count=3, remove_count=3)  # type: ignore[arg-type]
+
+        closed = await check_early_close(db_session, review)
+
+        await db_session.refresh(review)
+
+        assert closed is False
+        assert review.status == ReviewStatus.OPEN
+
+    async def test_early_close_large_margin_keep(self, db_session: AsyncSession):
+        """5 keep, 2 remove (margin=3) -> close with KEEP."""
+        image = await create_test_image(db_session)
+        review = await create_test_review(
+            db_session, image.image_id, deadline_offset_days=7
+        )
+        await add_votes(db_session, review.review_id, keep_count=5, remove_count=2)  # type: ignore[arg-type]
+
+        closed = await check_early_close(db_session, review)
+        await db_session.commit()
+
+        await db_session.refresh(review)
+        await db_session.refresh(image)
+
+        assert closed is True
+        assert review.outcome == ReviewOutcome.KEEP
+        assert image.status == ImageStatus.ACTIVE
+
+    async def test_early_close_creates_audit_log(self, db_session: AsyncSession):
+        """Early close creates an audit log entry with reason 'early_close_margin'."""
+        from sqlalchemy import select
+
+        image = await create_test_image(db_session)
+        review = await create_test_review(
+            db_session, image.image_id, deadline_offset_days=7
+        )
+        await add_votes(db_session, review.review_id, keep_count=3, remove_count=0)  # type: ignore[arg-type]
+
+        await check_early_close(db_session, review)
+        await db_session.commit()
+
+        stmt = select(AdminActions).where(
+            AdminActions.review_id == review.review_id,
+            AdminActions.action_type == AdminActionType.REVIEW_CLOSE,
+        )
+        result = await db_session.execute(stmt)
+        action = result.scalar_one_or_none()
+
+        assert action is not None
+        assert action.details["reason"] == "early_close_margin"
+        assert action.details["automatic"] is True
+
+    async def test_early_close_no_votes(self, db_session: AsyncSession):
+        """0 votes -> stays open."""
+        image = await create_test_image(db_session)
+        review = await create_test_review(
+            db_session, image.image_id, deadline_offset_days=7
+        )
+
+        closed = await check_early_close(db_session, review)
+
+        await db_session.refresh(review)
+
+        assert closed is False
+        assert review.status == ReviewStatus.OPEN


### PR DESCRIPTION
## Summary
- Reviews now auto-close immediately when one side leads by at least `REVIEW_EARLY_CLOSE_MARGIN` (default 3) votes, rather than waiting for the deadline
- New `check_early_close()` function in `review_jobs.py` reuses existing `_close_review` and `_get_vote_counts` helpers
- Called after each vote in the `vote_on_review` endpoint; audit log reason is `early_close_margin`
- New `REVIEW_EARLY_CLOSE_MARGIN` config setting (default 3) — e.g. 3-0, 4-1, 5-2 all trigger early close

## Test plan
- [x] 7 unit tests for `check_early_close` (margin met keep/remove, margin not met, tie, large margin, audit log, no votes)
- [x] 3 API tests for vote endpoint triggering early close (keep, remove, margin not met)
- [x] All 57 existing review tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)