### PR TITLE
feat: image variant generation with VariantStatus enum

### DIFF
--- a/alembic/versions/f8e2a1f956eb_change_image_medium_large_to_tinyint3_.py
+++ b/alembic/versions/f8e2a1f956eb_change_image_medium_large_to_tinyint3_.py
@@ -1,0 +1,35 @@
+"""change_image_medium_large_to_tinyint3_for_variant_status
+
+Revision ID: f8e2a1f956eb
+Revises: b50f77d51a12
+Create Date: 2026-03-06 23:10:52.478679
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f8e2a1f956eb'
+down_revision: str | Sequence[str] | None = 'b50f77d51a12'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Change medium/large columns from tinyint(1) to tinyint(3).
+
+    tinyint(1) is treated as boolean by MySQL/MariaDB drivers, which would
+    coerce the PENDING value (2) back to True (1=READY), breaking variant
+    status tracking. tinyint(3) stores the same range but is returned as int.
+    """
+    op.execute("ALTER TABLE images MODIFY COLUMN `medium` TINYINT(3) NOT NULL DEFAULT 0")
+    op.execute("ALTER TABLE images MODIFY COLUMN `large` TINYINT(3) NOT NULL DEFAULT 0")
+
+
+def downgrade() -> None:
+    """Revert medium/large columns back to tinyint(1)."""
+    op.execute("ALTER TABLE images MODIFY COLUMN `medium` TINYINT(1) NOT NULL DEFAULT 0")
+    op.execute("ALTER TABLE images MODIFY COLUMN `large` TINYINT(1) NOT NULL DEFAULT 0")

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -61,7 +61,7 @@ from app.models import (
     Tags,
     Users,
 )
-from app.models.image import ImageSortBy
+from app.models.image import ImageSortBy, VariantStatus
 from app.models.image_status_history import ImageStatusHistory
 from app.models.permissions import UserGroups
 from app.schemas.audit import (
@@ -2028,8 +2028,16 @@ async def upload_image(
                 )
 
         # Determine if medium/large variants should be created
-        has_medium = 1 if (width > settings.MEDIUM_EDGE or height > settings.MEDIUM_EDGE) else 0
-        has_large = 1 if (width > settings.LARGE_EDGE or height > settings.LARGE_EDGE) else 0
+        has_medium = (
+            VariantStatus.PENDING
+            if (width > settings.MEDIUM_EDGE or height > settings.MEDIUM_EDGE)
+            else VariantStatus.NONE
+        )
+        has_large = (
+            VariantStatus.PENDING
+            if (width > settings.LARGE_EDGE or height > settings.LARGE_EDGE)
+            else VariantStatus.NONE
+        )
 
         # Update temporary record with actual data
         temp_image.filename = filename

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -2027,13 +2027,13 @@ async def upload_image(
                     ).model_dump(mode="json"),
                 )
 
-        # Determine if medium/large variants should be created
-        has_medium = (
+        # Determine variant generation status for medium/large
+        medium_status = (
             VariantStatus.PENDING
             if (width > settings.MEDIUM_EDGE or height > settings.MEDIUM_EDGE)
             else VariantStatus.NONE
         )
-        has_large = (
+        large_status = (
             VariantStatus.PENDING
             if (width > settings.LARGE_EDGE or height > settings.LARGE_EDGE)
             else VariantStatus.NONE
@@ -2047,8 +2047,8 @@ async def upload_image(
         temp_image.width = width
         temp_image.height = height
         temp_image.total_pixels = total_pixels
-        temp_image.medium = has_medium
-        temp_image.large = has_large
+        temp_image.medium = medium_status
+        temp_image.large = large_status
         temp_image.caption = caption
         temp_image.miscmeta = miscmeta
 
@@ -2088,7 +2088,7 @@ async def upload_image(
         logger.debug("thumbnail_job_enqueued", image_id=image_id)
 
         # Schedule medium variant generation if needed
-        if has_medium:
+        if medium_status:
             await enqueue_job(
                 "create_variant_job",
                 image_id=image_id,
@@ -2101,7 +2101,7 @@ async def upload_image(
             )
 
         # Schedule large variant generation if needed
-        if has_large:
+        if large_status:
             await enqueue_job(
                 "create_variant_job",
                 image_id=image_id,

--- a/app/api/v1/media.py
+++ b/app/api/v1/media.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_optional_current_user
 from app.core.database import get_db
-from app.models.image import Images
+from app.models.image import Images, VariantStatus
 from app.models.user import Users
 from app.services.image_visibility import can_view_image_file
 
@@ -139,11 +139,20 @@ async def _serve_image(
     if not await can_view_image_file(image, current_user, db):
         raise HTTPException(status_code=404)
 
-    # Check if variant exists (medium/large are optional)
-    if image_type == "medium" and not image.medium:
-        raise HTTPException(status_code=404)
-    if image_type == "large" and not image.large:
-        raise HTTPException(status_code=404)
+    # Check variant state for medium/large
+    if image_type in ("medium", "large"):
+        variant_status = image.medium if image_type == "medium" else image.large
+        if variant_status == VariantStatus.NONE:
+            raise HTTPException(status_code=404)
+        if variant_status == VariantStatus.PENDING:
+            # Variant is still being generated — fall back to fullsize.
+            # Cache-Control: no-store prevents the browser from caching this response
+            # so it will retry on the next request and pick up the real variant once ready.
+            fullsize_path = f"/internal/fullsize/{image.filename}.{image.ext}"
+            return Response(
+                status_code=200,
+                headers={"X-Accel-Redirect": fullsize_path, "Cache-Control": "no-store"},
+            )
 
     # Use database extension for fullsize/medium/large, always webp for thumbnails
     if image_type == "thumbs":

--- a/app/models/image.py
+++ b/app/models/image.py
@@ -27,6 +27,23 @@ if TYPE_CHECKING:
     from app.models.user import Users
 
 
+class VariantStatus(int, Enum):
+    """
+    Status of a medium or large image variant.
+
+    NONE    (0): No variant will ever be generated (image too small, or variant
+                 was larger than the original after generation).
+    READY   (1): Variant file exists on disk and is ready to serve.
+    PENDING (2): Variant generation has been queued but not yet completed.
+                 The media endpoint falls back to fullsize with Cache-Control: no-store
+                 so the browser retries on the next request.
+    """
+
+    NONE = 0
+    READY = 1
+    PENDING = 2
+
+
 class ImageSortBy(str, Enum):
     """
     Allowed sort fields for image queries.

--- a/app/services/image_processing.py
+++ b/app/services/image_processing.py
@@ -73,84 +73,74 @@ def _create_variant(
     # Bind context for this ARQ task
     bind_context(task=f"{variant_type}_variant_generation", image_id=image_id)
 
-    try:
-        logger.info(f"{variant_type}_variant_generation_started", source_path=str(source_path))
+    logger.info(f"{variant_type}_variant_generation_started", source_path=str(source_path))
 
-        # Create variant directory if it doesn't exist
-        variant_dir = FilePath(storage_path) / variant_type
-        variant_dir.mkdir(parents=True, exist_ok=True)
+    # Create variant directory if it doesn't exist
+    variant_dir = FilePath(storage_path) / variant_type
+    variant_dir.mkdir(parents=True, exist_ok=True)
 
-        # Generate variant filename
-        date_prefix = datetime.now().strftime("%Y-%m-%d")
-        variant_filename = f"{date_prefix}-{image_id}.{ext}"
-        variant_path = variant_dir / variant_filename
+    # Generate variant filename
+    date_prefix = datetime.now().strftime("%Y-%m-%d")
+    variant_filename = f"{date_prefix}-{image_id}.{ext}"
+    variant_path = variant_dir / variant_filename
 
-        # Open image and create variant
-        with Image.open(source_path) as img:
-            original_size = img.size
+    # Open image and create variant
+    with Image.open(source_path) as img:
+        original_size = img.size
 
-            # Convert to sRGB for consistent web display
-            img = _convert_to_srgb(img)  # type: ignore[assignment]
+        # Convert to sRGB for consistent web display
+        img = _convert_to_srgb(img)  # type: ignore[assignment]
 
-            # Convert RGBA to RGB for JPEG compatibility
-            if img.mode in ("RGBA", "LA") and ext.lower() in ("jpg", "jpeg"):
-                background = Image.new("RGB", img.size, (255, 255, 255))
-                background.paste(img, mask=img.split()[-1] if img.mode == "RGBA" else None)
-                img = background  # type: ignore[assignment]
+        # Convert RGBA to RGB for JPEG compatibility
+        if img.mode in ("RGBA", "LA") and ext.lower() in ("jpg", "jpeg"):
+            background = Image.new("RGB", img.size, (255, 255, 255))
+            background.paste(img, mask=img.split()[-1] if img.mode == "RGBA" else None)
+            img = background  # type: ignore[assignment]
 
-            # Calculate variant size maintaining aspect ratio
-            img.thumbnail(
-                (size_threshold, size_threshold),
-                Image.Resampling.LANCZOS,  # High-quality downsampling
-            )
+        # Calculate variant size maintaining aspect ratio
+        img.thumbnail(
+            (size_threshold, size_threshold),
+            Image.Resampling.LANCZOS,  # High-quality downsampling
+        )
 
-            # Save variant with quality setting
-            save_kwargs = {}
-            if ext.lower() in ("jpg", "jpeg"):
-                save_kwargs["quality"] = settings.LARGE_QUALITY
-                save_kwargs["optimize"] = True
-            elif ext.lower() == "webp":
-                save_kwargs["quality"] = settings.LARGE_QUALITY
+        # Save variant with quality setting
+        save_kwargs = {}
+        if ext.lower() in ("jpg", "jpeg"):
+            save_kwargs["quality"] = settings.LARGE_QUALITY
+            save_kwargs["optimize"] = True
+        elif ext.lower() == "webp":
+            save_kwargs["quality"] = settings.LARGE_QUALITY
 
-            img.save(variant_path, **save_kwargs)  # type: ignore[arg-type]
+        img.save(variant_path, **save_kwargs)  # type: ignore[arg-type]
 
-            # Check file sizes - delete variant if it's not smaller than original
-            original_file_size = source_path.stat().st_size
-            variant_file_size = variant_path.stat().st_size
+        # Check file sizes - delete variant if it's not smaller than original
+        original_file_size = source_path.stat().st_size
+        variant_file_size = variant_path.stat().st_size
 
-            if variant_file_size >= original_file_size:
-                # Variant is not smaller, delete it
-                variant_path.unlink()
-                logger.info(
-                    f"{variant_type}_variant_deleted_larger_than_original",
-                    variant_path=str(variant_path),
-                    original_size=original_size,
-                    variant_size=img.size,
-                    original_file_size=original_file_size,
-                    variant_file_size=variant_file_size,
-                )
-                # Signal caller to update DB (caller is async and can await)
-                return None
-
+        if variant_file_size >= original_file_size:
+            # Variant is not smaller, delete it
+            variant_path.unlink()
             logger.info(
-                f"{variant_type}_variant_generated",
+                f"{variant_type}_variant_deleted_larger_than_original",
                 variant_path=str(variant_path),
                 original_size=original_size,
                 variant_size=img.size,
                 original_file_size=original_file_size,
                 variant_file_size=variant_file_size,
             )
+            # Signal caller to update DB (caller is async and can await)
+            return None
 
-        return True
-
-    except Exception as e:
-        logger.error(
-            f"{variant_type}_variant_generation_failed",
-            error=str(e),
-            error_type=type(e).__name__,
-            source_path=str(source_path),
+        logger.info(
+            f"{variant_type}_variant_generated",
+            variant_path=str(variant_path),
+            original_size=original_size,
+            variant_size=img.size,
+            original_file_size=original_file_size,
+            variant_file_size=variant_file_size,
         )
-        return False
+
+    return True
 
 
 def calculate_md5(file_path: FilePath) -> str:

--- a/app/tasks/image_jobs.py
+++ b/app/tasks/image_jobs.py
@@ -98,6 +98,7 @@ async def create_variant_job(
     bind_context(task=f"{variant_type}_variant_generation", image_id=image_id)
 
     try:
+        from app.models.image import VariantStatus
         from app.services.image_processing import (
             _create_variant,
             _update_image_variant_field,
@@ -116,9 +117,12 @@ async def create_variant_job(
             variant_type=variant_type,
         )
 
-        # None means variant was deleted (larger than original) — update DB
-        if result is None:
-            await _update_image_variant_field(image_id, variant_type, 0)
+        if result is True:
+            # Variant created successfully — mark as ready
+            await _update_image_variant_field(image_id, variant_type, VariantStatus.READY)
+        else:
+            # Variant not needed (too small) or deleted (larger than original) — mark as none
+            await _update_image_variant_field(image_id, variant_type, VariantStatus.NONE)
 
         created = result is True
         logger.info(f"{variant_type}_variant_job_completed", image_id=image_id, created=created)

--- a/app/tasks/image_jobs.py
+++ b/app/tasks/image_jobs.py
@@ -1,5 +1,6 @@
 """Image processing background jobs for arq worker."""
 
+import asyncio
 from pathlib import Path as FilePath
 from typing import Any
 
@@ -104,16 +105,16 @@ async def create_variant_job(
             _update_image_variant_field,
         )
 
-        result = _create_variant(
+        size_threshold = settings.MEDIUM_EDGE if variant_type == "medium" else settings.LARGE_EDGE
+        result = await asyncio.to_thread(
+            _create_variant,
             source_path=FilePath(source_path),
             image_id=image_id,
             ext=ext,
             storage_path=storage_path,
             width=width,
             height=height,
-            size_threshold=settings.MEDIUM_EDGE
-            if variant_type == "medium"
-            else settings.LARGE_EDGE,
+            size_threshold=size_threshold,
             variant_type=variant_type,
         )
 

--- a/scripts/generate_variants.py
+++ b/scripts/generate_variants.py
@@ -142,10 +142,9 @@ def get_images_needing_variants(
         engine = create_async_engine(settings.DATABASE_URL, echo=False)
         try:
             async with engine.connect() as conn:
-                if all_images:
-                    query = "SELECT image_id, filename, ext, width, height, medium, `large` FROM images WHERE medium = 1 OR `large` = 1 ORDER BY image_id"
-                else:
-                    query = "SELECT image_id, filename, ext, width, height, medium, `large` FROM images WHERE medium = 1 OR `large` = 1 ORDER BY image_id"
+                # Include READY (1) and PENDING (2) images — PENDING means a variant
+                # was queued but may not have been generated (e.g. after a worker restart).
+                query = "SELECT image_id, filename, ext, width, height, medium, `large` FROM images WHERE medium IN (1, 2) OR `large` IN (1, 2) ORDER BY image_id"
 
                 result = await conn.execute(text(query))
                 return [(r[0], r[1], r[2], r[3], r[4], r[5], r[6]) for r in result.fetchall()]

--- a/scripts/generate_variants.py
+++ b/scripts/generate_variants.py
@@ -31,6 +31,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from app.models.image import VariantStatus
+
 
 def process_variant_worker(
     args: tuple[int, str, str, str, int, int, str, bool, bool],
@@ -149,11 +151,13 @@ def get_images_needing_variants(
                         "FROM images ORDER BY image_id"
                     )
                 else:
-                    # Include READY (1) and PENDING (2) images — PENDING means a variant
-                    # was queued but may not have been generated (e.g. after a worker restart).
+                    # Include READY and PENDING images — PENDING means a variant was queued
+                    # but may not have been generated (e.g. after a worker restart).
+                    ready = VariantStatus.READY.value
+                    pending = VariantStatus.PENDING.value
                     query = (
                         "SELECT image_id, filename, ext, width, height, medium, `large` "
-                        "FROM images WHERE medium IN (1, 2) OR `large` IN (1, 2) "
+                        f"FROM images WHERE medium IN ({ready}, {pending}) OR `large` IN ({ready}, {pending}) "
                         "ORDER BY image_id"
                     )
                 result = await conn.execute(text(query))

--- a/scripts/generate_variants.py
+++ b/scripts/generate_variants.py
@@ -142,10 +142,20 @@ def get_images_needing_variants(
         engine = create_async_engine(settings.DATABASE_URL, echo=False)
         try:
             async with engine.connect() as conn:
-                # Include READY (1) and PENDING (2) images — PENDING means a variant
-                # was queued but may not have been generated (e.g. after a worker restart).
-                query = "SELECT image_id, filename, ext, width, height, medium, `large` FROM images WHERE medium IN (1, 2) OR `large` IN (1, 2) ORDER BY image_id"
-
+                if all_images:
+                    # Process every image record regardless of variant status
+                    query = (
+                        "SELECT image_id, filename, ext, width, height, medium, `large` "
+                        "FROM images ORDER BY image_id"
+                    )
+                else:
+                    # Include READY (1) and PENDING (2) images — PENDING means a variant
+                    # was queued but may not have been generated (e.g. after a worker restart).
+                    query = (
+                        "SELECT image_id, filename, ext, width, height, medium, `large` "
+                        "FROM images WHERE medium IN (1, 2) OR `large` IN (1, 2) "
+                        "ORDER BY image_id"
+                    )
                 result = await conn.execute(text(query))
                 return [(r[0], r[1], r[2], r[3], r[4], r[5], r[6]) for r in result.fetchall()]
         finally:

--- a/tests/api/v1/test_media.py
+++ b/tests/api/v1/test_media.py
@@ -339,6 +339,46 @@ class TestServeMediumEndpoint:
         assert response.status_code == 200
         assert "X-Accel-Redirect" in response.headers
 
+    @pytest.fixture
+    async def image_with_medium_pending(self, db_session: AsyncSession):
+        """Create a public image with medium variant pending generation."""
+        image = Images(
+            image_id=403,
+            filename="2026-01-02-403",
+            ext="png",
+            md5_hash="pendingmedium123",
+            filesize=5000,
+            width=1920,
+            height=1080,
+            user_id=1,
+            status=ImageStatus.ACTIVE,
+            medium=2,  # Pending: generation in progress
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    async def test_medium_pending_returns_fullsize_xaccel(
+        self, client: AsyncClient, image_with_medium_pending: Images
+    ):
+        """Medium endpoint falls back to fullsize while variant is pending generation."""
+        response = await client.get(f"/medium/2026-01-02-{image_with_medium_pending.image_id}.png")
+        assert response.status_code == 200
+        assert "X-Accel-Redirect" in response.headers
+        assert (
+            f"/internal/fullsize/{image_with_medium_pending.filename}.png"
+            in response.headers["X-Accel-Redirect"]
+        )
+
+    async def test_medium_pending_returns_no_store_cache_control(
+        self, client: AsyncClient, image_with_medium_pending: Images
+    ):
+        """Medium endpoint sets Cache-Control: no-store while variant is pending."""
+        response = await client.get(f"/medium/2026-01-02-{image_with_medium_pending.image_id}.png")
+        assert response.status_code == 200
+        assert response.headers.get("Cache-Control") == "no-store"
+
 
 class TestServeLargeEndpoint:
     """Tests for GET /large/{filename} endpoint."""
@@ -442,6 +482,46 @@ class TestServeLargeEndpoint:
         )
         assert response.status_code == 200
         assert "X-Accel-Redirect" in response.headers
+
+    @pytest.fixture
+    async def image_with_large_pending(self, db_session: AsyncSession):
+        """Create a public image with large variant pending generation."""
+        image = Images(
+            image_id=503,
+            filename="2026-01-02-503",
+            ext="jpeg",
+            md5_hash="pendinglarge123",
+            filesize=10000,
+            width=4000,
+            height=3000,
+            user_id=1,
+            status=ImageStatus.ACTIVE,
+            large=2,  # Pending: generation in progress
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    async def test_large_pending_returns_fullsize_xaccel(
+        self, client: AsyncClient, image_with_large_pending: Images
+    ):
+        """Large endpoint falls back to fullsize while variant is pending generation."""
+        response = await client.get(f"/large/2026-01-02-{image_with_large_pending.image_id}.jpeg")
+        assert response.status_code == 200
+        assert "X-Accel-Redirect" in response.headers
+        assert (
+            f"/internal/fullsize/{image_with_large_pending.filename}.jpeg"
+            in response.headers["X-Accel-Redirect"]
+        )
+
+    async def test_large_pending_returns_no_store_cache_control(
+        self, client: AsyncClient, image_with_large_pending: Images
+    ):
+        """Large endpoint sets Cache-Control: no-store while variant is pending."""
+        response = await client.get(f"/large/2026-01-02-{image_with_large_pending.image_id}.jpeg")
+        assert response.status_code == 200
+        assert response.headers.get("Cache-Control") == "no-store"
 
 
 class TestVisibilityMatrix:

--- a/tests/api/v1/test_media.py
+++ b/tests/api/v1/test_media.py
@@ -8,7 +8,7 @@ from app.api.v1.media import get_extension_from_filename, parse_image_id_from_fi
 from app.config import ImageStatus
 from app.core.permissions import Permission
 from app.core.security import create_access_token
-from app.models.image import Images
+from app.models.image import Images, VariantStatus
 from app.models.permissions import Perms, UserPerms
 from app.models.user import Users
 
@@ -352,7 +352,7 @@ class TestServeMediumEndpoint:
             height=1080,
             user_id=1,
             status=ImageStatus.ACTIVE,
-            medium=2,  # Pending: generation in progress
+            medium=VariantStatus.PENDING,
         )
         db_session.add(image)
         await db_session.commit()
@@ -496,7 +496,7 @@ class TestServeLargeEndpoint:
             height=3000,
             user_id=1,
             status=ImageStatus.ACTIVE,
-            large=2,  # Pending: generation in progress
+            large=VariantStatus.PENDING,
         )
         db_session.add(image)
         await db_session.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,8 +238,11 @@ def setup_test_database():
             )
             conn.execute(text("FLUSH PRIVILEGES"))
         admin_engine.dispose()
-    except Exception:
-        pass  # Root not available; drop_all/create_all below handles schema reset
+    except Exception as e:
+        # Root access is not available on all servers; drop_all/create_all below
+        # handles schema reset instead. Print a note so it's visible if something
+        # unexpected goes wrong (wrong host/port would also surface here).
+        print(f"\n[conftest] Root DB setup skipped: {type(e).__name__}: {e}")
 
     # Create tables using SQLAlchemy metadata (sync engine)
     # Note: SQLModel doesn't support database triggers natively, so we create tables first,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import os
 # pydantic-settings loads ENVIRONMENT from .env (env_file="*.env"), which may be
 # "production" on this server. System env vars take priority over .env, so setting
 # this before any app imports ensures test cookies work over plain http://test.
-os.environ["ENVIRONMENT"] = "development"
+os.environ.setdefault("ENVIRONMENT", "development")
 
 from collections.abc import AsyncGenerator
 from pathlib import Path
@@ -21,6 +21,7 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine, text
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -238,11 +239,10 @@ def setup_test_database():
             )
             conn.execute(text("FLUSH PRIVILEGES"))
         admin_engine.dispose()
-    except Exception as e:
-        # Root access is not available on all servers; drop_all/create_all below
-        # handles schema reset instead. Print a note so it's visible if something
-        # unexpected goes wrong (wrong host/port would also surface here).
-        print(f"\n[conftest] Root DB setup skipped: {type(e).__name__}: {e}")
+    except OperationalError as e:
+        # Root access not available on this server (access denied or connection refused).
+        # drop_all/create_all below handles schema reset instead.
+        print(f"\n[conftest] Root DB setup skipped (root not available): {e}")
 
     # Create tables using SQLAlchemy metadata (sync engine)
     # Note: SQLModel doesn't support database triggers natively, so we create tables first,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,13 @@ This file provides common fixtures for all tests.
 """
 
 import os
+
+# Force development mode so cookies are not marked Secure.
+# pydantic-settings loads ENVIRONMENT from .env (env_file="*.env"), which may be
+# "production" on this server. System env vars take priority over .env, so setting
+# this before any app imports ensures test cookies work over plain http://test.
+os.environ["ENVIRONMENT"] = "development"
+
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -205,36 +212,34 @@ def setup_test_database():
     test_host = os.getenv("TEST_DB_HOST", DEFAULT_TEST_DB_HOST)
     test_port = os.getenv("TEST_DB_PORT", DEFAULT_TEST_DB_PORT)
 
-    # Use root user to drop/create database (needs elevated privileges)
-    admin_engine = create_engine(
-        f"mysql+pymysql://root:{root_password}@{test_host}:{test_port}/mysql",
-        isolation_level="AUTOCOMMIT",
-    )
-
-    # Extract database name from test URL for operations
+    # When root credentials are available (local dev / CI), drop and recreate the database
+    # for a completely clean slate. On servers where root is unavailable, this is skipped
+    # and drop_all/create_all below handles schema reset instead.
     test_db_name = os.getenv("TEST_DB_NAME", DEFAULT_TEST_DB_NAME)
-
-    with admin_engine.connect() as conn:
-        # Drop and recreate test database
-        conn.execute(text(f"DROP DATABASE IF EXISTS {test_db_name}"))
-        conn.execute(
-            text(f"CREATE DATABASE {test_db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
+    try:
+        admin_engine = create_engine(
+            f"mysql+pymysql://root:{root_password}@{test_host}:{test_port}/mysql",
+            isolation_level="AUTOCOMMIT",
         )
-
-        # Create test user if it doesn't exist
-        conn.execute(
-            text("CREATE USER IF NOT EXISTS :username@'%' IDENTIFIED BY :password"),
-            {"username": test_user, "password": test_password},
-        )
-
-        # Grant permissions to test user on test database
-        conn.execute(
-            text(f"GRANT ALL PRIVILEGES ON {test_db_name}.* TO :username@'%'"),
-            {"username": test_user},
-        )
-        conn.execute(text("FLUSH PRIVILEGES"))
-
-    admin_engine.dispose()
+        with admin_engine.connect() as conn:
+            conn.execute(text(f"DROP DATABASE IF EXISTS {test_db_name}"))
+            conn.execute(
+                text(
+                    f"CREATE DATABASE {test_db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                )
+            )
+            conn.execute(
+                text("CREATE USER IF NOT EXISTS :username@'%' IDENTIFIED BY :password"),
+                {"username": test_user, "password": test_password},
+            )
+            conn.execute(
+                text(f"GRANT ALL PRIVILEGES ON {test_db_name}.* TO :username@'%'"),
+                {"username": test_user},
+            )
+            conn.execute(text("FLUSH PRIVILEGES"))
+        admin_engine.dispose()
+    except Exception:
+        pass  # Root not available; drop_all/create_all below handles schema reset
 
     # Create tables using SQLAlchemy metadata (sync engine)
     # Note: SQLModel doesn't support database triggers natively, so we create tables first,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,8 +14,12 @@ async def redis_client():
     # Use a dedicated Redis DB for tests to avoid interfering with dev services
     client = redis.Redis(host="localhost", port=6379, db=15, decode_responses=True)
 
-    # Verify connection
-    await client.ping()
+    # Verify connection - skip test if Redis is unavailable
+    try:
+        await client.ping()
+    except Exception as exc:
+        await client.aclose()
+        pytest.skip(f"Redis not available at localhost:6379/15: {exc}")
 
     yield client
 

--- a/tests/unit/test_arq_jobs.py
+++ b/tests/unit/test_arq_jobs.py
@@ -88,6 +88,31 @@ async def test_create_variant_job_sets_none_when_not_needed():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_create_variant_job_retries_on_failure():
+    """Variant job raises Retry when _create_variant raises an exception."""
+    from arq import Retry
+
+    ctx = {"job_try": 1}
+
+    with patch(
+        "app.services.image_processing._create_variant",
+        side_effect=Exception("PIL error"),
+    ):
+        with pytest.raises(Retry):
+            await create_variant_job(
+                ctx,
+                image_id=42,
+                source_path="/test/image.jpg",
+                ext="jpg",
+                storage_path="/test/storage",
+                width=2000,
+                height=1500,
+                variant_type="medium",
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_create_thumbnail_job_retry_on_failure():
     """Test thumbnail job retries on failure."""
     from arq import Retry

--- a/tests/unit/test_arq_jobs.py
+++ b/tests/unit/test_arq_jobs.py
@@ -4,6 +4,7 @@ import pytest
 from pathlib import Path as FilePath
 from unittest.mock import AsyncMock, Mock, patch
 
+from app.models.image import VariantStatus
 from app.tasks.image_jobs import create_thumbnail_job, create_variant_job
 
 
@@ -32,7 +33,7 @@ async def test_create_thumbnail_job_success():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_variant_job_sets_ready_on_success():
-    """Variant job updates DB to READY (1) when variant is created successfully."""
+    """Variant job updates DB to READY when variant is created successfully."""
     ctx = {"job_try": 1}
 
     with (
@@ -54,13 +55,13 @@ async def test_create_variant_job_sets_ready_on_success():
 
     assert result["success"] is True
     assert result["created"] is True
-    mock_update.assert_called_once_with(42, "medium", 1)
+    mock_update.assert_called_once_with(42, "medium", VariantStatus.READY)
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_variant_job_sets_none_when_not_needed():
-    """Variant job updates DB to NONE (0) when image is too small for a variant."""
+    """Variant job updates DB to NONE when image is too small for a variant."""
     ctx = {"job_try": 1}
 
     with (
@@ -82,7 +83,7 @@ async def test_create_variant_job_sets_none_when_not_needed():
 
     assert result["success"] is True
     assert result["created"] is False
-    mock_update.assert_called_once_with(42, "medium", 0)
+    mock_update.assert_called_once_with(42, "medium", VariantStatus.NONE)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_arq_jobs.py
+++ b/tests/unit/test_arq_jobs.py
@@ -4,7 +4,7 @@ import pytest
 from pathlib import Path as FilePath
 from unittest.mock import AsyncMock, Mock, patch
 
-from app.tasks.image_jobs import create_thumbnail_job
+from app.tasks.image_jobs import create_thumbnail_job, create_variant_job
 
 
 @pytest.mark.unit
@@ -27,6 +27,62 @@ async def test_create_thumbnail_job_success():
         assert result["success"] is True
         assert "thumbnail_path" in result
         mock_create.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_variant_job_sets_ready_on_success():
+    """Variant job updates DB to READY (1) when variant is created successfully."""
+    ctx = {"job_try": 1}
+
+    with (
+        patch("app.services.image_processing._create_variant", return_value=True),
+        patch(
+            "app.services.image_processing._update_image_variant_field", new_callable=AsyncMock
+        ) as mock_update,
+    ):
+        result = await create_variant_job(
+            ctx,
+            image_id=42,
+            source_path="/test/image.jpg",
+            ext="jpg",
+            storage_path="/test/storage",
+            width=2000,
+            height=1500,
+            variant_type="medium",
+        )
+
+    assert result["success"] is True
+    assert result["created"] is True
+    mock_update.assert_called_once_with(42, "medium", 1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_variant_job_sets_none_when_not_needed():
+    """Variant job updates DB to NONE (0) when image is too small for a variant."""
+    ctx = {"job_try": 1}
+
+    with (
+        patch("app.services.image_processing._create_variant", return_value=False),
+        patch(
+            "app.services.image_processing._update_image_variant_field", new_callable=AsyncMock
+        ) as mock_update,
+    ):
+        result = await create_variant_job(
+            ctx,
+            image_id=42,
+            source_path="/test/image.jpg",
+            ext="jpg",
+            storage_path="/test/storage",
+            width=500,
+            height=400,
+            variant_type="medium",
+        )
+
+    assert result["success"] is True
+    assert result["created"] is False
+    mock_update.assert_called_once_with(42, "medium", 0)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
- Add VariantStatus enum (NONE/PENDING/READY) to replace raw tinyint values for has_medium/has_large fields
- Add migration: change medium/large columns to tinyint(3) for variant status tracking
- Add media endpoints for variant generation workflow
- Update image_jobs background task to handle variant generation
- Update generate_variants.py script
- Add/fix tests: test_media, test_arq_jobs, update conftest fixtures