### PR TITLE
feat: include user_title in UserSummary responses

### DIFF
--- a/app/api/v1/favorites.py
+++ b/app/api/v1/favorites.py
@@ -47,10 +47,13 @@ async def get_favorite_images(
     query = (
         select(Images)
         .options(
-            selectinload(Images.user).load_only(
-                Users.user_id, Users.username, Users.avatar, Users.user_title
+            selectinload(Images.user).load_only(  # type: ignore[arg-type]
+                Users.user_id,  # type: ignore[arg-type]
+                Users.username,  # type: ignore[arg-type]
+                Users.avatar,  # type: ignore[arg-type]
+                Users.user_title,  # type: ignore[arg-type]
             )
-        )  # type: ignore[arg-type]
+        )
         .join(Favorites)
         .where(Favorites.user_id == user_id)  # type: ignore[arg-type]
     )

--- a/app/api/v1/favorites.py
+++ b/app/api/v1/favorites.py
@@ -46,7 +46,11 @@ async def get_favorite_images(
     # Get user's favorite images
     query = (
         select(Images)
-        .options(selectinload(Images.user).load_only(Users.user_id, Users.username, Users.avatar))  # type: ignore[arg-type]
+        .options(
+            selectinload(Images.user).load_only(
+                Users.user_id, Users.username, Users.avatar, Users.user_title
+            )
+        )  # type: ignore[arg-type]
         .join(Favorites)
         .where(Favorites.user_id == user_id)  # type: ignore[arg-type]
     )

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -128,9 +128,12 @@ async def _hydrate_similar_images(
     images_result = await db.execute(
         select(Images)
         .options(
-            selectinload(Images.user).load_only(
-                Users.user_id, Users.username, Users.avatar, Users.user_title
-            )  # type: ignore[arg-type]
+            selectinload(Images.user).load_only(  # type: ignore[arg-type]
+                Users.user_id,  # type: ignore[arg-type]
+                Users.username,  # type: ignore[arg-type]
+                Users.avatar,  # type: ignore[arg-type]
+                Users.user_title,  # type: ignore[arg-type]
+            )
         )
         .where(Images.image_id.in_(similar_ids))  # type: ignore[union-attr]
     )
@@ -1278,7 +1281,14 @@ async def search_by_hash(
     """
     result = await db.execute(
         select(Images)
-        .options(selectinload(Images.user).load_only(Users.user_id, Users.username, Users.avatar))  # type: ignore[arg-type]
+        .options(
+            selectinload(Images.user).load_only(  # type: ignore[arg-type]
+                Users.user_id,  # type: ignore[arg-type]
+                Users.username,  # type: ignore[arg-type]
+                Users.avatar,  # type: ignore[arg-type]
+                Users.user_title,  # type: ignore[arg-type]
+            )
+        )
         .where(Images.md5_hash == md5_hash)  # type: ignore[arg-type]
     )
     images = result.scalars().all()
@@ -1419,7 +1429,14 @@ async def get_bookmark_image(
 
     result = await db.execute(
         select(Images)
-        .options(selectinload(Images.user).load_only(Users.user_id, Users.username, Users.avatar))  # type: ignore[arg-type]
+        .options(
+            selectinload(Images.user).load_only(  # type: ignore[arg-type]
+                Users.user_id,  # type: ignore[arg-type]
+                Users.username,  # type: ignore[arg-type]
+                Users.avatar,  # type: ignore[arg-type]
+                Users.user_title,  # type: ignore[arg-type]
+            )
+        )
         .where(Images.image_id == current_user.bookmark)  # type: ignore[arg-type]
     )
     image = result.scalar_one_or_none()

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -128,7 +128,9 @@ async def _hydrate_similar_images(
     images_result = await db.execute(
         select(Images)
         .options(
-            selectinload(Images.user).load_only(Users.user_id, Users.username, Users.avatar)  # type: ignore[arg-type]
+            selectinload(Images.user).load_only(
+                Users.user_id, Users.username, Users.avatar, Users.user_title
+            )  # type: ignore[arg-type]
         )
         .where(Images.image_id.in_(similar_ids))  # type: ignore[union-attr]
     )
@@ -1074,6 +1076,7 @@ async def get_image_tag_history(
                 user_id=user.user_id,
                 username=user.username,
                 avatar=user.avatar,
+                user_title=user.user_title,
                 groups=user.groups if user else [],
             )
 
@@ -1158,6 +1161,7 @@ async def get_image_status_history(
                 user_id=user.user_id,
                 username=user.username,
                 avatar=user.avatar,
+                user_title=user.user_title,
                 groups=user.groups if user else [],
             )
 

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -637,7 +637,9 @@ async def get_images_by_tag(
     query = (
         select(Images)
         .options(
-            selectinload(Images.user).load_only(Users.user_id, Users.username, Users.avatar)  # type: ignore[arg-type]
+            selectinload(Images.user).load_only(
+                Users.user_id, Users.username, Users.avatar, Users.user_title
+            )  # type: ignore[arg-type]
         )
         .join(
             image_id_subquery,
@@ -806,6 +808,7 @@ async def get_tag(
             user_id=user.user_id or 0,
             username=user.username,
             avatar=user.avatar or None,
+            user_title=user.user_title,
             groups=user.groups,  # Uses the eager-loaded groups property
         )
 
@@ -972,6 +975,7 @@ async def get_tag_history(
                 user_id=user.user_id,
                 username=user.username,
                 avatar=user.avatar,
+                user_title=user.user_title,
                 groups=user.groups if user else [],
             )
 
@@ -1087,6 +1091,7 @@ async def get_tag_usage_history(
                 user_id=user.user_id,
                 username=user.username,
                 avatar=user.avatar,
+                user_title=user.user_title,
                 groups=user.groups if user else [],
             )
 

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -637,9 +637,12 @@ async def get_images_by_tag(
     query = (
         select(Images)
         .options(
-            selectinload(Images.user).load_only(
-                Users.user_id, Users.username, Users.avatar, Users.user_title
-            )  # type: ignore[arg-type]
+            selectinload(Images.user).load_only(  # type: ignore[arg-type]
+                Users.user_id,  # type: ignore[arg-type]
+                Users.username,  # type: ignore[arg-type]
+                Users.avatar,  # type: ignore[arg-type]
+                Users.user_title,  # type: ignore[arg-type]
+            )
         )
         .join(
             image_id_subquery,

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -621,9 +621,12 @@ async def get_user_images(
     query = (
         select(Images)
         .options(
-            selectinload(Images.user).load_only(
-                Users.user_id, Users.username, Users.avatar, Users.user_title
-            ),  # type: ignore[arg-type]
+            selectinload(Images.user).load_only(  # type: ignore[arg-type]
+                Users.user_id,  # type: ignore[arg-type]
+                Users.username,  # type: ignore[arg-type]
+                Users.avatar,  # type: ignore[arg-type]
+                Users.user_title,  # type: ignore[arg-type]
+            ),
             selectinload(Images.tag_links).selectinload(TagLinks.tag),  # type: ignore[arg-type]
         )
         .where(Images.user_id == user_id)  # type: ignore[arg-type]
@@ -732,9 +735,12 @@ async def get_user_favorites(
     query = (
         select(Images)
         .options(
-            selectinload(Images.user).load_only(
-                Users.user_id, Users.username, Users.avatar, Users.user_title
-            ),  # type: ignore[arg-type]
+            selectinload(Images.user).load_only(  # type: ignore[arg-type]
+                Users.user_id,  # type: ignore[arg-type]
+                Users.username,  # type: ignore[arg-type]
+                Users.avatar,  # type: ignore[arg-type]
+                Users.user_title,  # type: ignore[arg-type]
+            ),
             selectinload(Images.tag_links).selectinload(TagLinks.tag),  # type: ignore[arg-type]
         )
         .join(Favorites)

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -621,7 +621,9 @@ async def get_user_images(
     query = (
         select(Images)
         .options(
-            selectinload(Images.user).load_only(Users.user_id, Users.username, Users.avatar),  # type: ignore[arg-type]
+            selectinload(Images.user).load_only(
+                Users.user_id, Users.username, Users.avatar, Users.user_title
+            ),  # type: ignore[arg-type]
             selectinload(Images.tag_links).selectinload(TagLinks.tag),  # type: ignore[arg-type]
         )
         .where(Images.user_id == user_id)  # type: ignore[arg-type]
@@ -730,7 +732,9 @@ async def get_user_favorites(
     query = (
         select(Images)
         .options(
-            selectinload(Images.user).load_only(Users.user_id, Users.username, Users.avatar),  # type: ignore[arg-type]
+            selectinload(Images.user).load_only(
+                Users.user_id, Users.username, Users.avatar, Users.user_title
+            ),  # type: ignore[arg-type]
             selectinload(Images.tag_links).selectinload(TagLinks.tag),  # type: ignore[arg-type]
         )
         .join(Favorites)

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -18,6 +18,7 @@ class UserSummary(BaseModel):
     user_id: int
     username: str
     avatar: str | None = None  # Avatar filename from database
+    user_title: str | None = None
     groups: list[str] = []  # Group names for username coloring (e.g., ["mods", "admins"])
 
     # Allow Pydantic to read from SQLAlchemy model attributes (not just dicts)

--- a/tests/unit/test_comment_response_groups.py
+++ b/tests/unit/test_comment_response_groups.py
@@ -31,6 +31,7 @@ def _create_mock_comment(
     mock_user.user_id = user_id
     mock_user.username = username
     mock_user.avatar = None
+    mock_user.user_title = None
     mock_user.groups = groups if groups is not None else []
     mock_comment.user = mock_user
 

--- a/tests/unit/test_image_response_groups.py
+++ b/tests/unit/test_image_response_groups.py
@@ -45,6 +45,7 @@ def _create_mock_image(
     mock_user.user_id = user_id
     mock_user.username = username
     mock_user.avatar = None
+    mock_user.user_title = None
     mock_user.groups = user_groups if user_groups is not None else []
     mock_image.user = mock_user
 


### PR DESCRIPTION
## Summary
- Add `user_title` field to `UserSummary` schema so the frontend can display custom user titles wherever user info is embedded
- Updated all `load_only()` queries to include `Users.user_title` (prevents async lazy-load errors)
- Updated all manual `UserSummary()` constructions to pass `user_title`

## Test plan
- [x] All 1218 tests pass
- [x] Verify `user_title` appears in API responses for images, comments, tags, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)