### PR TITLE
fix: rewrite ALTER DATABASE references when restoring prod dumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
         run: uv run pip-audit
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,6 @@ jobs:
 
       - name: Upload Trivy results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
+        if: always() && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: 'trivy-results.sarif'

--- a/scripts/db_utils.py
+++ b/scripts/db_utils.py
@@ -241,19 +241,25 @@ async def import_sql_dump(sql_file: Path, db_config: dict[str, str]) -> bool:
 
     mysql_cmd.extend([
         db_config["database"],
-        "--init-command=SET SESSION FOREIGN_KEY_CHECKS=0; SET SESSION UNIQUE_CHECKS=0; SET autocommit=0;",
         "--max-allowed-packet=1073741824",  # 1GB in bytes
     ])
+
+    database = db_config["database"]
 
     # Build the full command with proper shell quoting
     # Pipe through sed to:
     # - Strip LOCK/UNLOCK TABLES (avoid locking conflicts with triggers/FKs)
     # - Strip DEFINER clauses (prod user may differ from local dev user)
+    # - Rewrite ALTER DATABASE to target the local database name (prod dumps
+    #   emit ALTER DATABASE `prod_db` around trigger definitions for charset
+    #   changes; if the prod db name doesn't exist locally, these fail and
+    #   abort the import in batch mode)
     cmd_str = " ".join(f'"{arg}"' if " " in arg or ";" in arg else arg for arg in mysql_cmd)
     import_cmd = (
         f"sed"
         f" -e '/^LOCK TABLES/d; /^UNLOCK TABLES/d'"
         f" -e 's/ DEFINER[ ]*=[ ]*[^ ]*@[^ ]* / /g'"
+        f" -e 's/^ALTER DATABASE `[^`]*`/ALTER DATABASE `{database}`/g'"
         f" {sql_file} | {cmd_str}"
     )
 

--- a/scripts/db_utils.py
+++ b/scripts/db_utils.py
@@ -6,6 +6,7 @@ the legacy migration script and the prod restore script.
 """
 
 import os
+import shlex
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -246,7 +247,7 @@ async def import_sql_dump(sql_file: Path, db_config: dict[str, str]) -> bool:
 
     database = db_config["database"]
 
-    # Build the full command with proper shell quoting
+    # Build the full command with proper shell quoting via shlex.quote
     # Pipe through sed to:
     # - Strip LOCK/UNLOCK TABLES (avoid locking conflicts with triggers/FKs)
     # - Strip DEFINER clauses (prod user may differ from local dev user)
@@ -254,13 +255,14 @@ async def import_sql_dump(sql_file: Path, db_config: dict[str, str]) -> bool:
     #   emit ALTER DATABASE `prod_db` around trigger definitions for charset
     #   changes; if the prod db name doesn't exist locally, these fail and
     #   abort the import in batch mode)
-    cmd_str = " ".join(f'"{arg}"' if " " in arg or ";" in arg else arg for arg in mysql_cmd)
+    cmd_str = " ".join(shlex.quote(arg) for arg in mysql_cmd)
+    alter_db_sed = f"s/^ALTER DATABASE `[^`]*`/ALTER DATABASE `{database}`/g"
     import_cmd = (
         f"sed"
         f" -e '/^LOCK TABLES/d; /^UNLOCK TABLES/d'"
         f" -e 's/ DEFINER[ ]*=[ ]*[^ ]*@[^ ]* / /g'"
-        f" -e 's/^ALTER DATABASE `[^`]*`/ALTER DATABASE `{database}`/g'"
-        f" {sql_file} | {cmd_str}"
+        f" -e {shlex.quote(alter_db_sed)}"
+        f" {shlex.quote(str(sql_file))} | {cmd_str}"
     )
 
     success = await run_command(

--- a/uv.lock
+++ b/uv.lock
@@ -1075,11 +1075,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Prod dumps contain `ALTER DATABASE `shuushuu_v2`` statements around trigger definitions for charset changes. When importing into a differently-named local database (e.g. `shuushuu_dev`), these fail and abort the entire import in batch mode.
- Added a sed substitution to rewrite `ALTER DATABASE` references to the target database name.
- Removed unnecessary `--init-command` (the dump already sets `FOREIGN_KEY_CHECKS=0` and manages its own transaction flow).

## Test plan
- [x] Verified full restore with `restore_prod_db.py --auto-confirm` completes all 5 steps with zero errors
- [x] Verified favorites table (5.7M rows) and images table (1.1M rows) imported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)