### PR TITLE
feat(r2): serve images from Cloudflare R2 with public CDN + private presigned URLs

### DIFF
--- a/alembic/versions/6ad847e3bc00_add_r2_location_to_images.py
+++ b/alembic/versions/6ad847e3bc00_add_r2_location_to_images.py
@@ -1,0 +1,50 @@
+"""add r2_location to images
+
+Revision ID: 6ad847e3bc00
+Revises: 8c950e7fa6f2
+Create Date: 2026-04-17 21:27:43.692812
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "6ad847e3bc00"
+down_revision: str | Sequence[str] | None = "8c950e7fa6f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add r2_location column to images.
+
+    0 = NONE (not in R2 yet), 1 = PUBLIC bucket, 2 = PRIVATE bucket.
+    Default NONE — backfill is a separate one-shot run.
+    """
+    op.add_column(
+        "images",
+        sa.Column(
+            "r2_location",
+            mysql.TINYINT(unsigned=True),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    # Index supports reconcile/health queries (WHERE r2_location = 0)
+    op.create_index(
+        "idx_r2_location",
+        "images",
+        ["r2_location"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Remove r2_location column."""
+    op.drop_index("idx_r2_location", table_name="images")
+    op.drop_column("images", "r2_location")

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -103,10 +103,10 @@ from app.schemas.report import (
     UnifiedReportListResponse,
     VoteResponse,
 )
+from app.services.image_status import enqueue_r2_sync_on_status_change
 from app.services.rating import schedule_rating_recalculation
 from app.services.repost import migrate_repost_data
 from app.services.review_jobs import check_early_close
-from app.tasks.queue import enqueue_job
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -809,13 +809,8 @@ async def change_image_status(
     await db.commit()
     await db.refresh(image)
 
-    if (
-        status_data.status is not None
-        and status_data.status != previous_status
-        and settings.R2_ENABLED
-    ):
-        await enqueue_job(
-            "sync_image_status_job",
+    if status_data.status is not None:
+        await enqueue_r2_sync_on_status_change(
             image_id=image_id,
             old_status=previous_status,
             new_status=status_data.status,
@@ -1694,6 +1689,12 @@ async def action_report(
 
     await db.commit()
 
+    await enqueue_r2_sync_on_status_change(
+        image_id=report.image_id,
+        old_status=previous_status,
+        new_status=action_data.new_status,
+    )
+
     return MessageResponse(message="Report processed and image status updated")
 
 
@@ -1786,6 +1787,12 @@ async def escalate_report(
 
     await db.commit()
     await db.refresh(review)
+
+    await enqueue_r2_sync_on_status_change(
+        image_id=report.image_id,
+        old_status=previous_status,
+        new_status=ImageStatus.REVIEW,
+    )
 
     summaries = await _build_user_summaries(db, {current_user.id})
     response = ReviewResponse.model_validate(review)
@@ -2035,6 +2042,12 @@ async def create_review(
     await db.commit()
     await db.refresh(review)
 
+    await enqueue_r2_sync_on_status_change(
+        image_id=image_id,
+        old_status=previous_status,
+        new_status=ImageStatus.REVIEW,
+    )
+
     summaries = await _build_user_summaries(db, {current_user.id})
     response = ReviewResponse.model_validate(review)
     response.initiated_by_user = summaries.get(current_user.id)
@@ -2106,10 +2119,16 @@ async def vote_on_review(
     await db.flush()
 
     # Check if vote margin triggers early close
-    await check_early_close(db, review)
+    transition = await check_early_close(db, review)
 
     await db.commit()
     await db.refresh(vote)
+
+    if transition is not None:
+        image_id, old_status, new_status = transition
+        await enqueue_r2_sync_on_status_change(
+            image_id=image_id, old_status=old_status, new_status=new_status
+        )
 
     summaries = await _build_user_summaries(db, {current_user.id})
     response = VoteResponse.model_validate(vote)
@@ -2171,6 +2190,7 @@ async def close_review(
     review.closed_by = current_user.user_id
 
     # Apply outcome to image
+    previous_image_status = image.status
     if close_data.outcome == ReviewOutcome.KEEP:
         image.status = ImageStatus.ACTIVE
     else:
@@ -2196,6 +2216,12 @@ async def close_review(
 
     await db.commit()
     await db.refresh(review)
+
+    await enqueue_r2_sync_on_status_change(
+        image_id=review.image_id,
+        old_status=previous_image_status,
+        new_status=image.status,
+    )
 
     close_user_ids: set[int] = {current_user.id}
     if review.initiated_by:

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -106,6 +106,7 @@ from app.schemas.report import (
 from app.services.rating import schedule_rating_recalculation
 from app.services.repost import migrate_repost_data
 from app.services.review_jobs import check_early_close
+from app.tasks.queue import enqueue_job
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -807,6 +808,18 @@ async def change_image_status(
 
     await db.commit()
     await db.refresh(image)
+
+    if (
+        status_data.status is not None
+        and status_data.status != previous_status
+        and settings.R2_ENABLED
+    ):
+        await enqueue_job(
+            "sync_image_status_job",
+            image_id=image_id,
+            old_status=previous_status,
+            new_status=status_data.status,
+        )
 
     # Schedule rating recalculation for original image after repost migration
     if status_data.status == ImageStatus.REPOST and status_data.replacement_id:

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -960,6 +960,14 @@ async def update_image(
 
     await db.commit()
 
+    if new_status is not None and new_status != previous_status and settings.R2_ENABLED:
+        await enqueue_job(
+            "sync_image_status_job",
+            image_id=image_id,
+            old_status=previous_status,
+            new_status=new_status,
+        )
+
     # Recalculate ratings for the original image after repost migration
     if new_status == ImageStatus.REPOST and replacement_id:
         await recalculate_image_ratings(db, replacement_id)

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -99,6 +99,7 @@ from app.services.image_processing import (
     get_image_dimensions,
     validate_image_file,
 )
+from app.services.image_status import enqueue_r2_sync_on_status_change
 from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 from app.services.iqdb import check_iqdb_similarity, remove_from_iqdb
 from app.services.rate_limit import check_similarity_rate_limit
@@ -981,9 +982,8 @@ async def update_image(
 
     await db.commit()
 
-    if new_status is not None and new_status != previous_status and settings.R2_ENABLED:
-        await enqueue_job(
-            "sync_image_status_job",
+    if new_status is not None:
+        await enqueue_r2_sync_on_status_change(
             image_id=image_id,
             old_status=previous_status,
             new_status=new_status,

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -2144,6 +2144,13 @@ async def upload_image(
             _defer_by=5.0,  # Wait 5 seconds for thumbnail to complete
         )
 
+        if settings.R2_ENABLED:
+            await enqueue_job(
+                "r2_finalize_upload_job",
+                image_id=image_id,
+                _defer_by=90,
+            )
+
         # Build response
         image_response = ImageResponse(
             image_id=temp_image.image_id or 0,  # image_id is guaranteed to exist after flush

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -833,7 +833,7 @@ async def delete_image(
         await enqueue_job(
             "r2_delete_image_job",
             image_id=image_id,
-            r2_location=prior_r2_location,
+            r2_location=int(prior_r2_location),
             filename=prior_filename,
             ext=prior_ext,
             variants=prior_variants,

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -46,6 +46,7 @@ from app.core.auth import CurrentUser, VerifiedUser, get_current_user, get_optio
 from app.core.database import get_db
 from app.core.logging import get_logger
 from app.core.permissions import Permission, has_permission
+from app.core.r2_constants import R2Location
 from app.core.redis import get_redis
 from app.models import (
     AdminActions,
@@ -828,7 +829,7 @@ async def delete_image(
         reason=reason,
     )
 
-    if settings.R2_ENABLED:
+    if settings.R2_ENABLED and prior_r2_location != R2Location.NONE:
         await enqueue_job(
             "r2_delete_image_job",
             image_id=image_id,

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -785,6 +785,16 @@ async def delete_image(
     if not remove_from_iqdb(image_id):
         logger.warning("iqdb_remove_failed_for_deleted_image", image_id=image_id)
 
+    # Capture R2 metadata before DB delete
+    prior_r2_location = image.r2_location
+    prior_filename = image.filename
+    prior_ext = image.ext
+    prior_variants = ["fullsize", "thumbs"]
+    if image.medium == VariantStatus.READY:
+        prior_variants.append("medium")
+    if image.large == VariantStatus.READY:
+        prior_variants.append("large")
+
     # Capture file paths before deleting from DB
     storage_path = FilePath(settings.STORAGE_PATH)
     files_to_delete = [
@@ -817,6 +827,16 @@ async def delete_image(
         deleted_by=current_user.user_id,
         reason=reason,
     )
+
+    if settings.R2_ENABLED:
+        await enqueue_job(
+            "r2_delete_image_job",
+            image_id=image_id,
+            r2_location=prior_r2_location,
+            filename=prior_filename,
+            ext=prior_ext,
+            variants=prior_variants,
+        )
 
 
 @router.patch("/{image_id}", response_model=ImageDetailedResponse)

--- a/app/api/v1/media.py
+++ b/app/api/v1/media.py
@@ -7,7 +7,7 @@ Routes:
 - GET /medium/{filename} - Serve medium variant (1280px) with permission check
 - GET /large/{filename} - Serve large variant (2048px) with permission check
 
-These endpoints return X-Accel-Redirect headers for nginx to serve the actual files.
+These endpoints serve images via X-Accel-Redirect (local FS) or HTTP 302 redirect (R2 CDN / presigned URL).
 Authentication is cookie-based (access_token HTTPOnly cookie).
 
 Note: Future enhancement could support ?token=xxx query param for non-browser clients.
@@ -19,11 +19,17 @@ from fastapi import APIRouter, Depends, Response
 from fastapi.exceptions import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.core.auth import get_optional_current_user
 from app.core.database import get_db
+from app.core.logging import get_logger
+from app.core.r2_client import get_r2_storage
+from app.core.r2_constants import R2Location
 from app.models.image import Images, VariantStatus
 from app.models.user import Users
 from app.services.image_visibility import can_view_image_file
+
+logger = get_logger(__name__)
 
 router = APIRouter()
 
@@ -126,7 +132,14 @@ async def _serve_image(
     db: AsyncSession,
     current_user: Users | None,
 ) -> Response:
-    """Internal handler for serving images."""
+    """Internal handler for serving images.
+
+    Routing:
+      - Permission check first (prevents leaking protected-image existence).
+      - If R2 enabled and r2_location=PUBLIC → 302 to CDN URL.
+      - If R2 enabled and r2_location=PRIVATE → 302 to presigned URL.
+      - Otherwise → X-Accel-Redirect to local /internal/ path (legacy fallback).
+    """
     image_id = parse_image_id_from_filename(filename)
     if image_id is None:
         raise HTTPException(status_code=404)
@@ -135,31 +148,51 @@ async def _serve_image(
     if image is None:
         raise HTTPException(status_code=404)
 
-    # Permission check first - prevents leaking info about protected images
+    # Permission check — prevents leaking info about protected images
     if not await can_view_image_file(image, current_user, db):
         raise HTTPException(status_code=404)
 
-    # Check variant state for medium/large
+    # Variant checks (unchanged)
     if image_type in ("medium", "large"):
         variant_status = image.medium if image_type == "medium" else image.large
         if variant_status == VariantStatus.NONE:
             raise HTTPException(status_code=404)
         if variant_status == VariantStatus.PENDING:
-            # Variant is still being generated — fall back to fullsize.
-            # Cache-Control: no-store prevents the browser from caching this response
-            # so it will retry on the next request and pick up the real variant once ready.
+            # TODO(r2): Pending variant falls back to local /internal/fullsize/ path even
+            # when the fullsize is in R2. Acceptable during migration (files exist locally
+            # until r2_sync backfills them), but must be revisited once local FS is retired.
             fullsize_path = f"/internal/fullsize/{image.filename}.{image.ext}"
             return Response(
                 status_code=200,
                 headers={"X-Accel-Redirect": fullsize_path, "Cache-Control": "no-store"},
             )
 
-    # Use database extension for fullsize/medium/large, always webp for thumbnails
-    if image_type == "thumbs":
-        ext = "webp"
-    else:
-        ext = image.ext
+    ext = "webp" if image_type == "thumbs" else image.ext
+    key = f"{image_type}/{image.filename}.{ext}"
 
-    # Files are stored with filename (e.g., 2025-12-29-1112174.jpeg)
-    internal_path = f"/internal/{image_type}/{image.filename}.{ext}"
-    return Response(status_code=200, headers={"X-Accel-Redirect": internal_path})
+    # R2 branches (only active when R2_ENABLED)
+    if settings.R2_ENABLED and image.r2_location == R2Location.PUBLIC:
+        cdn_url = f"{settings.R2_PUBLIC_CDN_URL}/{key}"
+        return Response(
+            status_code=302,
+            headers={"Location": cdn_url, "Cache-Control": "no-store"},
+        )
+
+    if settings.R2_ENABLED and image.r2_location == R2Location.PRIVATE:
+        r2 = get_r2_storage()
+        presigned = await r2.generate_presigned_url(
+            bucket=settings.R2_PRIVATE_BUCKET,
+            key=key,
+            ttl=settings.R2_PRESIGN_TTL_SECONDS,
+        )
+        logger.debug("r2_presigned_url_issued", image_id=image_id, variant=image_type)
+        return Response(
+            status_code=302,
+            headers={"Location": presigned, "Cache-Control": "no-store"},
+        )
+
+    # Local FS fallback (r2_location=NONE, or R2 disabled)
+    return Response(
+        status_code=200,
+        headers={"X-Accel-Redirect": f"/internal/{image_type}/{image.filename}.{ext}"},
+    )

--- a/app/api/v1/media.py
+++ b/app/api/v1/media.py
@@ -24,7 +24,7 @@ from app.core.auth import get_optional_current_user
 from app.core.database import get_db
 from app.core.logging import get_logger
 from app.core.r2_client import get_r2_storage
-from app.core.r2_constants import R2Location
+from app.core.r2_constants import PUBLIC_IMAGE_STATUSES_FOR_R2, R2Location
 from app.models.image import Images, VariantStatus
 from app.models.user import Users
 from app.services.image_visibility import can_view_image_file
@@ -171,7 +171,11 @@ async def _serve_image(
     key = f"{image_type}/{image.filename}.{ext}"
 
     # R2 branches (only active when R2_ENABLED)
-    if settings.R2_ENABLED and image.r2_location == R2Location.PUBLIC:
+    if (
+        settings.R2_ENABLED
+        and image.r2_location == R2Location.PUBLIC
+        and image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+    ):
         cdn_url = f"{settings.R2_PUBLIC_CDN_URL}/{key}"
         return Response(
             status_code=302,

--- a/app/config.py
+++ b/app/config.py
@@ -64,16 +64,9 @@ class Settings(BaseSettings):
     CELERY_BROKER_URL: str | None = Field(default=None)
     CELERY_RESULT_BACKEND: str | None = Field(default=None)
 
-    # File Storage
-    STORAGE_TYPE: str = Field(default="local", pattern="^(local|s3)$")
+    # Local filesystem root for image storage (used as fallback when R2 is
+    # disabled, or as the source for R2 uploads during phase 1).
     STORAGE_PATH: str = "/shuushuu/images"
-
-    # S3 Configuration (if using S3)
-    S3_BUCKET: str | None = None
-    S3_ACCESS_KEY: str | None = None
-    S3_SECRET_KEY: str | None = None
-    S3_ENDPOINT: str | None = None
-    S3_REGION: str = "us-east-1"
 
     # Cloudflare R2 (image storage)
     R2_ENABLED: bool = Field(

--- a/app/config.py
+++ b/app/config.py
@@ -209,7 +209,11 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def validate_r2_enabled_requirements(self) -> Settings:
-        """When R2_ENABLED=true, all R2_* and CLOUDFLARE_* credentials must be set."""
+        """When R2_ENABLED=true, R2 credentials must be set.
+
+        Cloudflare credentials are optional — purge_cache_by_urls raises at
+        call time if they're missing, so R2 works without CDN purging.
+        """
         if not self.R2_ENABLED:
             return self
         required = {
@@ -219,8 +223,6 @@ class Settings(BaseSettings):
             "R2_PUBLIC_BUCKET": self.R2_PUBLIC_BUCKET,
             "R2_PRIVATE_BUCKET": self.R2_PRIVATE_BUCKET,
             "R2_PUBLIC_CDN_URL": self.R2_PUBLIC_CDN_URL,
-            "CLOUDFLARE_API_TOKEN": self.CLOUDFLARE_API_TOKEN,
-            "CLOUDFLARE_ZONE_ID": self.CLOUDFLARE_ZONE_ID,
         }
         missing = [name for name, value in required.items() if not value]
         if missing:

--- a/app/config.py
+++ b/app/config.py
@@ -75,6 +75,34 @@ class Settings(BaseSettings):
     S3_ENDPOINT: str | None = None
     S3_REGION: str = "us-east-1"
 
+    # Cloudflare R2 (image storage)
+    R2_ENABLED: bool = Field(
+        default=False,
+        description="Enable R2 image serving. When false, app uses local FS only.",
+    )
+    R2_ACCESS_KEY_ID: str = Field(default="")
+    R2_SECRET_ACCESS_KEY: str = Field(default="")
+    R2_ENDPOINT: str = Field(default="", description="R2 S3-compatible endpoint URL")
+    R2_PUBLIC_BUCKET: str = Field(default="shuushuu-images")
+    R2_PRIVATE_BUCKET: str = Field(default="shuushuu-images-private")
+    R2_PUBLIC_CDN_URL: str = Field(
+        default="",
+        description="Custom domain attached to the public R2 bucket (no trailing slash)",
+    )
+    R2_PRESIGN_TTL_SECONDS: int = Field(default=900, ge=60, le=3600)
+    R2_ALLOW_BULK_BACKFILL: bool = Field(
+        default=False,
+        description=(
+            "Gate for r2_sync.py backfill-locations and reconcile. "
+            "Set true permanently in prod; leave false on staging to prevent "
+            "mass-uploading prod-imported images to the staging bucket."
+        ),
+    )
+
+    # Cloudflare API (for CDN cache purge)
+    CLOUDFLARE_API_TOKEN: str = Field(default="")
+    CLOUDFLARE_ZONE_ID: str = Field(default="")
+
     # Image Processing
     MAX_IMAGE_SIZE: int = 32 * 1024 * 1024  # 32MB
     MAX_THUMB_WIDTH: int = 500  # Thumbnail longest edge (WebP format)
@@ -183,6 +211,28 @@ class Settings(BaseSettings):
                 "Use SMTP_TLS=true for implicit TLS (port 465), "
                 "or SMTP_STARTTLS=true for STARTTLS (port 587), "
                 "or both false for unencrypted localhost relay."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_r2_enabled_requirements(self) -> Settings:
+        """When R2_ENABLED=true, all R2_* and CLOUDFLARE_* credentials must be set."""
+        if not self.R2_ENABLED:
+            return self
+        required = {
+            "R2_ACCESS_KEY_ID": self.R2_ACCESS_KEY_ID,
+            "R2_SECRET_ACCESS_KEY": self.R2_SECRET_ACCESS_KEY,
+            "R2_ENDPOINT": self.R2_ENDPOINT,
+            "R2_PUBLIC_BUCKET": self.R2_PUBLIC_BUCKET,
+            "R2_PRIVATE_BUCKET": self.R2_PRIVATE_BUCKET,
+            "R2_PUBLIC_CDN_URL": self.R2_PUBLIC_CDN_URL,
+            "CLOUDFLARE_API_TOKEN": self.CLOUDFLARE_API_TOKEN,
+            "CLOUDFLARE_ZONE_ID": self.CLOUDFLARE_ZONE_ID,
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise ValueError(
+                f"R2_ENABLED=true but these required settings are empty: {', '.join(missing)}"
             )
         return self
 

--- a/app/core/r2_client.py
+++ b/app/core/r2_client.py
@@ -1,0 +1,34 @@
+"""Process-wide R2 storage accessor.
+
+Returns a real R2Storage when R2_ENABLED, or a DummyR2Storage when disabled.
+The singleton is rebuilt after reset_r2_storage() — useful in tests.
+"""
+
+import aioboto3
+
+from app.config import settings
+from app.services.r2_storage import DummyR2Storage, R2Storage
+
+_instance: R2Storage | DummyR2Storage | None = None
+
+
+def get_r2_storage() -> R2Storage | DummyR2Storage:
+    """Return the process-wide R2 storage adapter."""
+    global _instance
+    if _instance is None:
+        if settings.R2_ENABLED:
+            session = aioboto3.Session(
+                aws_access_key_id=settings.R2_ACCESS_KEY_ID,
+                aws_secret_access_key=settings.R2_SECRET_ACCESS_KEY,
+                region_name="auto",
+            )
+            _instance = R2Storage(session=session, endpoint_url=settings.R2_ENDPOINT)
+        else:
+            _instance = DummyR2Storage()
+    return _instance
+
+
+def reset_r2_storage() -> None:
+    """Reset the singleton. Used by tests and on config reload."""
+    global _instance
+    _instance = None

--- a/app/core/r2_constants.py
+++ b/app/core/r2_constants.py
@@ -1,0 +1,32 @@
+"""Shared constants for R2 integration.
+
+Kept in its own module to avoid import cycles between models, schemas,
+services, and the scripts/r2_sync.py CLI.
+"""
+
+from enum import IntEnum
+
+from app.config import ImageStatus
+
+# Image statuses served from the public R2 bucket. Any other status is protected
+# and lives in the private bucket (accessed via presigned URLs).
+PUBLIC_IMAGE_STATUSES_FOR_R2: frozenset[int] = frozenset(
+    {ImageStatus.ACTIVE, ImageStatus.SPOILER, ImageStatus.REPOST}
+)
+
+# Key prefixes under each R2 bucket. Matches the local FS layout so the
+# one-time bucket split requires no key rewriting.
+R2_VARIANTS: tuple[str, ...] = ("fullsize", "thumbs", "medium", "large")
+
+
+class R2Location(IntEnum):
+    """Where an image's R2 objects physically live.
+
+    NONE    — not yet synced to R2 (pending finalizer, or R2 disabled).
+    PUBLIC  — canonical copy lives in R2_PUBLIC_BUCKET.
+    PRIVATE — canonical copy lives in R2_PRIVATE_BUCKET.
+    """
+
+    NONE = 0
+    PUBLIC = 1
+    PRIVATE = 2

--- a/app/models/admin_action.py
+++ b/app/models/admin_action.py
@@ -75,17 +75,14 @@ class AdminActions(SQLModel, table=True):
     action_id: int | None = Field(default=None, primary_key=True)
 
     # Admin who performed the action
-    user_id: int | None = Field(default=None, foreign_key="users.user_id")
+    # FKs with ON DELETE SET NULL are defined in __table_args__; don't duplicate via foreign_key= param
+    user_id: int | None = Field(default=None)
 
-    # Action type (stored as int, mapped to AdminActionType constants)
-    # 1=report_dismiss, 2=report_action, 3=review_start, 4=review_vote,
-    # 5=review_close, 6=review_extend
     action_type: int = Field(default=0)
 
-    # Related entities (nullable - not all actions have all references)
-    report_id: int | None = Field(default=None, foreign_key="image_reports.report_id")
-    review_id: int | None = Field(default=None, foreign_key="image_reviews.review_id")
-    image_id: int | None = Field(default=None, foreign_key="images.image_id")
+    report_id: int | None = Field(default=None)
+    review_id: int | None = Field(default=None)
+    image_id: int | None = Field(default=None)
 
     # JSON details with action context
     # Examples:

--- a/app/models/image.py
+++ b/app/models/image.py
@@ -13,7 +13,7 @@ This approach eliminates field duplication while maintaining security boundaries
 
 from datetime import datetime
 from decimal import Decimal
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import TYPE_CHECKING, Any
 
 from pydantic import ConfigDict, field_validator
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from app.models.user import Users
 
 
-class VariantStatus(int, Enum):
+class VariantStatus(IntEnum):
     """
     Status of a medium or large image variant.
 

--- a/app/models/image.py
+++ b/app/models/image.py
@@ -133,6 +133,7 @@ class ImageBase(SQLModel):
         """Validate that status is one of the allowed ImageStatus constants."""
         valid_statuses = {
             ImageStatus.REVIEW,
+            ImageStatus.LOW_QUALITY,
             ImageStatus.INAPPROPRIATE,
             ImageStatus.REPOST,
             ImageStatus.OTHER,
@@ -142,7 +143,7 @@ class ImageBase(SQLModel):
         if v not in valid_statuses:
             raise ValueError(
                 f"Invalid image status: {v}. Must be one of {valid_statuses} "
-                f"(-4=Review, -2=Inappropriate, -1=Repost, 0=Other, 1=Active, 2=Spoiler)"
+                f"(-4=Review, -3=LowQuality, -2=Inappropriate, -1=Repost, 0=Other, 1=Active, 2=Spoiler)"
             )
         return v
 

--- a/app/models/image.py
+++ b/app/models/image.py
@@ -21,6 +21,7 @@ from sqlalchemy import ForeignKeyConstraint, Index, text
 from sqlmodel import Field, Relationship, SQLModel
 
 from app.config import ImageStatus
+from app.core.r2_constants import R2Location
 
 if TYPE_CHECKING:
     from app.models.tag_link import TagLinks
@@ -241,6 +242,10 @@ class Images(ImageBase, table=True):
     # Internal metadata
     total_pixels: Decimal | None = Field(default=None)
     replacement_id: int | None = Field(default=None, foreign_key="images.image_id")
+
+    # R2 sync state. NONE=0 means object is not yet in R2; the finalizer
+    # or `r2_sync.py reconcile` will flip it to PUBLIC or PRIVATE.
+    r2_location: int = Field(default=R2Location.NONE)
 
     # Relationships - Example implementation
     # This demonstrates how to add relationships when needed. Key points:

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, computed_field, field_validator
 
 from app.config import TagType, settings
 from app.core.r2_constants import PUBLIC_IMAGE_STATUSES_FOR_R2, R2Location
-from app.models.image import ImageBase
+from app.models.image import ImageBase, VariantStatus
 from app.schemas.base import UTCDatetime
 from app.schemas.common import UserSummary
 
@@ -131,7 +131,7 @@ class ImageResponse(ImageBase):
         """Medium variant (1280px edge) URL, or None if variant is absent."""
         if not self.medium:
             return None
-        if self._should_use_cdn():
+        if self.medium == VariantStatus.READY and self._should_use_cdn():
             return f"{settings.R2_PUBLIC_CDN_URL}/medium/{self.filename}.{self.ext}"
         return f"{settings.IMAGE_BASE_URL}/medium/{self.filename}.{self.ext}"
 
@@ -141,7 +141,7 @@ class ImageResponse(ImageBase):
         """Large variant (2048px edge) URL, or None if variant is absent."""
         if not self.large:
             return None
-        if self._should_use_cdn():
+        if self.large == VariantStatus.READY and self._should_use_cdn():
             return f"{settings.R2_PUBLIC_CDN_URL}/large/{self.filename}.{self.ext}"
         return f"{settings.IMAGE_BASE_URL}/large/{self.filename}.{self.ext}"
 

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -7,6 +7,7 @@ from typing import Any
 from pydantic import BaseModel, Field, computed_field, field_validator
 
 from app.config import TagType, settings
+from app.core.r2_constants import PUBLIC_IMAGE_STATUSES_FOR_R2, R2Location
 from app.models.image import ImageBase
 from app.schemas.base import UTCDatetime
 from app.schemas.common import UserSummary
@@ -92,35 +93,57 @@ class ImageResponse(ImageBase):
     medium: int
     large: int
     replacement_id: int | None = None  # Original image ID when this is a repost (status=-1)
+    r2_location: int = R2Location.NONE  # Tri-state: 0=NONE, 1=PUBLIC, 2=PRIVATE
 
-    # Computed fields
+    def _should_use_cdn(self) -> bool:
+        """True when we can emit a direct-CDN URL for this image.
+
+        All three must hold: R2 enabled, status is publicly-viewable, and the
+        canonical object lives in the public bucket. A mismatch (e.g., public
+        status but PRIVATE location during a bucket move) falls back to the
+        /images/ path, which the endpoint routes based on current r2_location.
+        """
+        return (
+            settings.R2_ENABLED
+            and self.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+            and self.r2_location == R2Location.PUBLIC
+        )
+
     @computed_field  # type: ignore[prop-decorator]
     @property
     def url(self) -> str:
-        """Generate image URL (protected path with permission check)"""
+        """Fullsize URL — direct CDN when eligible, else protected path."""
+        if self._should_use_cdn():
+            return f"{settings.R2_PUBLIC_CDN_URL}/fullsize/{self.filename}.{self.ext}"
         return f"{settings.IMAGE_BASE_URL}/images/{self.filename}.{self.ext}"
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def thumbnail_url(self) -> str:
-        """Generate thumbnail URL (protected path with permission check)"""
+        """Thumbnail URL (always WebP)."""
+        if self._should_use_cdn():
+            return f"{settings.R2_PUBLIC_CDN_URL}/thumbs/{self.filename}.webp"
         return f"{settings.IMAGE_BASE_URL}/thumbs/{self.filename}.webp"
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def medium_url(self) -> str | None:
-        """Generate medium variant URL (1280px edge, protected path) if available"""
-        if self.medium:
-            return f"{settings.IMAGE_BASE_URL}/medium/{self.filename}.{self.ext}"
-        return None
+        """Medium variant (1280px edge) URL, or None if variant is absent."""
+        if not self.medium:
+            return None
+        if self._should_use_cdn():
+            return f"{settings.R2_PUBLIC_CDN_URL}/medium/{self.filename}.{self.ext}"
+        return f"{settings.IMAGE_BASE_URL}/medium/{self.filename}.{self.ext}"
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def large_url(self) -> str | None:
-        """Generate large variant URL (2048px edge, protected path) if available"""
-        if self.large:
-            return f"{settings.IMAGE_BASE_URL}/large/{self.filename}.{self.ext}"
-        return None
+        """Large variant (2048px edge) URL, or None if variant is absent."""
+        if not self.large:
+            return None
+        if self._should_use_cdn():
+            return f"{settings.R2_PUBLIC_CDN_URL}/large/{self.filename}.{self.ext}"
+        return f"{settings.IMAGE_BASE_URL}/large/{self.filename}.{self.ext}"
 
 
 class ImageDetailedResponse(ImageResponse):

--- a/app/services/cloudflare.py
+++ b/app/services/cloudflare.py
@@ -1,0 +1,62 @@
+"""Cloudflare API helpers.
+
+Currently covers cache purge only. Expand here as more Cloudflare features
+are needed (e.g., WAF, DNS) — don't sprinkle Cloudflare calls across services.
+"""
+
+import httpx
+
+from app.config import settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Free plan caps purge-by-URL calls at 30 URLs per request.
+_BATCH_SIZE = 30
+
+
+async def purge_cache_by_urls(urls: list[str]) -> None:
+    """Purge Cloudflare's edge cache for the given URLs.
+
+    Batches into groups of 30 (free-plan limit). No-op when list is empty.
+    Raises httpx.HTTPStatusError on non-2xx responses so the caller can
+    surface the failure to its retry/alerting machinery.
+    """
+    if not urls:
+        return
+
+    if not settings.CLOUDFLARE_ZONE_ID or not settings.CLOUDFLARE_API_TOKEN:
+        # Fail loudly — a silent no-op here would mask misconfiguration and
+        # stale CDN content for minutes or hours.
+        raise RuntimeError(
+            "purge_cache_by_urls called but CLOUDFLARE_ZONE_ID / "
+            "CLOUDFLARE_API_TOKEN are not configured"
+        )
+
+    api_url = (
+        f"https://api.cloudflare.com/client/v4/zones/{settings.CLOUDFLARE_ZONE_ID}/purge_cache"
+    )
+    headers = {
+        "Authorization": f"Bearer {settings.CLOUDFLARE_API_TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        for start in range(0, len(urls), _BATCH_SIZE):
+            batch = urls[start : start + _BATCH_SIZE]
+            logger.info("r2_cdn_purge_started", batch_size=len(batch))
+            response = await client.post(
+                api_url,
+                json={"files": batch},
+                headers=headers,
+            )
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError:
+                logger.error(
+                    "r2_cdn_purge_failed",
+                    status_code=response.status_code,
+                    body=response.text,
+                )
+                raise
+            logger.info("r2_cdn_purge_succeeded", batch_size=len(batch))

--- a/app/services/cloudflare.py
+++ b/app/services/cloudflare.py
@@ -59,4 +59,11 @@ async def purge_cache_by_urls(urls: list[str]) -> None:
                     body=response.text,
                 )
                 raise
+            body = response.json()
+            if not body.get("success"):
+                logger.error(
+                    "r2_cdn_purge_logical_failure",
+                    errors=body.get("errors"),
+                )
+                raise RuntimeError(f"Cloudflare purge returned success=false: {body.get('errors')}")
             logger.info("r2_cdn_purge_succeeded", batch_size=len(batch))

--- a/app/services/image_status.py
+++ b/app/services/image_status.py
@@ -1,0 +1,32 @@
+"""Side effects for image status transitions.
+
+Currently just the R2 bucket-move enqueue. Any status-change code path must
+route through this helper (or enqueue `sync_image_status_job` directly) so
+the canonical R2 object follows the public/protected boundary — otherwise
+a public→protected transition leaves the image reachable via CDN until the
+edge TTL expires.
+"""
+
+from app.config import settings
+from app.tasks.queue import enqueue_job
+
+
+async def enqueue_r2_sync_on_status_change(
+    image_id: int,
+    old_status: int,
+    new_status: int,
+) -> None:
+    """Enqueue R2 bucket move for an image whose status changed.
+
+    No-op when R2 is disabled or the status is unchanged. MUST be called AFTER
+    the DB commit that persists `new_status`; the worker loads the row in a
+    fresh session and derives the destination bucket from its current status.
+    """
+    if not settings.R2_ENABLED or old_status == new_status:
+        return
+    await enqueue_job(
+        "sync_image_status_job",
+        image_id=image_id,
+        old_status=old_status,
+        new_status=new_status,
+    )

--- a/app/services/image_status.py
+++ b/app/services/image_status.py
@@ -8,6 +8,7 @@ edge TTL expires.
 """
 
 from app.config import settings
+from app.core.r2_constants import PUBLIC_IMAGE_STATUSES_FOR_R2
 from app.tasks.queue import enqueue_job
 
 
@@ -18,11 +19,17 @@ async def enqueue_r2_sync_on_status_change(
 ) -> None:
     """Enqueue R2 bucket move for an image whose status changed.
 
-    No-op when R2 is disabled or the status is unchanged. MUST be called AFTER
-    the DB commit that persists `new_status`; the worker loads the row in a
-    fresh session and derives the destination bucket from its current status.
+    No-op when R2 is disabled, the status is unchanged, or the transition
+    stays on the same side of the public/protected boundary (e.g.
+    ACTIVE→SPOILER, both public) — the worker would early-return in those
+    cases, so skipping here saves an enqueue + DB round-trip per hop. MUST
+    be called AFTER the DB commit that persists `new_status`; the worker
+    loads the row in a fresh session and derives the destination bucket
+    from its current status.
     """
     if not settings.R2_ENABLED or old_status == new_status:
+        return
+    if (old_status in PUBLIC_IMAGE_STATUSES_FOR_R2) == (new_status in PUBLIC_IMAGE_STATUSES_FOR_R2):
         return
     await enqueue_job(
         "sync_image_status_job",

--- a/app/services/r2_storage.py
+++ b/app/services/r2_storage.py
@@ -68,3 +68,31 @@ class R2Storage:
                 Params={"Bucket": bucket, "Key": key},
                 ExpiresIn=ttl,
             )
+
+
+class DummyR2Storage:
+    """No-op R2 storage for R2_ENABLED=false mode.
+
+    Every method raises RuntimeError so any accidental call surfaces
+    loudly rather than silently succeeding.
+    """
+
+    _ERR = (
+        "R2 is disabled (R2_ENABLED=false). This code path should not have "
+        "reached the R2 storage adapter."
+    )
+
+    async def upload_file(self, bucket: str, key: str, path: Path) -> None:
+        raise RuntimeError(self._ERR)
+
+    async def copy_object(self, src_bucket: str, dst_bucket: str, key: str) -> None:
+        raise RuntimeError(self._ERR)
+
+    async def delete_object(self, bucket: str, key: str) -> None:
+        raise RuntimeError(self._ERR)
+
+    async def object_exists(self, bucket: str, key: str) -> bool:
+        raise RuntimeError(self._ERR)
+
+    async def generate_presigned_url(self, bucket: str, key: str, ttl: int) -> str:
+        raise RuntimeError(self._ERR)

--- a/app/services/r2_storage.py
+++ b/app/services/r2_storage.py
@@ -4,14 +4,25 @@ A single shared aioboto3.Session is reused for the life of the app.
 The adapter exposes only the operations the app needs; no leaky AWS details.
 """
 
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
 import aioboto3
+from aiobotocore.config import AioConfig
 
 from app.core.logging import get_logger
 
 logger = get_logger(__name__)
+
+# Bound every R2 request so a stalled connection can't hang the caller forever.
+# read_timeout covers server-side copy_object for large objects too; retries
+# cover transient network blips and 5xx responses from R2's edge.
+_R2_CLIENT_CONFIG = AioConfig(
+    connect_timeout=10,
+    read_timeout=60,
+    retries={"max_attempts": 3, "mode": "standard"},
+)
 
 
 class R2Storage:
@@ -24,19 +35,55 @@ class R2Storage:
     ) -> None:
         self._session = session
         self._endpoint_url = endpoint_url
+        self._shared_client_stack: list[Any] = []
 
     def _client(self) -> Any:
         """Yield a short-lived aioboto3 S3 client (async context manager)."""
-        return self._session.client("s3", endpoint_url=self._endpoint_url)
+        return self._session.client("s3", endpoint_url=self._endpoint_url, config=_R2_CLIENT_CONFIG)
+
+    @asynccontextmanager
+    async def bulk_session(self):  # type: ignore[no-untyped-def]
+        """Open one long-lived client for a burst of R2 ops.
+
+        While active, all R2Storage methods reuse the shared client instead of
+        opening a fresh one per call — eliminating TCP+TLS setup per request.
+        Designed for scripts (split-existing, reconcile) that issue hundreds
+        or thousands of ops in a row; app request paths should not use this.
+        Safe under concurrent coroutine use — aiobotocore clients multiplex.
+        Nests: inner blocks reuse the outer client.
+        """
+        if self._shared_client_stack:
+            # Nested bulk_session: reuse outer client, no new connection.
+            self._shared_client_stack.append(self._shared_client_stack[-1])
+            try:
+                yield
+            finally:
+                self._shared_client_stack.pop()
+            return
+        async with self._client() as s3:
+            self._shared_client_stack.append(s3)
+            try:
+                yield
+            finally:
+                self._shared_client_stack.pop()
+
+    @asynccontextmanager
+    async def _acquire_client(self):  # type: ignore[no-untyped-def]
+        """Yield the bulk-session client if one is active, else a one-shot client."""
+        if self._shared_client_stack:
+            yield self._shared_client_stack[-1]
+            return
+        async with self._client() as s3:
+            yield s3
 
     async def upload_file(self, bucket: str, key: str, path: Path) -> None:
         """Upload a local file to `{bucket}/{key}`."""
-        async with self._client() as s3:
+        async with self._acquire_client() as s3:
             await s3.upload_file(str(path), bucket, key)
 
     async def copy_object(self, src_bucket: str, dst_bucket: str, key: str) -> None:
         """Copy an object between buckets, preserving the key."""
-        async with self._client() as s3:
+        async with self._acquire_client() as s3:
             await s3.copy_object(
                 Bucket=dst_bucket,
                 Key=key,
@@ -45,12 +92,12 @@ class R2Storage:
 
     async def delete_object(self, bucket: str, key: str) -> None:
         """Delete an object. Idempotent — S3 treats missing keys as success."""
-        async with self._client() as s3:
+        async with self._acquire_client() as s3:
             await s3.delete_object(Bucket=bucket, Key=key)
 
     async def object_exists(self, bucket: str, key: str) -> bool:
         """Return True iff the object exists."""
-        async with self._client() as s3:
+        async with self._acquire_client() as s3:
             try:
                 await s3.head_object(Bucket=bucket, Key=key)
                 return True
@@ -63,7 +110,7 @@ class R2Storage:
 
     async def generate_presigned_url(self, bucket: str, key: str, ttl: int) -> str:
         """Generate a short-lived GET URL for a private-bucket object."""
-        async with self._client() as s3:
+        async with self._acquire_client() as s3:
             return await s3.generate_presigned_url(  # type: ignore[no-any-return]
                 ClientMethod="get_object",
                 Params={"Bucket": bucket, "Key": key},
@@ -82,6 +129,11 @@ class DummyR2Storage:
         "R2 is disabled (R2_ENABLED=false). This code path should not have "
         "reached the R2 storage adapter."
     )
+
+    @asynccontextmanager
+    async def bulk_session(self):  # type: ignore[no-untyped-def]
+        raise RuntimeError(self._ERR)
+        yield  # pragma: no cover  (unreachable; satisfies generator typing)
 
     async def upload_file(self, bucket: str, key: str, path: Path) -> None:
         raise RuntimeError(self._ERR)

--- a/app/services/r2_storage.py
+++ b/app/services/r2_storage.py
@@ -5,6 +5,7 @@ The adapter exposes only the operations the app needs; no leaky AWS details.
 """
 
 from pathlib import Path
+from typing import Any
 
 import aioboto3
 
@@ -24,7 +25,7 @@ class R2Storage:
         self._session = session
         self._endpoint_url = endpoint_url
 
-    def _client(self):
+    def _client(self) -> Any:
         """Yield a short-lived aioboto3 S3 client (async context manager)."""
         return self._session.client("s3", endpoint_url=self._endpoint_url)
 
@@ -63,7 +64,7 @@ class R2Storage:
     async def generate_presigned_url(self, bucket: str, key: str, ttl: int) -> str:
         """Generate a short-lived GET URL for a private-bucket object."""
         async with self._client() as s3:
-            return await s3.generate_presigned_url(
+            return await s3.generate_presigned_url(  # type: ignore[no-any-return]
                 ClientMethod="get_object",
                 Params={"Bucket": bucket, "Key": key},
                 ExpiresIn=ttl,

--- a/app/services/r2_storage.py
+++ b/app/services/r2_storage.py
@@ -1,0 +1,70 @@
+"""Thin async wrapper around aioboto3 for Cloudflare R2 (S3-compatible).
+
+A single shared aioboto3.Session is reused for the life of the app.
+The adapter exposes only the operations the app needs; no leaky AWS details.
+"""
+
+from pathlib import Path
+
+import aioboto3
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class R2Storage:
+    """R2 storage adapter. Wraps aioboto3 client calls with our semantics."""
+
+    def __init__(
+        self,
+        session: aioboto3.Session,
+        endpoint_url: str | None,
+    ) -> None:
+        self._session = session
+        self._endpoint_url = endpoint_url
+
+    def _client(self):
+        """Yield a short-lived aioboto3 S3 client (async context manager)."""
+        return self._session.client("s3", endpoint_url=self._endpoint_url)
+
+    async def upload_file(self, bucket: str, key: str, path: Path) -> None:
+        """Upload a local file to `{bucket}/{key}`."""
+        async with self._client() as s3:
+            await s3.upload_file(str(path), bucket, key)
+
+    async def copy_object(self, src_bucket: str, dst_bucket: str, key: str) -> None:
+        """Copy an object between buckets, preserving the key."""
+        async with self._client() as s3:
+            await s3.copy_object(
+                Bucket=dst_bucket,
+                Key=key,
+                CopySource={"Bucket": src_bucket, "Key": key},
+            )
+
+    async def delete_object(self, bucket: str, key: str) -> None:
+        """Delete an object. Idempotent — S3 treats missing keys as success."""
+        async with self._client() as s3:
+            await s3.delete_object(Bucket=bucket, Key=key)
+
+    async def object_exists(self, bucket: str, key: str) -> bool:
+        """Return True iff the object exists."""
+        async with self._client() as s3:
+            try:
+                await s3.head_object(Bucket=bucket, Key=key)
+                return True
+            except s3.exceptions.ClientError as e:
+                # botocore may stringify head_object 404 as "404", "NotFound",
+                # or "NoSuchKey" depending on version — accept all three.
+                if e.response["Error"]["Code"] in {"404", "NotFound", "NoSuchKey"}:
+                    return False
+                raise
+
+    async def generate_presigned_url(self, bucket: str, key: str, ttl: int) -> str:
+        """Generate a short-lived GET URL for a private-bucket object."""
+        async with self._client() as s3:
+            return await s3.generate_presigned_url(
+                ClientMethod="get_object",
+                Params={"Bucket": bucket, "Key": key},
+                ExpiresIn=ttl,
+            )

--- a/app/services/review_jobs.py
+++ b/app/services/review_jobs.py
@@ -48,8 +48,13 @@ async def check_review_deadlines(db: AsyncSession) -> dict[str, Any]:
             "closed": int,
             "extended": int,
             "errors": int,
-            "error_details": list
+            "error_details": list,
+            "transitions": list[tuple[int, int, int]],  # (image_id, old_status, new_status)
         }
+
+    `transitions` surfaces status changes that callers should propagate to the
+    R2 sync queue AFTER committing the outer transaction — see
+    `app/services/image_status.py`.
     """
     results: dict[str, Any] = {
         "processed": 0,
@@ -57,6 +62,7 @@ async def check_review_deadlines(db: AsyncSession) -> dict[str, Any]:
         "extended": 0,
         "errors": 0,
         "error_details": [],
+        "transitions": [],
     }
 
     # Query all open reviews past their deadline
@@ -73,12 +79,14 @@ async def check_review_deadlines(db: AsyncSession) -> dict[str, Any]:
     for review in reviews:
         try:
             async with db.begin_nested():  # Savepoint for each review
-                outcome = await _process_single_review(db, review)
+                outcome, transition = await _process_single_review(db, review)
                 results["processed"] += 1
                 if outcome == "closed":
                     results["closed"] += 1
                 elif outcome == "extended":
                     results["extended"] += 1
+                if transition is not None:
+                    results["transitions"].append(transition)
         except Exception as e:
             results["errors"] += 1
             results["error_details"].append(
@@ -101,7 +109,9 @@ async def check_review_deadlines(db: AsyncSession) -> dict[str, Any]:
     return results
 
 
-async def _process_single_review(db: AsyncSession, review: ImageReviews) -> str:
+async def _process_single_review(
+    db: AsyncSession, review: ImageReviews
+) -> tuple[str, tuple[int, int, int] | None]:
     """
     Process a single expired review.
 
@@ -110,7 +120,9 @@ async def _process_single_review(db: AsyncSession, review: ImageReviews) -> str:
         review: The review to process
 
     Returns:
-        "closed" if review was closed, "extended" if deadline was extended
+        Tuple of (outcome, transition) where outcome is "closed" or "extended"
+        and transition is (image_id, old_status, new_status) when the image
+        status changed, or None otherwise.
     """
     # Count votes by type
     vote_counts = await _get_vote_counts(db, review.review_id)  # type: ignore[arg-type]
@@ -130,16 +142,16 @@ async def _process_single_review(db: AsyncSession, review: ImageReviews) -> str:
     if has_quorum and not is_tie:
         # Has quorum and clear majority - close with outcome
         outcome = ReviewOutcome.KEEP if keep_votes > remove_votes else ReviewOutcome.REMOVE
-        await _close_review(db, review, outcome, "quorum_reached")
-        return "closed"
+        transition = await _close_review(db, review, outcome, "quorum_reached")
+        return "closed", transition
     elif not review.extension_used:
         # No quorum or tie, first time - extend deadline
         await _extend_review(db, review)
-        return "extended"
+        return "extended", None
     else:
         # No quorum or tie after extension - default to keep
-        await _close_review(db, review, ReviewOutcome.KEEP, "default_after_extension")
-        return "closed"
+        transition = await _close_review(db, review, ReviewOutcome.KEEP, "default_after_extension")
+        return "closed", transition
 
 
 async def _get_vote_counts(db: AsyncSession, review_id: int) -> dict[int, int]:
@@ -167,7 +179,7 @@ async def _close_review(
     review: ImageReviews,
     outcome: int,
     reason: str,
-) -> None:
+) -> tuple[int, int, int] | None:
     """
     Close a review and update the image status.
 
@@ -176,6 +188,10 @@ async def _close_review(
         review: The review to close
         outcome: ReviewOutcome value (KEEP or REMOVE)
         reason: Reason for closing (for audit log)
+
+    Returns:
+        (image_id, old_status, new_status) when the image row existed and its
+        status changed. None if the image was not found.
     """
     now = datetime.now(UTC)
 
@@ -186,7 +202,9 @@ async def _close_review(
 
     # Update image status
     image = await db.get(Images, review.image_id)
+    transition: tuple[int, int, int] | None = None
     if image:
+        old_status = image.status
         if outcome == ReviewOutcome.KEEP:
             image.status = ImageStatus.ACTIVE
         else:  # REMOVE
@@ -200,6 +218,7 @@ async def _close_review(
             user_id=None,  # System action
         )
         db.add(status_history)
+        transition = (review.image_id, old_status, image.status)
 
     # Create audit log entry
     action = AdminActions(
@@ -221,6 +240,8 @@ async def _close_review(
         f"Closed review {review.review_id} with outcome "
         f"{'KEEP' if outcome == ReviewOutcome.KEEP else 'REMOVE'} (reason: {reason})"
     )
+
+    return transition
 
 
 async def _extend_review(db: AsyncSession, review: ImageReviews) -> None:
@@ -260,7 +281,7 @@ async def _extend_review(db: AsyncSession, review: ImageReviews) -> None:
     )
 
 
-async def check_early_close(db: AsyncSession, review: ImageReviews) -> bool:
+async def check_early_close(db: AsyncSession, review: ImageReviews) -> tuple[int, int, int] | None:
     """
     Check if a review should be closed early based on vote margin.
 
@@ -272,27 +293,29 @@ async def check_early_close(db: AsyncSession, review: ImageReviews) -> bool:
         review: The review to check
 
     Returns:
-        True if the review was closed, False otherwise
+        (image_id, old_status, new_status) if the review was closed and the
+        image's status changed — callers must pass this to
+        `enqueue_r2_sync_on_status_change` after committing. None if the
+        review was not closed (no quorum / tie / already closed).
     """
     # Re-read review to guard against concurrent close by another request/job
     await db.refresh(review)
     if review.status != ReviewStatus.OPEN:
-        return False
+        return None
 
     vote_counts = await _get_vote_counts(db, review.review_id)  # type: ignore[arg-type]
     keep_votes = vote_counts.get(1, 0)
     remove_votes = vote_counts.get(0, 0)
 
     if keep_votes == remove_votes:
-        return False
+        return None
 
     margin = abs(keep_votes - remove_votes)
     if margin < settings.REVIEW_EARLY_CLOSE_MARGIN:
-        return False
+        return None
 
     outcome = ReviewOutcome.KEEP if keep_votes > remove_votes else ReviewOutcome.REMOVE
-    await _close_review(db, review, outcome, "early_close_margin")
-    return True
+    return await _close_review(db, review, outcome, "early_close_margin")
 
 
 async def prune_admin_actions(

--- a/app/tasks/r2_jobs.py
+++ b/app/tasks/r2_jobs.py
@@ -240,7 +240,7 @@ async def sync_image_status_job(
             .values(r2_location=dst_location)
         )
         await db.commit()
-        if result.rowcount == 0:
+        if result.rowcount == 0:  # type: ignore[attr-defined]
             logger.warning(
                 "r2_status_sync_clobbered",
                 image_id=image_id,

--- a/app/tasks/r2_jobs.py
+++ b/app/tasks/r2_jobs.py
@@ -101,6 +101,9 @@ async def r2_finalize_upload_job(ctx: dict[str, Any], image_id: int) -> dict[str
         r2 = get_r2_storage()
         for variant in variants:
             key = _variant_key(image, variant)
+            if await r2.object_exists(bucket=bucket, key=key):
+                logger.info("r2_upload_skipped_exists", image_id=image_id, key=key)
+                continue
             path = _local_path(image, variant)
             logger.info(
                 "r2_upload_started",
@@ -178,19 +181,18 @@ async def sync_image_status_job(
             )
             return {"skipped": "not_finalized"}
 
-        old_public = old_status in PUBLIC_IMAGE_STATUSES_FOR_R2
-        new_public = new_status in PUBLIC_IMAGE_STATUSES_FOR_R2
-        if old_public == new_public:
-            return {"skipped": "no_bucket_move"}
+        # Derive desired location from *current* DB status, not from the
+        # enqueued old/new args which may be stale if status changed again.
+        dst_location = _location_for_status(image.status)
+        if image.r2_location == dst_location:
+            return {"skipped": "already_correct"}
 
-        if old_public:
+        if image.r2_location == R2Location.PUBLIC:
             src_bucket = settings.R2_PUBLIC_BUCKET
             dst_bucket = settings.R2_PRIVATE_BUCKET
-            dst_location = R2Location.PRIVATE
         else:
             src_bucket = settings.R2_PRIVATE_BUCKET
             dst_bucket = settings.R2_PUBLIC_BUCKET
-            dst_location = R2Location.PUBLIC
 
         variants = _expected_variants(image)
         r2 = get_r2_storage()
@@ -236,7 +238,7 @@ async def sync_image_status_job(
 
     # Purge CDN when going public → protected. Do this after the DB flip and
     # outside the DB transaction; a purge failure doesn't roll back the move.
-    if old_public and moved_variants:
+    if dst_location == R2Location.PRIVATE and moved_variants:
         try:
             await purge_cache_by_urls(_cdn_urls_for(image, moved_variants))
         except Exception as e:

--- a/app/tasks/r2_jobs.py
+++ b/app/tasks/r2_jobs.py
@@ -15,6 +15,7 @@ from app.core.r2_constants import (
     R2Location,
 )
 from app.models.image import Images, VariantStatus
+from app.services.cloudflare import purge_cache_by_urls
 
 logger = get_logger(__name__)
 
@@ -132,3 +133,117 @@ async def r2_finalize_upload_job(ctx: dict[str, Any], image_id: int) -> dict[str
         r2_location=int(new_location),
     )
     return {"r2_location": int(new_location)}
+
+
+def _cdn_urls_for(image: Images, variants: list[str]) -> list[str]:
+    """Build the public-CDN URLs for the given variants of an image."""
+    urls: list[str] = []
+    for variant in variants:
+        key = _variant_key(image, variant)
+        urls.append(f"{settings.R2_PUBLIC_CDN_URL}/{key}")
+    return urls
+
+
+async def sync_image_status_job(
+    ctx: dict[str, Any],
+    image_id: int,
+    old_status: int,
+    new_status: int,
+) -> dict[str, Any]:
+    """Move an image's R2 objects when its status transitions across
+    the public/protected boundary.
+
+    - Early-return if r2_location=NONE (finalizer owns first-sync).
+    - Early-return if both old and new statuses are on the same side
+      of the public/protected boundary.
+    - Otherwise: copy each existing variant to destination bucket, verify,
+      delete from source. Atomically flip r2_location. If moving
+      public → protected, purge the CDN URLs so nobody can fetch the old
+      copy from edge cache.
+    """
+    bind_context(task="r2_status_sync", image_id=image_id)
+
+    if not settings.R2_ENABLED:
+        return {"skipped": "disabled"}
+
+    async with get_async_session() as db:
+        result = await db.execute(select(Images).where(Images.image_id == image_id))
+        image = result.scalar_one_or_none()
+        if image is None:
+            return {"skipped": "image_missing"}
+        if image.r2_location == R2Location.NONE:
+            logger.debug(
+                "r2_status_sync_skipped_not_finalized",
+                image_id=image_id,
+            )
+            return {"skipped": "not_finalized"}
+
+        old_public = old_status in PUBLIC_IMAGE_STATUSES_FOR_R2
+        new_public = new_status in PUBLIC_IMAGE_STATUSES_FOR_R2
+        if old_public == new_public:
+            return {"skipped": "no_bucket_move"}
+
+        if old_public:
+            src_bucket = settings.R2_PUBLIC_BUCKET
+            dst_bucket = settings.R2_PRIVATE_BUCKET
+            dst_location = R2Location.PRIVATE
+        else:
+            src_bucket = settings.R2_PRIVATE_BUCKET
+            dst_bucket = settings.R2_PUBLIC_BUCKET
+            dst_location = R2Location.PUBLIC
+
+        variants = _expected_variants(image)
+        r2 = get_r2_storage()
+
+        logger.info(
+            "r2_status_transition_started",
+            image_id=image_id,
+            src=src_bucket,
+            dst=dst_bucket,
+        )
+
+        moved_variants: list[str] = []
+        for variant in variants:
+            key = _variant_key(image, variant)
+            if not await r2.object_exists(bucket=src_bucket, key=key):
+                logger.warning(
+                    "r2_status_sync_source_missing",
+                    image_id=image_id,
+                    bucket=src_bucket,
+                    key=key,
+                )
+                continue
+            await r2.copy_object(src_bucket=src_bucket, dst_bucket=dst_bucket, key=key)
+            if not await r2.object_exists(bucket=dst_bucket, key=key):
+                raise RuntimeError(f"Copy succeeded but {dst_bucket}/{key} does not exist")
+            await r2.delete_object(bucket=src_bucket, key=key)
+            moved_variants.append(variant)
+
+        # Atomic flip
+        await db.execute(
+            update(Images).where(Images.image_id == image_id).values(r2_location=dst_location)
+        )
+        await db.commit()
+
+    # Purge CDN when going public → protected. Do this after the DB flip and
+    # outside the DB transaction; a purge failure doesn't roll back the move.
+    if old_public and moved_variants:
+        try:
+            await purge_cache_by_urls(_cdn_urls_for(image, moved_variants))
+        except Exception as e:
+            logger.error(
+                "r2_cdn_purge_failed_post_transition",
+                image_id=image_id,
+                error=str(e),
+            )
+            # Don't re-raise — the bucket move already committed.
+
+    logger.info(
+        "r2_status_transition_completed",
+        image_id=image_id,
+        moved_variants=moved_variants,
+    )
+    return {
+        "moved_variants": moved_variants,
+        "r2_location": int(dst_location),
+    }

--- a/app/tasks/r2_jobs.py
+++ b/app/tasks/r2_jobs.py
@@ -219,6 +219,15 @@ async def sync_image_status_job(
             await r2.delete_object(bucket=src_bucket, key=key)
             moved_variants.append(variant)
 
+        if not moved_variants:
+            logger.warning(
+                "r2_status_sync_nothing_moved",
+                image_id=image_id,
+                src=src_bucket,
+                dst=dst_bucket,
+            )
+            return {"skipped": "no_objects_moved"}
+
         # Atomic flip
         await db.execute(
             update(Images).where(Images.image_id == image_id).values(r2_location=dst_location)  # type: ignore[arg-type]

--- a/app/tasks/r2_jobs.py
+++ b/app/tasks/r2_jobs.py
@@ -217,15 +217,23 @@ async def sync_image_status_job(
         )
 
         moved_variants: list[str] = []
+        already_at_dst: list[str] = []
         for variant in variants:
             key = _variant_key(image, variant)
-            if not await r2.object_exists(bucket=src_bucket, key=key):
-                logger.warning(
-                    "r2_status_sync_source_missing",
-                    image_id=image_id,
-                    bucket=src_bucket,
-                    key=key,
-                )
+            src_exists = await r2.object_exists(bucket=src_bucket, key=key)
+            if not src_exists:
+                # Check if a previous attempt already moved this object. Treat
+                # that as "already moved" so we still commit the DB flip and
+                # don't leave r2_location stuck on src_location.
+                if await r2.object_exists(bucket=dst_bucket, key=key):
+                    already_at_dst.append(variant)
+                else:
+                    logger.warning(
+                        "r2_status_sync_source_missing",
+                        image_id=image_id,
+                        bucket=src_bucket,
+                        key=key,
+                    )
                 continue
             await r2.copy_object(src_bucket=src_bucket, dst_bucket=dst_bucket, key=key)
             if not await r2.object_exists(bucket=dst_bucket, key=key):
@@ -233,7 +241,8 @@ async def sync_image_status_job(
             await r2.delete_object(bucket=src_bucket, key=key)
             moved_variants.append(variant)
 
-        if not moved_variants:
+        effective_variants = moved_variants + already_at_dst
+        if not effective_variants:
             logger.warning(
                 "r2_status_sync_nothing_moved",
                 image_id=image_id,
@@ -242,12 +251,21 @@ async def sync_image_status_job(
             )
             return {"skipped": "no_objects_moved"}
 
-        missing_variants = set(variants) - set(moved_variants)
+        if already_at_dst:
+            logger.info(
+                "r2_status_sync_replay_detected",
+                image_id=image_id,
+                already_at_dst=already_at_dst,
+                moved=moved_variants,
+            )
+
+        missing_variants = set(variants) - set(effective_variants)
         if missing_variants:
             logger.warning(
                 "r2_status_sync_partial_move",
                 image_id=image_id,
                 moved=moved_variants,
+                already_at_dst=already_at_dst,
                 missing=sorted(missing_variants),
             )
 
@@ -270,9 +288,11 @@ async def sync_image_status_job(
 
     # Purge CDN when going public → protected. Do this after the DB flip and
     # outside the DB transaction; a purge failure doesn't roll back the move.
-    if dst_location == R2Location.PRIVATE and moved_variants:
+    # Include already_at_dst variants: on replay the prior run may have died
+    # before purging, so redo it (purge is idempotent).
+    if dst_location == R2Location.PRIVATE and effective_variants:
         try:
-            await purge_cache_by_urls(_cdn_urls_for(image, moved_variants))
+            await purge_cache_by_urls(_cdn_urls_for(image, effective_variants))
         except Exception as e:
             logger.error(
                 "r2_cdn_purge_failed_post_transition",

--- a/app/tasks/r2_jobs.py
+++ b/app/tasks/r2_jobs.py
@@ -166,7 +166,8 @@ async def sync_image_status_job(
     """Move an image's R2 objects when its status transitions across
     the public/protected boundary.
 
-    - Early-return if r2_location=NONE (finalizer owns first-sync).
+    - Retry if r2_location=NONE (finalizer hasn't finished yet; once it
+      flips r2_location we can move the objects to the correct bucket).
     - Early-return if both old and new statuses are on the same side
       of the public/protected boundary.
     - Otherwise: copy each existing variant to destination bucket, verify,
@@ -185,11 +186,11 @@ async def sync_image_status_job(
         if image is None:
             return {"skipped": "image_missing"}
         if image.r2_location == R2Location.NONE:
-            logger.debug(
-                "r2_status_sync_skipped_not_finalized",
+            logger.info(
+                "r2_status_sync_deferred_not_finalized",
                 image_id=image_id,
             )
-            return {"skipped": "not_finalized"}
+            raise Retry(defer=30)
 
         # Derive desired location from *current* DB status, not from the
         # enqueued old/new args which may be stale if status changed again.

--- a/app/tasks/r2_jobs.py
+++ b/app/tasks/r2_jobs.py
@@ -184,10 +184,11 @@ async def sync_image_status_job(
         # Derive desired location from *current* DB status, not from the
         # enqueued old/new args which may be stale if status changed again.
         dst_location = _location_for_status(image.status)
-        if image.r2_location == dst_location:
+        src_location = image.r2_location
+        if src_location == dst_location:
             return {"skipped": "already_correct"}
 
-        if image.r2_location == R2Location.PUBLIC:
+        if src_location == R2Location.PUBLIC:
             src_bucket = settings.R2_PUBLIC_BUCKET
             dst_bucket = settings.R2_PRIVATE_BUCKET
         else:
@@ -230,11 +231,22 @@ async def sync_image_status_job(
             )
             return {"skipped": "no_objects_moved"}
 
-        # Atomic flip
-        await db.execute(
-            update(Images).where(Images.image_id == image_id).values(r2_location=dst_location)  # type: ignore[arg-type]
+        # Conditional flip — only update if r2_location hasn't changed since
+        # we read it, avoiding clobbering a concurrent status transition.
+        result = await db.execute(
+            update(Images)
+            .where(Images.image_id == image_id)  # type: ignore[arg-type]
+            .where(Images.r2_location == src_location)  # type: ignore[arg-type]
+            .values(r2_location=dst_location)
         )
         await db.commit()
+        if result.rowcount == 0:
+            logger.warning(
+                "r2_status_sync_clobbered",
+                image_id=image_id,
+                expected_src=int(src_location),
+            )
+            return {"skipped": "concurrent_update"}
 
     # Purge CDN when going public → protected. Do this after the DB flip and
     # outside the DB transaction; a purge failure doesn't roll back the move.

--- a/app/tasks/r2_jobs.py
+++ b/app/tasks/r2_jobs.py
@@ -122,13 +122,19 @@ async def r2_finalize_upload_job(ctx: dict[str, Any], image_id: int) -> dict[str
         # Atomic flip. Re-check r2_location to avoid clobbering a concurrent
         # finalize (arq at-most-once + DB row as lock).
         new_location = _location_for_status(image.status)
-        await db.execute(
+        result = await db.execute(
             update(Images)
             .where(Images.image_id == image_id)  # type: ignore[arg-type]
             .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
             .values(r2_location=new_location)
         )
         await db.commit()
+        if result.rowcount == 0:  # type: ignore[attr-defined]
+            logger.warning(
+                "r2_finalize_clobbered",
+                image_id=image_id,
+            )
+            return {"skipped": "concurrent_update"}
 
     logger.info(
         "r2_finalize_succeeded",
@@ -230,6 +236,15 @@ async def sync_image_status_job(
                 dst=dst_bucket,
             )
             return {"skipped": "no_objects_moved"}
+
+        missing_variants = set(variants) - set(moved_variants)
+        if missing_variants:
+            logger.warning(
+                "r2_status_sync_partial_move",
+                image_id=image_id,
+                moved=moved_variants,
+                missing=sorted(missing_variants),
+            )
 
         # Conditional flip — only update if r2_location hasn't changed since
         # we read it, avoiding clobbering a concurrent status transition.

--- a/app/tasks/r2_jobs.py
+++ b/app/tasks/r2_jobs.py
@@ -1,0 +1,134 @@
+"""ARQ jobs for R2 sync: finalize, status transitions, deletions."""
+
+from pathlib import Path as FilePath
+from typing import Any
+
+from arq import Retry
+from sqlalchemy import select, update
+
+from app.config import settings
+from app.core.database import get_async_session
+from app.core.logging import bind_context, get_logger
+from app.core.r2_client import get_r2_storage
+from app.core.r2_constants import (
+    PUBLIC_IMAGE_STATUSES_FOR_R2,
+    R2Location,
+)
+from app.models.image import Images, VariantStatus
+
+logger = get_logger(__name__)
+
+
+def _bucket_for_status(status: int) -> str:
+    """Public bucket for public statuses, private bucket otherwise."""
+    return (
+        settings.R2_PUBLIC_BUCKET
+        if status in PUBLIC_IMAGE_STATUSES_FOR_R2
+        else settings.R2_PRIVATE_BUCKET
+    )
+
+
+def _location_for_status(status: int) -> R2Location:
+    return R2Location.PUBLIC if status in PUBLIC_IMAGE_STATUSES_FOR_R2 else R2Location.PRIVATE
+
+
+def _expected_variants(image: Images) -> list[str]:
+    """Variants that should exist on disk for this image."""
+    variants = ["fullsize", "thumbs"]
+    if image.medium == VariantStatus.READY:
+        variants.append("medium")
+    if image.large == VariantStatus.READY:
+        variants.append("large")
+    return variants
+
+
+def _variant_key(image: Images, variant: str) -> str:
+    ext = "webp" if variant == "thumbs" else image.ext
+    return f"{variant}/{image.filename}.{ext}"
+
+
+def _local_path(image: Images, variant: str) -> FilePath:
+    ext = "webp" if variant == "thumbs" else image.ext
+    return FilePath(settings.STORAGE_PATH) / variant / f"{image.filename}.{ext}"
+
+
+async def r2_finalize_upload_job(ctx: dict[str, Any], image_id: int) -> dict[str, Any]:
+    """First-time sync of a newly uploaded image to R2.
+
+    - Reads current image row to pick the right bucket based on status.
+    - Verifies all expected variant files exist on disk; retries if any are missing.
+    - Uploads every expected variant to the chosen bucket.
+    - Atomically flips r2_location to PUBLIC or PRIVATE.
+
+    No-ops when R2 is disabled or the image is already synced.
+    """
+    bind_context(task="r2_finalize_upload", image_id=image_id)
+
+    if not settings.R2_ENABLED:
+        logger.debug("r2_finalize_skipped_disabled", image_id=image_id)
+        return {"skipped": "disabled"}
+
+    async with get_async_session() as db:
+        result = await db.execute(select(Images).where(Images.image_id == image_id))
+        image = result.scalar_one_or_none()
+        if image is None:
+            logger.warning("r2_finalize_image_missing", image_id=image_id)
+            return {"skipped": "image_missing"}
+        if image.r2_location != R2Location.NONE:
+            logger.debug(
+                "r2_finalize_skipped_already_synced",
+                image_id=image_id,
+                r2_location=image.r2_location,
+            )
+            return {"skipped": "already_synced"}
+
+        variants = _expected_variants(image)
+        # Verify all expected files exist — otherwise let the job retry so
+        # in-flight variant jobs have time to complete.
+        for variant in variants:
+            path = _local_path(image, variant)
+            if not path.exists():
+                logger.info(
+                    "r2_finalize_retry_missing_variant",
+                    image_id=image_id,
+                    variant=variant,
+                    path=str(path),
+                )
+                raise Retry(defer=ctx.get("job_try", 1) * 30)
+
+        bucket = _bucket_for_status(image.status)
+        r2 = get_r2_storage()
+        for variant in variants:
+            key = _variant_key(image, variant)
+            path = _local_path(image, variant)
+            logger.info(
+                "r2_upload_started",
+                image_id=image_id,
+                bucket=bucket,
+                key=key,
+            )
+            await r2.upload_file(bucket=bucket, key=key, path=path)
+            logger.info(
+                "r2_upload_succeeded",
+                image_id=image_id,
+                bucket=bucket,
+                key=key,
+            )
+
+        # Atomic flip. Re-check r2_location to avoid clobbering a concurrent
+        # finalize (arq at-most-once + DB row as lock).
+        new_location = _location_for_status(image.status)
+        await db.execute(
+            update(Images)
+            .where(Images.image_id == image_id)
+            .where(Images.r2_location == R2Location.NONE)
+            .values(r2_location=new_location)
+        )
+        await db.commit()
+
+    logger.info(
+        "r2_finalize_succeeded",
+        image_id=image_id,
+        r2_location=int(new_location),
+    )
+    return {"r2_location": int(new_location)}

--- a/app/tasks/r2_jobs.py
+++ b/app/tasks/r2_jobs.py
@@ -247,3 +247,54 @@ async def sync_image_status_job(
         "moved_variants": moved_variants,
         "r2_location": int(dst_location),
     }
+
+
+async def r2_delete_image_job(
+    ctx: dict[str, Any],
+    image_id: int,
+    r2_location: int,
+    filename: str,
+    ext: str,
+    variants: list[str],
+) -> dict[str, Any]:
+    """Delete an image's R2 objects after hard-deletion of the DB row.
+
+    Arguments are denormalised (filename, ext, variants list) because the DB
+    row is already gone by the time this runs. `r2_location` tells us which
+    bucket the canonical copy lived in; NONE means nothing to do.
+    """
+    bind_context(task="r2_delete_image", image_id=image_id)
+
+    if not settings.R2_ENABLED:
+        return {"skipped": "disabled"}
+    if r2_location == R2Location.NONE:
+        return {"skipped": "never_in_r2"}
+
+    bucket = (
+        settings.R2_PUBLIC_BUCKET
+        if r2_location == R2Location.PUBLIC
+        else settings.R2_PRIVATE_BUCKET
+    )
+
+    r2 = get_r2_storage()
+    keys: list[str] = []
+    for variant in variants:
+        variant_ext = "webp" if variant == "thumbs" else ext
+        keys.append(f"{variant}/{filename}.{variant_ext}")
+
+    for key in keys:
+        await r2.delete_object(bucket=bucket, key=key)
+        logger.info("r2_object_deleted", image_id=image_id, bucket=bucket, key=key)
+
+    if r2_location == R2Location.PUBLIC:
+        urls = [f"{settings.R2_PUBLIC_CDN_URL}/{k}" for k in keys]
+        try:
+            await purge_cache_by_urls(urls)
+        except Exception as e:
+            logger.error(
+                "r2_cdn_purge_failed_post_delete",
+                image_id=image_id,
+                error=str(e),
+            )
+
+    return {"deleted_keys": keys}

--- a/app/tasks/r2_jobs.py
+++ b/app/tasks/r2_jobs.py
@@ -70,7 +70,7 @@ async def r2_finalize_upload_job(ctx: dict[str, Any], image_id: int) -> dict[str
         return {"skipped": "disabled"}
 
     async with get_async_session() as db:
-        result = await db.execute(select(Images).where(Images.image_id == image_id))
+        result = await db.execute(select(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
         image = result.scalar_one_or_none()
         if image is None:
             logger.warning("r2_finalize_image_missing", image_id=image_id)
@@ -121,8 +121,8 @@ async def r2_finalize_upload_job(ctx: dict[str, Any], image_id: int) -> dict[str
         new_location = _location_for_status(image.status)
         await db.execute(
             update(Images)
-            .where(Images.image_id == image_id)
-            .where(Images.r2_location == R2Location.NONE)
+            .where(Images.image_id == image_id)  # type: ignore[arg-type]
+            .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
             .values(r2_location=new_location)
         )
         await db.commit()
@@ -167,7 +167,7 @@ async def sync_image_status_job(
         return {"skipped": "disabled"}
 
     async with get_async_session() as db:
-        result = await db.execute(select(Images).where(Images.image_id == image_id))
+        result = await db.execute(select(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
         image = result.scalar_one_or_none()
         if image is None:
             return {"skipped": "image_missing"}
@@ -221,7 +221,7 @@ async def sync_image_status_job(
 
         # Atomic flip
         await db.execute(
-            update(Images).where(Images.image_id == image_id).values(r2_location=dst_location)
+            update(Images).where(Images.image_id == image_id).values(r2_location=dst_location)  # type: ignore[arg-type]
         )
         await db.commit()
 

--- a/app/tasks/r2_jobs.py
+++ b/app/tasks/r2_jobs.py
@@ -34,11 +34,15 @@ def _location_for_status(status: int) -> R2Location:
 
 
 def _expected_variants(image: Images) -> list[str]:
-    """Variants that should exist on disk for this image."""
+    """Variants that should exist on disk for this image.
+
+    Includes PENDING variants so the finalize job retries until they are
+    generated and uploaded, rather than marking the image synced too early.
+    """
     variants = ["fullsize", "thumbs"]
-    if image.medium == VariantStatus.READY:
+    if image.medium in (VariantStatus.PENDING, VariantStatus.READY):
         variants.append("medium")
-    if image.large == VariantStatus.READY:
+    if image.large in (VariantStatus.PENDING, VariantStatus.READY):
         variants.append("large")
     return variants
 

--- a/app/tasks/worker.py
+++ b/app/tasks/worker.py
@@ -21,6 +21,7 @@ from arq.worker import func
 
 from app.config import settings
 from app.core.database import get_async_session
+from app.services.image_status import enqueue_r2_sync_on_status_change
 from app.services.review_jobs import check_review_deadlines
 from app.services.user_cleanup import cleanup_unverified_accounts
 from app.tasks.email_jobs import send_password_reset_email_job, send_verification_email_job
@@ -71,6 +72,11 @@ async def process_review_deadlines(ctx: dict[str, Any]) -> None:
         try:
             results = await check_review_deadlines(db)
             await db.commit()
+            # Enqueue R2 bucket moves AFTER the commit — the worker that runs
+            # sync_image_status_job loads the row in a fresh session and needs
+            # to see the post-transition status.
+            for image_id, old_status, new_status in results.get("transitions", []):
+                await enqueue_r2_sync_on_status_change(image_id, old_status, new_status)
             logger.info(
                 "review_deadline_job_complete",
                 processed=results["processed"],

--- a/app/tasks/worker.py
+++ b/app/tasks/worker.py
@@ -30,6 +30,11 @@ from app.tasks.image_jobs import (
     create_variant_job,
 )
 from app.tasks.pm_jobs import send_pm_notification
+from app.tasks.r2_jobs import (
+    r2_delete_image_job,
+    r2_finalize_upload_job,
+    sync_image_status_job,
+)
 from app.tasks.rating_jobs import recalculate_rating_job
 
 
@@ -122,6 +127,9 @@ class WorkerSettings:
         func(send_pm_notification, max_tries=3),
         func(send_verification_email_job, max_tries=3),
         func(send_password_reset_email_job, max_tries=3),
+        func(r2_finalize_upload_job, max_tries=5),
+        func(sync_image_status_job, max_tries=settings.ARQ_MAX_TRIES),
+        func(r2_delete_image_job, max_tries=settings.ARQ_MAX_TRIES),
     ]
 
     cron_jobs = [

--- a/docs/image-serving-nginx.md
+++ b/docs/image-serving-nginx.md
@@ -76,7 +76,7 @@ The frontend uses URLs returned by the API directly:
 
 ```svelte
 <a href={data.image.url}>
-  <img src={data.image.thumbnail_url} alt={`Image ${img.image_id}`} />
+  <img src={data.image.thumbnail_url} alt={`Image ${data.image.image_id}`} />
 </a>
 ```
 

--- a/docs/image-serving-nginx.md
+++ b/docs/image-serving-nginx.md
@@ -2,22 +2,28 @@
 
 ## Overview
 
-Images are served directly by nginx for optimal performance, rather than going through the FastAPI application server. This approach:
+All image requests (`/images/*`, `/thumbs/*`, `/medium/*`, `/large/*`) are
+proxied through FastAPI for permission checks before serving. FastAPI decides
+the serving method:
 
-- **Reduces FastAPI load** - Static files don't consume application resources
-- **Improves performance** - nginx is highly optimized for static file serving
-- **Enables caching** - Long cache headers (1 year) for immutable image files
-- **Scales better** - Can add CDN or separate image servers later
+- **X-Accel-Redirect** to an internal nginx location (local filesystem)
+- **302 redirect** to a CDN URL or presigned R2 URL (when `R2_ENABLED=true`)
+
+This approach ensures permission checks are always enforced while keeping
+nginx responsible for actual file serving in the local-FS path.
 
 ## Architecture
 
 ```
 Client Request
     ↓
-nginx (port 80/3000)
-    ├─ /api/v1/* → FastAPI (port 8000)
-    └─ /storage/fullsize/* → Filesystem (/shuushuu/images/fullsize/)
-    └─ /storage/thumbs/* → Filesystem (/shuushuu/images/thumbs/)
+nginx (port 80/443)
+    ├─ /api/v1/*                → FastAPI (port 8000)
+    ├─ /images/{filename}       → FastAPI (permission check)
+    ├─ /thumbs/{filename}       → FastAPI (permission check)
+    ├─ /medium/{filename}       → FastAPI (permission check)
+    ├─ /large/{filename}        → FastAPI (permission check)
+    └─ /internal/{type}/*       → Filesystem (internal only, via X-Accel-Redirect)
 ```
 
 ## Configuration
@@ -29,220 +35,164 @@ nginx (port 80/3000)
 IMAGE_BASE_URL: str = "http://localhost:3000"
 ```
 
-This setting controls the base URL prepended to image paths in API responses.
-
-**Environment Variable:**
-```bash
-IMAGE_BASE_URL=http://localhost:3000  # Development
-IMAGE_BASE_URL=https://your-domain.com  # Production
-IMAGE_BASE_URL=https://cdn.your-domain.com  # With CDN
-```
+This setting controls the base URL prepended to image paths in API responses
+when R2 is disabled or the image hasn't been synced to R2 yet.
 
 **File: `app/schemas/image.py`**
+
+URL generation uses computed fields that route based on R2 state:
+
 ```python
+def _should_use_cdn(self) -> bool:
+    """Direct-CDN URL when R2 enabled, status is public, and object is in public bucket."""
+    return (
+        settings.R2_ENABLED
+        and self.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+        and self.r2_location == R2Location.PUBLIC
+    )
+
 @computed_field
 @property
 def url(self) -> str:
-    """Generate image URL"""
-    return f"{settings.IMAGE_BASE_URL}/storage/fullsize/{self.filename}.{self.ext}"
+    if self._should_use_cdn():
+        return f"{settings.R2_PUBLIC_CDN_URL}/fullsize/{self.filename}.{self.ext}"
+    return f"{settings.IMAGE_BASE_URL}/images/{self.filename}.{self.ext}"
 
 @computed_field
 @property
 def thumbnail_url(self) -> str:
-    """Generate thumbnail URL"""
-    return f"{settings.IMAGE_BASE_URL}/storage/thumbs/{self.filename}.jpeg"
+    if self._should_use_cdn():
+        return f"{settings.R2_PUBLIC_CDN_URL}/thumbs/{self.filename}.webp"
+    return f"{settings.IMAGE_BASE_URL}/thumbs/{self.filename}.webp"
 ```
 
-These computed fields generate complete URLs that the frontend can use directly.
-
-### Nginx
-
-**File: `docker/nginx/frontend.conf.template`**
-```nginx
-# Serve images directly from storage
-location ^~ /storage/fullsize/ {
-    alias ${STORAGE_PATH}/fullsize/;
-    autoindex off;
-    expires 1y;
-    add_header Cache-Control "public, immutable";
-}
-
-location ^~ /storage/thumbs/ {
-    alias ${STORAGE_PATH}/thumbs/;
-    autoindex off;
-    expires 1y;
-    add_header Cache-Control "public, immutable";
-}
-```
-
-The `^~` prefix gives these locations priority over regex locations.
+Medium/large variants only use CDN URLs when the variant status is `READY`
+(not `PENDING`), so the media endpoint's fullsize fallback works during
+variant generation.
 
 ### Frontend (SvelteKit)
 
-The frontend simply uses the URLs returned by the API:
+The frontend uses URLs returned by the API directly:
 
 ```svelte
-<!-- Image detail page -->
 <a href={data.image.url}>
-  <img src={data.image.thumbnail_url} alt={data.image.title} />
+  <img src={data.image.thumbnail_url} alt={`Image ${img.image_id}`} />
 </a>
-
-<!-- Gallery page -->
-<img src={img.thumbnail_url} alt={`Image ${img.image_id}`} />
 ```
 
-No manual URL construction needed - the API provides complete URLs.
+No manual URL construction needed.
 
-## API Response Example
+### API Response Example
 
 ```json
 {
   "image_id": 1111520,
   "filename": "2024-11-15-1111520",
   "ext": "jpeg",
-  "url": "http://localhost:3000/storage/fullsize/2024-11-15-1111520.jpeg",
-  "thumbnail_url": "http://localhost:3000/storage/thumbs/2024-11-15-1111520.jpeg",
+  "url": "http://localhost:3000/images/2024-11-15-1111520.jpeg",
+  "thumbnail_url": "http://localhost:3000/thumbs/2024-11-15-1111520.webp",
+  "medium_url": "http://localhost:3000/medium/2024-11-15-1111520.jpeg",
+  "large_url": null,
   ...
 }
 ```
 
-## Deployment Considerations
+When R2 is enabled and the image is in the public bucket:
 
-### Development
-- Images served via nginx on port 3000
-- `IMAGE_BASE_URL=http://localhost:3000`
-
-### Production
-- Configure nginx to serve images from filesystem or mounted volume
-- Set `IMAGE_BASE_URL` to your domain (e.g., `https://e-shuushuu.net`)
-- Consider adding a CDN for global distribution
-
-### CDN Integration
-To serve images from a CDN:
-
-1. Sync images to CDN storage (S3, Cloudflare R2, etc.)
-2. Set `IMAGE_BASE_URL=https://cdn.your-domain.com`
-3. Images will automatically use CDN URLs in API responses
-
-No frontend changes needed - it just uses whatever URLs the API provides.
-
-## Cache Headers
-
-Images use aggressive caching since they're immutable (filename includes upload date):
-
-```nginx
-expires 1y;
-add_header Cache-Control "public, immutable";
+```json
+{
+  "url": "https://cdn.e-shuushuu.net/fullsize/2024-11-15-1111520.jpeg",
+  "thumbnail_url": "https://cdn.e-shuushuu.net/thumbs/2024-11-15-1111520.webp",
+  ...
+}
 ```
 
-This means:
-- Browsers cache for 1 year
-- `immutable` tells browsers the file will never change
-- Reduces bandwidth and improves load times
+## URL Patterns
 
-## Protected Image Serving (Visibility Control)
-
-Some images require permission checks before serving (e.g., images under review, flagged inappropriate). For these, we use X-Accel-Redirect to maintain nginx's file-serving performance while adding FastAPI permission checks.
-
-### Legacy-Compatible URL Pattern
-
-To maintain compatibility with the original e-shuushuu.net URLs, protected images use:
 - `/images/{date}-{image_id}.{ext}` (e.g., `/images/2026-01-02-1112196.png`) - fullsize
-- `/thumbs/{date}-{image_id}.{ext}` (e.g., `/thumbs/2026-01-02-1112196.png`) - thumbnail
+- `/thumbs/{date}-{image_id}.webp` - thumbnail (always WebP)
 - `/medium/{date}-{image_id}.{ext}` - medium variant (1280px edge, if available)
 - `/large/{date}-{image_id}.{ext}` - large variant (2048px edge, if available)
 
-### Request Flow
+## Nginx Configuration
 
-```
-Client → nginx → FastAPI (permission check) → X-Accel-Redirect → nginx → file
-```
-
-1. nginx proxies `/images/*`, `/thumbs/*`, `/medium/*`, `/large/*` requests to FastAPI
-2. FastAPI checks if user can view the image (based on status, ownership, permissions)
-3. If authorized: returns `X-Accel-Redirect: /internal/{type}/{filename}.{ext}`
-4. If unauthorized: returns 404 (not 403, to hide existence)
-5. nginx serves from internal location (not directly accessible)
-
-### Nginx Configuration
-
-Add these locations to your nginx config:
+### Protected image routes (proxy to FastAPI)
 
 ```nginx
-# Proxy protected image requests to FastAPI for permission checks
-location ~ ^/images/\d{4}-\d{2}-\d{2}-\d+\.(png|jpg|jpeg|gif|webp)$ {
-    proxy_pass http://fastapi:8000;
+location ~ "^/images/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
+    proxy_pass http://api:8000;
     proxy_set_header Host $host;
     proxy_set_header Cookie $http_cookie;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
 }
 
-location ~ ^/thumbs/\d{4}-\d{2}-\d{2}-\d+\.(png|jpg|jpeg|gif|webp)$ {
-    proxy_pass http://fastapi:8000;
-    proxy_set_header Host $host;
-    proxy_set_header Cookie $http_cookie;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
+# Same pattern for /thumbs/, /medium/, /large/
+```
 
-location ~ ^/medium/\d{4}-\d{2}-\d{2}-\d+\.(png|jpg|jpeg|gif|webp)$ {
-    proxy_pass http://fastapi:8000;
-    proxy_set_header Host $host;
-    proxy_set_header Cookie $http_cookie;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
+### Internal locations (X-Accel-Redirect targets)
 
-location ~ ^/large/\d{4}-\d{2}-\d{2}-\d+\.(png|jpg|jpeg|gif|webp)$ {
-    proxy_pass http://fastapi:8000;
-    proxy_set_header Host $host;
-    proxy_set_header Cookie $http_cookie;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-# Internal locations - only accessible via X-Accel-Redirect from FastAPI
-# Files are stored with the filename format (e.g., 2025-12-29-1112174.jpeg)
+```nginx
 location /internal/fullsize/ {
-    internal;  # Cannot be accessed directly by clients
+    internal;
     alias ${STORAGE_PATH}/fullsize/;
     expires 1y;
     add_header Cache-Control "public, immutable";
 }
 
 location /internal/thumbs/ {
-    internal;  # Cannot be accessed directly by clients
+    internal;
     alias ${STORAGE_PATH}/thumbs/;
     expires 1y;
     add_header Cache-Control "public, immutable";
 }
 
-location /internal/medium/ {
-    internal;  # Cannot be accessed directly by clients
-    alias ${STORAGE_PATH}/medium/;
-    expires 1y;
-    add_header Cache-Control "public, immutable";
-}
-
-location /internal/large/ {
-    internal;  # Cannot be accessed directly by clients
-    alias ${STORAGE_PATH}/large/;
-    expires 1y;
-    add_header Cache-Control "public, immutable";
-}
+# Same pattern for /internal/medium/, /internal/large/
 ```
 
-### Visibility Rules
+## Request Flow
 
-| Status | Status Code | Public? |
-|--------|-------------|---------|
-| ACTIVE (1) | Active | Yes |
-| SPOILER (2) | Marked spoiler | Yes |
-| REPOST (-1) | Duplicate | Yes |
-| REVIEW (-4) | Under review | No* |
-| INAPPROPRIATE (-2) | Flagged | No* |
-| OTHER (0) | Uncategorized | No* |
+### Local filesystem (R2 disabled or `r2_location=NONE`)
+
+```
+Client → nginx → FastAPI (permission check) → X-Accel-Redirect → nginx → file
+```
+
+1. nginx proxies the request to FastAPI
+2. FastAPI checks visibility (status, ownership, permissions)
+3. If authorized: returns `X-Accel-Redirect: /internal/{type}/{filename}.{ext}`
+4. If unauthorized: returns 404 (not 403, to hide existence)
+5. nginx serves from internal location
+
+### R2 serving (`R2_ENABLED=true`)
+
+```
+Client → nginx → FastAPI (permission check) → 302 redirect → R2/CDN
+```
+
+- **Public images** (`r2_location=PUBLIC` and status is public): 302 to CDN
+  domain. Both conditions must hold — a public-bucket image whose status just
+  changed to protected falls back to the app endpoint until the sync job
+  moves it.
+- **Protected images** (`r2_location=PRIVATE`): 302 to a short-lived presigned
+  URL against the private R2 bucket. Each request issues a fresh presigned URL.
+- **Unsynced images** (`r2_location=NONE`): falls back to X-Accel-Redirect
+  (same as local FS path above).
+
+All 302 responses include `Cache-Control: no-store` so nginx and browsers
+do not cache the redirect.
+
+## Visibility Rules
+
+| Status | Value | Public? |
+|--------|-------|---------|
+| ACTIVE | 1 | Yes |
+| SPOILER | 2 | Yes |
+| REPOST | -1 | Yes |
+| REVIEW | -4 | No* |
+| INAPPROPRIATE | -2 | No* |
+| OTHER | 0 | No* |
 
 *Protected images are visible to:
 - The image uploader (owner)
@@ -250,63 +200,24 @@ location /internal/large/ {
 
 ### Authentication
 
-Permission checks use the `access_token` HTTPOnly cookie for authentication. Anonymous users can only view public status images.
+Permission checks use the `access_token` HTTPOnly cookie. Anonymous users
+can only view public-status images.
 
-### Caching Considerations
+## Caching Considerations
 
 Since the same URL can return different responses based on authentication:
-- nginx should NOT cache responses from `/images/*`, `/thumbs/*`, `/medium/*`, `/large/*`
-- The internal locations (`/internal/*`) use immutable caching since they bypass permission checks
+- nginx must NOT cache responses from `/images/*`, `/thumbs/*`, `/medium/*`,
+  `/large/*` (add `proxy_cache off;` if proxy caching is enabled)
+- The `/internal/*` locations use immutable caching since they're only
+  reached after a successful permission check
+- R2 302 responses include `Cache-Control: no-store`
 
-To prevent nginx caching protected paths, add `proxy_cache off;` to each protected image location block:
+## Cache Headers
+
+Images use aggressive caching on the internal/CDN paths since filenames are
+immutable (they include the upload date):
 
 ```nginx
-# Example: Add proxy_cache off to the existing proxy_pass locations
-location ~ "^/images/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
-    proxy_cache off;  # Don't cache permission-dependent responses
-    proxy_pass http://api:8000;
-    proxy_set_header Host $host;
-    proxy_set_header Cookie $http_cookie;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location ~ "^/thumbs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
-    proxy_cache off;  # Don't cache permission-dependent responses
-    proxy_pass http://api:8000;
-    # ... same headers as above
-}
-
-# Apply the same pattern to /medium/ and /large/ locations
+expires 1y;
+add_header Cache-Control "public, immutable";
 ```
-
-Note: The development config (`frontend.conf.dev`) doesn't enable proxy caching by default, so this is primarily relevant for production deployments with caching enabled.
-
-## R2 serving (R2_ENABLED=true)
-
-When `R2_ENABLED=true`, the FastAPI `/images/*` endpoint returns 302 redirects
-with `Cache-Control: no-store` instead of `X-Accel-Redirect`:
-
-- Public images (`r2_location=PUBLIC`) 302 to the public CDN domain. Browsers
-  follow the redirect; nginx is not in the path for the actual image bytes.
-- Protected images (`r2_location=PRIVATE`) 302 to a short-lived presigned URL
-  against the private R2 bucket. Each request issues a fresh presigned URL.
-- Unfinalized or disabled-mode images (`r2_location=NONE`) still return
-  `X-Accel-Redirect` headers pointing at `/internal/*` — same behaviour as
-  before the R2 work.
-
-No nginx configuration change is required. The existing `proxy_cache off`
-directive on `/images/*`, `/thumbs/*`, `/medium/*`, `/large/*` blocks must be
-preserved — nginx must not cache the 302 responses. The `/internal/*` location
-blocks remain for the fallback path.
-
-## Migration Notes
-
-Previous setup had FastAPI serving images via `app.mount()`:
-```python
-# Old code (removed)
-app.mount("/storage/fullsize", StaticFiles(directory=f"{settings.STORAGE_PATH}/fullsize"))
-app.mount("/storage/thumbs", StaticFiles(directory=f"{settings.STORAGE_PATH}/thumbs"))
-```
-
-This was replaced with nginx serving for better performance.

--- a/docs/image-serving-nginx.md
+++ b/docs/image-serving-nginx.md
@@ -282,6 +282,24 @@ location ~ "^/thumbs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg
 
 Note: The development config (`frontend.conf.dev`) doesn't enable proxy caching by default, so this is primarily relevant for production deployments with caching enabled.
 
+## R2 serving (R2_ENABLED=true)
+
+When `R2_ENABLED=true`, the FastAPI `/images/*` endpoint returns 302 redirects
+with `Cache-Control: no-store` instead of `X-Accel-Redirect`:
+
+- Public images (`r2_location=PUBLIC`) 302 to the public CDN domain. Browsers
+  follow the redirect; nginx is not in the path for the actual image bytes.
+- Protected images (`r2_location=PRIVATE`) 302 to a short-lived presigned URL
+  against the private R2 bucket. Each request issues a fresh presigned URL.
+- Unfinalized or disabled-mode images (`r2_location=NONE`) still return
+  `X-Accel-Redirect` headers pointing at `/internal/*` — same behaviour as
+  before the R2 work.
+
+No nginx configuration change is required. The existing `proxy_cache off`
+directive on `/images/*`, `/thumbs/*`, `/medium/*`, `/large/*` blocks must be
+preserved — nginx must not cache the 302 responses. The `/internal/*` location
+blocks remain for the fallback path.
+
 ## Migration Notes
 
 Previous setup had FastAPI serving images via `app.mount()`:

--- a/docs/plans/2026-04-16-r2-image-serving-design.md
+++ b/docs/plans/2026-04-16-r2-image-serving-design.md
@@ -201,25 +201,31 @@ Logic:
 
 ```
 if image.r2_location == R2Location.NONE:
-    return  # object not yet in R2; finalizer owns first-sync
+    raise Retry(defer=30)  # finalizer hasn't flipped r2_location yet;
+                           # retry instead of returning so we don't leave
+                           # the object in the wrong bucket after first-sync
 
-old_public = old_status in PUBLIC_STATUSES
-new_public = new_status in PUBLIC_STATUSES
-
-if old_public == new_public:
+# Derive desired location from current DB status (not the enqueued args,
+# which may be stale if status changed again).
+dst_location = location_for_status(image.status)
+src_location = image.r2_location
+if src_location == dst_location:
     return  # no bucket move needed
-
-src, dst = (public, private) if old_public else (private, public)
 
 for variant in (fullsize, thumbs, medium, large):
     key = variant_key(image, variant)
-    if not object_exists(src, key): continue
+    if not object_exists(src, key):
+        # Idempotent replay: if object already at dst, treat as moved so
+        # we still commit the DB flip rather than leaving r2_location stale.
+        if object_exists(dst, key): already_at_dst.append(variant)
+        continue
     copy_object(src, dst, key)
     assert object_exists(dst, key)
     delete_object(src, key)
 
-# Atomic flip — this is the moment URL generation switches:
-update image set r2_location = dst_location
+# Conditional flip — only update if r2_location hasn't changed since we
+# read it, avoiding clobbering a concurrent status transition:
+update image set r2_location = dst_location where r2_location = src_location
 
 if new_public is False:  # public → protected
     cloudflare_purge([cdn_url(v) for v in variants])

--- a/docs/plans/2026-04-16-r2-image-serving-design.md
+++ b/docs/plans/2026-04-16-r2-image-serving-design.md
@@ -289,13 +289,14 @@ No `R2_*` or `CLOUDFLARE_*` env vars required. App behaves exactly like today.
 
 ### When `R2_ENABLED=true`
 
-Everything in this design activates. A config validator in `app/config.py` requires all of these to be non-empty at startup; mismatch fails fast:
+Everything in this design activates. A config validator in `app/config.py` requires these R2-serving settings to be non-empty at startup; mismatch fails fast:
 
 - `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ENDPOINT`
 - `R2_PUBLIC_BUCKET`, `R2_PRIVATE_BUCKET`
 - `R2_PUBLIC_CDN_URL`
 - `R2_PRESIGN_TTL_SECONDS` (default 900)
-- `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID`
+
+`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ZONE_ID` are optional. They are only needed for CDN cache purge operations and are not required to enable R2-backed image serving.
 
 The DB schema is identical in both modes. A prod DB dump restored on dev works without surgery; images will just show `r2_location=NONE` and serve from wherever the dev filesystem has them (or 404 if not present).
 

--- a/docs/plans/2026-04-16-r2-image-serving-design.md
+++ b/docs/plans/2026-04-16-r2-image-serving-design.md
@@ -1,0 +1,495 @@
+# R2 Image Serving Design
+
+**Date:** 2026-04-16
+
+## Problem
+
+Images are served from a local filesystem at `/shuushuu/images/{fullsize,thumbs,medium,large}/`. The current production server's local storage cannot grow to accommodate continued uploads, and a planned migration to a new server with less local disk requires moving image storage off the box. All 1.6TB of existing images have already been uploaded to a single Cloudflare R2 bucket named `shuushuu-images`, but no public access is configured and the application does not read from or write to R2.
+
+This design covers serving images from R2 while keeping local filesystem storage operational in development and as a transitional fallback in production.
+
+## Goals
+
+- Serve public images (status ACTIVE, SPOILER, REPOST) directly from Cloudflare CDN, bypassing FastAPI on the read path.
+- Serve protected images (status REVIEW, LOW_QUALITY, INAPPROPRIATE, OTHER) through FastAPI permission checks that 302-redirect to short-lived R2 presigned URLs.
+- New uploads write to local filesystem AND R2 (dual-write) so local remains a working fallback during phase 1.
+- Development environment continues using local-only storage with no R2 dependency.
+- Rollback to local-only serving is a single flag change.
+
+## Non-goals (deferred to phase 2)
+
+- IQDB image-matching service reading from R2 instead of local FS.
+- Removal of local filesystem image storage.
+- Migration of avatars and banners to R2.
+
+## Architecture
+
+### Two R2 buckets
+
+- `shuushuu-images` — existing bucket, becomes the **public** bucket. A custom domain (e.g. `cdn.e-shuushuu.net`) is attached; anyone can read via that domain (R2 has no per-object ACLs — bucket access is binary).
+- `shuushuu-images-private` — new bucket, **private**. S3 API access only. Reads issued as short-lived presigned URLs.
+
+Protected-status images cannot live in the public bucket because their keys are predictable (`{date}-{image_id}.{ext}` with sequential IDs). Moving them to a private bucket is the only safe option absent a Cloudflare Worker.
+
+### Key layout (identical in both buckets)
+
+```
+fullsize/{date}-{image_id}.{ext}
+thumbs/{date}-{image_id}.webp
+medium/{date}-{image_id}.{ext}
+large/{date}-{image_id}.{ext}
+```
+
+Matches the current local FS layout, so the one-time split migration requires no key rewriting.
+
+### Access paths
+
+Normal traffic (URLs generated from the current schema):
+```
+Public image (status public, r2_location=PUBLIC, R2_ENABLED=true):
+    client → CDN → R2 public bucket                           (FastAPI never touched)
+
+Protected image (status protected, r2_location=PRIVATE):
+    client → nginx → FastAPI → 302 → presigned R2 private URL
+
+Transitional / fallback (r2_location=NONE, or R2_ENABLED=false, or any mismatch):
+    client → nginx → FastAPI → X-Accel-Redirect or 302        (served from wherever the object is)
+```
+
+Requests that hit the `/images/*` (or `/thumbs/*`, `/medium/*`, `/large/*`) path — bookmarks, legacy URLs, any case where the schema's direct-CDN URL wasn't used — are still served correctly: FastAPI runs the permission check and redirects to the appropriate location based on `r2_location`. The endpoint is not deprecated; it is the fallback and handles every case.
+
+## Database schema
+
+New column on `images`:
+
+```
+r2_location: tinyint not null default 0
+```
+
+`R2Location` IntEnum:
+- `NONE = 0` — object not confirmed in R2 (in-flight upload, or R2 disabled).
+- `PUBLIC = 1` — canonical copy in `shuushuu-images`.
+- `PRIVATE = 2` — canonical copy in `shuushuu-images-private`.
+
+Alembic migration adds the column with default `NONE`. A separate `r2_sync.py backfill-locations` command populates existing rows based on current status after the initial bucket split is run in production.
+
+## URL generation (`app/schemas/image.py`)
+
+```python
+PUBLIC_STATUSES = {ImageStatus.ACTIVE, ImageStatus.SPOILER, ImageStatus.REPOST}
+
+def _should_use_cdn(self) -> bool:
+    return (
+        settings.R2_ENABLED
+        and self.status in PUBLIC_STATUSES
+        and self.r2_location == R2Location.PUBLIC
+    )
+
+@computed_field
+@property
+def url(self) -> str:
+    if self._should_use_cdn():
+        return f"{settings.R2_PUBLIC_CDN_URL}/fullsize/{self.filename}.{self.ext}"
+    return f"{settings.IMAGE_BASE_URL}/images/{self.filename}.{self.ext}"
+
+@computed_field
+@property
+def thumbnail_url(self) -> str:
+    if self._should_use_cdn():
+        return f"{settings.R2_PUBLIC_CDN_URL}/thumbs/{self.filename}.webp"
+    return f"{settings.IMAGE_BASE_URL}/thumbs/{self.filename}.webp"
+
+@computed_field
+@property
+def medium_url(self) -> str | None:
+    if not self.medium:
+        return None
+    if self._should_use_cdn():
+        return f"{settings.R2_PUBLIC_CDN_URL}/medium/{self.filename}.{self.ext}"
+    return f"{settings.IMAGE_BASE_URL}/medium/{self.filename}.{self.ext}"
+
+@computed_field
+@property
+def large_url(self) -> str | None:
+    if not self.large:
+        return None
+    if self._should_use_cdn():
+        return f"{settings.R2_PUBLIC_CDN_URL}/large/{self.filename}.{self.ext}"
+    return f"{settings.IMAGE_BASE_URL}/large/{self.filename}.{self.ext}"
+```
+
+Direct CDN URL is emitted only when **all three** hold: `R2_ENABLED=true`, status is public, and `r2_location=PUBLIC`. Any mismatch (including `NONE` and disabled-mode) falls back to the relevant `/images/`, `/thumbs/`, `/medium/`, or `/large/` path. The `R2_ENABLED` check is essential: without it, running `backfill-locations` before flipping the flag would immediately emit CDN URLs pointing at an un-configured CDN domain.
+
+## `/images/*` endpoint (`app/api/v1/media.py`)
+
+```python
+async def _serve_image(image, variant, db, user):
+    if not await can_view_image_file(image, user, db):
+        raise HTTPException(404)
+
+    if settings.R2_ENABLED and image.r2_location == R2Location.PUBLIC:
+        return RedirectResponse(
+            public_cdn_url(image, variant),
+            status_code=302,
+            headers={"Cache-Control": "no-store"},
+        )
+    if settings.R2_ENABLED and image.r2_location == R2Location.PRIVATE:
+        presigned = r2.generate_presigned_url(
+            bucket=settings.R2_PRIVATE_BUCKET,
+            key=variant_key(image, variant),
+            ttl=settings.R2_PRESIGN_TTL_SECONDS,
+        )
+        return RedirectResponse(
+            presigned,
+            status_code=302,
+            headers={"Cache-Control": "no-store"},
+        )
+
+    # r2_location == NONE, or R2_ENABLED=false — serve from local FS
+    return Response(headers={"X-Accel-Redirect": f"/internal/{variant}/{image.filename}.{ext}"})
+```
+
+**`Cache-Control: no-store` on 302 responses is required.** Without it, nginx or browsers may cache the redirect itself, continuing to point users at a presigned URL that has since expired (or a CDN URL whose object has since been deleted on status change). The cached image at the *target* of the redirect is still freely cacheable (CDN objects carry their own long immutable headers; presigned private-bucket responses carry no cache headers and are effectively one-shot).
+
+Same endpoint handles both phases and both modes. Phase 2 (no local FS) simply never reaches the `NONE` branch because all uploads will have completed R2 sync before the DB row commits.
+
+### nginx configuration
+
+No change to existing `/images/*`, `/thumbs/*`, `/medium/*`, `/large/*` proxy blocks: they still `proxy_pass` to FastAPI. Existing `proxy_cache off` directive on these blocks remains correct — FastAPI now returns `Cache-Control: no-store` 302s, which nginx must not cache.
+
+The `/internal/*` locations remain for the `r2_location=NONE` / `R2_ENABLED=false` fallback.
+
+When `R2_ENABLED=true` and traffic has stabilized, the public-bucket traffic is going direct to the CDN custom domain — nginx no longer sees it at all.
+
+## Upload flow (new images)
+
+Existing flow unchanged:
+
+1. `POST /images/upload` saves file to `{STORAGE_PATH}/fullsize/` locally.
+2. DB row created with `r2_location=NONE`.
+3. ARQ jobs enqueued for thumbnail, medium, large variants (existing `create_thumbnail_job`, `create_medium_variant_job`, `create_large_variant_job`).
+4. API responds immediately.
+
+New single orchestration job `r2_finalize_upload_job(image_id)`:
+
+5. Enqueued immediately after step 3 with a short delay (e.g. `defer_by=60s`) so the variant jobs have time to run first.
+6. On execution: reads the image row, determines which variants are expected based on the `medium`/`large` columns (which the variant jobs set). Expected set is always `{fullsize, thumbs}`, plus `medium` if `image.medium == VariantStatus.DONE`, plus `large` if `image.large == VariantStatus.DONE`.
+7. For each expected variant: checks that the local file exists, then uploads it to the bucket selected by current `image.status`. If a variant file is missing (variant job failed or still pending), the finalizer logs `r2_finalize_retry` and the ARQ job retries.
+8. After all expected variants are uploaded, atomically sets `r2_location` to `PUBLIC` or `PRIVATE` based on current status.
+
+Bucket selection:
+```python
+def bucket_for(image: Images) -> str:
+    return (
+        settings.R2_PUBLIC_BUCKET
+        if image.status in PUBLIC_STATUSES
+        else settings.R2_PRIVATE_BUCKET
+    )
+```
+
+**Why one finalizer instead of per-variant R2 upload jobs:** a single orchestration point owns the flip of `r2_location`, which is the consistency point. Per-variant jobs would race: if three jobs each try to flip `r2_location` when they finish, ordering becomes fragile. The finalizer runs once, checks everything is ready, and performs the atomic flip.
+
+**Bucket race with status change during upload:** if status changes between upload and finalizer completion, the finalizer uploads to the bucket matching current status (re-read from DB at job start). The separate `sync_image_status_job` triggered by the status change will early-return if `r2_location` is still `NONE` — the finalizer is the authoritative writer for first-sync. If the finalizer later races with another status change, its final write might target a now-stale bucket; `r2_sync.py reconcile` and `verify` catch this.
+
+If R2 sync fails after exhausting ARQ retries, `r2_location` stays `NONE` and the image is served from local FS via the fallback path. No user-visible impact; caught later by `r2_sync.py reconcile`.
+
+## Status change handling
+
+A new ARQ job `sync_image_status_job(image_id, old_status, new_status)` runs post-commit whenever `images.status` changes. Enqueued from the routes that change status (admin actions, review outcomes, repost marking, spoiler toggle).
+
+Logic:
+
+```
+if image.r2_location == R2Location.NONE:
+    return  # object not yet in R2; finalizer owns first-sync
+
+old_public = old_status in PUBLIC_STATUSES
+new_public = new_status in PUBLIC_STATUSES
+
+if old_public == new_public:
+    return  # no bucket move needed
+
+src, dst = (public, private) if old_public else (private, public)
+
+for variant in (fullsize, thumbs, medium, large):
+    key = variant_key(image, variant)
+    if not object_exists(src, key): continue
+    copy_object(src, dst, key)
+    assert object_exists(dst, key)
+    delete_object(src, key)
+
+# Atomic flip — this is the moment URL generation switches:
+update image set r2_location = dst_location
+
+if new_public is False:  # public → protected
+    cloudflare_purge([cdn_url(v) for v in variants])
+```
+
+The flip of `r2_location` is the consistency point. Before the flip, schema emits URLs pointing to the old bucket (which still has the object). After the flip, URLs point to the new bucket. Delete-from-source runs after the flip; the CDN purge closes the exposure window for anyone who cached the old URL.
+
+### Known cache-purge window
+
+There is a small window (seconds to minutes) between a public→protected status change committing and Cloudflare's purge-by-URL API completing. Anyone holding the CDN URL during that window may still fetch the image from edge cache. Accepted as a phase-1 tradeoff; a future synchronous "nuke from CDN" admin action can close the window for urgent cases.
+
+### Presigned URL lifetime on status change
+
+Presigned URLs issued from the private bucket remain valid until their `R2_PRESIGN_TTL_SECONDS` TTL elapses, regardless of subsequent status changes. Transitioning an image between two protected statuses (e.g., REVIEW → INAPPROPRIATE) does not invalidate outstanding presigned URLs. This is acceptable: both origin and destination statuses require the same permission-check gate to receive a presigned URL in the first place. Shortening the TTL is the only lever; tightening beyond 15 min traded off against re-signing cost is not warranted in phase 1.
+
+## Image deletion flow
+
+When an image is hard-deleted (`AdminActionType.IMAGE_DELETE`), R2 objects must be removed too. A new ARQ job `r2_delete_image_job(image_id, r2_location, filename, ext, variants)` runs post-commit:
+
+- Reads the image's prior `r2_location` and variant flags (passed as arguments since the row is gone).
+- Deletes all four object keys (or whichever exist) from the bucket indicated by `r2_location`.
+- If `r2_location=PUBLIC`, also issues a Cloudflare cache purge for the four CDN URLs — otherwise the deleted image remains cached at edges indefinitely.
+
+Failures are logged and retried by ARQ. If retries exhaust, orphan objects accumulate in R2; `r2_sync.py verify` flags orphans (objects in R2 with no matching DB row) and a future `r2_sync.py gc-orphans` command can sweep them. Out of scope for this spec; orphans are a minor storage-cost issue, not a correctness issue.
+
+## Storage adapter (`app/services/r2_storage.py`)
+
+Thin wrapper over `aioboto3` (R2 is S3-compatible at its endpoint).
+
+```python
+class R2Storage:
+    async def upload_file(self, bucket: str, key: str, path: Path) -> None
+    async def copy_object(self, src_bucket: str, dst_bucket: str, key: str) -> None
+    async def delete_object(self, bucket: str, key: str) -> None
+    async def generate_presigned_url(self, bucket: str, key: str, ttl: int) -> str
+    async def object_exists(self, bucket: str, key: str) -> bool
+```
+
+Single shared `aioboto3.Session` reused across the app. A `DummyR2Storage` with the same interface is swapped in when `R2_ENABLED=false` — all methods raise `RuntimeError` to catch mistakes in disabled mode; no silent no-ops.
+
+## Cloudflare cache purge (`app/services/cloudflare.py`)
+
+One function:
+
+```python
+async def purge_cache_by_urls(urls: list[str]) -> None
+```
+
+Calls `POST https://api.cloudflare.com/client/v4/zones/{zone_id}/purge_cache` with `{"files": urls}`. Batches into groups of 30 URLs per call (free plan limit). Uses `CLOUDFLARE_API_TOKEN` scoped to zone cache purge.
+
+Failures are logged at ERROR and surface via `r2_sync.py verify`. An operator can issue a manual purge via `r2_sync.py purge-cache <image_id>`.
+
+## Dual-mode operation: `R2_ENABLED` flag
+
+A single explicit boolean `R2_ENABLED` in `app/config.py` controls which mode the app runs in. Default `false`; dev environments leave it alone. Production sets it `true` after bucket setup and the one-time split.
+
+### When `R2_ENABLED=false`
+
+- Upload flow does not enqueue R2 sync jobs. `r2_location` stays `NONE`.
+- URL generation never emits a CDN URL (always the `/images/*` path).
+- `/images/*` endpoint serves from local via X-Accel-Redirect (the `NONE` branch).
+- Status-change job is a no-op.
+- Cloudflare cache purge is skipped.
+- `r2_sync.py` commands refuse to run, printing an error pointing at the config flag.
+
+No `R2_*` or `CLOUDFLARE_*` env vars required. App behaves exactly like today.
+
+### When `R2_ENABLED=true`
+
+Everything in this design activates. A config validator in `app/config.py` requires all of these to be non-empty at startup; mismatch fails fast:
+
+- `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ENDPOINT`
+- `R2_PUBLIC_BUCKET`, `R2_PRIVATE_BUCKET`
+- `R2_PUBLIC_CDN_URL`
+- `R2_PRESIGN_TTL_SECONDS` (default 900)
+- `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID`
+
+The DB schema is identical in both modes. A prod DB dump restored on dev works without surgery; images will just show `r2_location=NONE` and serve from wherever the dev filesystem has them (or 404 if not present).
+
+## Operational tooling (`scripts/r2_sync.py`)
+
+A single CLI script with subcommands, sharing the app's R2 storage adapter and DB config.
+
+- **`split-existing`** — one-time initial migration. Queries DB for protected-status images and moves their four object keys from `shuushuu-images` to `shuushuu-images-private`. Idempotent; `--dry-run` prints what would move.
+- **`backfill-locations`** — one-shot. Query: `WHERE r2_location = 0`, chunked in batches of ~1000 with a fresh read per batch so rows whose status changes during the run use the latest value. Sets `PUBLIC`/`PRIVATE` based on current status. Rows finalized by a concurrent upload already have `r2_location != 0` and are naturally skipped. Any missed rows are caught later by `reconcile`.
+- **`reconcile [--stale-after <duration>]`** — heals. Finds images with `r2_location=NONE` older than the threshold, checks R2, uploads missing objects from local FS, flips the flag.
+- **`image <image_id>`** — inspects and re-syncs one image for operator debugging.
+- **`verify [--sample N]`** — audits (read-only). Reports discrepancies only: `PUBLIC` rows whose object is missing from the public bucket; `PRIVATE` rows whose object is missing from the private bucket; `NONE` rows whose object unexpectedly exists in either bucket; cross-bucket orphans. `r2_location=NONE` with no R2 object is a legitimate state (pending finalizer, or mode disabled, or staging-imported) and is NOT reported.
+- **`purge-cache <image_id>`** — manually invokes Cloudflare purge for one image's four URLs.
+
+All commands refuse to run when `R2_ENABLED=false`.
+
+### Bulk-backfill kill switch: `R2_ALLOW_BULK_BACKFILL`
+
+`backfill-locations` and `reconcile` both refuse to run when `R2_ALLOW_BULK_BACKFILL=false`. Default is `false`. Steady state: **prod sets it `true` permanently, staging leaves it `false` permanently.**
+
+Reason: both commands walk the DB for `r2_location=NONE` rows and upload local files to R2. On staging (which has a full local copy of prod images but only a small R2 bucket), an unguarded run would upload the entire prod dataset into the staging bucket. The flag is declarative and cron-proof — a nightly `reconcile` cron inherited from prod config is a no-op on staging because the flag is off, while it still heals stuck rows in prod where the flag is on. `image <image_id>` (the single-image version) and `verify` do not touch this flag; operators can still debug individual images on staging.
+
+## Error handling and observability
+
+Structured log events via `get_logger`: `r2_upload_started|succeeded|failed`, `r2_status_transition_started|completed|failed`, `r2_cdn_purge_started|succeeded|failed`, `r2_presigned_url_issued` (DEBUG).
+
+Existing ARQ retry config (`ARQ_MAX_TRIES=3`) applies to new R2 jobs. Exhausted retries log at ERROR and dead-letter via existing mechanisms — no automatic alerting in this spec; surfaces via `r2_sync.py verify` / `reconcile`.
+
+### Failure matrix
+
+| Failure | Effect | Recovery |
+|---|---|---|
+| R2 API transient 5xx on upload | ARQ retries; on exhaustion `r2_location=NONE`, served from local | `r2_sync.py reconcile` |
+| R2 credentials revoked | All R2 ops fail; serving still works (local fallback) | Fix credentials, reconcile |
+| Cloudflare purge API fails | Object moved but cache not purged — exposure window open | `r2_sync.py purge-cache <image_id>` |
+| Copy succeeds, delete fails on status change | Object in both buckets; `r2_location` already flipped | Idempotent `reconcile` deletes orphan |
+| `r2_location` mismatches reality | URL generation points to wrong place | `verify` catches; `reconcile` fixes |
+
+App never blocks on R2 availability. R2 outage means new uploads' R2 sync fails (falls back to local) and status changes defer the bucket move (fall back to local serving via FastAPI). App stays up.
+
+## Testing
+
+### Unit (`tests/unit/`)
+
+- `test_r2_storage.py` — adapter methods over `moto`-mocked S3.
+- `test_image_url_generation.py` — 7 statuses × 3 `r2_location` values × 2 `R2_ENABLED` values matrix (42 cases per URL field, across `url`, `thumbnail_url`, `medium_url`, `large_url`). Asserts direct CDN URL only when all three conditions align; everything else falls back to `/images/`, `/thumbs/`, `/medium/`, or `/large/` paths. Also verifies `medium_url`/`large_url` return `None` when the variant flag is `NONE`.
+- `test_cloudflare_purge.py` — mocked HTTP. Batching (30 URLs per call), error handling, auth header.
+- `test_dummy_r2_storage.py` — disabled-mode adapter raises rather than silently succeeding.
+
+### Integration (`tests/integration/`)
+
+- `test_r2_sync_jobs.py` — moto + in-memory Redis ARQ. Upload flow end-to-end; `r2_location` transitions from `NONE` to `PUBLIC`/`PRIVATE`.
+- `test_status_transition_job.py` — seed object in public bucket, change status, run job, assert copy + delete + purge. Run twice; assert idempotent.
+
+### API (`tests/api/v1/`)
+
+- `test_media_serving.py` — extend to cover 302 redirects for `PUBLIC` and `PRIVATE` locations. Existing `NONE` path (X-Accel-Redirect) still covered.
+
+### Dual-mode coverage
+
+The full suite runs with `R2_ENABLED=false` (same as today). R2-specific tests explicitly enable it via a fixture that spins up moto and patches the storage singleton. CI has two jobs: one runs the default-disabled suite, another runs the R2-enabled tests only.
+
+## Migration plan
+
+Ordered, independently verifiable steps:
+
+1. **Code lands behind disabled flag (safe merge).** Alembic migration adds `r2_location` (default `NONE`). Storage adapter, sync jobs, status-change job, URL logic, `/images/*` refactor, `r2_sync.py` — all implemented but gated by `R2_ENABLED=false`. Existing behavior unchanged in dev and prod.
+2. **Deploy to prod, flag off.** Confirm migration runs and no behavior changed.
+3. **Cloudflare setup (operator, out-of-band).** Create `shuushuu-images-private`. Attach custom domain to `shuushuu-images`. Create zone cache-purge API token. Set all `R2_*` and `CLOUDFLARE_*` env vars in the prod environment (flag still off).
+4. **One-time split.** Run `r2_sync.py split-existing --dry-run`, verify counts. Run `split-existing`. Run `verify --sample 1000`.
+5. **Backfill `r2_location`.** Set `R2_ALLOW_BULK_BACKFILL=true` in prod env (stays on permanently in prod), then run `r2_sync.py backfill-locations`.
+6. **Flip the flag.** `R2_ENABLED=true`; restart app and workers. New uploads dual-write. Reads for public images go to CDN. Status changes move objects and purge.
+7. **Verify and observe.** `verify --sample 1000` post-cutover. Monitor logs for `r2_*_failed` events for a week. Cron `r2_sync.py reconcile` daily (prod's `R2_ALLOW_BULK_BACKFILL=true` allows it; staging's `false` makes it a no-op even if cron config is inherited).
+
+### Rollback
+
+Set `R2_ENABLED=false`, restart. All URLs fall back to `/images/*`, served from local. R2 objects remain (harmless). DB `r2_location` values stay (not consulted while flag off). Rollback is cheap because local FS remains source-of-truth during phase 1.
+
+## Config reference
+
+New settings in `app/config.py`:
+
+| Name | Default | Required when |
+|---|---|---|
+| `R2_ENABLED` | `false` | — |
+| `R2_ACCESS_KEY_ID` | `""` | `R2_ENABLED=true` |
+| `R2_SECRET_ACCESS_KEY` | `""` | `R2_ENABLED=true` |
+| `R2_ENDPOINT` | `""` | `R2_ENABLED=true` |
+| `R2_PUBLIC_BUCKET` | `"shuushuu-images"` | `R2_ENABLED=true` |
+| `R2_PRIVATE_BUCKET` | `"shuushuu-images-private"` | `R2_ENABLED=true` |
+| `R2_PUBLIC_CDN_URL` | `""` | `R2_ENABLED=true` |
+| `R2_PRESIGN_TTL_SECONDS` | `900` | — |
+| `R2_ALLOW_BULK_BACKFILL` | `false` | — (set true permanently in prod; leave false on staging) |
+| `CLOUDFLARE_API_TOKEN` | `""` | `R2_ENABLED=true` |
+| `CLOUDFLARE_ZONE_ID` | `""` | `R2_ENABLED=true` |
+
+The existing `STORAGE_TYPE` and `S3_*` placeholders are removed to avoid confusion with the new `R2_*` names. `.env` files in the wild that still define these will be silently ignored (`Settings.model_config` has `extra="ignore"`), so removal is a hard delete with no deprecation period needed.
+
+## Phase 2 failure behavior and operator responsibilities
+
+Phase 2 (local FS no longer source of truth) is out of scope for implementation here, but the phase 1 design must not close off the right failure semantics for phase 2. Two invariants guide that.
+
+### Invariant 1: local files are only deleted after R2 confirmation
+
+When phase 2 adds a `local_cleanup_job(image_id)`, it MUST refuse to delete any local file unless `r2_location in {PUBLIC, PRIVATE}`. If `r2_location == NONE`, the local file stays regardless of its age. This is encoded as a hard precondition in the job body, not an if-else branch.
+
+Consequence: a broken R2 integration cannot cause data loss. The worst that can happen is local files accumulate.
+
+### Invariant 2: sustained finalizer failures surface to operators
+
+If R2 is completely unavailable for an extended period in phase 2:
+
+- Uploads still succeed (write to local FS). User experience unaffected.
+- Finalizer jobs exhaust retries and log `event=r2_finalize_permanently_failed` at WARNING.
+- `r2_location=NONE` rows accumulate.
+- Local cleanup never runs for these rows → local disk usage grows.
+- Reads for recent uploads still work via the local-FS fallback path.
+- Once local disk fills, new uploads start failing at the OS level.
+
+The app cannot self-heal from total R2 outage. An operator must:
+1. Be alerted that sustained failures are happening.
+2. Investigate and fix the R2 issue (credentials, quota, network, Cloudflare incident).
+3. Run `r2_sync.py reconcile` to catch up.
+4. Once `r2_location != NONE` for all backlog, the phase 2 cleanup job will sweep local copies.
+
+### `r2_sync.py health` command (added to operational tooling)
+
+A read-only health subcommand designed for monitoring integration:
+
+```
+$ r2_sync.py health
+unsynced_count: 3
+oldest_unsynced_age_seconds: 420
+local_storage_used_bytes: 1680123456789
+local_storage_path: /shuushuu/images
+
+$ r2_sync.py health --json
+{"unsynced_count": 3, "oldest_unsynced_age_seconds": 420, ...}
+```
+
+`unsynced_count` is `SELECT COUNT(*) FROM images WHERE r2_location = 0`. `oldest_unsynced_age_seconds` is age of the oldest such row. `local_storage_used_bytes` shells out to `du -sb {STORAGE_PATH}` (cheap — MariaDB row count dominates).
+
+Operators are expected to wire this output to their alerting of choice. Suggested thresholds (tune per deployment):
+
+- WARNING if `unsynced_count > 0` and `oldest_unsynced_age_seconds > 3600` (a single image stuck for an hour).
+- CRITICAL if `unsynced_count > 100` or `oldest_unsynced_age_seconds > 21600` (widespread failure).
+- CRITICAL if `local_storage_used_bytes` exceeds some per-deployment ceiling (separate OS-level check recommended too).
+
+This command is available in both phase 1 and phase 2, and respects `R2_ENABLED` — refuses to run when disabled.
+
+## Staging environment
+
+Staging runs with its own prod-shaped DB but keeps a **full local copy of production images** on disk. To avoid double-paying R2 storage for 1.6TB, staging uses small dedicated R2 buckets containing only images generated by staging test activity.
+
+### Isolation
+
+- Separate buckets: `shuushuu-images-staging` (public), `shuushuu-images-staging-private`. Configured via staging's `R2_PUBLIC_BUCKET` / `R2_PRIVATE_BUCKET` env vars. Credentials in staging's `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` — ideally scoped to these buckets only so a bug can't touch prod objects.
+- Separate CDN domain (e.g. `cdn-staging.e-shuushuu.net`) attached to `shuushuu-images-staging`. Set as staging's `R2_PUBLIC_CDN_URL`.
+- Separate `CLOUDFLARE_ZONE_ID` for the staging zone. Purges issued from staging only affect the staging zone, never prod.
+
+### `r2_location` strategy on staging
+
+Staging sets `R2_ALLOW_BULK_BACKFILL=false` permanently. Both `backfill-locations` and `reconcile` refuse to run, so imported prod DB rows keep `r2_location=NONE` forever. URL generation and the `/images/*` fallback serve those rows from the local FS copy that staging has — the existing dev path, zero changes.
+
+Only images **uploaded on staging** go through the normal finalizer flow and get `r2_location=PUBLIC` or `PRIVATE` pointing at the staging buckets. Staging exercises every R2 code path — dual-write, status transitions, cache purges, presigned URLs, deletions — using only those locally-created test images.
+
+The status-change job's `r2_location==NONE` early-return (see Status change handling) is what makes this safe when an operator changes the status of a prod-imported image on staging: the job no-ops instead of flipping `r2_location` to a bucket that doesn't contain the object.
+
+### Testing flows covered
+
+- **Uploads:** new uploads on staging dual-write to local + staging R2. `r2_location` transitions `NONE → PUBLIC/PRIVATE`.
+- **Status changes:** status transitions on staging-uploaded images move objects between staging public and private buckets, and purge staging CDN URLs.
+- **Deletions:** `IMAGE_DELETE` on staging-uploaded images deletes from staging R2 and purges staging CDN.
+- **Fallback path:** browsing any prod-imported image hits the `r2_location=NONE` branch and serves from local, identical to today.
+
+Prod-imported images cannot be used to exercise status-change R2 moves on staging (their objects don't exist in staging R2). Any test scenario that requires that transition must use staging-uploaded images.
+
+### Known-noisy operational commands on staging
+
+- `r2_sync.py health` reports `unsynced_count` equal to the entire prod row count on staging, permanently tripping the suggested CRITICAL threshold. Monitoring wiring should either exclude staging or use a staging-specific counting scope (only rows after the import cutoff).
+- `r2_sync.py verify` is quiet on staging because `NONE` rows with no R2 object are a legitimate state by definition (see Operational tooling). Only real bucket/DB mismatches surface.
+
+### Phase 2 compatibility
+
+Phase 2's `local_cleanup_job` will not touch prod-imported rows on staging because Invariant 1 (local cleanup requires `r2_location != NONE`) holds permanently for them. Staging keeps its full local image copy indefinitely by construction — no special staging handling needed in phase 2.
+
+### Cost
+
+A staging R2 bucket accumulates only test uploads — tens to hundreds of images. Storage cost is a rounding error. Optionally seed with a handful of curated images at setup time if ready-made test fixtures are wanted; otherwise the first staging upload populates it.
+
+## Legacy PHP application
+
+The `shuu-php/` directory holds the legacy PHP codebase as read-only reference (`AGENTS.md`: "DO NOT modify"). It is not part of the production serving path. No coordination required for this migration.
+
+## Cloudflare plan assumptions
+
+Purge-by-URL is available on all Cloudflare plans (Free through Enterprise). Rate limits differ between plans; this design assumes the free-tier limit of 1000 URL-purge requests per minute is sufficient (it is — at batch size 30, that's 30,000 URLs/minute, far above expected status-change volume). If the deployment is on a paid plan, limits are higher and nothing changes.

--- a/docs/plans/2026-04-16-r2-image-serving-impl.md
+++ b/docs/plans/2026-04-16-r2-image-serving-impl.md
@@ -1,6 +1,6 @@
 # R2 Image Serving Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use `**Step N:**` format; tick them off by updating this file as you complete each one if desired.
+> **For Agents:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use `**Step N:**` format; tick them off by updating this file as you complete each one if desired.
 
 **Goal:** Serve images from Cloudflare R2 (two buckets — public via CDN, private via presigned URLs) while keeping local filesystem as a fallback. Dual-write new uploads. Gated behind `R2_ENABLED` so dev stays local-only.
 

--- a/docs/plans/2026-04-16-r2-image-serving-impl.md
+++ b/docs/plans/2026-04-16-r2-image-serving-impl.md
@@ -1,0 +1,3908 @@
+# R2 Image Serving Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use `**Step N:**` format; tick them off by updating this file as you complete each one if desired.
+
+**Goal:** Serve images from Cloudflare R2 (two buckets — public via CDN, private via presigned URLs) while keeping local filesystem as a fallback. Dual-write new uploads. Gated behind `R2_ENABLED` so dev stays local-only.
+
+**Architecture:** Thin `R2Storage` adapter over `aioboto3`. A `r2_location` tri-state column on `images` drives URL generation: public-CDN, presigned-private, or local-FS fallback. Finalizer ARQ job uploads to R2 after variant jobs complete and flips `r2_location`. Status-change and delete flows enqueue their own ARQ jobs that move/purge objects and invalidate Cloudflare cache. A `scripts/r2_sync.py` CLI provides one-time migration and ongoing reconciliation.
+
+**Tech Stack:** FastAPI, SQLModel, Alembic, aioboto3, ARQ, moto (S3 mocking), httpx (Cloudflare API), pytest
+
+**Design doc:** `docs/plans/2026-04-16-r2-image-serving-design.md`
+
+---
+
+## Chunk 1: Foundation
+
+Groundwork: dependencies, config, DB migration, model changes, shared constants. Everything after this assumes `r2_location` exists on `Images` and the `R2Location` enum is importable.
+
+---
+
+### Task 1: Add Dependencies
+
+**Files:**
+- Modify: `pyproject.toml` (dependencies list)
+
+**Step 1: Add aioboto3 to main dependencies**
+
+In `pyproject.toml`, add after the `arq>=0.27.0` entry in `dependencies`:
+
+```toml
+    "aioboto3>=13.0.0",  # Async S3-compatible client for Cloudflare R2
+```
+
+**Step 2: Add moto and types-aioboto3 to dev dependencies**
+
+In `pyproject.toml` under `[dependency-groups]` `dev`, add:
+
+```toml
+    "moto[s3]>=5.0.0",  # Mock S3 for R2 adapter tests
+    "types-aioboto3>=13.0.0",  # Type stubs
+```
+
+**Step 3: Install**
+
+Run: `uv sync`
+Expected: `aioboto3`, `moto`, `types-aioboto3` installed; no other changes.
+
+**Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "feat(r2): add aioboto3 and moto dependencies"
+```
+
+---
+
+### Task 2: Add R2 Settings to Config
+
+**Files:**
+- Modify: `app/config.py`
+
+**Step 1: Add R2 and Cloudflare settings**
+
+In `app/config.py`, add a new settings block after the `S3_REGION` field (around line 76). The existing `STORAGE_TYPE` and `S3_*` fields remain for now; they're removed in a later task to keep this step scoped.
+
+```python
+    # Cloudflare R2 (image storage)
+    R2_ENABLED: bool = Field(
+        default=False,
+        description="Enable R2 image serving. When false, app uses local FS only.",
+    )
+    R2_ACCESS_KEY_ID: str = Field(default="")
+    R2_SECRET_ACCESS_KEY: str = Field(default="")
+    R2_ENDPOINT: str = Field(default="", description="R2 S3-compatible endpoint URL")
+    R2_PUBLIC_BUCKET: str = Field(default="shuushuu-images")
+    R2_PRIVATE_BUCKET: str = Field(default="shuushuu-images-private")
+    R2_PUBLIC_CDN_URL: str = Field(
+        default="",
+        description="Custom domain attached to the public R2 bucket (no trailing slash)",
+    )
+    R2_PRESIGN_TTL_SECONDS: int = Field(default=900, ge=60, le=3600)
+    R2_ALLOW_BULK_BACKFILL: bool = Field(
+        default=False,
+        description=(
+            "Gate for r2_sync.py backfill-locations and reconcile. "
+            "Set true permanently in prod; leave false on staging to prevent "
+            "mass-uploading prod-imported images to the staging bucket."
+        ),
+    )
+
+    # Cloudflare API (for CDN cache purge)
+    CLOUDFLARE_API_TOKEN: str = Field(default="")
+    CLOUDFLARE_ZONE_ID: str = Field(default="")
+```
+
+**Step 2: Add validator that requires R2_* and CLOUDFLARE_* when R2_ENABLED=true**
+
+In `app/config.py`, add a new `@model_validator(mode="after")` method inside the `Settings` class. Place it below the existing `validate_smtp_tls_settings` validator:
+
+```python
+    @model_validator(mode="after")
+    def validate_r2_enabled_requirements(self) -> Settings:
+        """When R2_ENABLED=true, all R2_* and CLOUDFLARE_* credentials must be set."""
+        if not self.R2_ENABLED:
+            return self
+        required = {
+            "R2_ACCESS_KEY_ID": self.R2_ACCESS_KEY_ID,
+            "R2_SECRET_ACCESS_KEY": self.R2_SECRET_ACCESS_KEY,
+            "R2_ENDPOINT": self.R2_ENDPOINT,
+            "R2_PUBLIC_BUCKET": self.R2_PUBLIC_BUCKET,
+            "R2_PRIVATE_BUCKET": self.R2_PRIVATE_BUCKET,
+            "R2_PUBLIC_CDN_URL": self.R2_PUBLIC_CDN_URL,
+            "CLOUDFLARE_API_TOKEN": self.CLOUDFLARE_API_TOKEN,
+            "CLOUDFLARE_ZONE_ID": self.CLOUDFLARE_ZONE_ID,
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise ValueError(
+                f"R2_ENABLED=true but these required settings are empty: {', '.join(missing)}"
+            )
+        return self
+```
+
+**Step 3: Write validator tests**
+
+Create `tests/unit/test_config_r2.py`:
+
+```python
+"""Tests for R2 config validation."""
+
+import pytest
+
+from app.config import Settings
+
+
+@pytest.mark.unit
+class TestR2ConfigValidation:
+    """R2_ENABLED requires all R2_* and CLOUDFLARE_* credentials."""
+
+    def test_r2_disabled_requires_no_credentials(self):
+        """When R2_ENABLED=false, empty R2/Cloudflare fields are fine."""
+        s = Settings(_env_file=None, R2_ENABLED=False)
+        assert s.R2_ENABLED is False
+
+    def test_r2_enabled_requires_all_credentials(self):
+        """When R2_ENABLED=true, missing credentials fail validation."""
+        with pytest.raises(ValueError, match="R2_ACCESS_KEY_ID"):
+            Settings(
+                _env_file=None,
+                R2_ENABLED=True,
+                R2_ACCESS_KEY_ID="",
+                R2_SECRET_ACCESS_KEY="sk",
+                R2_ENDPOINT="https://example.r2.cloudflarestorage.com",
+                R2_PUBLIC_CDN_URL="https://cdn.example.com",
+                CLOUDFLARE_API_TOKEN="tok",
+                CLOUDFLARE_ZONE_ID="zone",
+            )
+
+    def test_r2_enabled_with_all_credentials_passes(self):
+        """Full credentials pass validation."""
+        s = Settings(
+            _env_file=None,
+            R2_ENABLED=True,
+            R2_ACCESS_KEY_ID="ak",
+            R2_SECRET_ACCESS_KEY="sk",
+            R2_ENDPOINT="https://example.r2.cloudflarestorage.com",
+            R2_PUBLIC_CDN_URL="https://cdn.example.com",
+            CLOUDFLARE_API_TOKEN="tok",
+            CLOUDFLARE_ZONE_ID="zone",
+        )
+        assert s.R2_ENABLED is True
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/test_config_r2.py -v`
+Expected: 3 PASS
+
+**Step 5: Commit**
+
+```bash
+git add app/config.py tests/unit/test_config_r2.py
+git commit -m "feat(r2): add R2 config settings and validator"
+```
+
+---
+
+### Task 3: Create R2Location Enum and Shared Constants
+
+**Files:**
+- Create: `app/core/r2_constants.py`
+- Test: `tests/unit/test_r2_constants.py`
+
+Rationale for a dedicated module: these constants are imported from models, schemas, services, and scripts. Putting them in a standalone module avoids import cycles.
+
+**Step 1: Write failing test**
+
+Create `tests/unit/test_r2_constants.py`:
+
+```python
+"""Tests for R2 shared constants."""
+
+import pytest
+
+from app.config import ImageStatus
+from app.core.r2_constants import (
+    PUBLIC_IMAGE_STATUSES_FOR_R2,
+    R2_VARIANTS,
+    R2Location,
+)
+
+
+@pytest.mark.unit
+class TestR2Location:
+    """R2Location enum values."""
+
+    def test_values(self):
+        assert R2Location.NONE == 0
+        assert R2Location.PUBLIC == 1
+        assert R2Location.PRIVATE == 2
+
+    def test_int_comparison(self):
+        """Enum is IntEnum so it compares to ints directly."""
+        assert R2Location.NONE == 0
+        assert int(R2Location.PUBLIC) == 1
+
+
+@pytest.mark.unit
+class TestPublicStatuses:
+    """The set of statuses that map to the public bucket."""
+
+    def test_members(self):
+        assert PUBLIC_IMAGE_STATUSES_FOR_R2 == frozenset(
+            {ImageStatus.ACTIVE, ImageStatus.SPOILER, ImageStatus.REPOST}
+        )
+
+    def test_is_frozen(self):
+        with pytest.raises(AttributeError):
+            PUBLIC_IMAGE_STATUSES_FOR_R2.add(999)  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
+class TestR2Variants:
+    """The canonical list of variant prefixes used as R2 key prefixes."""
+
+    def test_list(self):
+        assert R2_VARIANTS == ("fullsize", "thumbs", "medium", "large")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_r2_constants.py -v`
+Expected: FAIL (module not found)
+
+**Step 3: Implement**
+
+Create `app/core/r2_constants.py`:
+
+```python
+"""Shared constants for R2 integration.
+
+Kept in its own module to avoid import cycles between models, schemas,
+services, and the scripts/r2_sync.py CLI.
+"""
+
+from enum import IntEnum
+
+from app.config import ImageStatus
+
+# Image statuses served from the public R2 bucket. Any other status is protected
+# and lives in the private bucket (accessed via presigned URLs).
+PUBLIC_IMAGE_STATUSES_FOR_R2: frozenset[int] = frozenset(
+    {ImageStatus.ACTIVE, ImageStatus.SPOILER, ImageStatus.REPOST}
+)
+
+# Key prefixes under each R2 bucket. Matches the local FS layout so the
+# one-time bucket split requires no key rewriting.
+R2_VARIANTS: tuple[str, ...] = ("fullsize", "thumbs", "medium", "large")
+
+
+class R2Location(IntEnum):
+    """Where an image's R2 objects physically live.
+
+    NONE    — not yet synced to R2 (pending finalizer, or R2 disabled).
+    PUBLIC  — canonical copy lives in R2_PUBLIC_BUCKET.
+    PRIVATE — canonical copy lives in R2_PRIVATE_BUCKET.
+    """
+
+    NONE = 0
+    PUBLIC = 1
+    PRIVATE = 2
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_constants.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add app/core/r2_constants.py tests/unit/test_r2_constants.py
+git commit -m "feat(r2): add R2Location enum and shared constants"
+```
+
+---
+
+### Task 4: Add `r2_location` Column Migration
+
+**Files:**
+- Create: `alembic/versions/<generated>_add_r2_location_to_images.py`
+
+**Step 1: Generate migration**
+
+Run: `uv run alembic revision -m "add r2_location to images"`
+Expected: New revision file created in `alembic/versions/`. Note the revision id.
+
+**Step 2: Edit migration**
+
+Replace the generated file's body with (substitute `<generated>` and `<down_revision>` appropriately — the current head is `8c950e7fa6f2`):
+
+```python
+"""add r2_location to images
+
+Revision ID: <generated>
+Revises: 8c950e7fa6f2
+Create Date: <generated>
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "<generated>"
+down_revision: str | Sequence[str] | None = "8c950e7fa6f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add r2_location column to images.
+
+    0 = NONE (not in R2 yet), 1 = PUBLIC bucket, 2 = PRIVATE bucket.
+    Default NONE — backfill is a separate one-shot run.
+    """
+    op.add_column(
+        "images",
+        sa.Column(
+            "r2_location",
+            mysql.TINYINT(unsigned=True),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    # Index supports reconcile/health queries (WHERE r2_location = 0)
+    op.create_index(
+        "idx_r2_location",
+        "images",
+        ["r2_location"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Remove r2_location column."""
+    op.drop_index("idx_r2_location", table_name="images")
+    op.drop_column("images", "r2_location")
+```
+
+**Step 3: Apply migration**
+
+Run: `uv run alembic upgrade head`
+Expected: Migration applies successfully against the dev DB.
+
+**Step 4: Commit**
+
+```bash
+git add alembic/versions/*_add_r2_location_to_images.py
+git commit -m "feat(r2): add r2_location column to images table"
+```
+
+---
+
+### Task 5: Add `r2_location` Field to Images Model
+
+**Files:**
+- Modify: `app/models/image.py`
+
+**Step 1: Add import and field**
+
+In `app/models/image.py`, add the import near the top with the other app imports (around line 23):
+
+```python
+from app.core.r2_constants import R2Location
+```
+
+Add the `r2_location` field to the `Images` class. Place it after the `replacement_id` field (currently at line 243):
+
+```python
+    # R2 sync state. NONE=0 means object is not yet in R2; the finalizer
+    # or `r2_sync.py reconcile` will flip it to PUBLIC or PRIVATE.
+    r2_location: int = Field(default=R2Location.NONE)
+```
+
+**Step 2: Write a model test**
+
+Create `tests/unit/test_image_r2_location.py`:
+
+```python
+"""Test r2_location field on Images model."""
+
+import pytest
+
+from app.core.r2_constants import R2Location
+from app.models.image import Images
+
+
+@pytest.mark.unit
+class TestImageR2Location:
+    def test_default_is_none(self):
+        """New image instances default r2_location to NONE=0."""
+        img = Images(ext="jpg", user_id=1)
+        assert img.r2_location == R2Location.NONE == 0
+
+    def test_can_set_public(self):
+        img = Images(ext="jpg", user_id=1, r2_location=R2Location.PUBLIC)
+        assert img.r2_location == 1
+
+    def test_can_set_private(self):
+        img = Images(ext="jpg", user_id=1, r2_location=R2Location.PRIVATE)
+        assert img.r2_location == 2
+```
+
+**Step 3: Run tests**
+
+Run: `uv run pytest tests/unit/test_image_r2_location.py -v`
+Expected: 3 PASS
+
+**Step 4: Run full unit suite to confirm no regressions**
+
+Run: `uv run pytest -m unit -x --tb=short`
+Expected: all pass (no changes to existing behaviour).
+
+**Step 5: Commit**
+
+```bash
+git add app/models/image.py tests/unit/test_image_r2_location.py
+git commit -m "feat(r2): add r2_location field to Images model"
+```
+
+---
+
+## Chunk 2: Storage Adapter and Cloudflare Purge
+
+The thin wrappers that every higher layer depends on. An explicit `DummyR2Storage` keeps disabled-mode safe — calling R2 when `R2_ENABLED=false` is a bug and must raise, not silently succeed.
+
+---
+
+### Task 6: R2Storage Adapter
+
+**Files:**
+- Create: `app/services/r2_storage.py`
+- Test: `tests/unit/test_r2_storage.py`
+
+**Step 1: Write failing tests**
+
+Create `tests/unit/test_r2_storage.py`:
+
+```python
+"""Tests for R2Storage adapter (backed by moto S3 mock)."""
+
+from pathlib import Path
+
+import aioboto3
+import pytest
+from moto import mock_aws
+
+from app.services.r2_storage import R2Storage
+
+
+@pytest.fixture
+def moto_s3():
+    """Start a moto S3 mock and yield an aioboto3 session pointed at it."""
+    with mock_aws():
+        session = aioboto3.Session(
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+            region_name="us-east-1",
+        )
+        yield session
+
+
+@pytest.fixture
+async def storage(moto_s3):
+    """R2Storage instance wired to the moto session."""
+    # moto's in-memory S3 endpoint is injected at the aioboto3 client level via env
+    # or positional kwarg; moto.mock_aws() patches boto3's network calls transparently,
+    # so no explicit endpoint_url override is required here.
+    return R2Storage(session=moto_s3, endpoint_url=None)
+
+
+@pytest.fixture
+async def setup_buckets(storage, moto_s3):
+    async with moto_s3.client("s3") as s3:
+        await s3.create_bucket(Bucket="public")
+        await s3.create_bucket(Bucket="private")
+    return storage
+
+
+@pytest.mark.unit
+class TestR2Storage:
+    async def test_upload_and_exists(self, setup_buckets, tmp_path: Path):
+        storage = setup_buckets
+        src = tmp_path / "a.bin"
+        src.write_bytes(b"hello")
+        await storage.upload_file(bucket="public", key="fullsize/a.bin", path=src)
+        assert await storage.object_exists(bucket="public", key="fullsize/a.bin") is True
+        assert await storage.object_exists(bucket="public", key="fullsize/missing.bin") is False
+
+    async def test_copy_object(self, setup_buckets, tmp_path: Path):
+        storage = setup_buckets
+        src = tmp_path / "a.bin"
+        src.write_bytes(b"data")
+        await storage.upload_file(bucket="public", key="fullsize/a.bin", path=src)
+        await storage.copy_object(
+            src_bucket="public", dst_bucket="private", key="fullsize/a.bin"
+        )
+        assert await storage.object_exists(bucket="private", key="fullsize/a.bin") is True
+
+    async def test_delete_object(self, setup_buckets, tmp_path: Path):
+        storage = setup_buckets
+        src = tmp_path / "a.bin"
+        src.write_bytes(b"data")
+        await storage.upload_file(bucket="public", key="fullsize/a.bin", path=src)
+        await storage.delete_object(bucket="public", key="fullsize/a.bin")
+        assert await storage.object_exists(bucket="public", key="fullsize/a.bin") is False
+
+    async def test_delete_missing_is_idempotent(self, setup_buckets):
+        storage = setup_buckets
+        # Deleting a key that doesn't exist must not raise — S3 returns 204.
+        await storage.delete_object(bucket="public", key="fullsize/missing.bin")
+
+    async def test_generate_presigned_url(self, setup_buckets, tmp_path: Path):
+        storage = setup_buckets
+        src = tmp_path / "a.bin"
+        src.write_bytes(b"data")
+        await storage.upload_file(bucket="private", key="fullsize/a.bin", path=src)
+        url = await storage.generate_presigned_url(
+            bucket="private", key="fullsize/a.bin", ttl=60
+        )
+        assert "a.bin" in url
+        assert "Signature" in url or "X-Amz-Signature" in url
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_r2_storage.py -v`
+Expected: FAIL (module not found)
+
+**Step 3: Implement adapter**
+
+Create `app/services/r2_storage.py`:
+
+```python
+"""Thin async wrapper around aioboto3 for Cloudflare R2 (S3-compatible).
+
+A single shared aioboto3.Session is reused for the life of the app.
+The adapter exposes only the operations the app needs; no leaky AWS details.
+"""
+
+from pathlib import Path
+
+import aioboto3
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class R2Storage:
+    """R2 storage adapter. Wraps aioboto3 client calls with our semantics."""
+
+    def __init__(
+        self,
+        session: aioboto3.Session,
+        endpoint_url: str | None,
+    ) -> None:
+        self._session = session
+        self._endpoint_url = endpoint_url
+
+    def _client(self):
+        """Yield a short-lived aioboto3 S3 client (async context manager)."""
+        return self._session.client("s3", endpoint_url=self._endpoint_url)
+
+    async def upload_file(self, bucket: str, key: str, path: Path) -> None:
+        """Upload a local file to `{bucket}/{key}`."""
+        async with self._client() as s3:
+            await s3.upload_file(str(path), bucket, key)
+
+    async def copy_object(self, src_bucket: str, dst_bucket: str, key: str) -> None:
+        """Copy an object between buckets, preserving the key."""
+        async with self._client() as s3:
+            await s3.copy_object(
+                Bucket=dst_bucket,
+                Key=key,
+                CopySource={"Bucket": src_bucket, "Key": key},
+            )
+
+    async def delete_object(self, bucket: str, key: str) -> None:
+        """Delete an object. Idempotent — S3 treats missing keys as success."""
+        async with self._client() as s3:
+            await s3.delete_object(Bucket=bucket, Key=key)
+
+    async def object_exists(self, bucket: str, key: str) -> bool:
+        """Return True iff the object exists."""
+        async with self._client() as s3:
+            try:
+                await s3.head_object(Bucket=bucket, Key=key)
+                return True
+            except s3.exceptions.ClientError as e:
+                # botocore may stringify head_object 404 as "404", "NotFound",
+                # or "NoSuchKey" depending on version — accept all three.
+                if e.response["Error"]["Code"] in {"404", "NotFound", "NoSuchKey"}:
+                    return False
+                raise
+
+    async def generate_presigned_url(self, bucket: str, key: str, ttl: int) -> str:
+        """Generate a short-lived GET URL for a private-bucket object."""
+        async with self._client() as s3:
+            return await s3.generate_presigned_url(
+                ClientMethod="get_object",
+                Params={"Bucket": bucket, "Key": key},
+                ExpiresIn=ttl,
+            )
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_storage.py -v`
+Expected: all PASS
+
+**Step 5: Commit**
+
+```bash
+git add app/services/r2_storage.py tests/unit/test_r2_storage.py
+git commit -m "feat(r2): add R2Storage adapter over aioboto3"
+```
+
+---
+
+### Task 7: DummyR2Storage and DI Singleton
+
+**Files:**
+- Modify: `app/services/r2_storage.py` (add `DummyR2Storage`)
+- Create: `app/core/r2_client.py` (singleton accessor)
+- Test: `tests/unit/test_r2_client.py`
+
+**Step 1: Add DummyR2Storage to r2_storage.py**
+
+In `app/services/r2_storage.py`, append:
+
+```python
+class DummyR2Storage:
+    """No-op R2 storage for R2_ENABLED=false mode.
+
+    Every method raises RuntimeError so any accidental call surfaces
+    loudly rather than silently succeeding.
+    """
+
+    _ERR = (
+        "R2 is disabled (R2_ENABLED=false). This code path should not have "
+        "reached the R2 storage adapter."
+    )
+
+    async def upload_file(self, bucket: str, key: str, path: Path) -> None:
+        raise RuntimeError(self._ERR)
+
+    async def copy_object(self, src_bucket: str, dst_bucket: str, key: str) -> None:
+        raise RuntimeError(self._ERR)
+
+    async def delete_object(self, bucket: str, key: str) -> None:
+        raise RuntimeError(self._ERR)
+
+    async def object_exists(self, bucket: str, key: str) -> bool:
+        raise RuntimeError(self._ERR)
+
+    async def generate_presigned_url(self, bucket: str, key: str, ttl: int) -> str:
+        raise RuntimeError(self._ERR)
+```
+
+**Step 2: Write failing tests**
+
+Create `tests/unit/test_r2_client.py`:
+
+```python
+"""Tests for the R2 client singleton accessor."""
+
+import pytest
+
+from app.config import settings
+from app.core.r2_client import get_r2_storage, reset_r2_storage
+from app.services.r2_storage import DummyR2Storage, R2Storage
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_r2_storage()
+    yield
+    reset_r2_storage()
+
+
+@pytest.mark.unit
+class TestGetR2Storage:
+    def test_returns_dummy_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        storage = get_r2_storage()
+        assert isinstance(storage, DummyR2Storage)
+
+    def test_returns_real_when_enabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ACCESS_KEY_ID", "ak")
+        monkeypatch.setattr(settings, "R2_SECRET_ACCESS_KEY", "sk")
+        monkeypatch.setattr(
+            settings, "R2_ENDPOINT", "https://example.r2.cloudflarestorage.com"
+        )
+        storage = get_r2_storage()
+        assert isinstance(storage, R2Storage)
+
+    def test_singleton_stable_within_mode(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        assert get_r2_storage() is get_r2_storage()
+
+    async def test_dummy_methods_raise(self):
+        storage = DummyR2Storage()
+        with pytest.raises(RuntimeError, match="R2 is disabled"):
+            await storage.object_exists(bucket="b", key="k")
+```
+
+**Step 3: Run tests to verify fail**
+
+Run: `uv run pytest tests/unit/test_r2_client.py -v`
+Expected: FAIL (module not found)
+
+**Step 4: Implement singleton**
+
+Create `app/core/r2_client.py`:
+
+```python
+"""Process-wide R2 storage accessor.
+
+Returns a real R2Storage when R2_ENABLED, or a DummyR2Storage when disabled.
+The singleton is rebuilt after reset_r2_storage() — useful in tests.
+"""
+
+import aioboto3
+
+from app.config import settings
+from app.services.r2_storage import DummyR2Storage, R2Storage
+
+_instance: R2Storage | DummyR2Storage | None = None
+
+
+def get_r2_storage() -> R2Storage | DummyR2Storage:
+    """Return the process-wide R2 storage adapter."""
+    global _instance
+    if _instance is None:
+        if settings.R2_ENABLED:
+            session = aioboto3.Session(
+                aws_access_key_id=settings.R2_ACCESS_KEY_ID,
+                aws_secret_access_key=settings.R2_SECRET_ACCESS_KEY,
+                region_name="auto",
+            )
+            _instance = R2Storage(session=session, endpoint_url=settings.R2_ENDPOINT)
+        else:
+            _instance = DummyR2Storage()
+    return _instance
+
+
+def reset_r2_storage() -> None:
+    """Reset the singleton. Used by tests and on config reload."""
+    global _instance
+    _instance = None
+```
+
+**Step 5: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_client.py tests/unit/test_r2_storage.py -v`
+Expected: all PASS
+
+**Step 6: Commit**
+
+```bash
+git add app/services/r2_storage.py app/core/r2_client.py tests/unit/test_r2_client.py
+git commit -m "feat(r2): add DummyR2Storage and singleton accessor"
+```
+
+---
+
+### Task 8: Cloudflare Cache Purge Service
+
+**Files:**
+- Create: `app/services/cloudflare.py`
+- Test: `tests/unit/test_cloudflare_purge.py`
+
+**Step 1: Write failing tests**
+
+Create `tests/unit/test_cloudflare_purge.py`:
+
+```python
+"""Tests for Cloudflare cache purge service."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.config import settings
+from app.services.cloudflare import purge_cache_by_urls
+
+
+@pytest.mark.unit
+class TestPurgeCacheByUrls:
+    async def test_no_op_when_urls_empty(self):
+        """Empty URL list is a no-op (no HTTP calls)."""
+        with patch("app.services.cloudflare.httpx.AsyncClient") as client_cls:
+            await purge_cache_by_urls([])
+            client_cls.assert_not_called()
+
+    async def test_raises_when_credentials_missing(self, monkeypatch):
+        """Missing Cloudflare config is a misconfiguration — raise, don't silently no-op."""
+        monkeypatch.setattr(settings, "CLOUDFLARE_API_TOKEN", "")
+        monkeypatch.setattr(settings, "CLOUDFLARE_ZONE_ID", "")
+        with pytest.raises(RuntimeError, match="CLOUDFLARE_ZONE_ID"):
+            await purge_cache_by_urls(["https://cdn.example.com/x.jpg"])
+
+    async def test_posts_to_cloudflare_api(self, monkeypatch):
+        monkeypatch.setattr(settings, "CLOUDFLARE_API_TOKEN", "tok")
+        monkeypatch.setattr(settings, "CLOUDFLARE_ZONE_ID", "zone")
+
+        mock_client = AsyncMock()
+        # httpx.Response is sync — use MagicMock, not AsyncMock, so .text/.json
+        # don't get turned into coroutines.
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.text = ""
+        mock_response.json = lambda: {"success": True, "errors": []}
+        mock_response.raise_for_status = lambda: None
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = False
+
+        with patch("app.services.cloudflare.httpx.AsyncClient", return_value=mock_client):
+            await purge_cache_by_urls(["https://cdn.example.com/x.jpg"])
+
+        mock_client.post.assert_awaited_once()
+        call = mock_client.post.await_args
+        assert "zones/zone/purge_cache" in call.args[0]
+        assert call.kwargs["json"] == {"files": ["https://cdn.example.com/x.jpg"]}
+        assert call.kwargs["headers"]["Authorization"] == "Bearer tok"
+
+    async def test_batches_urls_in_groups_of_30(self, monkeypatch):
+        """Cloudflare free plan accepts max 30 URLs per call — we chunk accordingly."""
+        monkeypatch.setattr(settings, "CLOUDFLARE_API_TOKEN", "tok")
+        monkeypatch.setattr(settings, "CLOUDFLARE_ZONE_ID", "zone")
+
+        mock_client = AsyncMock()
+        # httpx.Response is sync — use MagicMock, not AsyncMock, so .text/.json
+        # don't get turned into coroutines.
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.text = ""
+        mock_response.json = lambda: {"success": True, "errors": []}
+        mock_response.raise_for_status = lambda: None
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = False
+
+        urls = [f"https://cdn.example.com/{i}.jpg" for i in range(65)]
+        with patch("app.services.cloudflare.httpx.AsyncClient", return_value=mock_client):
+            await purge_cache_by_urls(urls)
+
+        # 65 URLs → 30 + 30 + 5 = 3 calls
+        assert mock_client.post.await_count == 3
+        first_batch = mock_client.post.await_args_list[0].kwargs["json"]["files"]
+        last_batch = mock_client.post.await_args_list[2].kwargs["json"]["files"]
+        assert len(first_batch) == 30
+        assert len(last_batch) == 5
+
+    async def test_logs_and_raises_on_cloudflare_error(self, monkeypatch, caplog):
+        monkeypatch.setattr(settings, "CLOUDFLARE_API_TOKEN", "tok")
+        monkeypatch.setattr(settings, "CLOUDFLARE_ZONE_ID", "zone")
+
+        mock_client = AsyncMock()
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 400
+        mock_response.text = '{"success": false, "errors": [{"message": "bad"}]}'
+        mock_response.json = lambda: {"success": False, "errors": [{"message": "bad"}]}
+
+        # httpx.HTTPStatusError requires a real Request object — passing None
+        # TypeErrors at construction time on httpx ≥0.24.
+        fake_request = httpx.Request("POST", "https://api.cloudflare.com/")
+
+        def raise_for_status():
+            raise httpx.HTTPStatusError("400", request=fake_request, response=mock_response)
+
+        mock_response.raise_for_status = raise_for_status
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = False
+
+        with patch("app.services.cloudflare.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(httpx.HTTPStatusError):
+                await purge_cache_by_urls(["https://cdn.example.com/x.jpg"])
+```
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/unit/test_cloudflare_purge.py -v`
+Expected: FAIL (module not found)
+
+**Step 3: Implement**
+
+Create `app/services/cloudflare.py`:
+
+```python
+"""Cloudflare API helpers.
+
+Currently covers cache purge only. Expand here as more Cloudflare features
+are needed (e.g., WAF, DNS) — don't sprinkle Cloudflare calls across services.
+"""
+
+import httpx
+
+from app.config import settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Free plan caps purge-by-URL calls at 30 URLs per request.
+_BATCH_SIZE = 30
+
+
+async def purge_cache_by_urls(urls: list[str]) -> None:
+    """Purge Cloudflare's edge cache for the given URLs.
+
+    Batches into groups of 30 (free-plan limit). No-op when list is empty.
+    Raises httpx.HTTPStatusError on non-2xx responses so the caller can
+    surface the failure to its retry/alerting machinery.
+    """
+    if not urls:
+        return
+
+    if not settings.CLOUDFLARE_ZONE_ID or not settings.CLOUDFLARE_API_TOKEN:
+        # Fail loudly — a silent no-op here would mask misconfiguration and
+        # stale CDN content for minutes or hours.
+        raise RuntimeError(
+            "purge_cache_by_urls called but CLOUDFLARE_ZONE_ID / "
+            "CLOUDFLARE_API_TOKEN are not configured"
+        )
+
+    api_url = (
+        f"https://api.cloudflare.com/client/v4/zones/"
+        f"{settings.CLOUDFLARE_ZONE_ID}/purge_cache"
+    )
+    headers = {
+        "Authorization": f"Bearer {settings.CLOUDFLARE_API_TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        for start in range(0, len(urls), _BATCH_SIZE):
+            batch = urls[start : start + _BATCH_SIZE]
+            logger.info("r2_cdn_purge_started", batch_size=len(batch))
+            response = await client.post(
+                api_url,
+                json={"files": batch},
+                headers=headers,
+            )
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError:
+                logger.error(
+                    "r2_cdn_purge_failed",
+                    status_code=response.status_code,
+                    body=response.text,
+                )
+                raise
+            logger.info("r2_cdn_purge_succeeded", batch_size=len(batch))
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/test_cloudflare_purge.py -v`
+Expected: all PASS
+
+**Step 5: Commit**
+
+```bash
+git add app/services/cloudflare.py tests/unit/test_cloudflare_purge.py
+git commit -m "feat(r2): add Cloudflare cache-purge service"
+```
+
+---
+
+## Chunk 3: URL Generation and Serving Endpoint
+
+These two changes are user-visible on their own even before any R2 data is present — with `r2_location=NONE` everywhere and `R2_ENABLED=false` they must be no-ops.
+
+---
+
+### Task 9: Status-Aware URL Generation
+
+**Files:**
+- Modify: `app/schemas/image.py`
+- Test: `tests/unit/test_image_url_generation.py`
+
+**Step 1: Write failing tests**
+
+Create `tests/unit/test_image_url_generation.py`:
+
+```python
+"""Tests for status-aware image URL generation.
+
+Matrix: 7 statuses × 3 r2_location values × 2 R2_ENABLED values. A direct-CDN
+URL must be emitted only when R2_ENABLED=true AND status is public AND
+r2_location=PUBLIC. Every other combination falls back to the /images/ path.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+from app.schemas.image import ImageResponse
+
+ALL_STATUSES = [
+    ImageStatus.REVIEW,
+    ImageStatus.LOW_QUALITY,
+    ImageStatus.INAPPROPRIATE,
+    ImageStatus.REPOST,
+    ImageStatus.OTHER,
+    ImageStatus.ACTIVE,
+    ImageStatus.SPOILER,
+]
+PUBLIC_STATUSES = [ImageStatus.ACTIVE, ImageStatus.SPOILER, ImageStatus.REPOST]
+
+
+def _make_image(status: int, r2_location: int, medium: int = 0, large: int = 0) -> ImageResponse:
+    return ImageResponse(
+        image_id=1,
+        user_id=1,
+        filename="2026-04-17-1",
+        ext="jpg",
+        status=status,
+        r2_location=r2_location,
+        date_added=datetime(2026, 4, 17),
+        locked=0,
+        posts=0,
+        favorites=0,
+        bayesian_rating=0.0,
+        num_ratings=0,
+        medium=medium,
+        large=large,
+    )
+
+
+@pytest.fixture
+def r2_on(monkeypatch):
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://localhost:3000")
+
+
+@pytest.fixture
+def r2_off(monkeypatch):
+    monkeypatch.setattr(settings, "R2_ENABLED", False)
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://localhost:3000")
+
+
+@pytest.mark.unit
+class TestUrlGenerationR2Off:
+    """With R2 disabled, everything goes through /images/ — no exceptions."""
+
+    @pytest.mark.parametrize("status", ALL_STATUSES)
+    @pytest.mark.parametrize(
+        "location", [R2Location.NONE, R2Location.PUBLIC, R2Location.PRIVATE]
+    )
+    def test_url_fallback(self, r2_off, status, location):
+        img = _make_image(status=status, r2_location=location)
+        assert img.url == "http://localhost:3000/images/2026-04-17-1.jpg"
+        assert img.thumbnail_url == "http://localhost:3000/thumbs/2026-04-17-1.webp"
+
+
+@pytest.mark.unit
+class TestUrlGenerationR2On:
+    @pytest.mark.parametrize("status", PUBLIC_STATUSES)
+    def test_cdn_direct_for_public_status_public_location(self, r2_on, status):
+        img = _make_image(status=status, r2_location=R2Location.PUBLIC)
+        assert img.url == "https://cdn.example.com/fullsize/2026-04-17-1.jpg"
+        assert img.thumbnail_url == "https://cdn.example.com/thumbs/2026-04-17-1.webp"
+
+    @pytest.mark.parametrize("status", PUBLIC_STATUSES)
+    def test_fallback_when_location_none(self, r2_on, status):
+        img = _make_image(status=status, r2_location=R2Location.NONE)
+        assert img.url.startswith("http://localhost:3000/images/")
+        assert img.thumbnail_url.startswith("http://localhost:3000/thumbs/")
+
+    @pytest.mark.parametrize("status", PUBLIC_STATUSES)
+    def test_fallback_when_location_private(self, r2_on, status):
+        """Public status with PRIVATE location means a transition is in flight."""
+        img = _make_image(status=status, r2_location=R2Location.PRIVATE)
+        assert img.url.startswith("http://localhost:3000/images/")
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            ImageStatus.REVIEW,
+            ImageStatus.LOW_QUALITY,
+            ImageStatus.INAPPROPRIATE,
+            ImageStatus.OTHER,
+        ],
+    )
+    @pytest.mark.parametrize(
+        "location", [R2Location.NONE, R2Location.PUBLIC, R2Location.PRIVATE]
+    )
+    def test_protected_never_direct_cdn(self, r2_on, status, location):
+        """Protected statuses must never emit a CDN URL, regardless of location."""
+        img = _make_image(status=status, r2_location=location)
+        assert "cdn.example.com" not in img.url
+        assert img.url.startswith("http://localhost:3000/images/")
+
+
+@pytest.mark.unit
+class TestMediumLargeUrls:
+    def test_medium_none_returns_none(self, r2_on):
+        img = _make_image(
+            status=ImageStatus.ACTIVE, r2_location=R2Location.PUBLIC, medium=0, large=0
+        )
+        assert img.medium_url is None
+        assert img.large_url is None
+
+    def test_medium_ready_uses_cdn(self, r2_on):
+        img = _make_image(
+            status=ImageStatus.ACTIVE, r2_location=R2Location.PUBLIC, medium=1, large=1
+        )
+        assert img.medium_url == "https://cdn.example.com/medium/2026-04-17-1.jpg"
+        assert img.large_url == "https://cdn.example.com/large/2026-04-17-1.jpg"
+
+    def test_medium_ready_fallback_when_none_location(self, r2_on):
+        img = _make_image(
+            status=ImageStatus.ACTIVE, r2_location=R2Location.NONE, medium=1, large=1
+        )
+        assert img.medium_url == "http://localhost:3000/medium/2026-04-17-1.jpg"
+        assert img.large_url == "http://localhost:3000/large/2026-04-17-1.jpg"
+```
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/unit/test_image_url_generation.py -v`
+Expected: FAIL (ImageResponse doesn't yet accept r2_location, no CDN logic)
+
+**Step 3: Update ImageResponse**
+
+In `app/schemas/image.py`:
+
+Add imports near the existing ones:
+
+```python
+from app.core.r2_constants import PUBLIC_IMAGE_STATUSES_FOR_R2, R2Location
+```
+
+Add `r2_location` field to `ImageResponse` (insert after `large: int` at line 93):
+
+```python
+    r2_location: int = R2Location.NONE  # Tri-state: 0=NONE, 1=PUBLIC, 2=PRIVATE
+```
+
+Replace the four `@computed_field` URL properties (lines 97-123) with:
+
+```python
+    def _should_use_cdn(self) -> bool:
+        """True when we can emit a direct-CDN URL for this image.
+
+        All three must hold: R2 enabled, status is publicly-viewable, and the
+        canonical object lives in the public bucket. A mismatch (e.g., public
+        status but PRIVATE location during a bucket move) falls back to the
+        /images/ path, which the endpoint routes based on current r2_location.
+        """
+        return (
+            settings.R2_ENABLED
+            and self.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+            and self.r2_location == R2Location.PUBLIC
+        )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def url(self) -> str:
+        """Fullsize URL — direct CDN when eligible, else protected path."""
+        if self._should_use_cdn():
+            return f"{settings.R2_PUBLIC_CDN_URL}/fullsize/{self.filename}.{self.ext}"
+        return f"{settings.IMAGE_BASE_URL}/images/{self.filename}.{self.ext}"
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def thumbnail_url(self) -> str:
+        """Thumbnail URL (always WebP)."""
+        if self._should_use_cdn():
+            return f"{settings.R2_PUBLIC_CDN_URL}/thumbs/{self.filename}.webp"
+        return f"{settings.IMAGE_BASE_URL}/thumbs/{self.filename}.webp"
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def medium_url(self) -> str | None:
+        """Medium variant (1280px edge) URL, or None if variant is absent."""
+        if not self.medium:
+            return None
+        if self._should_use_cdn():
+            return f"{settings.R2_PUBLIC_CDN_URL}/medium/{self.filename}.{self.ext}"
+        return f"{settings.IMAGE_BASE_URL}/medium/{self.filename}.{self.ext}"
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def large_url(self) -> str | None:
+        """Large variant (2048px edge) URL, or None if variant is absent."""
+        if not self.large:
+            return None
+        if self._should_use_cdn():
+            return f"{settings.R2_PUBLIC_CDN_URL}/large/{self.filename}.{self.ext}"
+        return f"{settings.IMAGE_BASE_URL}/large/{self.filename}.{self.ext}"
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/test_image_url_generation.py -v`
+Expected: all PASS
+
+**Step 5: Confirm no existing test regressions**
+
+Run: `uv run pytest -m unit -x --tb=short`
+Expected: all pass.
+
+**Step 6: Commit**
+
+```bash
+git add app/schemas/image.py tests/unit/test_image_url_generation.py
+git commit -m "feat(r2): status-aware URL generation with CDN fallback"
+```
+
+---
+
+### Task 10: `/images/*` Endpoint R2 Branches
+
+**Files:**
+- Modify: `app/api/v1/media.py`
+- Modify (extend): `tests/api/v1/test_media_serving.py` if present, else create it.
+
+**Step 1: Locate existing media test or create one**
+
+Run: `ls tests/api/v1/test_media_serving.py 2>/dev/null && echo exists || echo create`
+If it doesn't exist, note the outcome — we'll create it below.
+
+**Step 2: Write failing tests**
+
+Create (or extend) `tests/api/v1/test_media_serving.py`:
+
+```python
+"""Tests for /images/* media-serving endpoint R2 branches."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+
+
+@pytest.mark.api
+class TestMediaServingR2:
+    async def test_public_bucket_302s_to_cdn(self, client, test_image_public, monkeypatch):
+        """status=ACTIVE, r2_location=PUBLIC, R2 on → 302 to CDN URL with no-store."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+
+        # test_image_public fixture must create an Images row with
+        # status=ACTIVE and r2_location=PUBLIC.
+        response = await client.get(
+            f"/images/{test_image_public.filename}.{test_image_public.ext}",
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.headers["Location"].startswith("https://cdn.example.com/fullsize/")
+        assert response.headers["Cache-Control"] == "no-store"
+
+    async def test_private_bucket_302s_to_presigned(self, client, test_image_private, monkeypatch):
+        """Protected status + PRIVATE location → 302 to presigned URL."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+        with patch(
+            "app.api.v1.media.get_r2_storage",
+            return_value=AsyncMock(
+                generate_presigned_url=AsyncMock(
+                    return_value="https://presigned.example.com/foo?sig=xxx"
+                )
+            ),
+        ):
+            response = await client.get(
+                f"/images/{test_image_private.filename}.{test_image_private.ext}",
+                follow_redirects=False,
+                # Must provide auth as owner or moderator to view protected.
+                headers={"Authorization": f"Bearer {test_image_private.owner_token}"},
+            )
+        assert response.status_code == 302
+        assert response.headers["Location"].startswith("https://presigned.example.com/")
+        assert response.headers["Cache-Control"] == "no-store"
+
+    async def test_location_none_falls_back_to_xaccel(self, client, test_image_local, monkeypatch):
+        """r2_location=NONE → X-Accel-Redirect to /internal/ (unchanged behaviour)."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+        response = await client.get(
+            f"/images/{test_image_local.filename}.{test_image_local.ext}",
+            follow_redirects=False,
+        )
+        assert response.status_code == 200
+        assert response.headers["X-Accel-Redirect"].startswith("/internal/fullsize/")
+
+    async def test_r2_disabled_always_xaccel(self, client, test_image_public, monkeypatch):
+        """R2_ENABLED=false → X-Accel-Redirect regardless of r2_location."""
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+
+        response = await client.get(
+            f"/images/{test_image_public.filename}.{test_image_public.ext}",
+            follow_redirects=False,
+        )
+        assert response.status_code == 200
+        assert response.headers["X-Accel-Redirect"].startswith("/internal/")
+
+    async def test_permission_check_still_runs(self, anon_client, test_image_private, monkeypatch):
+        """Anonymous request for a protected image returns 404 before any R2 logic."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        response = await anon_client.get(
+            f"/images/{test_image_private.filename}.{test_image_private.ext}",
+        )
+        assert response.status_code == 404
+```
+
+(Fixtures `test_image_public`, `test_image_private`, `test_image_local`, `client`, `anon_client` follow existing project conventions — inspect `tests/conftest.py` to reuse what's there or add minimal new fixtures. If the existing suite uses different fixture names, rename to match.)
+
+**Step 3: Run tests**
+
+Run: `uv run pytest tests/api/v1/test_media_serving.py -v`
+Expected: FAIL (endpoint doesn't yet route by r2_location)
+
+**Step 4: Update `_serve_image` in `app/api/v1/media.py`**
+
+Replace the body of `_serve_image` (currently lines 123-165) with:
+
+```python
+async def _serve_image(
+    filename: str,
+    image_type: Literal["fullsize", "thumbs", "medium", "large"],
+    db: AsyncSession,
+    current_user: Users | None,
+) -> Response:
+    """Internal handler for serving images.
+
+    Routing:
+      - Permission check first (prevents leaking protected-image existence).
+      - If R2 enabled and r2_location=PUBLIC → 302 to CDN URL.
+      - If R2 enabled and r2_location=PRIVATE → 302 to presigned URL.
+      - Otherwise → X-Accel-Redirect to local /internal/ path (legacy fallback).
+    """
+    image_id = parse_image_id_from_filename(filename)
+    if image_id is None:
+        raise HTTPException(status_code=404)
+
+    image = await db.get(Images, image_id)
+    if image is None:
+        raise HTTPException(status_code=404)
+
+    # Permission check — prevents leaking info about protected images
+    if not await can_view_image_file(image, current_user, db):
+        raise HTTPException(status_code=404)
+
+    # Variant checks (unchanged)
+    if image_type in ("medium", "large"):
+        variant_status = image.medium if image_type == "medium" else image.large
+        if variant_status == VariantStatus.NONE:
+            raise HTTPException(status_code=404)
+        if variant_status == VariantStatus.PENDING:
+            fullsize_path = f"/internal/fullsize/{image.filename}.{image.ext}"
+            return Response(
+                status_code=200,
+                headers={"X-Accel-Redirect": fullsize_path, "Cache-Control": "no-store"},
+            )
+
+    ext = "webp" if image_type == "thumbs" else image.ext
+    key = f"{image_type}/{image.filename}.{ext}"
+
+    # R2 branches (only active when R2_ENABLED)
+    if settings.R2_ENABLED and image.r2_location == R2Location.PUBLIC:
+        cdn_url = f"{settings.R2_PUBLIC_CDN_URL}/{key}"
+        return Response(
+            status_code=302,
+            headers={"Location": cdn_url, "Cache-Control": "no-store"},
+        )
+
+    if settings.R2_ENABLED and image.r2_location == R2Location.PRIVATE:
+        r2 = get_r2_storage()
+        presigned = await r2.generate_presigned_url(
+            bucket=settings.R2_PRIVATE_BUCKET,
+            key=key,
+            ttl=settings.R2_PRESIGN_TTL_SECONDS,
+        )
+        logger.debug(
+            "r2_presigned_url_issued", image_id=image_id, variant=image_type
+        )
+        return Response(
+            status_code=302,
+            headers={"Location": presigned, "Cache-Control": "no-store"},
+        )
+
+    # Local FS fallback (r2_location=NONE, or R2 disabled)
+    return Response(
+        status_code=200,
+        headers={"X-Accel-Redirect": f"/internal/{image_type}/{image.filename}.{ext}"},
+    )
+```
+
+Add the required imports near the top of the file:
+
+```python
+from app.config import settings
+from app.core.logging import get_logger
+from app.core.r2_client import get_r2_storage
+from app.core.r2_constants import R2Location
+
+logger = get_logger(__name__)
+```
+
+**Step 5: Run tests**
+
+Run: `uv run pytest tests/api/v1/test_media_serving.py -v`
+Expected: all PASS
+
+**Step 6: Run existing API tests for regressions**
+
+Run: `uv run pytest tests/api/v1/ -x --tb=short`
+Expected: all pass.
+
+**Step 7: Commit**
+
+```bash
+git add app/api/v1/media.py tests/api/v1/test_media_serving.py
+git commit -m "feat(r2): route /images/* by r2_location (CDN / presigned / local)"
+```
+
+---
+
+## Chunk 4: ARQ Jobs
+
+Three jobs: `r2_finalize_upload_job` (first-sync after upload), `sync_image_status_job` (bucket move on status change), `r2_delete_image_job` (full delete from R2 + CDN purge).
+
+---
+
+### Task 11: `r2_finalize_upload_job`
+
+**Files:**
+- Create: `app/tasks/r2_jobs.py`
+- Test: `tests/unit/test_r2_finalize_job.py`
+
+**Step 1: Write failing tests**
+
+Create `tests/unit/test_r2_finalize_job.py`:
+
+```python
+"""Tests for r2_finalize_upload_job — first-sync of a newly uploaded image."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+from app.models.image import Images, VariantStatus
+from app.tasks.r2_jobs import r2_finalize_upload_job
+
+
+@pytest.fixture
+async def fresh_image(db_session):
+    img = Images(
+        user_id=1,
+        filename="2026-04-17-42",
+        ext="jpg",
+        status=ImageStatus.ACTIVE,
+        medium=VariantStatus.NONE,
+        large=VariantStatus.NONE,
+        r2_location=R2Location.NONE,
+    )
+    db_session.add(img)
+    await db_session.commit()
+    await db_session.refresh(img)
+    return img
+
+
+@pytest.mark.unit
+class TestR2FinalizeUploadJob:
+    async def test_uploads_two_variants_and_flips_public(self, fresh_image, db_session, monkeypatch, tmp_path):
+        """Image with no medium/large: uploads fullsize+thumbs to public bucket."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        # Create the local files that the finalizer expects
+        (tmp_path / "fullsize").mkdir()
+        (tmp_path / "thumbs").mkdir()
+        (tmp_path / "fullsize" / "2026-04-17-42.jpg").write_bytes(b"x")
+        (tmp_path / "thumbs" / "2026-04-17-42.webp").write_bytes(b"x")
+
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
+
+        assert mock_r2.upload_file.await_count == 2
+        calls = {
+            (c.kwargs["bucket"], c.kwargs["key"])
+            for c in mock_r2.upload_file.await_args_list
+        }
+        assert (settings.R2_PUBLIC_BUCKET, "fullsize/2026-04-17-42.jpg") in calls
+        assert (settings.R2_PUBLIC_BUCKET, "thumbs/2026-04-17-42.webp") in calls
+
+        # Flip happened
+        await db_session.refresh(fresh_image)
+        assert fresh_image.r2_location == R2Location.PUBLIC
+
+    async def test_protected_status_goes_to_private_bucket(
+        self, fresh_image, db_session, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        (tmp_path / "fullsize").mkdir()
+        (tmp_path / "thumbs").mkdir()
+        (tmp_path / "fullsize" / "2026-04-17-42.jpg").write_bytes(b"x")
+        (tmp_path / "thumbs" / "2026-04-17-42.webp").write_bytes(b"x")
+
+        fresh_image.status = ImageStatus.REVIEW
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
+
+        for c in mock_r2.upload_file.await_args_list:
+            assert c.kwargs["bucket"] == settings.R2_PRIVATE_BUCKET
+
+        await db_session.refresh(fresh_image)
+        assert fresh_image.r2_location == R2Location.PRIVATE
+
+    async def test_uploads_medium_and_large_when_ready(
+        self, fresh_image, db_session, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        for sub in ("fullsize", "thumbs", "medium", "large"):
+            (tmp_path / sub).mkdir()
+            suffix = "webp" if sub == "thumbs" else "jpg"
+            (tmp_path / sub / f"2026-04-17-42.{suffix}").write_bytes(b"x")
+
+        fresh_image.medium = VariantStatus.READY
+        fresh_image.large = VariantStatus.READY
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
+
+        assert mock_r2.upload_file.await_count == 4
+
+    async def test_retries_when_expected_variant_file_missing(
+        self, fresh_image, db_session, monkeypatch, tmp_path
+    ):
+        """If medium=READY but file is missing on disk, the finalizer must retry."""
+        from arq import Retry
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        (tmp_path / "fullsize").mkdir()
+        (tmp_path / "thumbs").mkdir()
+        (tmp_path / "medium").mkdir()
+        (tmp_path / "fullsize" / "2026-04-17-42.jpg").write_bytes(b"x")
+        (tmp_path / "thumbs" / "2026-04-17-42.webp").write_bytes(b"x")
+        # medium dir exists but file does not
+
+        fresh_image.medium = VariantStatus.READY
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            with pytest.raises(Retry):
+                await r2_finalize_upload_job(
+                    {"job_try": 1}, image_id=fresh_image.image_id
+                )
+
+        await db_session.refresh(fresh_image)
+        assert fresh_image.r2_location == R2Location.NONE  # no flip on retry
+
+    async def test_no_op_when_r2_disabled(self, fresh_image, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
+        mock_r2.upload_file.assert_not_awaited()
+
+    async def test_no_op_when_already_synced(self, fresh_image, db_session, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        fresh_image.r2_location = R2Location.PUBLIC
+        await db_session.commit()
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
+        mock_r2.upload_file.assert_not_awaited()
+```
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_finalize_job.py -v`
+Expected: FAIL (module not found)
+
+**Step 3: Implement**
+
+Create `app/tasks/r2_jobs.py`:
+
+```python
+"""ARQ jobs for R2 sync: finalize, status transitions, deletions."""
+
+from pathlib import Path as FilePath
+from typing import Any
+
+from arq import Retry
+from sqlalchemy import select, update
+
+from app.config import settings
+from app.core.database import get_async_session
+from app.core.logging import bind_context, get_logger
+from app.core.r2_client import get_r2_storage
+from app.core.r2_constants import (
+    PUBLIC_IMAGE_STATUSES_FOR_R2,
+    R2_VARIANTS,
+    R2Location,
+)
+from app.models.image import Images, VariantStatus
+
+logger = get_logger(__name__)
+
+
+def _bucket_for_status(status: int) -> str:
+    """Public bucket for public statuses, private bucket otherwise."""
+    return (
+        settings.R2_PUBLIC_BUCKET
+        if status in PUBLIC_IMAGE_STATUSES_FOR_R2
+        else settings.R2_PRIVATE_BUCKET
+    )
+
+
+def _location_for_status(status: int) -> R2Location:
+    return (
+        R2Location.PUBLIC
+        if status in PUBLIC_IMAGE_STATUSES_FOR_R2
+        else R2Location.PRIVATE
+    )
+
+
+def _expected_variants(image: Images) -> list[str]:
+    """Variants that should exist on disk for this image."""
+    variants = ["fullsize", "thumbs"]
+    if image.medium == VariantStatus.READY:
+        variants.append("medium")
+    if image.large == VariantStatus.READY:
+        variants.append("large")
+    return variants
+
+
+def _variant_key(image: Images, variant: str) -> str:
+    ext = "webp" if variant == "thumbs" else image.ext
+    return f"{variant}/{image.filename}.{ext}"
+
+
+def _local_path(image: Images, variant: str) -> FilePath:
+    ext = "webp" if variant == "thumbs" else image.ext
+    return FilePath(settings.STORAGE_PATH) / variant / f"{image.filename}.{ext}"
+
+
+async def r2_finalize_upload_job(
+    ctx: dict[str, Any], image_id: int
+) -> dict[str, Any]:
+    """First-time sync of a newly uploaded image to R2.
+
+    - Reads current image row to pick the right bucket based on status.
+    - Verifies all expected variant files exist on disk; retries if any are missing.
+    - Uploads every expected variant to the chosen bucket.
+    - Atomically flips r2_location to PUBLIC or PRIVATE.
+
+    No-ops when R2 is disabled or the image is already synced.
+    """
+    bind_context(task="r2_finalize_upload", image_id=image_id)
+
+    if not settings.R2_ENABLED:
+        logger.debug("r2_finalize_skipped_disabled", image_id=image_id)
+        return {"skipped": "disabled"}
+
+    async with get_async_session() as db:
+        result = await db.execute(
+            select(Images).where(Images.image_id == image_id)
+        )
+        image = result.scalar_one_or_none()
+        if image is None:
+            logger.warning("r2_finalize_image_missing", image_id=image_id)
+            return {"skipped": "image_missing"}
+        if image.r2_location != R2Location.NONE:
+            logger.debug(
+                "r2_finalize_skipped_already_synced",
+                image_id=image_id,
+                r2_location=image.r2_location,
+            )
+            return {"skipped": "already_synced"}
+
+        variants = _expected_variants(image)
+        # Verify all expected files exist — otherwise let the job retry so
+        # in-flight variant jobs have time to complete.
+        for variant in variants:
+            path = _local_path(image, variant)
+            if not path.exists():
+                logger.info(
+                    "r2_finalize_retry_missing_variant",
+                    image_id=image_id,
+                    variant=variant,
+                    path=str(path),
+                )
+                raise Retry(defer=ctx.get("job_try", 1) * 30)
+
+        bucket = _bucket_for_status(image.status)
+        r2 = get_r2_storage()
+        for variant in variants:
+            key = _variant_key(image, variant)
+            path = _local_path(image, variant)
+            logger.info(
+                "r2_upload_started",
+                image_id=image_id,
+                bucket=bucket,
+                key=key,
+            )
+            await r2.upload_file(bucket=bucket, key=key, path=path)
+            logger.info(
+                "r2_upload_succeeded",
+                image_id=image_id,
+                bucket=bucket,
+                key=key,
+            )
+
+        # Atomic flip. Re-check r2_location to avoid clobbering a concurrent
+        # finalize (arq at-most-once + DB row as lock).
+        new_location = _location_for_status(image.status)
+        await db.execute(
+            update(Images)
+            .where(Images.image_id == image_id)
+            .where(Images.r2_location == R2Location.NONE)
+            .values(r2_location=new_location)
+        )
+        await db.commit()
+
+    logger.info(
+        "r2_finalize_succeeded",
+        image_id=image_id,
+        r2_location=int(new_location),
+    )
+    return {"r2_location": int(new_location)}
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_finalize_job.py -v`
+Expected: all PASS
+
+**Step 5: Commit**
+
+```bash
+git add app/tasks/r2_jobs.py tests/unit/test_r2_finalize_job.py
+git commit -m "feat(r2): add r2_finalize_upload_job for first-sync"
+```
+
+---
+
+### Task 12: `sync_image_status_job`
+
+**Files:**
+- Modify: `app/tasks/r2_jobs.py`
+- Test: `tests/unit/test_r2_status_sync_job.py`
+
+**Step 1: Write failing tests**
+
+Create `tests/unit/test_r2_status_sync_job.py`:
+
+```python
+"""Tests for sync_image_status_job — bucket move on status change."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+from app.models.image import Images, VariantStatus
+from app.tasks.r2_jobs import sync_image_status_job
+
+
+@pytest.fixture
+async def synced_public_image(db_session):
+    img = Images(
+        user_id=1,
+        filename="2026-04-17-7",
+        ext="jpg",
+        status=ImageStatus.ACTIVE,
+        r2_location=R2Location.PUBLIC,
+        medium=VariantStatus.READY,
+        large=VariantStatus.NONE,
+    )
+    db_session.add(img)
+    await db_session.commit()
+    await db_session.refresh(img)
+    return img
+
+
+@pytest.mark.unit
+class TestSyncImageStatusJob:
+    async def test_early_return_when_location_none(self, db_session, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        img = Images(
+            user_id=1,
+            filename="2026-04-17-8",
+            ext="jpg",
+            status=ImageStatus.REVIEW,
+            r2_location=R2Location.NONE,
+        )
+        db_session.add(img)
+        await db_session.commit()
+        await db_session.refresh(img)
+
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await sync_image_status_job(
+                {},
+                image_id=img.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.REVIEW,
+            )
+        mock_r2.copy_object.assert_not_awaited()
+        mock_r2.delete_object.assert_not_awaited()
+
+    async def test_no_op_when_public_to_public(self, synced_public_image, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await sync_image_status_job(
+                {},
+                image_id=synced_public_image.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.SPOILER,
+            )
+        mock_r2.copy_object.assert_not_awaited()
+
+    async def test_public_to_protected_copies_deletes_and_purges(
+        self, synced_public_image, db_session, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=True)
+
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
+            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await sync_image_status_job(
+                {},
+                image_id=synced_public_image.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.REVIEW,
+            )
+
+        # Per variant (fullsize, thumbs, medium — large=NONE): copy + delete
+        assert mock_r2.copy_object.await_count == 3
+        assert mock_r2.delete_object.await_count == 3
+        # Flip to PRIVATE
+        await db_session.refresh(synced_public_image)
+        assert synced_public_image.r2_location == R2Location.PRIVATE
+        # Purge called with CDN URLs for the 3 variants
+        mock_purge.assert_awaited_once()
+        urls = mock_purge.await_args.args[0]
+        assert all(u.startswith("https://cdn.example.com/") for u in urls)
+        assert len(urls) == 3
+
+    async def test_protected_to_public_copies_deletes_no_purge(
+        self, db_session, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        img = Images(
+            user_id=1,
+            filename="2026-04-17-9",
+            ext="jpg",
+            status=ImageStatus.ACTIVE,
+            r2_location=R2Location.PRIVATE,
+        )
+        db_session.add(img)
+        await db_session.commit()
+        await db_session.refresh(img)
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=True)
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
+            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await sync_image_status_job(
+                {},
+                image_id=img.image_id,
+                old_status=ImageStatus.REVIEW,
+                new_status=ImageStatus.ACTIVE,
+            )
+
+        # 2 expected variants (fullsize, thumbs) — medium/large=NONE by default
+        assert mock_r2.copy_object.await_count == 2
+        assert mock_r2.delete_object.await_count == 2
+        # No purge — protected → public doesn't need to invalidate the CDN
+        mock_purge.assert_not_awaited()
+        await db_session.refresh(img)
+        assert img.r2_location == R2Location.PUBLIC
+
+    async def test_skips_missing_source_objects(self, synced_public_image, monkeypatch):
+        """Missing source objects don't crash — the variant is skipped."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=False)
+
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
+            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
+        ):
+            await sync_image_status_job(
+                {},
+                image_id=synced_public_image.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.REVIEW,
+            )
+        mock_r2.copy_object.assert_not_awaited()
+        mock_r2.delete_object.assert_not_awaited()
+
+    async def test_no_op_when_r2_disabled(self, synced_public_image, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await sync_image_status_job(
+                {},
+                image_id=synced_public_image.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.REVIEW,
+            )
+        mock_r2.copy_object.assert_not_awaited()
+```
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_status_sync_job.py -v`
+Expected: FAIL
+
+**Step 3: Append job to `app/tasks/r2_jobs.py`**
+
+Add imports at the top of the file:
+
+```python
+from app.services.cloudflare import purge_cache_by_urls
+```
+
+Append:
+
+```python
+def _cdn_urls_for(image: Images, variants: list[str]) -> list[str]:
+    """Build the public-CDN URLs for the given variants of an image."""
+    urls: list[str] = []
+    for variant in variants:
+        key = _variant_key(image, variant)
+        urls.append(f"{settings.R2_PUBLIC_CDN_URL}/{key}")
+    return urls
+
+
+async def sync_image_status_job(
+    ctx: dict[str, Any],
+    image_id: int,
+    old_status: int,
+    new_status: int,
+) -> dict[str, Any]:
+    """Move an image's R2 objects when its status transitions across
+    the public/protected boundary.
+
+    - Early-return if r2_location=NONE (finalizer owns first-sync).
+    - Early-return if both old and new statuses are on the same side
+      of the public/protected boundary.
+    - Otherwise: copy each existing variant to destination bucket, verify,
+      delete from source. Atomically flip r2_location. If moving
+      public → protected, purge the CDN URLs so nobody can fetch the old
+      copy from edge cache.
+    """
+    bind_context(task="r2_status_sync", image_id=image_id)
+
+    if not settings.R2_ENABLED:
+        return {"skipped": "disabled"}
+
+    async with get_async_session() as db:
+        result = await db.execute(
+            select(Images).where(Images.image_id == image_id)
+        )
+        image = result.scalar_one_or_none()
+        if image is None:
+            return {"skipped": "image_missing"}
+        if image.r2_location == R2Location.NONE:
+            logger.debug(
+                "r2_status_sync_skipped_not_finalized",
+                image_id=image_id,
+            )
+            return {"skipped": "not_finalized"}
+
+        old_public = old_status in PUBLIC_IMAGE_STATUSES_FOR_R2
+        new_public = new_status in PUBLIC_IMAGE_STATUSES_FOR_R2
+        if old_public == new_public:
+            return {"skipped": "no_bucket_move"}
+
+        if old_public:
+            src_bucket = settings.R2_PUBLIC_BUCKET
+            dst_bucket = settings.R2_PRIVATE_BUCKET
+            dst_location = R2Location.PRIVATE
+        else:
+            src_bucket = settings.R2_PRIVATE_BUCKET
+            dst_bucket = settings.R2_PUBLIC_BUCKET
+            dst_location = R2Location.PUBLIC
+
+        variants = _expected_variants(image)
+        r2 = get_r2_storage()
+
+        logger.info(
+            "r2_status_transition_started",
+            image_id=image_id,
+            src=src_bucket,
+            dst=dst_bucket,
+        )
+
+        moved_variants: list[str] = []
+        for variant in variants:
+            key = _variant_key(image, variant)
+            if not await r2.object_exists(bucket=src_bucket, key=key):
+                logger.warning(
+                    "r2_status_sync_source_missing",
+                    image_id=image_id,
+                    bucket=src_bucket,
+                    key=key,
+                )
+                continue
+            await r2.copy_object(src_bucket=src_bucket, dst_bucket=dst_bucket, key=key)
+            if not await r2.object_exists(bucket=dst_bucket, key=key):
+                raise RuntimeError(
+                    f"Copy succeeded but {dst_bucket}/{key} does not exist"
+                )
+            await r2.delete_object(bucket=src_bucket, key=key)
+            moved_variants.append(variant)
+
+        # Atomic flip
+        await db.execute(
+            update(Images)
+            .where(Images.image_id == image_id)
+            .values(r2_location=dst_location)
+        )
+        await db.commit()
+
+    # Purge CDN when going public → protected. Do this after the DB flip and
+    # outside the DB transaction; a purge failure doesn't roll back the move.
+    if old_public and moved_variants:
+        try:
+            await purge_cache_by_urls(_cdn_urls_for(image, moved_variants))
+        except Exception as e:
+            logger.error(
+                "r2_cdn_purge_failed_post_transition",
+                image_id=image_id,
+                error=str(e),
+            )
+            # Don't re-raise — the bucket move already committed.
+
+    logger.info(
+        "r2_status_transition_completed",
+        image_id=image_id,
+        moved_variants=moved_variants,
+    )
+    return {
+        "moved_variants": moved_variants,
+        "r2_location": int(dst_location),
+    }
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_status_sync_job.py -v`
+Expected: all PASS
+
+**Step 5: Commit**
+
+```bash
+git add app/tasks/r2_jobs.py tests/unit/test_r2_status_sync_job.py
+git commit -m "feat(r2): add sync_image_status_job for bucket moves"
+```
+
+---
+
+### Task 13: `r2_delete_image_job`
+
+**Files:**
+- Modify: `app/tasks/r2_jobs.py`
+- Test: `tests/unit/test_r2_delete_job.py`
+
+**Step 1: Write failing tests**
+
+Create `tests/unit/test_r2_delete_job.py`:
+
+```python
+"""Tests for r2_delete_image_job — full delete from R2 and CDN purge."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import settings
+from app.core.r2_constants import R2Location
+from app.tasks.r2_jobs import r2_delete_image_job
+
+
+@pytest.mark.unit
+class TestR2DeleteImageJob:
+    async def test_deletes_all_four_variants_from_public_and_purges(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
+            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await r2_delete_image_job(
+                {},
+                image_id=42,
+                r2_location=int(R2Location.PUBLIC),
+                filename="2026-04-17-42",
+                ext="jpg",
+                variants=["fullsize", "thumbs", "medium", "large"],
+            )
+        assert mock_r2.delete_object.await_count == 4
+        for c in mock_r2.delete_object.await_args_list:
+            assert c.kwargs["bucket"] == settings.R2_PUBLIC_BUCKET
+        mock_purge.assert_awaited_once()
+        assert len(mock_purge.await_args.args[0]) == 4
+
+    async def test_deletes_from_private_no_purge(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
+            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await r2_delete_image_job(
+                {},
+                image_id=42,
+                r2_location=int(R2Location.PRIVATE),
+                filename="2026-04-17-42",
+                ext="jpg",
+                variants=["fullsize", "thumbs"],
+            )
+        assert mock_r2.delete_object.await_count == 2
+        for c in mock_r2.delete_object.await_args_list:
+            assert c.kwargs["bucket"] == settings.R2_PRIVATE_BUCKET
+        mock_purge.assert_not_awaited()
+
+    async def test_no_op_when_location_none(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_delete_image_job(
+                {},
+                image_id=42,
+                r2_location=int(R2Location.NONE),
+                filename="2026-04-17-42",
+                ext="jpg",
+                variants=["fullsize", "thumbs"],
+            )
+        mock_r2.delete_object.assert_not_awaited()
+
+    async def test_no_op_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_delete_image_job(
+                {},
+                image_id=42,
+                r2_location=int(R2Location.PUBLIC),
+                filename="2026-04-17-42",
+                ext="jpg",
+                variants=["fullsize", "thumbs"],
+            )
+        mock_r2.delete_object.assert_not_awaited()
+```
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_delete_job.py -v`
+Expected: FAIL
+
+**Step 3: Append job**
+
+In `app/tasks/r2_jobs.py`, append:
+
+```python
+async def r2_delete_image_job(
+    ctx: dict[str, Any],
+    image_id: int,
+    r2_location: int,
+    filename: str,
+    ext: str,
+    variants: list[str],
+) -> dict[str, Any]:
+    """Delete an image's R2 objects after hard-deletion of the DB row.
+
+    Arguments are denormalised (filename, ext, variants list) because the DB
+    row is already gone by the time this runs. `r2_location` tells us which
+    bucket the canonical copy lived in; NONE means nothing to do.
+    """
+    bind_context(task="r2_delete_image", image_id=image_id)
+
+    if not settings.R2_ENABLED:
+        return {"skipped": "disabled"}
+    if r2_location == R2Location.NONE:
+        return {"skipped": "never_in_r2"}
+
+    bucket = (
+        settings.R2_PUBLIC_BUCKET
+        if r2_location == R2Location.PUBLIC
+        else settings.R2_PRIVATE_BUCKET
+    )
+
+    r2 = get_r2_storage()
+    keys: list[str] = []
+    for variant in variants:
+        variant_ext = "webp" if variant == "thumbs" else ext
+        keys.append(f"{variant}/{filename}.{variant_ext}")
+
+    for key in keys:
+        await r2.delete_object(bucket=bucket, key=key)
+        logger.info("r2_object_deleted", image_id=image_id, bucket=bucket, key=key)
+
+    # Purge CDN only for public-bucket deletes (private bucket was never cached).
+    if r2_location == R2Location.PUBLIC:
+        urls = [f"{settings.R2_PUBLIC_CDN_URL}/{k}" for k in keys]
+        try:
+            await purge_cache_by_urls(urls)
+        except Exception as e:
+            logger.error(
+                "r2_cdn_purge_failed_post_delete",
+                image_id=image_id,
+                error=str(e),
+            )
+
+    return {"deleted_keys": keys}
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_delete_job.py -v`
+Expected: all PASS
+
+**Step 5: Register all three jobs in the worker**
+
+In `app/tasks/worker.py`, add import (near existing image_jobs import):
+
+```python
+from app.tasks.r2_jobs import (
+    r2_delete_image_job,
+    r2_finalize_upload_job,
+    sync_image_status_job,
+)
+```
+
+Add to `WorkerSettings.functions` (list currently starting at line 117):
+
+```python
+        func(r2_finalize_upload_job, max_tries=5),
+        func(sync_image_status_job, max_tries=settings.ARQ_MAX_TRIES),
+        func(r2_delete_image_job, max_tries=settings.ARQ_MAX_TRIES),
+```
+
+**Step 6: Run full unit suite**
+
+Run: `uv run pytest -m unit -x --tb=short`
+Expected: all pass.
+
+**Step 7: Commit**
+
+```bash
+git add app/tasks/r2_jobs.py app/tasks/worker.py tests/unit/test_r2_delete_job.py
+git commit -m "feat(r2): add r2_delete_image_job and register all R2 jobs"
+```
+
+---
+
+## Chunk 5: Route Integration
+
+Wire the three jobs into the upload, status-change, and delete routes. Each integration must be a no-op when `R2_ENABLED=false` (no side-effects in dev).
+
+---
+
+### Task 14: Enqueue `r2_finalize_upload_job` After Upload
+
+**Files:**
+- Modify: `app/api/v1/images.py` (upload handler)
+- Test: `tests/api/v1/test_image_upload_r2.py`
+
+**Step 1: Locate upload handler**
+
+Run: `uv run grep -n "create_thumbnail_job\|enqueue_job" app/api/v1/images.py | head -20`
+Expected: shows the block where thumbnail/variant jobs are enqueued.
+
+**Step 2: Write failing tests**
+
+Create `tests/api/v1/test_image_upload_r2.py`:
+
+```python
+"""Tests for R2 finalize job enqueued after upload."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import settings
+
+
+@pytest.mark.api
+class TestUploadEnqueuesR2Finalize:
+    async def test_enqueues_finalize_when_r2_enabled(
+        self, client, auth_headers, sample_image_bytes, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        with patch(
+            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            response = await client.post(
+                "/api/v1/images/upload",
+                files={"file": ("test.jpg", sample_image_bytes, "image/jpeg")},
+                headers=auth_headers,
+            )
+        assert response.status_code in (200, 201)
+        finalize_calls = [
+            c for c in mock_enqueue.await_args_list
+            if c.args[0] == "r2_finalize_upload_job"
+        ]
+        assert len(finalize_calls) == 1
+        # Deferred long enough for variant jobs to complete first
+        assert finalize_calls[0].kwargs.get("_defer_by", 0) >= 60
+
+    async def test_no_finalize_when_r2_disabled(
+        self, client, auth_headers, sample_image_bytes, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        with patch(
+            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            await client.post(
+                "/api/v1/images/upload",
+                files={"file": ("test.jpg", sample_image_bytes, "image/jpeg")},
+                headers=auth_headers,
+            )
+        finalize_calls = [
+            c for c in mock_enqueue.await_args_list
+            if c.args[0] == "r2_finalize_upload_job"
+        ]
+        assert finalize_calls == []
+```
+
+(Reuse existing project fixtures for `client`, `auth_headers`, `sample_image_bytes`. If they don't exist with those names, adapt to the ones in `tests/conftest.py`.)
+
+**Step 3: Run tests**
+
+Run: `uv run pytest tests/api/v1/test_image_upload_r2.py -v`
+Expected: FAIL (finalize not enqueued)
+
+**Step 4: Add enqueue call to upload handler**
+
+In `app/api/v1/images.py`, find the block where `create_thumbnail_job` / variant jobs are enqueued (near the end of the upload route). Directly after those enqueues, add:
+
+```python
+    # Enqueue R2 first-sync. Deferred so variant jobs (thumbnail, medium, large)
+    # have time to finish; the finalizer retries if their files aren't on disk
+    # yet. No-op when R2_ENABLED=false (the job returns early).
+    if settings.R2_ENABLED:
+        await enqueue_job(
+            "r2_finalize_upload_job",
+            image_id=new_image.image_id,
+            _defer_by=90,
+        )
+```
+
+If `enqueue_job` isn't already imported in `images.py`, add:
+
+```python
+from app.tasks.queue import enqueue_job
+```
+
+**Step 5: Run tests**
+
+Run: `uv run pytest tests/api/v1/test_image_upload_r2.py -v`
+Expected: PASS
+
+**Step 6: Run broader suite**
+
+Run: `uv run pytest tests/api/v1/ -x --tb=short`
+Expected: pass.
+
+**Step 7: Commit**
+
+```bash
+git add app/api/v1/images.py tests/api/v1/test_image_upload_r2.py
+git commit -m "feat(r2): enqueue finalize job after successful upload"
+```
+
+---
+
+### Task 15: Enqueue `sync_image_status_job` on Status Change
+
+**Files:**
+- Modify: `app/api/v1/images.py` (PATCH/status-change handler around line 943-946)
+- Test: `tests/api/v1/test_image_status_r2.py`
+
+**Step 1: Write failing tests**
+
+Create `tests/api/v1/test_image_status_r2.py`:
+
+```python
+"""Tests for sync_image_status_job enqueued on status change."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import ImageStatus, settings
+
+
+@pytest.mark.api
+class TestStatusChangeEnqueuesSync:
+    async def test_enqueues_sync_when_status_changes_and_r2_enabled(
+        self, client, admin_headers, test_image_active, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        with patch(
+            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            response = await client.patch(
+                f"/api/v1/images/{test_image_active.image_id}",
+                json={"status": ImageStatus.REVIEW},
+                headers=admin_headers,
+            )
+        assert response.status_code == 200
+        sync_calls = [
+            c for c in mock_enqueue.await_args_list
+            if c.args[0] == "sync_image_status_job"
+        ]
+        assert len(sync_calls) == 1
+        assert sync_calls[0].kwargs["image_id"] == test_image_active.image_id
+        assert sync_calls[0].kwargs["old_status"] == ImageStatus.ACTIVE
+        assert sync_calls[0].kwargs["new_status"] == ImageStatus.REVIEW
+
+    async def test_no_enqueue_when_status_unchanged(
+        self, client, admin_headers, test_image_active, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        with patch(
+            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            await client.patch(
+                f"/api/v1/images/{test_image_active.image_id}",
+                json={"caption": "x"},
+                headers=admin_headers,
+            )
+        sync_calls = [
+            c for c in mock_enqueue.await_args_list
+            if c.args[0] == "sync_image_status_job"
+        ]
+        assert sync_calls == []
+
+    async def test_no_enqueue_when_r2_disabled(
+        self, client, admin_headers, test_image_active, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        with patch(
+            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            await client.patch(
+                f"/api/v1/images/{test_image_active.image_id}",
+                json={"status": ImageStatus.REVIEW},
+                headers=admin_headers,
+            )
+        sync_calls = [
+            c for c in mock_enqueue.await_args_list
+            if c.args[0] == "sync_image_status_job"
+        ]
+        assert sync_calls == []
+```
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/api/v1/test_image_status_r2.py -v`
+Expected: FAIL
+
+**Step 3: Add enqueue in the status-change block**
+
+In `app/api/v1/images.py`, find the status-change block starting around line 943 (`previous_status = image.status`). After the existing `db.add(history)` / `await db.commit()` block that persists the change, add:
+
+```python
+    # Enqueue R2 bucket-move if the status actually changed. The job itself
+    # early-returns when r2_location=NONE or old/new statuses are on the same
+    # side of the public/protected boundary, so this is safe to always call.
+    if new_status is not None and new_status != previous_status and settings.R2_ENABLED:
+        await enqueue_job(
+            "sync_image_status_job",
+            image_id=image_id,
+            old_status=previous_status,
+            new_status=new_status,
+        )
+```
+
+Make sure `enqueue_job` import is present (Task 14 may already have added it).
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/api/v1/test_image_status_r2.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add app/api/v1/images.py tests/api/v1/test_image_status_r2.py
+git commit -m "feat(r2): enqueue sync_image_status_job on status change"
+```
+
+---
+
+### Task 16: Enqueue `r2_delete_image_job` on Hard Delete
+
+**Files:**
+- Modify: `app/api/v1/images.py` (delete handler, starting line 731)
+- Test: `tests/api/v1/test_image_delete_r2.py`
+
+**Step 1: Write failing tests**
+
+Create `tests/api/v1/test_image_delete_r2.py`:
+
+```python
+"""Tests for r2_delete_image_job enqueued on hard delete."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import settings
+from app.core.r2_constants import R2Location
+
+
+@pytest.mark.api
+class TestDeleteEnqueuesR2:
+    async def test_enqueues_delete_with_prior_location(
+        self, client, admin_headers, test_image_public_r2, monkeypatch
+    ):
+        """Image had r2_location=PUBLIC; delete job receives that value."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+        with patch(
+            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            response = await client.delete(
+                f"/api/v1/images/{test_image_public_r2.image_id}?reason=test",
+                headers=admin_headers,
+            )
+        assert response.status_code == 204
+        delete_calls = [
+            c for c in mock_enqueue.await_args_list
+            if c.args[0] == "r2_delete_image_job"
+        ]
+        assert len(delete_calls) == 1
+        assert delete_calls[0].kwargs["r2_location"] == int(R2Location.PUBLIC)
+        assert delete_calls[0].kwargs["filename"] == test_image_public_r2.filename
+        assert "fullsize" in delete_calls[0].kwargs["variants"]
+        assert "thumbs" in delete_calls[0].kwargs["variants"]
+
+    async def test_no_enqueue_when_r2_disabled(
+        self, client, admin_headers, test_image_public_r2, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        with patch(
+            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            await client.delete(
+                f"/api/v1/images/{test_image_public_r2.image_id}?reason=test",
+                headers=admin_headers,
+            )
+        delete_calls = [
+            c for c in mock_enqueue.await_args_list
+            if c.args[0] == "r2_delete_image_job"
+        ]
+        assert delete_calls == []
+```
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/api/v1/test_image_delete_r2.py -v`
+Expected: FAIL
+
+**Step 3: Update delete handler**
+
+In `app/api/v1/images.py` delete handler (starting line 731), after `image = result.scalar_one_or_none()` has confirmed the image, capture metadata for the R2 job before the DB delete. After the existing local-file deletion loop and `logger.info("image_deleted", ...)`, add:
+
+```python
+    # Enqueue R2 cleanup. We capture r2_location/filename/ext/variants before
+    # the DB row was deleted (see above). No-op when R2_ENABLED=false.
+    if settings.R2_ENABLED:
+        await enqueue_job(
+            "r2_delete_image_job",
+            image_id=image_id,
+            r2_location=prior_r2_location,
+            filename=prior_filename,
+            ext=prior_ext,
+            variants=prior_variants,
+        )
+```
+
+Add the capture earlier — right after `image = result.scalar_one_or_none()` confirms existence, and before any delete happens:
+
+```python
+    prior_r2_location = image.r2_location
+    prior_filename = image.filename
+    prior_ext = image.ext
+    prior_variants = ["fullsize", "thumbs"]
+    if image.medium == VariantStatus.READY:
+        prior_variants.append("medium")
+    if image.large == VariantStatus.READY:
+        prior_variants.append("large")
+```
+
+Add the import for `VariantStatus` at the top of `images.py` if not already present:
+
+```python
+from app.models.image import Images, VariantStatus
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/api/v1/test_image_delete_r2.py -v`
+Expected: PASS
+
+**Step 5: Run the full API suite**
+
+Run: `uv run pytest tests/api/v1/ -x --tb=short`
+Expected: pass.
+
+**Step 6: Commit**
+
+```bash
+git add app/api/v1/images.py tests/api/v1/test_image_delete_r2.py
+git commit -m "feat(r2): enqueue r2_delete_image_job on hard delete"
+```
+
+---
+
+## Chunk 6: Operational Tooling (`scripts/r2_sync.py`)
+
+A CLI with subcommands shared by the initial cutover and ongoing ops. Each subcommand is its own task; they all share a common module for bucket-picking logic and arg parsing.
+
+---
+
+### Task 17: CLI Skeleton with `R2_ENABLED` and `R2_ALLOW_BULK_BACKFILL` Guards
+
+**Files:**
+- Create: `scripts/r2_sync.py`
+- Test: `tests/unit/test_r2_sync_cli_guards.py`
+
+**Step 1: Write failing tests**
+
+Create `tests/unit/test_r2_sync_cli_guards.py`:
+
+```python
+"""Tests for r2_sync.py CLI guards (R2_ENABLED, R2_ALLOW_BULK_BACKFILL)."""
+
+import pytest
+
+from app.config import settings
+from scripts.r2_sync import (
+    BulkBackfillDisallowedError,
+    R2DisabledError,
+    require_bulk_backfill,
+    require_r2_enabled,
+)
+
+
+@pytest.mark.unit
+class TestRequireR2Enabled:
+    def test_passes_when_enabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        require_r2_enabled()
+
+    def test_raises_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        with pytest.raises(R2DisabledError):
+            require_r2_enabled()
+
+
+@pytest.mark.unit
+class TestRequireBulkBackfill:
+    def test_passes_when_allowed(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", True)
+        require_bulk_backfill()
+
+    def test_raises_when_disallowed(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", False)
+        with pytest.raises(BulkBackfillDisallowedError):
+            require_bulk_backfill()
+```
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_sync_cli_guards.py -v`
+Expected: FAIL (module not found)
+
+**Step 3: Implement skeleton**
+
+Create `scripts/r2_sync.py`:
+
+```python
+"""R2 operational tooling.
+
+Subcommands:
+    split-existing       — one-time move protected images from public bucket to private
+    backfill-locations   — one-shot flip r2_location for existing rows (gated)
+    reconcile            — heal: upload missing R2 objects from local FS (gated)
+    image                — inspect/re-sync a single image
+    verify               — audit R2 vs DB state (read-only)
+    purge-cache          — manually purge CDN for one image
+    health               — report unsynced counts and storage usage (read-only)
+
+Guarded by R2_ENABLED=true (all commands). backfill-locations and reconcile
+additionally require R2_ALLOW_BULK_BACKFILL=true to prevent staging from
+mass-uploading prod-imported images to its small staging bucket.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from typing import Any
+
+from app.config import settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class R2SyncError(Exception):
+    """Base for r2_sync CLI errors."""
+
+
+class R2DisabledError(R2SyncError):
+    """Raised when R2_ENABLED=false."""
+
+
+class BulkBackfillDisallowedError(R2SyncError):
+    """Raised when R2_ALLOW_BULK_BACKFILL=false."""
+
+
+def require_r2_enabled() -> None:
+    if not settings.R2_ENABLED:
+        raise R2DisabledError(
+            "R2_ENABLED=false. Enable R2 in config before running r2_sync commands."
+        )
+
+
+def require_bulk_backfill() -> None:
+    """Require both R2 enabled AND bulk backfill explicitly allowed."""
+    require_r2_enabled()
+    if not settings.R2_ALLOW_BULK_BACKFILL:
+        raise BulkBackfillDisallowedError(
+            "R2_ALLOW_BULK_BACKFILL=false. This command walks the DB for "
+            "unsynced rows and uploads local files to R2; on staging this "
+            "would mass-upload the prod dataset. Set the flag true only in "
+            "prod's steady-state config."
+        )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="R2 operational tooling")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # Subcommands — each task below fills in its handler.
+    # --dry-run is only on split-existing for now; other bulk commands could
+    # add one later but the underlying function must actually honor it.
+    se = sub.add_parser("split-existing")
+    se.add_argument("--dry-run", action="store_true")
+    sub.add_parser("backfill-locations")
+    rec = sub.add_parser("reconcile")
+    rec.add_argument("--stale-after", type=int, default=600)
+    img = sub.add_parser("image")
+    img.add_argument("image_id", type=int)
+    ver = sub.add_parser("verify")
+    ver.add_argument("--sample", type=int, default=None)
+    pc = sub.add_parser("purge-cache")
+    pc.add_argument("image_id", type=int)
+    h = sub.add_parser("health")
+    h.add_argument("--json", action="store_true")
+
+    return parser
+
+
+async def _dispatch(args: argparse.Namespace) -> int:
+    require_r2_enabled()
+    raise NotImplementedError(
+        f"Subcommand '{args.command}' is not yet implemented in this chunk."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return asyncio.run(_dispatch(args))
+    except R2SyncError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_sync_cli_guards.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add scripts/r2_sync.py tests/unit/test_r2_sync_cli_guards.py
+git commit -m "feat(r2): scripts/r2_sync.py skeleton with guards"
+```
+
+---
+
+### Task 18: `split-existing` Subcommand
+
+**Files:**
+- Modify: `scripts/r2_sync.py`
+- Test: `tests/integration/test_r2_sync_split.py`
+
+**Step 1: Write failing integration test**
+
+Create `tests/integration/test_r2_sync_split.py`:
+
+```python
+"""Integration test: split-existing moves protected images to private bucket."""
+
+import aioboto3
+import pytest
+from moto import mock_aws
+
+from app.config import ImageStatus, settings
+from app.core.r2_client import reset_r2_storage
+from app.models.image import Images
+from scripts.r2_sync import split_existing
+
+
+@pytest.fixture
+def moto_session():
+    """Yield an aioboto3 session inside a moto mock_aws context.
+
+    moto.mock_aws() patches botocore (which aioboto3 uses) at a layer below
+    the Session class, so every aioboto3 Session created while this context
+    is active — including the one get_r2_storage() builds internally — routes
+    to moto's shared in-memory S3 backend.
+    """
+    with mock_aws():
+        yield aioboto3.Session(
+            aws_access_key_id="t",
+            aws_secret_access_key="t",
+            region_name="us-east-1",
+        )
+
+
+@pytest.mark.integration
+class TestSplitExisting:
+    async def test_moves_protected_images_only(self, moto_session, db_session, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ACCESS_KEY_ID", "t")
+        monkeypatch.setattr(settings, "R2_SECRET_ACCESS_KEY", "t")
+        monkeypatch.setattr(settings, "R2_ENDPOINT", "https://example.r2.cloudflarestorage.com")
+        monkeypatch.setattr(settings, "R2_PUBLIC_BUCKET", "public")
+        monkeypatch.setattr(settings, "R2_PRIVATE_BUCKET", "private")
+        # Reset singleton so get_r2_storage() picks up the new settings.
+        reset_r2_storage()
+
+        async with moto_session.client("s3") as s3:
+            await s3.create_bucket(Bucket="public")
+            await s3.create_bucket(Bucket="private")
+            # Seed objects — one public image, one protected image, one repost.
+            for img in [
+                ("2026-04-17-1", ImageStatus.ACTIVE),     # stays public
+                ("2026-04-17-2", ImageStatus.REVIEW),     # moves
+                ("2026-04-17-3", ImageStatus.INAPPROPRIATE),  # moves
+                ("2026-04-17-4", ImageStatus.REPOST),     # stays public
+            ]:
+                for variant, ext in [("fullsize", "jpg"), ("thumbs", "webp")]:
+                    await s3.put_object(
+                        Bucket="public", Key=f"{variant}/{img[0]}.{ext}", Body=b"x"
+                    )
+
+        # Corresponding DB rows
+        for i, (fn, st) in enumerate(
+            [
+                ("2026-04-17-1", ImageStatus.ACTIVE),
+                ("2026-04-17-2", ImageStatus.REVIEW),
+                ("2026-04-17-3", ImageStatus.INAPPROPRIATE),
+                ("2026-04-17-4", ImageStatus.REPOST),
+            ],
+            start=1,
+        ):
+            db_session.add(Images(image_id=i, user_id=1, filename=fn, ext="jpg", status=st))
+        await db_session.commit()
+
+        # Run split — moto intercepts all S3 calls made by get_r2_storage()
+        # while the moto_session fixture's mock_aws() context is still open.
+        await split_existing(dry_run=False)
+
+        async with moto_session.client("s3") as s3:
+            # Public bucket still has actives + repost
+            assert "Contents" in await s3.list_objects_v2(Bucket="public")
+            public_keys = {
+                o["Key"] for o in (await s3.list_objects_v2(Bucket="public"))["Contents"]
+            }
+            assert "fullsize/2026-04-17-1.jpg" in public_keys
+            assert "fullsize/2026-04-17-4.jpg" in public_keys
+            assert "fullsize/2026-04-17-2.jpg" not in public_keys
+            # Private has the moved items
+            private_keys = {
+                o["Key"] for o in (await s3.list_objects_v2(Bucket="private"))["Contents"]
+            }
+            assert "fullsize/2026-04-17-2.jpg" in private_keys
+            assert "fullsize/2026-04-17-3.jpg" in private_keys
+```
+
+**Step 2: Run test**
+
+Run: `uv run pytest tests/integration/test_r2_sync_split.py -v`
+Expected: FAIL (function not exported)
+
+**Step 3: Implement subcommand**
+
+In `scripts/r2_sync.py`, replace the `_dispatch` stub and add the implementation. Add imports near the top:
+
+```python
+from sqlalchemy import select
+
+from app.core.database import get_async_session
+from app.core.r2_client import get_r2_storage
+from app.core.r2_constants import (
+    PUBLIC_IMAGE_STATUSES_FOR_R2,
+    R2_VARIANTS,
+    R2Location,
+)
+from app.models.image import Images, VariantStatus
+from app.services.cloudflare import purge_cache_by_urls
+```
+
+Replace the `_dispatch` function with:
+
+```python
+async def _dispatch(args: argparse.Namespace) -> int:
+    require_r2_enabled()
+
+    if args.command == "split-existing":
+        await split_existing(dry_run=args.dry_run)
+        return 0
+    raise NotImplementedError(
+        f"Subcommand '{args.command}' is not yet implemented."
+    )
+```
+
+Add the `split_existing` function:
+
+```python
+async def split_existing(*, dry_run: bool) -> None:
+    """Move protected-status images' R2 objects from public → private bucket.
+
+    Assumes existing R2 state is "everything in R2_PUBLIC_BUCKET" (the starting
+    point for the production cutover). Idempotent — objects already moved are
+    skipped via object_exists checks.
+    """
+    r2 = get_r2_storage()
+
+    async with get_async_session() as db:
+        result = await db.execute(
+            select(Images).where(Images.status.notin_(PUBLIC_IMAGE_STATUSES_FOR_R2))
+        )
+        rows = list(result.scalars())
+
+    logger.info("split_existing_started", count=len(rows), dry_run=dry_run)
+
+    moved = 0
+    for image in rows:
+        variants = ["fullsize", "thumbs"]
+        if image.medium == VariantStatus.READY:
+            variants.append("medium")
+        if image.large == VariantStatus.READY:
+            variants.append("large")
+        for variant in variants:
+            ext = "webp" if variant == "thumbs" else image.ext
+            key = f"{variant}/{image.filename}.{ext}"
+            if not await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key):
+                continue
+            if dry_run:
+                print(f"DRY_RUN move {settings.R2_PUBLIC_BUCKET}/{key} → {settings.R2_PRIVATE_BUCKET}/{key}")
+                moved += 1
+                continue
+            await r2.copy_object(
+                src_bucket=settings.R2_PUBLIC_BUCKET,
+                dst_bucket=settings.R2_PRIVATE_BUCKET,
+                key=key,
+            )
+            await r2.delete_object(bucket=settings.R2_PUBLIC_BUCKET, key=key)
+            moved += 1
+
+    logger.info("split_existing_completed", moved=moved, dry_run=dry_run)
+    print(f"{'[dry-run] ' if dry_run else ''}moved {moved} objects")
+```
+
+**Step 4: Run test**
+
+Run: `uv run pytest tests/integration/test_r2_sync_split.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add scripts/r2_sync.py tests/integration/test_r2_sync_split.py
+git commit -m "feat(r2): add r2_sync.py split-existing subcommand"
+```
+
+---
+
+### Task 19: `backfill-locations` Subcommand
+
+**Files:**
+- Modify: `scripts/r2_sync.py`
+- Test: `tests/integration/test_r2_sync_backfill.py`
+
+**Step 1: Write failing test**
+
+Create `tests/integration/test_r2_sync_backfill.py`:
+
+```python
+"""Integration test: backfill-locations fills r2_location based on current status."""
+
+import pytest
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+from app.models.image import Images
+from scripts.r2_sync import backfill_locations
+
+
+@pytest.mark.integration
+class TestBackfillLocations:
+    async def test_respects_r2_allow_bulk_backfill_flag(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", False)
+        from scripts.r2_sync import BulkBackfillDisallowedError
+
+        with pytest.raises(BulkBackfillDisallowedError):
+            await backfill_locations()
+
+    async def test_flips_public_and_private(self, db_session, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", True)
+
+        db_session.add(Images(user_id=1, filename="a", ext="jpg", status=ImageStatus.ACTIVE))
+        db_session.add(Images(user_id=1, filename="b", ext="jpg", status=ImageStatus.REVIEW))
+        db_session.add(Images(user_id=1, filename="c", ext="jpg", status=ImageStatus.REPOST))
+        await db_session.commit()
+
+        await backfill_locations(batch_size=2)
+
+        from sqlalchemy import select
+        result = await db_session.execute(select(Images))
+        images = {img.filename: img for img in result.scalars()}
+        assert images["a"].r2_location == R2Location.PUBLIC
+        assert images["b"].r2_location == R2Location.PRIVATE
+        assert images["c"].r2_location == R2Location.PUBLIC
+```
+
+**Step 2: Run test**
+
+Run: `uv run pytest tests/integration/test_r2_sync_backfill.py -v`
+Expected: FAIL
+
+**Step 3: Implement**
+
+Append to `scripts/r2_sync.py`:
+
+```python
+async def backfill_locations(*, batch_size: int = 1000) -> None:
+    """Flip r2_location for rows still at NONE based on current status.
+
+    Query: WHERE r2_location = 0 (NONE). Chunked with a fresh read per batch
+    so rows updated by the finalizer mid-run (r2_location != 0) are skipped.
+    """
+    require_bulk_backfill()
+
+    from sqlalchemy import update
+
+    total_flipped = 0
+    while True:
+        async with get_async_session() as db:
+            result = await db.execute(
+                select(Images)
+                .where(Images.r2_location == R2Location.NONE)
+                .limit(batch_size)
+            )
+            rows = list(result.scalars())
+            if not rows:
+                break
+
+            public_ids = [
+                img.image_id for img in rows
+                if img.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+            ]
+            private_ids = [
+                img.image_id for img in rows
+                if img.status not in PUBLIC_IMAGE_STATUSES_FOR_R2
+            ]
+
+            if public_ids:
+                await db.execute(
+                    update(Images)
+                    .where(Images.image_id.in_(public_ids))
+                    .where(Images.r2_location == R2Location.NONE)
+                    .values(r2_location=R2Location.PUBLIC)
+                )
+            if private_ids:
+                await db.execute(
+                    update(Images)
+                    .where(Images.image_id.in_(private_ids))
+                    .where(Images.r2_location == R2Location.NONE)
+                    .values(r2_location=R2Location.PRIVATE)
+                )
+
+            await db.commit()
+            total_flipped += len(public_ids) + len(private_ids)
+            logger.info(
+                "backfill_batch",
+                batch_size=len(rows),
+                total_flipped=total_flipped,
+            )
+
+    print(f"backfilled {total_flipped} rows")
+```
+
+Add dispatch:
+
+```python
+    if args.command == "backfill-locations":
+        await backfill_locations()
+        return 0
+```
+
+**Step 4: Run test**
+
+Run: `uv run pytest tests/integration/test_r2_sync_backfill.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add scripts/r2_sync.py tests/integration/test_r2_sync_backfill.py
+git commit -m "feat(r2): add r2_sync.py backfill-locations subcommand"
+```
+
+---
+
+### Task 20: `reconcile`, `image`, `verify`, `purge-cache`, `health` Subcommands
+
+These are a related cluster. Each is a thin wrapper around existing building blocks.
+
+**Files:**
+- Modify: `scripts/r2_sync.py`
+- Test: `tests/unit/test_r2_sync_remaining.py`
+
+**Step 1: Write tests**
+
+Create `tests/unit/test_r2_sync_remaining.py`:
+
+```python
+"""Tests for the remaining r2_sync.py subcommands."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+from scripts.r2_sync import (
+    BulkBackfillDisallowedError,
+    health,
+    purge_cache_command,
+    reconcile,
+    resync_image,
+    verify,
+)
+
+
+@pytest.mark.unit
+class TestReconcileGuard:
+    async def test_requires_bulk_backfill_flag(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", False)
+        with pytest.raises(BulkBackfillDisallowedError):
+            await reconcile(stale_after=60)
+
+
+@pytest.mark.unit
+class TestHealth:
+    async def test_reports_unsynced_count_and_oldest_age(self, db_session, monkeypatch, tmp_path):
+        from app.models.image import Images
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        # tmp_path is isolated per-test — avoids du-ing all of /tmp (slow/flaky)
+        # and avoids permission issues on shared CI runners.
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        db_session.add(Images(user_id=1, filename="a", ext="jpg", status=ImageStatus.ACTIVE, r2_location=R2Location.NONE))
+        db_session.add(Images(user_id=1, filename="b", ext="jpg", status=ImageStatus.ACTIVE, r2_location=R2Location.PUBLIC))
+        await db_session.commit()
+
+        result = await health(output_json=True)
+        assert result["unsynced_count"] == 1
+        assert result["local_storage_path"] == str(tmp_path)
+
+
+@pytest.mark.unit
+class TestPurgeCacheCommand:
+    async def test_calls_cloudflare_with_all_variant_urls(self, db_session, monkeypatch):
+        from app.models.image import Images, VariantStatus
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+        db_session.add(
+            Images(
+                image_id=42,
+                user_id=1,
+                filename="2026-04-17-42",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                medium=VariantStatus.READY,
+                large=VariantStatus.READY,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        with patch(
+            "scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await purge_cache_command(image_id=42)
+        mock_purge.assert_awaited_once()
+        urls = mock_purge.await_args.args[0]
+        assert len(urls) == 4
+
+
+@pytest.mark.unit
+class TestResyncImage:
+    async def test_prints_state_for_known_image(self, db_session, monkeypatch, capsys):
+        from app.models.image import Images
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_BUCKET", "public")
+        db_session.add(
+            Images(image_id=99, user_id=1, filename="a", ext="jpg",
+                   status=ImageStatus.ACTIVE, r2_location=R2Location.PUBLIC)
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=True)
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            await resync_image(99)
+
+        out = capsys.readouterr().out
+        assert "image 99" in out
+        assert "fullsize" in out and "thumbs" in out
+
+    async def test_prints_not_found_for_missing_image(self, db_session, monkeypatch, capsys):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        await resync_image(99999999)
+        assert "not found" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+class TestVerify:
+    """verify must implement the spec's full discrepancy rules."""
+
+    async def test_none_with_no_object_is_clean(self, db_session, monkeypatch):
+        """NONE + no object is a legitimate state (spec §Operational tooling)."""
+        from app.models.image import Images
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        db_session.add(
+            Images(user_id=1, filename="x", ext="jpg", status=ImageStatus.ACTIVE, r2_location=R2Location.NONE)
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=False)
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            report = await verify(sample=None)
+        assert report["discrepancies"] == []
+
+    async def test_none_with_unexpected_object_reports_unexpected(self, db_session, monkeypatch):
+        """NONE row + object present in either bucket → leaked upload, must report."""
+        from app.models.image import Images
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        db_session.add(
+            Images(image_id=10, user_id=1, filename="orphan", ext="jpg",
+                   status=ImageStatus.ACTIVE, r2_location=R2Location.NONE)
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        # Object exists in public bucket despite DB saying NONE.
+        mock_r2.object_exists = AsyncMock(
+            side_effect=lambda bucket, key: bucket == settings.R2_PUBLIC_BUCKET
+        )
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            report = await verify(sample=None)
+        kinds = {d["kind"] for d in report["discrepancies"]}
+        assert "unexpected" in kinds
+
+    async def test_cross_bucket_orphan_reports_wrong_bucket(self, db_session, monkeypatch):
+        """PUBLIC row with copy also in private bucket → incomplete move, must report."""
+        from app.models.image import Images
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        db_session.add(
+            Images(image_id=11, user_id=1, filename="moved", ext="jpg",
+                   status=ImageStatus.ACTIVE, r2_location=R2Location.PUBLIC)
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        # Exists in BOTH buckets — the expected check passes, but a cross-bucket
+        # copy is still an error (probably a failed delete mid-move).
+        mock_r2.object_exists = AsyncMock(return_value=True)
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            report = await verify(sample=None)
+        kinds = {d["kind"] for d in report["discrepancies"]}
+        assert "wrong_bucket" in kinds
+
+    async def test_missing_from_expected_bucket_reports_missing(self, db_session, monkeypatch):
+        """PUBLIC row with object missing from public bucket → report missing."""
+        from app.models.image import Images
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        db_session.add(
+            Images(image_id=12, user_id=1, filename="gone", ext="jpg",
+                   status=ImageStatus.ACTIVE, r2_location=R2Location.PUBLIC)
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=False)
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            report = await verify(sample=None)
+        kinds = {d["kind"] for d in report["discrepancies"]}
+        assert "missing" in kinds
+```
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_sync_remaining.py -v`
+Expected: FAIL
+
+**Step 3: Implement subcommands**
+
+Append to `scripts/r2_sync.py`:
+
+```python
+async def reconcile(*, stale_after: int) -> None:
+    """Heal: upload missing R2 objects for unsynced rows older than `stale_after`.
+
+    Idempotent: uploaded variants are re-detected via object_exists on the next
+    pass, so a partial run that uploads some variants before failing on a
+    missing local file will simply skip those keys next time. Orphaned partial
+    uploads (if the row is later deleted before reconcile finishes) are the
+    responsibility of a future orphan-gc command — out of scope here.
+    """
+    require_bulk_backfill()
+
+    from datetime import UTC, datetime, timedelta
+    from pathlib import Path as FilePath
+    from sqlalchemy import update
+
+    # DB columns are naive UTC; strip tz for the subtraction.
+    cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=stale_after)
+    r2 = get_r2_storage()
+
+    async with get_async_session() as db:
+        result = await db.execute(
+            select(Images)
+            .where(Images.r2_location == R2Location.NONE)
+            .where(Images.date_added < cutoff)
+        )
+        rows = list(result.scalars())
+
+    healed = 0
+    for image in rows:
+        variants = ["fullsize", "thumbs"]
+        if image.medium == VariantStatus.READY:
+            variants.append("medium")
+        if image.large == VariantStatus.READY:
+            variants.append("large")
+        bucket = (
+            settings.R2_PUBLIC_BUCKET
+            if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+            else settings.R2_PRIVATE_BUCKET
+        )
+        all_uploaded = True
+        for variant in variants:
+            ext = "webp" if variant == "thumbs" else image.ext
+            key = f"{variant}/{image.filename}.{ext}"
+            local = FilePath(settings.STORAGE_PATH) / variant / f"{image.filename}.{ext}"
+            if not local.exists():
+                logger.warning("reconcile_local_missing", image_id=image.image_id, variant=variant)
+                all_uploaded = False
+                break
+            if not await r2.object_exists(bucket=bucket, key=key):
+                await r2.upload_file(bucket=bucket, key=key, path=local)
+
+        if all_uploaded:
+            new_location = (
+                R2Location.PUBLIC
+                if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+                else R2Location.PRIVATE
+            )
+            async with get_async_session() as db:
+                await db.execute(
+                    update(Images)
+                    .where(Images.image_id == image.image_id)
+                    .where(Images.r2_location == R2Location.NONE)
+                    .values(r2_location=new_location)
+                )
+                await db.commit()
+            healed += 1
+
+    print(f"reconciled {healed}/{len(rows)} rows")
+
+
+async def resync_image(image_id: int) -> None:
+    """Debug tool: print current R2 state for one image (read-only).
+
+    Intentionally does NOT re-upload — use `reconcile` for healing. This is a
+    diagnostic for operators asking "what does R2 think about image N?".
+    """
+    r2 = get_r2_storage()
+    async with get_async_session() as db:
+        result = await db.execute(select(Images).where(Images.image_id == image_id))
+        image = result.scalar_one_or_none()
+    if image is None:
+        print(f"image {image_id} not found")
+        return
+
+    print(f"image {image_id} filename={image.filename} status={image.status} "
+          f"r2_location={image.r2_location}")
+    bucket = (
+        settings.R2_PUBLIC_BUCKET
+        if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+        else settings.R2_PRIVATE_BUCKET
+    )
+    for variant in R2_VARIANTS:
+        ext = "webp" if variant == "thumbs" else image.ext
+        key = f"{variant}/{image.filename}.{ext}"
+        exists = await r2.object_exists(bucket=bucket, key=key)
+        print(f"  {variant}: {bucket}/{key} exists={exists}")
+
+
+async def verify(*, sample: int | None) -> dict[str, Any]:
+    """Audit: report DB/R2 discrepancies per spec §Operational tooling.
+
+    Reports:
+      - PUBLIC rows whose object is missing from the public bucket (`missing`)
+      - PRIVATE rows whose object is missing from the private bucket (`missing`)
+      - NONE rows whose object unexpectedly exists in either bucket (`unexpected`)
+      - Cross-bucket placement: PUBLIC row found in private bucket / vice versa (`wrong_bucket`)
+
+    `r2_location=NONE` with no R2 object is a legitimate state (pending
+    finalizer, mode disabled, or staging-imported prod data) and is NOT reported.
+    """
+    r2 = get_r2_storage()
+    discrepancies: list[dict[str, Any]] = []
+
+    async with get_async_session() as db:
+        stmt = select(Images)
+        if sample:
+            stmt = stmt.order_by(Images.image_id.desc()).limit(sample)
+        result = await db.execute(stmt)
+        rows = list(result.scalars())
+
+    def _variants_for(image: Images) -> list[str]:
+        variants = ["fullsize", "thumbs"]
+        if image.medium == VariantStatus.READY:
+            variants.append("medium")
+        if image.large == VariantStatus.READY:
+            variants.append("large")
+        return variants
+
+    for image in rows:
+        variants = _variants_for(image)
+        for variant in variants:
+            ext = "webp" if variant == "thumbs" else image.ext
+            key = f"{variant}/{image.filename}.{ext}"
+            in_public = await r2.object_exists(
+                bucket=settings.R2_PUBLIC_BUCKET, key=key
+            )
+            in_private = await r2.object_exists(
+                bucket=settings.R2_PRIVATE_BUCKET, key=key
+            )
+            if image.r2_location == R2Location.NONE:
+                # NONE + no object is clean. Either bucket having the object
+                # is a leaked/orphaned upload and must be reported.
+                if in_public or in_private:
+                    discrepancies.append({
+                        "kind": "unexpected",
+                        "image_id": image.image_id,
+                        "key": key,
+                        "found_in_public": in_public,
+                        "found_in_private": in_private,
+                    })
+                continue
+            expected_bucket = (
+                settings.R2_PUBLIC_BUCKET
+                if image.r2_location == R2Location.PUBLIC
+                else settings.R2_PRIVATE_BUCKET
+            )
+            found_expected = (
+                in_public if image.r2_location == R2Location.PUBLIC else in_private
+            )
+            found_other = (
+                in_private if image.r2_location == R2Location.PUBLIC else in_public
+            )
+            if not found_expected:
+                discrepancies.append({
+                    "kind": "missing",
+                    "image_id": image.image_id,
+                    "bucket": expected_bucket,
+                    "key": key,
+                })
+            if found_other:
+                # Cross-bucket orphan: either split-existing left a copy behind
+                # or a status-change move didn't complete its delete.
+                discrepancies.append({
+                    "kind": "wrong_bucket",
+                    "image_id": image.image_id,
+                    "key": key,
+                    "r2_location": int(image.r2_location),
+                    "found_in_public": in_public,
+                    "found_in_private": in_private,
+                })
+
+    report = {"checked": len(rows), "discrepancies": discrepancies}
+    print(f"checked {report['checked']} rows, {len(discrepancies)} discrepancies")
+    for d in discrepancies[:20]:
+        print(f"  {d['kind']}: {d.get('bucket', '')}{d['key']} (image_id={d['image_id']})")
+    return report
+
+
+async def purge_cache_command(*, image_id: int) -> None:
+    """Manually invoke Cloudflare purge for one image's CDN URLs."""
+    async with get_async_session() as db:
+        result = await db.execute(select(Images).where(Images.image_id == image_id))
+        image = result.scalar_one_or_none()
+    if image is None:
+        print(f"image {image_id} not found")
+        return
+    variants = ["fullsize", "thumbs"]
+    if image.medium == VariantStatus.READY:
+        variants.append("medium")
+    if image.large == VariantStatus.READY:
+        variants.append("large")
+    urls = []
+    for variant in variants:
+        ext = "webp" if variant == "thumbs" else image.ext
+        urls.append(f"{settings.R2_PUBLIC_CDN_URL}/{variant}/{image.filename}.{ext}")
+    await purge_cache_by_urls(urls)
+    print(f"purged {len(urls)} URLs for image {image_id}")
+
+
+async def health(*, output_json: bool = False) -> dict[str, Any]:
+    """Read-only health report for monitoring wiring."""
+    import asyncio as _asyncio
+    import subprocess
+    from datetime import UTC, datetime
+    from sqlalchemy import func
+
+    async with get_async_session() as db:
+        count_result = await db.execute(
+            select(func.count()).select_from(Images).where(Images.r2_location == R2Location.NONE)
+        )
+        unsynced_count = count_result.scalar_one()
+
+        oldest_result = await db.execute(
+            select(func.min(Images.date_added)).where(Images.r2_location == R2Location.NONE)
+        )
+        oldest = oldest_result.scalar_one_or_none()
+        # DB columns are naive UTC; strip tz from "now" for a clean subtraction.
+        oldest_age = (
+            int((datetime.now(UTC).replace(tzinfo=None) - oldest).total_seconds())
+            if oldest
+            else 0
+        )
+
+    try:
+        # subprocess is sync — offload so we don't block the event loop.
+        du_output = await _asyncio.to_thread(
+            subprocess.check_output, ["du", "-sb", settings.STORAGE_PATH], text=True
+        )
+        local_bytes = int(du_output.split()[0])
+    except Exception:
+        local_bytes = -1
+
+    report = {
+        "unsynced_count": unsynced_count,
+        "oldest_unsynced_age_seconds": oldest_age,
+        "local_storage_used_bytes": local_bytes,
+        "local_storage_path": settings.STORAGE_PATH,
+    }
+    if output_json:
+        import json
+        print(json.dumps(report))
+    else:
+        for k, v in report.items():
+            print(f"{k}: {v}")
+    return report
+```
+
+Update `_dispatch`:
+
+```python
+async def _dispatch(args: argparse.Namespace) -> int:
+    require_r2_enabled()
+
+    if args.command == "split-existing":
+        await split_existing(dry_run=args.dry_run)
+    elif args.command == "backfill-locations":
+        await backfill_locations()
+    elif args.command == "reconcile":
+        await reconcile(stale_after=args.stale_after)
+    elif args.command == "image":
+        await resync_image(args.image_id)
+    elif args.command == "verify":
+        # Parser default is None; argparse keeps None when --sample is omitted.
+        await verify(sample=args.sample)
+    elif args.command == "purge-cache":
+        await purge_cache_command(image_id=args.image_id)
+    elif args.command == "health":
+        await health(output_json=args.json)
+    else:
+        raise ValueError(f"unknown command: {args.command}")
+    return 0
+```
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/unit/test_r2_sync_remaining.py -v`
+Expected: all PASS
+
+**Step 5: Run full test suite**
+
+Run: `uv run pytest -x --tb=short`
+Expected: pass.
+
+**Step 6: Commit**
+
+```bash
+git add scripts/r2_sync.py tests/unit/test_r2_sync_remaining.py
+git commit -m "feat(r2): add reconcile/image/verify/purge-cache/health subcommands"
+```
+
+---
+
+## Chunk 7: Cleanup and Operator Docs
+
+Remove legacy `STORAGE_TYPE` / `S3_*` placeholders, document the nginx config, write the operator runbook.
+
+---
+
+### Task 21: Remove Legacy `STORAGE_TYPE` and `S3_*` Settings
+
+**Files:**
+- Modify: `app/config.py`
+
+**Step 1: Confirm they're unused**
+
+Run: `uv run grep -rn "STORAGE_TYPE\|S3_BUCKET\|S3_ACCESS_KEY\|S3_SECRET_KEY\|S3_ENDPOINT\|S3_REGION" app/ tests/ scripts/ | grep -v "app/config.py"`
+Expected: no matches (other than `app/config.py` itself).
+
+**Step 2: Remove from `app/config.py`**
+
+In `app/config.py`, delete the block:
+
+```python
+    # File Storage
+    STORAGE_TYPE: str = Field(default="local", pattern="^(local|s3)$")
+    STORAGE_PATH: str = "/shuushuu/images"
+
+    # S3 Configuration (if using S3)
+    S3_BUCKET: str | None = None
+    S3_ACCESS_KEY: str | None = None
+    S3_SECRET_KEY: str | None = None
+    S3_ENDPOINT: str | None = None
+    S3_REGION: str = "us-east-1"
+```
+
+Keep `STORAGE_PATH` — it's still the local filesystem root:
+
+```python
+    # Local filesystem root for image storage (used as fallback when R2 is
+    # disabled, or as the source for R2 uploads during phase 1).
+    STORAGE_PATH: str = "/shuushuu/images"
+```
+
+**Step 3: Run full test suite**
+
+Run: `uv run pytest -x --tb=short`
+Expected: pass. `.env` files in the wild that still set `STORAGE_TYPE` / `S3_*` are silently ignored by `extra="ignore"` on `SettingsConfigDict`.
+
+**Step 4: Commit**
+
+```bash
+git add app/config.py
+git commit -m "chore(r2): remove unused STORAGE_TYPE and S3_* config"
+```
+
+---
+
+### Task 22: Document nginx, Env Vars, and Operator Runbook
+
+**Files:**
+- Modify: `docs/image-serving-nginx.md`
+- Create: `docs/r2-operations.md`
+
+**Step 1: Update nginx doc**
+
+In `docs/image-serving-nginx.md`, add a section at the end:
+
+```markdown
+## R2 serving (R2_ENABLED=true)
+
+When `R2_ENABLED=true`, the FastAPI `/images/*` endpoint returns 302 redirects
+with `Cache-Control: no-store` instead of `X-Accel-Redirect`:
+
+- Public images (`r2_location=PUBLIC`) 302 to the public CDN domain. Browsers
+  follow the redirect; nginx is not in the path for the actual image bytes.
+- Protected images (`r2_location=PRIVATE`) 302 to a short-lived presigned URL
+  against the private R2 bucket. Each request issues a fresh presigned URL.
+- Unfinalized or disabled-mode images (`r2_location=NONE`) still return
+  `X-Accel-Redirect` headers pointing at `/internal/*` — same behaviour as
+  before the R2 work.
+
+No nginx configuration change is required. The existing `proxy_cache off`
+directive on `/images/*`, `/thumbs/*`, `/medium/*`, `/large/*` blocks must be
+preserved — nginx must not cache the 302 responses. The `/internal/*` location
+blocks remain for the fallback path.
+```
+
+**Step 2: Create the operator runbook**
+
+Create `docs/r2-operations.md`:
+
+```markdown
+# R2 Operations Runbook
+
+See `docs/plans/2026-04-16-r2-image-serving-design.md` for the full design.
+This file is the short reference for operators.
+
+## Environment variables
+
+| Name | Prod | Staging | Dev |
+|------|------|---------|-----|
+| `R2_ENABLED` | `true` | `true` | `false` |
+| `R2_ALLOW_BULK_BACKFILL` | `true` | `false` | — |
+| `R2_ACCESS_KEY_ID` | per-env | per-env | — |
+| `R2_SECRET_ACCESS_KEY` | per-env | per-env | — |
+| `R2_ENDPOINT` | R2 endpoint URL | same | — |
+| `R2_PUBLIC_BUCKET` | `shuushuu-images` | `shuushuu-images-staging` | — |
+| `R2_PRIVATE_BUCKET` | `shuushuu-images-private` | `shuushuu-images-staging-private` | — |
+| `R2_PUBLIC_CDN_URL` | `https://cdn.e-shuushuu.net` | `https://cdn-staging.e-shuushuu.net` | — |
+| `R2_PRESIGN_TTL_SECONDS` | `900` | `900` | — |
+| `CLOUDFLARE_API_TOKEN` | per-env | per-env | — |
+| `CLOUDFLARE_ZONE_ID` | per-env (prod zone) | per-env (staging zone) | — |
+
+Staging's separate `CLOUDFLARE_ZONE_ID` ensures purges issued from staging
+never affect prod. Staging's `R2_ALLOW_BULK_BACKFILL=false` ensures a
+`reconcile` or `backfill-locations` (including inherited nightly crons)
+cannot mass-upload prod-imported images into the small staging bucket.
+
+## One-time cutover
+
+1. Create `shuushuu-images-private` bucket.
+2. Attach custom CDN domain to `shuushuu-images`.
+3. Create a Cloudflare API token with zone-level cache purge permission.
+4. Set all R2/Cloudflare env vars (flag still off).
+5. Dry-run: `R2_ENABLED=true uv run python scripts/r2_sync.py split-existing --dry-run`
+6. Run for real: `R2_ENABLED=true uv run python scripts/r2_sync.py split-existing`
+7. Verify: `R2_ENABLED=true uv run python scripts/r2_sync.py verify --sample 1000`
+8. Flip bulk-backfill on: set `R2_ALLOW_BULK_BACKFILL=true`.
+9. Backfill: `uv run python scripts/r2_sync.py backfill-locations`
+10. Flip `R2_ENABLED=true` in the app config, restart app + ARQ workers.
+11. Monitor logs for `r2_*_failed` events for a week.
+
+`R2_ALLOW_BULK_BACKFILL` stays `true` in prod permanently so the nightly
+`reconcile` cron can heal stuck rows. Staging's `false` setting neutralises
+the same cron on that environment.
+
+## Common commands
+
+```bash
+# Inspect one image
+R2_ENABLED=true uv run python scripts/r2_sync.py image 12345
+
+# Audit recent rows
+R2_ENABLED=true uv run python scripts/r2_sync.py verify --sample 1000
+
+# Manual CDN purge
+R2_ENABLED=true uv run python scripts/r2_sync.py purge-cache 12345
+
+# Health (wire to monitoring)
+R2_ENABLED=true uv run python scripts/r2_sync.py health --json
+```
+
+## Rollback
+
+Set `R2_ENABLED=false`, restart app + workers. URLs fall back to `/images/*`
+paths served from the local filesystem. R2 objects remain (harmless). DB
+`r2_location` values stay (not consulted while the flag is off).
+
+## Alerting thresholds
+
+From `r2_sync.py health --json`:
+
+- WARNING if `unsynced_count > 0` and `oldest_unsynced_age_seconds > 3600`
+- CRITICAL if `unsynced_count > 100` or `oldest_unsynced_age_seconds > 21600`
+- CRITICAL if `local_storage_used_bytes` exceeds your per-deployment ceiling
+
+These thresholds are NOT useful on staging (which has millions of
+`r2_location=NONE` rows by construction — prod DB copy, small R2 bucket).
+Scope alerting to prod only, or add a staging-specific counting mode.
+
+## Invariant to preserve in phase 2
+
+When phase 2 removes local filesystem as source-of-truth, the
+`local_cleanup_job` MUST refuse to delete any local file unless
+`r2_location in {PUBLIC, PRIVATE}`. Do not add a fallback branch that deletes
+based on age alone — a broken R2 integration then becomes a data-loss bug.
+```
+
+**Step 3: Commit**
+
+```bash
+git add docs/image-serving-nginx.md docs/r2-operations.md
+git commit -m "docs(r2): operator runbook and nginx-serving notes"
+```
+
+---
+
+## Final Verification
+
+Run the entire test suite, mypy, and ruff once more before opening the PR:
+
+```bash
+uv run pytest -x --tb=short
+uv run mypy app/ scripts/
+uv run ruff check app/ scripts/ tests/
+uv run ruff format --check app/ scripts/ tests/
+```
+
+All must pass. Then push the branch and open a PR against `main`.
+
+The `R2_ENABLED=false` default means this work can merge without touching prod
+behaviour. Production cutover follows the runbook in `docs/r2-operations.md`.

--- a/docs/r2-operations.md
+++ b/docs/r2-operations.md
@@ -62,6 +62,10 @@ the same cron on that environment.
 # Inspect one image
 R2_ENABLED=true uv run python scripts/r2_sync.py image 12345
 
+# Force delete + re-upload one image's variants (heals a corrupted object)
+R2_ENABLED=true uv run python scripts/r2_sync.py image 12345 --force-reupload --dry-run
+R2_ENABLED=true uv run python scripts/r2_sync.py image 12345 --force-reupload
+
 # Audit recent rows (--sample N or --all required)
 R2_ENABLED=true uv run python scripts/r2_sync.py verify --sample 1000
 

--- a/docs/r2-operations.md
+++ b/docs/r2-operations.md
@@ -16,8 +16,15 @@ This file is the short reference for operators.
 | `R2_PRIVATE_BUCKET` | `shuushuu-images-private` | `shuushuu-images-staging-private` | — |
 | `R2_PUBLIC_CDN_URL` | `https://cdn.e-shuushuu.net` | `https://cdn-staging.e-shuushuu.net` | — |
 | `R2_PRESIGN_TTL_SECONDS` | `900` | `900` | — |
-| `CLOUDFLARE_API_TOKEN` | per-env | per-env | — |
-| `CLOUDFLARE_ZONE_ID` | per-env (prod zone) | per-env (staging zone) | — |
+| `CLOUDFLARE_API_TOKEN` | per-env | per-env (optional) | — |
+| `CLOUDFLARE_ZONE_ID` | per-env (prod zone) | per-env (optional) | — |
+
+Cloudflare credentials are **optional**. Without them R2 storage works
+normally but CDN cache purge is skipped — public→private transitions and
+deletions will leave stale objects in Cloudflare edge cache until they
+expire naturally. Set them when you have a custom domain attached to the
+public bucket via Cloudflare. The token only needs **Zone > Cache Purge >
+Purge** permission.
 
 Staging's separate `CLOUDFLARE_ZONE_ID` ensures purges issued from staging
 never affect prod. Staging's `R2_ALLOW_BULK_BACKFILL=false` ensures a
@@ -48,7 +55,7 @@ the same cron on that environment.
 # Inspect one image
 R2_ENABLED=true uv run python scripts/r2_sync.py image 12345
 
-# Audit recent rows
+# Audit recent rows (--sample N or --all required)
 R2_ENABLED=true uv run python scripts/r2_sync.py verify --sample 1000
 
 # Manual CDN purge

--- a/docs/r2-operations.md
+++ b/docs/r2-operations.md
@@ -1,0 +1,84 @@
+# R2 Operations Runbook
+
+See `docs/plans/2026-04-16-r2-image-serving-design.md` for the full design.
+This file is the short reference for operators.
+
+## Environment variables
+
+| Name | Prod | Staging | Dev |
+|------|------|---------|-----|
+| `R2_ENABLED` | `true` | `true` | `false` |
+| `R2_ALLOW_BULK_BACKFILL` | `true` | `false` | — |
+| `R2_ACCESS_KEY_ID` | per-env | per-env | — |
+| `R2_SECRET_ACCESS_KEY` | per-env | per-env | — |
+| `R2_ENDPOINT` | R2 endpoint URL | same | — |
+| `R2_PUBLIC_BUCKET` | `shuushuu-images` | `shuushuu-images-staging` | — |
+| `R2_PRIVATE_BUCKET` | `shuushuu-images-private` | `shuushuu-images-staging-private` | — |
+| `R2_PUBLIC_CDN_URL` | `https://cdn.e-shuushuu.net` | `https://cdn-staging.e-shuushuu.net` | — |
+| `R2_PRESIGN_TTL_SECONDS` | `900` | `900` | — |
+| `CLOUDFLARE_API_TOKEN` | per-env | per-env | — |
+| `CLOUDFLARE_ZONE_ID` | per-env (prod zone) | per-env (staging zone) | — |
+
+Staging's separate `CLOUDFLARE_ZONE_ID` ensures purges issued from staging
+never affect prod. Staging's `R2_ALLOW_BULK_BACKFILL=false` ensures a
+`reconcile` or `backfill-locations` (including inherited nightly crons)
+cannot mass-upload prod-imported images into the small staging bucket.
+
+## One-time cutover
+
+1. Create `shuushuu-images-private` bucket.
+2. Attach custom CDN domain to `shuushuu-images`.
+3. Create a Cloudflare API token with zone-level cache purge permission.
+4. Set all R2/Cloudflare env vars (flag still off).
+5. Dry-run: `R2_ENABLED=true uv run python scripts/r2_sync.py split-existing --dry-run`
+6. Run for real: `R2_ENABLED=true uv run python scripts/r2_sync.py split-existing`
+7. Verify: `R2_ENABLED=true uv run python scripts/r2_sync.py verify --sample 1000`
+8. Flip bulk-backfill on: set `R2_ALLOW_BULK_BACKFILL=true`.
+9. Backfill: `uv run python scripts/r2_sync.py backfill-locations`
+10. Flip `R2_ENABLED=true` in the app config, restart app + ARQ workers.
+11. Monitor logs for `r2_*_failed` events for a week.
+
+`R2_ALLOW_BULK_BACKFILL` stays `true` in prod permanently so the nightly
+`reconcile` cron can heal stuck rows. Staging's `false` setting neutralises
+the same cron on that environment.
+
+## Common commands
+
+```bash
+# Inspect one image
+R2_ENABLED=true uv run python scripts/r2_sync.py image 12345
+
+# Audit recent rows
+R2_ENABLED=true uv run python scripts/r2_sync.py verify --sample 1000
+
+# Manual CDN purge
+R2_ENABLED=true uv run python scripts/r2_sync.py purge-cache 12345
+
+# Health (wire to monitoring)
+R2_ENABLED=true uv run python scripts/r2_sync.py health --json
+```
+
+## Rollback
+
+Set `R2_ENABLED=false`, restart app + workers. URLs fall back to `/images/*`
+paths served from the local filesystem. R2 objects remain (harmless). DB
+`r2_location` values stay (not consulted while the flag is off).
+
+## Alerting thresholds
+
+From `r2_sync.py health --json`:
+
+- WARNING if `unsynced_count > 0` and `oldest_unsynced_age_seconds > 3600`
+- CRITICAL if `unsynced_count > 100` or `oldest_unsynced_age_seconds > 21600`
+- CRITICAL if `local_storage_used_bytes` exceeds your per-deployment ceiling
+
+These thresholds are NOT useful on staging (which has millions of
+`r2_location=NONE` rows by construction — prod DB copy, small R2 bucket).
+Scope alerting to prod only, or add a staging-specific counting mode.
+
+## Invariant to preserve in phase 2
+
+When phase 2 removes local filesystem as source-of-truth, the
+`local_cleanup_job` MUST refuse to delete any local file unless
+`r2_location in {PUBLIC, PRIVATE}`. Do not add a fallback branch that deletes
+based on age alone — a broken R2 integration then becomes a data-loss bug.

--- a/docs/r2-operations.md
+++ b/docs/r2-operations.md
@@ -19,12 +19,19 @@ This file is the short reference for operators.
 | `CLOUDFLARE_API_TOKEN` | per-env | per-env (optional) | — |
 | `CLOUDFLARE_ZONE_ID` | per-env (prod zone) | per-env (optional) | — |
 
-Cloudflare credentials are **optional**. Without them R2 storage works
-normally but CDN cache purge is skipped — public→private transitions and
-deletions will leave stale objects in Cloudflare edge cache until they
-expire naturally. Set them when you have a custom domain attached to the
-public bucket via Cloudflare. The token only needs **Zone > Cache Purge >
-Purge** permission.
+Cloudflare credentials are **optional** for R2 storage itself.
+`purge_cache_by_urls` raises when they're missing, so:
+
+- **Automatic purges** (post-transition and post-delete in
+  `sync_image_status_job` / `r2_delete_image_job`) catch and log the
+  raise as `r2_cdn_purge_failed_*` — best-effort. Objects will sit in
+  Cloudflare edge cache until they expire naturally.
+- **Manual `r2_sync.py purge-cache`** does **not** catch: running it
+  without `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ZONE_ID` set will error.
+
+Set them when you have a custom domain attached to the public bucket
+via Cloudflare. The token only needs **Zone > Cache Purge > Purge**
+permission.
 
 Staging's separate `CLOUDFLARE_ZONE_ID` ensures purges issued from staging
 never affect prod. Staging's `R2_ALLOW_BULK_BACKFILL=false` ensures a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "python-json-logger>=2.0.7",
     # Task queue
     "arq>=0.27.0", # Task queue for background jobs
+    "aioboto3>=13.0.0",  # Async S3-compatible client for Cloudflare R2
     # "python-magic>=0.4.27",  # File type detection - for validating image uploads
     # "slowapi>=0.1.9",  # Rate limiting - for API throttling
     # "python-multipart>=0.0.20",  # Multipart form data - needed for image uploads
@@ -56,6 +57,8 @@ dev = [
     "types-redis>=4.6.0",
     # Security / Auditing
     "pip-audit>=2.10.0",
+    "moto[s3]>=5.0.0",  # Mock S3 for R2 adapter tests
+    "types-aioboto3>=13.0.0",  # Type stubs
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = [
     "types-redis>=4.6.0",
     # Security / Auditing
     "pip-audit>=2.10.0",
-    "moto[s3]>=5.0.0",  # Mock S3 for R2 adapter tests
+    "moto[s3,server]>=5.0.0",  # Mock S3 for R2 adapter tests
     "types-aioboto3>=13.0.0",  # Type stubs
 ]
 

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -20,8 +20,17 @@ import argparse
 import asyncio
 import sys
 
+from sqlalchemy import select, update
+
 from app.config import settings
+from app.core.database import get_async_session
 from app.core.logging import get_logger
+from app.core.r2_client import get_r2_storage
+from app.core.r2_constants import (
+    PUBLIC_IMAGE_STATUSES_FOR_R2,
+    R2Location,
+)
+from app.models.image import Images, VariantStatus
 
 logger = get_logger(__name__)
 
@@ -77,10 +86,119 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+async def split_existing(*, dry_run: bool) -> None:
+    """Move protected-status images' R2 objects from public to private bucket.
+
+    Assumes existing R2 state is "everything in R2_PUBLIC_BUCKET" (the starting
+    point for the production cutover). Idempotent — objects already moved are
+    skipped via object_exists checks.
+    """
+    r2 = get_r2_storage()
+
+    async with get_async_session() as db:
+        result = await db.execute(
+            select(Images).where(Images.status.notin_(PUBLIC_IMAGE_STATUSES_FOR_R2))
+        )
+        rows = list(result.scalars())
+
+    logger.info("split_existing_started", count=len(rows), dry_run=dry_run)
+
+    moved = 0
+    for image in rows:
+        variants = ["fullsize", "thumbs"]
+        if image.medium == VariantStatus.READY:
+            variants.append("medium")
+        if image.large == VariantStatus.READY:
+            variants.append("large")
+        for variant in variants:
+            ext = "webp" if variant == "thumbs" else image.ext
+            key = f"{variant}/{image.filename}.{ext}"
+            if not await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key):
+                continue
+            if dry_run:
+                print(
+                    f"DRY_RUN move {settings.R2_PUBLIC_BUCKET}/{key}"
+                    f" -> {settings.R2_PRIVATE_BUCKET}/{key}"
+                )
+                moved += 1
+                continue
+            await r2.copy_object(
+                src_bucket=settings.R2_PUBLIC_BUCKET,
+                dst_bucket=settings.R2_PRIVATE_BUCKET,
+                key=key,
+            )
+            await r2.delete_object(bucket=settings.R2_PUBLIC_BUCKET, key=key)
+            moved += 1
+
+    logger.info("split_existing_completed", moved=moved, dry_run=dry_run)
+    print(f"{'[dry-run] ' if dry_run else ''}moved {moved} objects")
+
+
+async def backfill_locations(*, batch_size: int = 1000) -> None:
+    """Flip r2_location for rows still at NONE based on current status."""
+    require_bulk_backfill()
+
+    total_flipped = 0
+    while True:
+        async with get_async_session() as db:
+            result = await db.execute(
+                select(Images)
+                .where(Images.r2_location == R2Location.NONE)
+                .limit(batch_size)
+            )
+            rows = list(result.scalars())
+            if not rows:
+                break
+
+            public_ids = [
+                img.image_id
+                for img in rows
+                if img.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+            ]
+            private_ids = [
+                img.image_id
+                for img in rows
+                if img.status not in PUBLIC_IMAGE_STATUSES_FOR_R2
+            ]
+
+            if public_ids:
+                await db.execute(
+                    update(Images)
+                    .where(Images.image_id.in_(public_ids))
+                    .where(Images.r2_location == R2Location.NONE)
+                    .values(r2_location=R2Location.PUBLIC)
+                )
+            if private_ids:
+                await db.execute(
+                    update(Images)
+                    .where(Images.image_id.in_(private_ids))
+                    .where(Images.r2_location == R2Location.NONE)
+                    .values(r2_location=R2Location.PRIVATE)
+                )
+
+            await db.commit()
+            total_flipped += len(public_ids) + len(private_ids)
+            logger.info(
+                "backfill_batch",
+                batch_size=len(rows),
+                total_flipped=total_flipped,
+            )
+
+    print(f"backfilled {total_flipped} rows")
+
+
 async def _dispatch(args: argparse.Namespace) -> int:
     require_r2_enabled()
+
+    if args.command == "split-existing":
+        await split_existing(dry_run=args.dry_run)
+        return 0
+    if args.command == "backfill-locations":
+        await backfill_locations()
+        return 0
+
     raise NotImplementedError(
-        f"Subcommand '{args.command}' is not yet implemented in this chunk."
+        f"Subcommand '{args.command}' is not yet implemented."
     )
 
 

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -108,6 +108,20 @@ def _build_parser() -> argparse.ArgumentParser:
     rec.add_argument("--stale-after", type=_positive_int, default=600)
     img = sub.add_parser("image")
     img.add_argument("image_id", type=int)
+    img.add_argument(
+        "--force-reupload",
+        action="store_true",
+        help=(
+            "Delete + re-upload each ready variant from the local filesystem. "
+            "Refuses if r2_location=NONE (use 'reconcile' first). Triggers a "
+            "best-effort CDN purge for PUBLIC rows."
+        ),
+    )
+    img.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="With --force-reupload: report actions without touching R2.",
+    )
     ver = sub.add_parser(
         "verify",
         description=(
@@ -450,6 +464,76 @@ async def resync_image(image_id: int) -> None:
         print(f"  {variant}: {bucket}/{key} exists={exists}")
 
 
+async def force_reupload_image(*, image_id: int, dry_run: bool) -> None:
+    """Delete + re-upload each ready variant for one image from local files.
+
+    For healing a partially-corrupted R2 object (truncated upload that passes
+    HEAD but fails GET, or a CDN-cached bad copy) where `reconcile` wouldn't
+    help because `object_exists` returns true. Refuses when r2_location=NONE
+    — that's reconcile's job. Variants whose local file is missing are
+    skipped with a warning (no delete, no upload). PUBLIC bucket uploads
+    trigger a best-effort CDN purge after re-upload.
+    """
+    from pathlib import Path as FilePath
+
+    r2 = get_r2_storage()
+    async with get_async_session() as db:
+        result = await db.execute(select(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
+        image = result.scalar_one_or_none()
+
+    if image is None:
+        print(f"image {image_id} not found")
+        return
+
+    if image.r2_location == R2Location.NONE:
+        print(
+            f"image {image_id} has r2_location=NONE — use 'reconcile' to upload "
+            "from local first; force-reupload only operates on already-synced rows"
+        )
+        return
+
+    bucket = (
+        settings.R2_PUBLIC_BUCKET
+        if image.r2_location == R2Location.PUBLIC
+        else settings.R2_PRIVATE_BUCKET
+    )
+    variants = _ready_variants(image)
+    processed_keys: list[str] = []
+
+    async with r2.bulk_session():
+        for variant in variants:
+            ext = "webp" if variant == "thumbs" else image.ext
+            key = f"{variant}/{image.filename}.{ext}"
+            local = FilePath(settings.STORAGE_PATH) / variant / f"{image.filename}.{ext}"
+            if not local.exists():
+                logger.warning(
+                    "force_reupload_local_missing",
+                    image_id=image_id,
+                    variant=variant,
+                )
+                continue
+            processed_keys.append(key)
+            if dry_run:
+                print(f"DRY_RUN delete+reupload {bucket}/{key}")
+                continue
+            await r2.delete_object(bucket=bucket, key=key)
+            await r2.upload_file(bucket=bucket, key=key, path=local)
+
+    if not dry_run and processed_keys and image.r2_location == R2Location.PUBLIC:
+        urls = [f"{settings.R2_PUBLIC_CDN_URL}/{k}" for k in processed_keys]
+        try:
+            await purge_cache_by_urls(urls)
+        except Exception as exc:
+            logger.warning(
+                "force_reupload_cdn_purge_failed",
+                image_id=image_id,
+                error=repr(exc),
+            )
+
+    verb = "would re-upload" if dry_run else "re-uploaded"
+    print(f"{verb} {len(processed_keys)} variants for image {image_id}")
+
+
 async def verify(
     *,
     sample: int | None = None,
@@ -759,7 +843,10 @@ async def _run(args: argparse.Namespace) -> int:
     elif args.command == "reconcile":
         await reconcile(stale_after=args.stale_after)
     elif args.command == "image":
-        await resync_image(args.image_id)
+        if args.force_reupload:
+            await force_reupload_image(image_id=args.image_id, dry_run=args.dry_run)
+        else:
+            await resync_image(args.image_id)
     elif args.command == "verify":
         await verify(
             sample=args.sample,

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -223,6 +223,9 @@ async def reconcile(*, stale_after: int) -> None:
         if not rows:
             break
 
+        public_healed_ids: list[int] = []
+        private_healed_ids: list[int] = []
+
         for image in rows:
             processed += 1
             last_image_id = image.image_id  # type: ignore[assignment]
@@ -250,20 +253,29 @@ async def reconcile(*, stale_after: int) -> None:
                     await r2.upload_file(bucket=bucket, key=key, path=local)
 
             if all_uploaded:
-                new_location = (
-                    R2Location.PUBLIC
-                    if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
-                    else R2Location.PRIVATE
+                if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2:
+                    public_healed_ids.append(image.image_id)  # type: ignore[arg-type]
+                else:
+                    private_healed_ids.append(image.image_id)  # type: ignore[arg-type]
+
+        async with get_async_session() as db:
+            if public_healed_ids:
+                await db.execute(
+                    update(Images)
+                    .where(Images.image_id.in_(public_healed_ids))  # type: ignore[union-attr]
+                    .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
+                    .values(r2_location=R2Location.PUBLIC)
                 )
-                async with get_async_session() as db:
-                    await db.execute(
-                        update(Images)
-                        .where(Images.image_id == image.image_id)  # type: ignore[arg-type]
-                        .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
-                        .values(r2_location=new_location)
-                    )
-                    await db.commit()
-                healed += 1
+            if private_healed_ids:
+                await db.execute(
+                    update(Images)
+                    .where(Images.image_id.in_(private_healed_ids))  # type: ignore[union-attr]
+                    .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
+                    .values(r2_location=R2Location.PRIVATE)
+                )
+            if public_healed_ids or private_healed_ids:
+                await db.commit()
+                healed += len(public_healed_ids) + len(private_healed_ids)
 
     print(f"reconciled {healed}/{processed} rows")
 

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -68,6 +68,13 @@ def require_bulk_backfill() -> None:
         )
 
 
+def _positive_int(value: str) -> int:
+    n = int(value)
+    if n <= 0:
+        raise argparse.ArgumentTypeError(f"must be > 0, got {n}")
+    return n
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="R2 operational tooling")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -81,7 +88,7 @@ def _build_parser() -> argparse.ArgumentParser:
     img.add_argument("image_id", type=int)
     ver = sub.add_parser("verify")
     ver_group = ver.add_mutually_exclusive_group(required=True)
-    ver_group.add_argument("--sample", type=int)
+    ver_group.add_argument("--sample", type=_positive_int)
     ver_group.add_argument("--all", action="store_true")
     pc = sub.add_parser("purge-cache")
     pc.add_argument("image_id", type=int)
@@ -322,7 +329,7 @@ async def verify(*, sample: int | None) -> dict[str, Any]:
 
     async with get_async_session() as db:
         stmt = select(Images)
-        if sample:
+        if sample is not None:
             stmt = stmt.order_by(Images.image_id.desc()).limit(sample)  # type: ignore[union-attr]
         stmt = stmt.execution_options(yield_per=500)
         stream = await db.stream_scalars(stmt)

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -97,41 +97,43 @@ async def split_existing(*, dry_run: bool) -> None:
     skipped via object_exists checks.
     """
     r2 = get_r2_storage()
+    moved = 0
+
+    logger.info("split_existing_started", dry_run=dry_run)
 
     async with get_async_session() as db:
-        result = await db.execute(
-            select(Images).where(Images.status.notin_(PUBLIC_IMAGE_STATUSES_FOR_R2))  # type: ignore[attr-defined]
+        stmt = (
+            select(Images)
+            .where(Images.status.notin_(PUBLIC_IMAGE_STATUSES_FOR_R2))  # type: ignore[attr-defined]
+            .execution_options(yield_per=500)
         )
-        rows = list(result.scalars())
+        stream = await db.stream_scalars(stmt)
 
-    logger.info("split_existing_started", count=len(rows), dry_run=dry_run)
-
-    moved = 0
-    for image in rows:
-        variants = ["fullsize", "thumbs"]
-        if image.medium == VariantStatus.READY:
-            variants.append("medium")
-        if image.large == VariantStatus.READY:
-            variants.append("large")
-        for variant in variants:
-            ext = "webp" if variant == "thumbs" else image.ext
-            key = f"{variant}/{image.filename}.{ext}"
-            if not await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key):
-                continue
-            if dry_run:
-                print(
-                    f"DRY_RUN move {settings.R2_PUBLIC_BUCKET}/{key}"
-                    f" -> {settings.R2_PRIVATE_BUCKET}/{key}"
+        async for image in stream:
+            variants = ["fullsize", "thumbs"]
+            if image.medium == VariantStatus.READY:
+                variants.append("medium")
+            if image.large == VariantStatus.READY:
+                variants.append("large")
+            for variant in variants:
+                ext = "webp" if variant == "thumbs" else image.ext
+                key = f"{variant}/{image.filename}.{ext}"
+                if not await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key):
+                    continue
+                if dry_run:
+                    print(
+                        f"DRY_RUN move {settings.R2_PUBLIC_BUCKET}/{key}"
+                        f" -> {settings.R2_PRIVATE_BUCKET}/{key}"
+                    )
+                    moved += 1
+                    continue
+                await r2.copy_object(
+                    src_bucket=settings.R2_PUBLIC_BUCKET,
+                    dst_bucket=settings.R2_PRIVATE_BUCKET,
+                    key=key,
                 )
+                await r2.delete_object(bucket=settings.R2_PUBLIC_BUCKET, key=key)
                 moved += 1
-                continue
-            await r2.copy_object(
-                src_bucket=settings.R2_PUBLIC_BUCKET,
-                dst_bucket=settings.R2_PRIVATE_BUCKET,
-                key=key,
-            )
-            await r2.delete_object(bucket=settings.R2_PUBLIC_BUCKET, key=key)
-            moved += 1
 
     logger.info("split_existing_completed", moved=moved, dry_run=dry_run)
     print(f"{'[dry-run] ' if dry_run else ''}moved {moved} objects")
@@ -288,67 +290,69 @@ async def verify(*, sample: int | None) -> dict[str, Any]:
     """
     r2 = get_r2_storage()
     discrepancies: list[dict[str, Any]] = []
+    checked = 0
 
     async with get_async_session() as db:
         stmt = select(Images)
         if sample:
             stmt = stmt.order_by(Images.image_id.desc()).limit(sample)  # type: ignore[union-attr]
-        result = await db.execute(stmt)
-        rows = list(result.scalars())
+        stmt = stmt.execution_options(yield_per=500)
+        stream = await db.stream_scalars(stmt)
 
-    for image in rows:
-        variants = ["fullsize", "thumbs"]
-        if image.medium == VariantStatus.READY:
-            variants.append("medium")
-        if image.large == VariantStatus.READY:
-            variants.append("large")
+        async for image in stream:
+            checked += 1
+            variants = ["fullsize", "thumbs"]
+            if image.medium == VariantStatus.READY:
+                variants.append("medium")
+            if image.large == VariantStatus.READY:
+                variants.append("large")
 
-        for variant in variants:
-            ext = "webp" if variant == "thumbs" else image.ext
-            key = f"{variant}/{image.filename}.{ext}"
-            in_public = await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key)
-            in_private = await r2.object_exists(bucket=settings.R2_PRIVATE_BUCKET, key=key)
-            if image.r2_location == R2Location.NONE:
-                if in_public or in_private:
+            for variant in variants:
+                ext = "webp" if variant == "thumbs" else image.ext
+                key = f"{variant}/{image.filename}.{ext}"
+                in_public = await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key)
+                in_private = await r2.object_exists(bucket=settings.R2_PRIVATE_BUCKET, key=key)
+                if image.r2_location == R2Location.NONE:
+                    if in_public or in_private:
+                        discrepancies.append(
+                            {
+                                "kind": "unexpected",
+                                "image_id": image.image_id,
+                                "key": key,
+                                "found_in_public": in_public,
+                                "found_in_private": in_private,
+                            }
+                        )
+                    continue
+                expected_bucket = (
+                    settings.R2_PUBLIC_BUCKET
+                    if image.r2_location == R2Location.PUBLIC
+                    else settings.R2_PRIVATE_BUCKET
+                )
+                found_expected = in_public if image.r2_location == R2Location.PUBLIC else in_private
+                found_other = in_private if image.r2_location == R2Location.PUBLIC else in_public
+                if not found_expected:
                     discrepancies.append(
                         {
-                            "kind": "unexpected",
+                            "kind": "missing",
+                            "image_id": image.image_id,
+                            "bucket": expected_bucket,
+                            "key": key,
+                        }
+                    )
+                if found_other:
+                    discrepancies.append(
+                        {
+                            "kind": "wrong_bucket",
                             "image_id": image.image_id,
                             "key": key,
+                            "r2_location": int(image.r2_location),
                             "found_in_public": in_public,
                             "found_in_private": in_private,
                         }
                     )
-                continue
-            expected_bucket = (
-                settings.R2_PUBLIC_BUCKET
-                if image.r2_location == R2Location.PUBLIC
-                else settings.R2_PRIVATE_BUCKET
-            )
-            found_expected = in_public if image.r2_location == R2Location.PUBLIC else in_private
-            found_other = in_private if image.r2_location == R2Location.PUBLIC else in_public
-            if not found_expected:
-                discrepancies.append(
-                    {
-                        "kind": "missing",
-                        "image_id": image.image_id,
-                        "bucket": expected_bucket,
-                        "key": key,
-                    }
-                )
-            if found_other:
-                discrepancies.append(
-                    {
-                        "kind": "wrong_bucket",
-                        "image_id": image.image_id,
-                        "key": key,
-                        "r2_location": int(image.r2_location),
-                        "found_in_public": in_public,
-                        "found_in_private": in_private,
-                    }
-                )
 
-    report = {"checked": len(rows), "discrepancies": discrepancies}
+    report = {"checked": checked, "discrepancies": discrepancies}
     print(f"checked {report['checked']} rows, {len(discrepancies)} discrepancies")
     for d in discrepancies[:20]:
         print(f"  {d['kind']}: {d.get('bucket', '')}{d['key']} (image_id={d['image_id']})")

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -100,7 +100,7 @@ async def split_existing(*, dry_run: bool) -> None:
 
     async with get_async_session() as db:
         result = await db.execute(
-            select(Images).where(Images.status.notin_(PUBLIC_IMAGE_STATUSES_FOR_R2))
+            select(Images).where(Images.status.notin_(PUBLIC_IMAGE_STATUSES_FOR_R2))  # type: ignore[attr-defined]
         )
         rows = list(result.scalars())
 
@@ -145,7 +145,7 @@ async def backfill_locations(*, batch_size: int = 1000) -> None:
     while True:
         async with get_async_session() as db:
             result = await db.execute(
-                select(Images).where(Images.r2_location == R2Location.NONE).limit(batch_size)
+                select(Images).where(Images.r2_location == R2Location.NONE).limit(batch_size)  # type: ignore[arg-type]
             )
             rows = list(result.scalars())
             if not rows:
@@ -161,15 +161,15 @@ async def backfill_locations(*, batch_size: int = 1000) -> None:
             if public_ids:
                 await db.execute(
                     update(Images)
-                    .where(Images.image_id.in_(public_ids))
-                    .where(Images.r2_location == R2Location.NONE)
+                    .where(Images.image_id.in_(public_ids))  # type: ignore[union-attr]
+                    .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
                     .values(r2_location=R2Location.PUBLIC)
                 )
             if private_ids:
                 await db.execute(
                     update(Images)
-                    .where(Images.image_id.in_(private_ids))
-                    .where(Images.r2_location == R2Location.NONE)
+                    .where(Images.image_id.in_(private_ids))  # type: ignore[union-attr]
+                    .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
                     .values(r2_location=R2Location.PRIVATE)
                 )
 
@@ -202,8 +202,8 @@ async def reconcile(*, stale_after: int) -> None:
     async with get_async_session() as db:
         result = await db.execute(
             select(Images)
-            .where(Images.r2_location == R2Location.NONE)
-            .where(Images.date_added < cutoff)
+            .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
+            .where(Images.date_added < cutoff)  # type: ignore[arg-type,operator]
         )
         rows = list(result.scalars())
 
@@ -240,8 +240,8 @@ async def reconcile(*, stale_after: int) -> None:
             async with get_async_session() as db:
                 await db.execute(
                     update(Images)
-                    .where(Images.image_id == image.image_id)
-                    .where(Images.r2_location == R2Location.NONE)
+                    .where(Images.image_id == image.image_id)  # type: ignore[arg-type]
+                    .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
                     .values(r2_location=new_location)
                 )
                 await db.commit()
@@ -254,7 +254,7 @@ async def resync_image(image_id: int) -> None:
     """Debug tool: print current R2 state for one image (read-only)."""
     r2 = get_r2_storage()
     async with get_async_session() as db:
-        result = await db.execute(select(Images).where(Images.image_id == image_id))
+        result = await db.execute(select(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
         image = result.scalar_one_or_none()
     if image is None:
         print(f"image {image_id} not found")
@@ -292,7 +292,7 @@ async def verify(*, sample: int | None) -> dict[str, Any]:
     async with get_async_session() as db:
         stmt = select(Images)
         if sample:
-            stmt = stmt.order_by(Images.image_id.desc()).limit(sample)
+            stmt = stmt.order_by(Images.image_id.desc()).limit(sample)  # type: ignore[union-attr]
         result = await db.execute(stmt)
         rows = list(result.scalars())
 
@@ -358,7 +358,7 @@ async def verify(*, sample: int | None) -> dict[str, Any]:
 async def purge_cache_command(*, image_id: int) -> None:
     """Manually invoke Cloudflare purge for one image's CDN URLs."""
     async with get_async_session() as db:
-        result = await db.execute(select(Images).where(Images.image_id == image_id))
+        result = await db.execute(select(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
         image = result.scalar_one_or_none()
     if image is None:
         print(f"image {image_id} not found")
@@ -386,12 +386,12 @@ async def health(*, output_json: bool = False) -> dict[str, Any]:
 
     async with get_async_session() as db:
         count_result = await db.execute(
-            select(func.count()).select_from(Images).where(Images.r2_location == R2Location.NONE)
+            select(func.count()).select_from(Images).where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
         )
         unsynced_count = count_result.scalar_one()
 
         oldest_result = await db.execute(
-            select(func.min(Images.date_added)).where(Images.r2_location == R2Location.NONE)
+            select(func.min(Images.date_added)).where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
         )
         oldest = oldest_result.scalar_one_or_none()
         oldest_age = (

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -105,7 +105,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     sub.add_parser("backfill-locations")
     rec = sub.add_parser("reconcile")
-    rec.add_argument("--stale-after", type=int, default=600)
+    rec.add_argument("--stale-after", type=_positive_int, default=600)
     img = sub.add_parser("image")
     img.add_argument("image_id", type=int)
     ver = sub.add_parser(
@@ -355,70 +355,71 @@ async def reconcile(*, stale_after: int) -> None:
     healed = 0
     processed = 0
 
-    while True:
-        async with get_async_session() as db:
-            result = await db.execute(
-                select(Images)
-                .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
-                .where(Images.date_added < cutoff)  # type: ignore[arg-type,operator]
-                .where(Images.image_id > last_image_id)  # type: ignore[arg-type,operator]
-                .order_by(Images.image_id)  # type: ignore[arg-type]
-                .limit(batch_size)
-            )
-            rows = list(result.scalars())
-
-        if not rows:
-            break
-
-        public_healed_ids: list[int] = []
-        private_healed_ids: list[int] = []
-
-        for image in rows:
-            processed += 1
-            last_image_id = image.image_id  # type: ignore[assignment]
-
-            variants = _ready_variants(image)
-            bucket = (
-                settings.R2_PUBLIC_BUCKET
-                if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
-                else settings.R2_PRIVATE_BUCKET
-            )
-            all_uploaded = True
-            for variant in variants:
-                ext = "webp" if variant == "thumbs" else image.ext
-                key = f"{variant}/{image.filename}.{ext}"
-                local = FilePath(settings.STORAGE_PATH) / variant / f"{image.filename}.{ext}"
-                if not local.exists():
-                    logger.warning("reconcile_local_missing", image_id=image.image_id, variant=variant)
-                    all_uploaded = False
-                    break
-                if not await r2.object_exists(bucket=bucket, key=key):
-                    await r2.upload_file(bucket=bucket, key=key, path=local)
-
-            if all_uploaded:
-                if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2:
-                    public_healed_ids.append(image.image_id)  # type: ignore[arg-type]
-                else:
-                    private_healed_ids.append(image.image_id)  # type: ignore[arg-type]
-
-        async with get_async_session() as db:
-            if public_healed_ids:
-                await db.execute(
-                    update(Images)
-                    .where(Images.image_id.in_(public_healed_ids))  # type: ignore[union-attr]
+    async with r2.bulk_session():
+        while True:
+            async with get_async_session() as db:
+                result = await db.execute(
+                    select(Images)
                     .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
-                    .values(r2_location=R2Location.PUBLIC)
+                    .where(Images.date_added < cutoff)  # type: ignore[arg-type,operator]
+                    .where(Images.image_id > last_image_id)  # type: ignore[arg-type,operator]
+                    .order_by(Images.image_id)  # type: ignore[arg-type]
+                    .limit(batch_size)
                 )
-            if private_healed_ids:
-                await db.execute(
-                    update(Images)
-                    .where(Images.image_id.in_(private_healed_ids))  # type: ignore[union-attr]
-                    .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
-                    .values(r2_location=R2Location.PRIVATE)
+                rows = list(result.scalars())
+
+            if not rows:
+                break
+
+            public_healed_ids: list[int] = []
+            private_healed_ids: list[int] = []
+
+            for image in rows:
+                processed += 1
+                last_image_id = image.image_id  # type: ignore[assignment]
+
+                variants = _ready_variants(image)
+                bucket = (
+                    settings.R2_PUBLIC_BUCKET
+                    if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+                    else settings.R2_PRIVATE_BUCKET
                 )
-            if public_healed_ids or private_healed_ids:
-                await db.commit()
-                healed += len(public_healed_ids) + len(private_healed_ids)
+                all_uploaded = True
+                for variant in variants:
+                    ext = "webp" if variant == "thumbs" else image.ext
+                    key = f"{variant}/{image.filename}.{ext}"
+                    local = FilePath(settings.STORAGE_PATH) / variant / f"{image.filename}.{ext}"
+                    if not local.exists():
+                        logger.warning("reconcile_local_missing", image_id=image.image_id, variant=variant)
+                        all_uploaded = False
+                        break
+                    if not await r2.object_exists(bucket=bucket, key=key):
+                        await r2.upload_file(bucket=bucket, key=key, path=local)
+
+                if all_uploaded:
+                    if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2:
+                        public_healed_ids.append(image.image_id)  # type: ignore[arg-type]
+                    else:
+                        private_healed_ids.append(image.image_id)  # type: ignore[arg-type]
+
+            async with get_async_session() as db:
+                if public_healed_ids:
+                    await db.execute(
+                        update(Images)
+                        .where(Images.image_id.in_(public_healed_ids))  # type: ignore[union-attr]
+                        .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
+                        .values(r2_location=R2Location.PUBLIC)
+                    )
+                if private_healed_ids:
+                    await db.execute(
+                        update(Images)
+                        .where(Images.image_id.in_(private_healed_ids))  # type: ignore[union-attr]
+                        .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
+                        .values(r2_location=R2Location.PRIVATE)
+                    )
+                if public_healed_ids or private_healed_ids:
+                    await db.commit()
+                    healed += len(public_healed_ids) + len(private_healed_ids)
 
     print(f"reconciled {healed}/{processed} rows")
 

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -29,8 +29,8 @@ from app.core.logging import get_logger
 from app.core.r2_client import get_r2_storage
 from app.core.r2_constants import (
     PUBLIC_IMAGE_STATUSES_FOR_R2,
-    R2Location,
     R2_VARIANTS,
+    R2Location,
 )
 from app.models.image import Images, VariantStatus
 from app.services.cloudflare import purge_cache_by_urls
@@ -145,23 +145,17 @@ async def backfill_locations(*, batch_size: int = 1000) -> None:
     while True:
         async with get_async_session() as db:
             result = await db.execute(
-                select(Images)
-                .where(Images.r2_location == R2Location.NONE)
-                .limit(batch_size)
+                select(Images).where(Images.r2_location == R2Location.NONE).limit(batch_size)
             )
             rows = list(result.scalars())
             if not rows:
                 break
 
             public_ids = [
-                img.image_id
-                for img in rows
-                if img.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+                img.image_id for img in rows if img.status in PUBLIC_IMAGE_STATUSES_FOR_R2
             ]
             private_ids = [
-                img.image_id
-                for img in rows
-                if img.status not in PUBLIC_IMAGE_STATUSES_FOR_R2
+                img.image_id for img in rows if img.status not in PUBLIC_IMAGE_STATUSES_FOR_R2
             ]
 
             if public_ids:
@@ -266,8 +260,10 @@ async def resync_image(image_id: int) -> None:
         print(f"image {image_id} not found")
         return
 
-    print(f"image {image_id} filename={image.filename} status={image.status} "
-          f"r2_location={image.r2_location}")
+    print(
+        f"image {image_id} filename={image.filename} status={image.status} "
+        f"r2_location={image.r2_location}"
+    )
     bucket = (
         settings.R2_PUBLIC_BUCKET
         if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
@@ -310,49 +306,47 @@ async def verify(*, sample: int | None) -> dict[str, Any]:
         for variant in variants:
             ext = "webp" if variant == "thumbs" else image.ext
             key = f"{variant}/{image.filename}.{ext}"
-            in_public = await r2.object_exists(
-                bucket=settings.R2_PUBLIC_BUCKET, key=key
-            )
-            in_private = await r2.object_exists(
-                bucket=settings.R2_PRIVATE_BUCKET, key=key
-            )
+            in_public = await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key)
+            in_private = await r2.object_exists(bucket=settings.R2_PRIVATE_BUCKET, key=key)
             if image.r2_location == R2Location.NONE:
                 if in_public or in_private:
-                    discrepancies.append({
-                        "kind": "unexpected",
-                        "image_id": image.image_id,
-                        "key": key,
-                        "found_in_public": in_public,
-                        "found_in_private": in_private,
-                    })
+                    discrepancies.append(
+                        {
+                            "kind": "unexpected",
+                            "image_id": image.image_id,
+                            "key": key,
+                            "found_in_public": in_public,
+                            "found_in_private": in_private,
+                        }
+                    )
                 continue
             expected_bucket = (
                 settings.R2_PUBLIC_BUCKET
                 if image.r2_location == R2Location.PUBLIC
                 else settings.R2_PRIVATE_BUCKET
             )
-            found_expected = (
-                in_public if image.r2_location == R2Location.PUBLIC else in_private
-            )
-            found_other = (
-                in_private if image.r2_location == R2Location.PUBLIC else in_public
-            )
+            found_expected = in_public if image.r2_location == R2Location.PUBLIC else in_private
+            found_other = in_private if image.r2_location == R2Location.PUBLIC else in_public
             if not found_expected:
-                discrepancies.append({
-                    "kind": "missing",
-                    "image_id": image.image_id,
-                    "bucket": expected_bucket,
-                    "key": key,
-                })
+                discrepancies.append(
+                    {
+                        "kind": "missing",
+                        "image_id": image.image_id,
+                        "bucket": expected_bucket,
+                        "key": key,
+                    }
+                )
             if found_other:
-                discrepancies.append({
-                    "kind": "wrong_bucket",
-                    "image_id": image.image_id,
-                    "key": key,
-                    "r2_location": int(image.r2_location),
-                    "found_in_public": in_public,
-                    "found_in_private": in_private,
-                })
+                discrepancies.append(
+                    {
+                        "kind": "wrong_bucket",
+                        "image_id": image.image_id,
+                        "key": key,
+                        "r2_location": int(image.r2_location),
+                        "found_in_public": in_public,
+                        "found_in_private": in_private,
+                    }
+                )
 
     report = {"checked": len(rows), "discrepancies": discrepancies}
     print(f"checked {report['checked']} rows, {len(discrepancies)} discrepancies")
@@ -401,9 +395,7 @@ async def health(*, output_json: bool = False) -> dict[str, Any]:
         )
         oldest = oldest_result.scalar_one_or_none()
         oldest_age = (
-            int((datetime.now(UTC).replace(tzinfo=None) - oldest).total_seconds())
-            if oldest
-            else 0
+            int((datetime.now(UTC).replace(tzinfo=None) - oldest).total_seconds()) if oldest else 0
         )
 
     try:

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -80,7 +80,9 @@ def _build_parser() -> argparse.ArgumentParser:
     img = sub.add_parser("image")
     img.add_argument("image_id", type=int)
     ver = sub.add_parser("verify")
-    ver.add_argument("--sample", type=int, default=None)
+    ver_group = ver.add_mutually_exclusive_group(required=True)
+    ver_group.add_argument("--sample", type=int)
+    ver_group.add_argument("--all", action="store_true")
     pc = sub.add_parser("purge-cache")
     pc.add_argument("image_id", type=int)
     h = sub.add_parser("health")
@@ -201,55 +203,69 @@ async def reconcile(*, stale_after: int) -> None:
     cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=stale_after)
     r2 = get_r2_storage()
 
-    async with get_async_session() as db:
-        result = await db.execute(
-            select(Images)
-            .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
-            .where(Images.date_added < cutoff)  # type: ignore[arg-type,operator]
-        )
-        rows = list(result.scalars())
-
+    batch_size = 500
+    last_image_id = 0
     healed = 0
-    for image in rows:
-        variants = ["fullsize", "thumbs"]
-        if image.medium == VariantStatus.READY:
-            variants.append("medium")
-        if image.large == VariantStatus.READY:
-            variants.append("large")
-        bucket = (
-            settings.R2_PUBLIC_BUCKET
-            if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
-            else settings.R2_PRIVATE_BUCKET
-        )
-        all_uploaded = True
-        for variant in variants:
-            ext = "webp" if variant == "thumbs" else image.ext
-            key = f"{variant}/{image.filename}.{ext}"
-            local = FilePath(settings.STORAGE_PATH) / variant / f"{image.filename}.{ext}"
-            if not local.exists():
-                logger.warning("reconcile_local_missing", image_id=image.image_id, variant=variant)
-                all_uploaded = False
-                break
-            if not await r2.object_exists(bucket=bucket, key=key):
-                await r2.upload_file(bucket=bucket, key=key, path=local)
+    processed = 0
 
-        if all_uploaded:
-            new_location = (
-                R2Location.PUBLIC
-                if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
-                else R2Location.PRIVATE
+    while True:
+        async with get_async_session() as db:
+            result = await db.execute(
+                select(Images)
+                .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
+                .where(Images.date_added < cutoff)  # type: ignore[arg-type,operator]
+                .where(Images.image_id > last_image_id)  # type: ignore[arg-type,operator]
+                .order_by(Images.image_id)  # type: ignore[arg-type]
+                .limit(batch_size)
             )
-            async with get_async_session() as db:
-                await db.execute(
-                    update(Images)
-                    .where(Images.image_id == image.image_id)  # type: ignore[arg-type]
-                    .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
-                    .values(r2_location=new_location)
-                )
-                await db.commit()
-            healed += 1
+            rows = list(result.scalars())
 
-    print(f"reconciled {healed}/{len(rows)} rows")
+        if not rows:
+            break
+
+        for image in rows:
+            processed += 1
+            last_image_id = image.image_id  # type: ignore[assignment]
+
+            variants = ["fullsize", "thumbs"]
+            if image.medium == VariantStatus.READY:
+                variants.append("medium")
+            if image.large == VariantStatus.READY:
+                variants.append("large")
+            bucket = (
+                settings.R2_PUBLIC_BUCKET
+                if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+                else settings.R2_PRIVATE_BUCKET
+            )
+            all_uploaded = True
+            for variant in variants:
+                ext = "webp" if variant == "thumbs" else image.ext
+                key = f"{variant}/{image.filename}.{ext}"
+                local = FilePath(settings.STORAGE_PATH) / variant / f"{image.filename}.{ext}"
+                if not local.exists():
+                    logger.warning("reconcile_local_missing", image_id=image.image_id, variant=variant)
+                    all_uploaded = False
+                    break
+                if not await r2.object_exists(bucket=bucket, key=key):
+                    await r2.upload_file(bucket=bucket, key=key, path=local)
+
+            if all_uploaded:
+                new_location = (
+                    R2Location.PUBLIC
+                    if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+                    else R2Location.PRIVATE
+                )
+                async with get_async_session() as db:
+                    await db.execute(
+                        update(Images)
+                        .where(Images.image_id == image.image_id)  # type: ignore[arg-type]
+                        .where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
+                        .values(r2_location=new_location)
+                    )
+                    await db.commit()
+                healed += 1
+
+    print(f"reconciled {healed}/{processed} rows")
 
 
 async def resync_image(image_id: int) -> None:

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -5,13 +5,13 @@ Subcommands:
     backfill-locations   — one-shot flip r2_location for existing rows (gated)
     reconcile            — heal: upload missing R2 objects from local FS (gated)
     image                — inspect/re-sync a single image
-    verify               — audit R2 vs DB state (read-only)
+    verify               — audit R2 vs DB state (read-only; --fix flips drifted rows to NONE)
     purge-cache          — manually purge CDN for one image
     health               — report unsynced counts and storage usage (read-only)
 
-Guarded by R2_ENABLED=true (all commands). backfill-locations and reconcile
-additionally require R2_ALLOW_BULK_BACKFILL=true to prevent staging from
-mass-uploading prod-imported images to its small staging bucket.
+Guarded by R2_ENABLED=true (all commands). backfill-locations, reconcile, and
+verify --fix additionally require R2_ALLOW_BULK_BACKFILL=true to prevent
+staging from mass-touching prod-imported images against its small staging bucket.
 """
 
 from __future__ import annotations
@@ -19,12 +19,13 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+import time
 from typing import Any
 
 from sqlalchemy import select, update
 
 from app.config import settings
-from app.core.database import get_async_session
+from app.core.database import engine, get_async_session
 from app.core.logging import get_logger
 from app.core.r2_client import get_r2_storage
 from app.core.r2_constants import (
@@ -75,21 +76,79 @@ def _positive_int(value: str) -> int:
     return n
 
 
+def _ready_variants(image: Images) -> list[str]:
+    """Variants that should currently exist in R2 for this image.
+
+    Excludes PENDING — those are still being generated and haven't been
+    uploaded yet. (Contrast with app.tasks.r2_jobs._expected_variants,
+    which includes PENDING so r2_finalize_upload_job waits for them.)
+    """
+    variants = ["fullsize", "thumbs"]
+    if image.medium == VariantStatus.READY:
+        variants.append("medium")
+    if image.large == VariantStatus.READY:
+        variants.append("large")
+    return variants
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="R2 operational tooling")
     sub = parser.add_subparsers(dest="command", required=True)
 
     se = sub.add_parser("split-existing")
     se.add_argument("--dry-run", action="store_true")
+    se.add_argument(
+        "--concurrency",
+        type=_positive_int,
+        default=8,
+        help="Max images processed in parallel (default: 8).",
+    )
     sub.add_parser("backfill-locations")
     rec = sub.add_parser("reconcile")
     rec.add_argument("--stale-after", type=int, default=600)
     img = sub.add_parser("image")
     img.add_argument("image_id", type=int)
-    ver = sub.add_parser("verify")
-    ver_group = ver.add_mutually_exclusive_group(required=True)
-    ver_group.add_argument("--sample", type=_positive_int)
-    ver_group.add_argument("--all", action="store_true")
+    ver = sub.add_parser(
+        "verify",
+        description=(
+            "Audit R2 vs DB state. Reports missing/unexpected/wrong_bucket "
+            "discrepancies. With --fix, flips non-NONE rows back to "
+            "r2_location=NONE when their expected object is missing so "
+            "reconcile can heal them."
+        ),
+    )
+    ver_scope = ver.add_mutually_exclusive_group(required=True)
+    ver_scope.add_argument("--sample", type=_positive_int)
+    ver_scope.add_argument("--all", action="store_true")
+    ver_scope.add_argument(
+        "--since-id",
+        type=_positive_int,
+        help="Only check rows with image_id >= this value.",
+    )
+    ver_scope.add_argument(
+        "--since-date",
+        help="Only check rows with date_added >= this ISO date (e.g. 2026-04-15).",
+    )
+    ver.add_argument(
+        "--concurrency",
+        type=_positive_int,
+        default=8,
+        help="Max images HEADed in parallel (default: 8).",
+    )
+    ver.add_argument(
+        "--fix",
+        action="store_true",
+        help=(
+            "Flip non-NONE rows with missing R2 objects to r2_location=NONE "
+            "so the next reconcile run uploads them. Requires "
+            "R2_ALLOW_BULK_BACKFILL=true."
+        ),
+    )
+    ver.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="With --fix: report would-flip rows without updating the DB.",
+    )
     pc = sub.add_parser("purge-cache")
     pc.add_argument("image_id", type=int)
     h = sub.add_parser("health")
@@ -98,54 +157,135 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-async def split_existing(*, dry_run: bool) -> None:
+async def split_existing(*, dry_run: bool, concurrency: int = 8) -> None:
     """Move protected-status images' R2 objects from public to private bucket.
 
     Assumes existing R2 state is "everything in R2_PUBLIC_BUCKET" (the starting
     point for the production cutover). Idempotent — objects already moved are
     skipped via object_exists checks.
+
+    Shares one aioboto3 client across the whole run (via bulk_session) and
+    processes `concurrency` images in parallel.
     """
     r2 = get_r2_storage()
     moved = 0
+    errors = 0
+    images_seen = 0
+    sem = asyncio.Semaphore(concurrency)
+    in_flight: set[asyncio.Task[tuple[int, int]]] = set()
+    # Cap in-flight task buildup so we don't accumulate thousands of pending
+    # coroutines while the semaphore gates actual network work.
+    max_in_flight = concurrency * 2
+    started_at = time.monotonic()
+    last_tick_at = started_at
+    last_tick_moved = 0
 
-    logger.info("split_existing_started", dry_run=dry_run)
+    logger.info(
+        "split_existing_started", dry_run=dry_run, concurrency=concurrency
+    )
 
-    async with get_async_session() as db:
-        stmt = (
-            select(Images)
-            .where(Images.status.notin_(PUBLIC_IMAGE_STATUSES_FOR_R2))  # type: ignore[attr-defined]
-            .execution_options(yield_per=500)
-        )
-        stream = await db.stream_scalars(stmt)
-
-        async for image in stream:
-            variants = ["fullsize", "thumbs"]
-            if image.medium == VariantStatus.READY:
-                variants.append("medium")
-            if image.large == VariantStatus.READY:
-                variants.append("large")
+    async def process_image(image: Images) -> tuple[int, int]:
+        """Process one image. Returns (moved_count, error_count)."""
+        async with sem:
+            variants = _ready_variants(image)
+            local_moved = 0
+            local_errors = 0
             for variant in variants:
                 ext = "webp" if variant == "thumbs" else image.ext
                 key = f"{variant}/{image.filename}.{ext}"
-                if not await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key):
-                    continue
-                if dry_run:
-                    print(
-                        f"DRY_RUN move {settings.R2_PUBLIC_BUCKET}/{key}"
-                        f" -> {settings.R2_PRIVATE_BUCKET}/{key}"
+                try:
+                    if not await r2.object_exists(
+                        bucket=settings.R2_PUBLIC_BUCKET, key=key
+                    ):
+                        continue
+                    if dry_run:
+                        print(
+                            f"DRY_RUN move {settings.R2_PUBLIC_BUCKET}/{key}"
+                            f" -> {settings.R2_PRIVATE_BUCKET}/{key}"
+                        )
+                        local_moved += 1
+                        continue
+                    await r2.copy_object(
+                        src_bucket=settings.R2_PUBLIC_BUCKET,
+                        dst_bucket=settings.R2_PRIVATE_BUCKET,
+                        key=key,
                     )
-                    moved += 1
-                    continue
-                await r2.copy_object(
-                    src_bucket=settings.R2_PUBLIC_BUCKET,
-                    dst_bucket=settings.R2_PRIVATE_BUCKET,
-                    key=key,
-                )
-                await r2.delete_object(bucket=settings.R2_PUBLIC_BUCKET, key=key)
-                moved += 1
+                    await r2.delete_object(
+                        bucket=settings.R2_PUBLIC_BUCKET, key=key
+                    )
+                    local_moved += 1
+                except Exception as exc:
+                    # Isolate per-variant failures — one bad object shouldn't
+                    # kill the whole run. Rerunning the script re-tries them.
+                    logger.error(
+                        "split_existing_move_failed",
+                        image_id=image.image_id,
+                        key=key,
+                        error=repr(exc),
+                    )
+                    local_errors += 1
+            return local_moved, local_errors
 
-    logger.info("split_existing_completed", moved=moved, dry_run=dry_run)
-    print(f"{'[dry-run] ' if dry_run else ''}moved {moved} objects")
+    async def drain(*, until: int) -> None:
+        """Drain completed tasks until in_flight is below `until`."""
+        nonlocal moved, errors
+        while len(in_flight) > until:
+            done, _ = await asyncio.wait(
+                in_flight, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in done:
+                in_flight.discard(task)
+                m, e = task.result()
+                moved += m
+                errors += e
+
+    async with r2.bulk_session():
+        async with get_async_session() as db:
+            stmt = (
+                select(Images)
+                .where(Images.status.notin_(PUBLIC_IMAGE_STATUSES_FOR_R2))  # type: ignore[attr-defined]
+                .execution_options(yield_per=500)
+            )
+            stream = await db.stream_scalars(stmt)
+
+            async for image in stream:
+                images_seen += 1
+                if len(in_flight) >= max_in_flight:
+                    await drain(until=max_in_flight - 1)
+                in_flight.add(asyncio.create_task(process_image(image)))
+                if images_seen % 100 == 0:
+                    now = time.monotonic()
+                    window = now - last_tick_at
+                    recent_rate = (
+                        (moved - last_tick_moved) / window if window > 0 else 0.0
+                    )
+                    overall_rate = (
+                        moved / (now - started_at) if now > started_at else 0.0
+                    )
+                    logger.info(
+                        "split_existing_progress",
+                        images_seen=images_seen,
+                        moved=moved,
+                        errors=errors,
+                        moves_per_sec=round(recent_rate, 1),
+                        avg_moves_per_sec=round(overall_rate, 1),
+                    )
+                    last_tick_at = now
+                    last_tick_moved = moved
+
+            await drain(until=0)
+
+    logger.info(
+        "split_existing_completed",
+        images_seen=images_seen,
+        moved=moved,
+        errors=errors,
+        dry_run=dry_run,
+    )
+    print(
+        f"{'[dry-run] ' if dry_run else ''}moved {moved} objects"
+        f" ({errors} errors) across {images_seen} images"
+    )
 
 
 async def backfill_locations(*, batch_size: int = 1000) -> None:
@@ -237,11 +377,7 @@ async def reconcile(*, stale_after: int) -> None:
             processed += 1
             last_image_id = image.image_id  # type: ignore[assignment]
 
-            variants = ["fullsize", "thumbs"]
-            if image.medium == VariantStatus.READY:
-                variants.append("medium")
-            if image.large == VariantStatus.READY:
-                variants.append("large")
+            variants = _ready_variants(image)
             bucket = (
                 settings.R2_PUBLIC_BUCKET
                 if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
@@ -313,8 +449,16 @@ async def resync_image(image_id: int) -> None:
         print(f"  {variant}: {bucket}/{key} exists={exists}")
 
 
-async def verify(*, sample: int | None) -> dict[str, Any]:
-    """Audit: report DB/R2 discrepancies.
+async def verify(
+    *,
+    sample: int | None = None,
+    since_id: int | None = None,
+    since_date: str | None = None,
+    concurrency: int = 8,
+    fix: bool = False,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Audit: report DB/R2 discrepancies; optionally heal drifted rows.
 
     Reports:
       - PUBLIC/PRIVATE rows whose object is missing from expected bucket (`missing`)
@@ -322,34 +466,82 @@ async def verify(*, sample: int | None) -> dict[str, Any]:
       - Cross-bucket placement (`wrong_bucket`)
 
     NONE with no R2 object is legitimate and is NOT reported.
+
+    Scope is exactly one of: sample (last N by image_id desc), since_id,
+    since_date, or none (== --all). `--fix` flips `missing`-kind rows to
+    r2_location=NONE so the next `reconcile` run uploads them; other
+    discrepancy kinds are reported only.
+
+    Uses paginated (image_id > last) batch fetches so each batch runs under a
+    short-lived DB connection — a long streaming cursor gets killed by the
+    server after a few minutes of HEAD work.
     """
+    if fix:
+        require_bulk_backfill()
+
+    from datetime import datetime
+
+    scope_predicate: Any = None
+    if since_date is not None:
+        try:
+            scope_date = datetime.fromisoformat(since_date)
+        except ValueError as exc:
+            raise R2SyncError(
+                f"invalid --since-date {since_date!r}: expected ISO format"
+                " (e.g. 2026-04-15 or 2026-04-15T00:00:00)"
+            ) from exc
+        scope_predicate = Images.date_added >= scope_date  # type: ignore[operator]
+        scope_desc = f"date_added >= {scope_date.isoformat()}"
+    elif since_id is not None:
+        scope_desc = f"image_id >= {since_id}"
+    elif sample is not None:
+        scope_desc = f"sample={sample}"
+    else:
+        scope_desc = "all"
+
     r2 = get_r2_storage()
     discrepancies: list[dict[str, Any]] = []
     checked = 0
+    flipped = 0
+    errors = 0
+    sem = asyncio.Semaphore(concurrency)
 
-    async with get_async_session() as db:
-        stmt = select(Images)
-        if sample is not None:
-            stmt = stmt.order_by(Images.image_id.desc()).limit(sample)  # type: ignore[union-attr]
-        stmt = stmt.execution_options(yield_per=500)
-        stream = await db.stream_scalars(stmt)
+    logger.info(
+        "verify_started",
+        scope=scope_desc,
+        concurrency=concurrency,
+        fix=fix,
+        dry_run=dry_run,
+    )
 
-        async for image in stream:
-            checked += 1
-            variants = ["fullsize", "thumbs"]
-            if image.medium == VariantStatus.READY:
-                variants.append("medium")
-            if image.large == VariantStatus.READY:
-                variants.append("large")
-
-            for variant in variants:
+    async def check_image(image: Images) -> list[dict[str, Any]]:
+        """HEAD each ready variant against both buckets. Return discrepancies."""
+        nonlocal errors
+        async with sem:
+            local_discrepancies: list[dict[str, Any]] = []
+            for variant in _ready_variants(image):
                 ext = "webp" if variant == "thumbs" else image.ext
                 key = f"{variant}/{image.filename}.{ext}"
-                in_public = await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key)
-                in_private = await r2.object_exists(bucket=settings.R2_PRIVATE_BUCKET, key=key)
+                try:
+                    in_public = await r2.object_exists(
+                        bucket=settings.R2_PUBLIC_BUCKET, key=key
+                    )
+                    in_private = await r2.object_exists(
+                        bucket=settings.R2_PRIVATE_BUCKET, key=key
+                    )
+                except Exception as exc:
+                    # Don't report bogus discrepancies on transient HEAD failures.
+                    logger.error(
+                        "verify_head_failed",
+                        image_id=image.image_id,
+                        key=key,
+                        error=repr(exc),
+                    )
+                    errors += 1
+                    continue
                 if image.r2_location == R2Location.NONE:
                     if in_public or in_private:
-                        discrepancies.append(
+                        local_discrepancies.append(
                             {
                                 "kind": "unexpected",
                                 "image_id": image.image_id,
@@ -367,7 +559,7 @@ async def verify(*, sample: int | None) -> dict[str, Any]:
                 found_expected = in_public if image.r2_location == R2Location.PUBLIC else in_private
                 found_other = in_private if image.r2_location == R2Location.PUBLIC else in_public
                 if not found_expected:
-                    discrepancies.append(
+                    local_discrepancies.append(
                         {
                             "kind": "missing",
                             "image_id": image.image_id,
@@ -376,7 +568,7 @@ async def verify(*, sample: int | None) -> dict[str, Any]:
                         }
                     )
                 if found_other:
-                    discrepancies.append(
+                    local_discrepancies.append(
                         {
                             "kind": "wrong_bucket",
                             "image_id": image.image_id,
@@ -386,11 +578,100 @@ async def verify(*, sample: int | None) -> dict[str, Any]:
                             "found_in_private": in_private,
                         }
                     )
+            return local_discrepancies
 
-    report = {"checked": checked, "discrepancies": discrepancies}
-    print(f"checked {report['checked']} rows, {len(discrepancies)} discrepancies")
+    async def process_batch(rows: list[Images]) -> None:
+        nonlocal checked, flipped
+        batch_results = await asyncio.gather(*(check_image(image) for image in rows))
+        batch_missing_ids: set[int] = set()
+        for row_discrepancies in batch_results:
+            discrepancies.extend(row_discrepancies)
+            for d in row_discrepancies:
+                if d["kind"] == "missing":
+                    batch_missing_ids.add(d["image_id"])
+        checked += len(rows)
+
+        if fix and batch_missing_ids:
+            ordered_ids = sorted(batch_missing_ids)
+            if dry_run:
+                for image_id in ordered_ids:
+                    print(f"DRY_RUN flip image_id={image_id} -> r2_location=NONE")
+            else:
+                async with get_async_session() as db:
+                    await db.execute(
+                        update(Images)
+                        .where(Images.image_id.in_(ordered_ids))  # type: ignore[union-attr]
+                        .where(Images.r2_location != R2Location.NONE)  # type: ignore[arg-type]
+                        .values(r2_location=R2Location.NONE)
+                    )
+                    await db.commit()
+            flipped += len(batch_missing_ids)
+
+    async with r2.bulk_session():
+        if sample is not None:
+            # Small, one-shot read — last N rows by image_id desc.
+            async with get_async_session() as db:
+                result = await db.execute(
+                    select(Images)
+                    .order_by(Images.image_id.desc())  # type: ignore[union-attr]
+                    .limit(sample)
+                )
+                rows = list(result.scalars())
+            if rows:
+                await process_batch(rows)
+        else:
+            batch_size = 500
+            last_image_id = (since_id - 1) if since_id is not None else 0
+            while True:
+                async with get_async_session() as db:
+                    stmt = (
+                        select(Images)
+                        .where(Images.image_id > last_image_id)  # type: ignore[arg-type,operator]
+                        .order_by(Images.image_id)  # type: ignore[arg-type]
+                        .limit(batch_size)
+                    )
+                    if scope_predicate is not None:
+                        stmt = stmt.where(scope_predicate)
+                    result = await db.execute(stmt)
+                    rows = list(result.scalars())
+
+                if not rows:
+                    break
+
+                last_image_id = rows[-1].image_id  # type: ignore[assignment]
+                await process_batch(rows)
+                logger.info(
+                    "verify_progress",
+                    checked=checked,
+                    discrepancies=len(discrepancies),
+                    flipped=flipped,
+                    errors=errors,
+                    last_image_id=last_image_id,
+                )
+
+    logger.info(
+        "verify_completed",
+        checked=checked,
+        discrepancies=len(discrepancies),
+        flipped=flipped,
+        errors=errors,
+        fix=fix,
+        dry_run=dry_run,
+    )
+    report: dict[str, Any] = {
+        "checked": checked,
+        "discrepancies": discrepancies,
+        "flipped": flipped,
+        "errors": errors,
+    }
+    suffix = f", flipped {flipped} to NONE" if fix else ""
+    print(
+        f"checked {checked} rows, {len(discrepancies)} discrepancies"
+        f" ({errors} errors){suffix}"
+    )
     for d in discrepancies[:20]:
-        print(f"  {d['kind']}: {d.get('bucket', '')}{d['key']} (image_id={d['image_id']})")
+        location = f"{d['bucket']}/{d['key']}" if d.get("bucket") else d["key"]
+        print(f"  {d['kind']}: {location} (image_id={d['image_id']})")
     return report
 
 
@@ -402,11 +683,7 @@ async def purge_cache_command(*, image_id: int) -> None:
     if image is None:
         print(f"image {image_id} not found")
         return
-    variants = ["fullsize", "thumbs"]
-    if image.medium == VariantStatus.READY:
-        variants.append("medium")
-    if image.large == VariantStatus.READY:
-        variants.append("large")
+    variants = _ready_variants(image)
     urls = []
     for variant in variants:
         ext = "webp" if variant == "thumbs" else image.ext
@@ -464,8 +741,18 @@ async def health(*, output_json: bool = False) -> dict[str, Any]:
 async def _dispatch(args: argparse.Namespace) -> int:
     require_r2_enabled()
 
+    try:
+        return await _run(args)
+    finally:
+        # Close pooled DB connections while the event loop is still running;
+        # otherwise aiomysql's Connection.__del__ fires during interpreter
+        # shutdown and tries to schedule work on a closed loop.
+        await engine.dispose()
+
+
+async def _run(args: argparse.Namespace) -> int:
     if args.command == "split-existing":
-        await split_existing(dry_run=args.dry_run)
+        await split_existing(dry_run=args.dry_run, concurrency=args.concurrency)
     elif args.command == "backfill-locations":
         await backfill_locations()
     elif args.command == "reconcile":
@@ -473,7 +760,14 @@ async def _dispatch(args: argparse.Namespace) -> int:
     elif args.command == "image":
         await resync_image(args.image_id)
     elif args.command == "verify":
-        await verify(sample=args.sample)
+        await verify(
+            sample=args.sample,
+            since_id=args.since_id,
+            since_date=args.since_date,
+            concurrency=args.concurrency,
+            fix=args.fix,
+            dry_run=args.dry_run,
+        )
     elif args.command == "purge-cache":
         await purge_cache_command(image_id=args.image_id)
     elif args.command == "health":

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+from typing import Any
 
 from sqlalchemy import select, update
 
@@ -29,8 +30,10 @@ from app.core.r2_client import get_r2_storage
 from app.core.r2_constants import (
     PUBLIC_IMAGE_STATUSES_FOR_R2,
     R2Location,
+    R2_VARIANTS,
 )
 from app.models.image import Images, VariantStatus
+from app.services.cloudflare import purge_cache_by_urls
 
 logger = get_logger(__name__)
 
@@ -187,19 +190,266 @@ async def backfill_locations(*, batch_size: int = 1000) -> None:
     print(f"backfilled {total_flipped} rows")
 
 
+async def reconcile(*, stale_after: int) -> None:
+    """Heal: upload missing R2 objects for unsynced rows older than `stale_after`.
+
+    Idempotent: uploaded variants are re-detected via object_exists on the next
+    pass, so a partial run that uploads some variants before failing on a
+    missing local file will simply skip those keys next time.
+    """
+    require_bulk_backfill()
+
+    from datetime import UTC, datetime, timedelta
+    from pathlib import Path as FilePath
+
+    cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=stale_after)
+    r2 = get_r2_storage()
+
+    async with get_async_session() as db:
+        result = await db.execute(
+            select(Images)
+            .where(Images.r2_location == R2Location.NONE)
+            .where(Images.date_added < cutoff)
+        )
+        rows = list(result.scalars())
+
+    healed = 0
+    for image in rows:
+        variants = ["fullsize", "thumbs"]
+        if image.medium == VariantStatus.READY:
+            variants.append("medium")
+        if image.large == VariantStatus.READY:
+            variants.append("large")
+        bucket = (
+            settings.R2_PUBLIC_BUCKET
+            if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+            else settings.R2_PRIVATE_BUCKET
+        )
+        all_uploaded = True
+        for variant in variants:
+            ext = "webp" if variant == "thumbs" else image.ext
+            key = f"{variant}/{image.filename}.{ext}"
+            local = FilePath(settings.STORAGE_PATH) / variant / f"{image.filename}.{ext}"
+            if not local.exists():
+                logger.warning("reconcile_local_missing", image_id=image.image_id, variant=variant)
+                all_uploaded = False
+                break
+            if not await r2.object_exists(bucket=bucket, key=key):
+                await r2.upload_file(bucket=bucket, key=key, path=local)
+
+        if all_uploaded:
+            new_location = (
+                R2Location.PUBLIC
+                if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+                else R2Location.PRIVATE
+            )
+            async with get_async_session() as db:
+                await db.execute(
+                    update(Images)
+                    .where(Images.image_id == image.image_id)
+                    .where(Images.r2_location == R2Location.NONE)
+                    .values(r2_location=new_location)
+                )
+                await db.commit()
+            healed += 1
+
+    print(f"reconciled {healed}/{len(rows)} rows")
+
+
+async def resync_image(image_id: int) -> None:
+    """Debug tool: print current R2 state for one image (read-only)."""
+    r2 = get_r2_storage()
+    async with get_async_session() as db:
+        result = await db.execute(select(Images).where(Images.image_id == image_id))
+        image = result.scalar_one_or_none()
+    if image is None:
+        print(f"image {image_id} not found")
+        return
+
+    print(f"image {image_id} filename={image.filename} status={image.status} "
+          f"r2_location={image.r2_location}")
+    bucket = (
+        settings.R2_PUBLIC_BUCKET
+        if image.status in PUBLIC_IMAGE_STATUSES_FOR_R2
+        else settings.R2_PRIVATE_BUCKET
+    )
+    for variant in R2_VARIANTS:
+        ext = "webp" if variant == "thumbs" else image.ext
+        key = f"{variant}/{image.filename}.{ext}"
+        exists = await r2.object_exists(bucket=bucket, key=key)
+        print(f"  {variant}: {bucket}/{key} exists={exists}")
+
+
+async def verify(*, sample: int | None) -> dict[str, Any]:
+    """Audit: report DB/R2 discrepancies.
+
+    Reports:
+      - PUBLIC/PRIVATE rows whose object is missing from expected bucket (`missing`)
+      - NONE rows whose object unexpectedly exists in either bucket (`unexpected`)
+      - Cross-bucket placement (`wrong_bucket`)
+
+    NONE with no R2 object is legitimate and is NOT reported.
+    """
+    r2 = get_r2_storage()
+    discrepancies: list[dict[str, Any]] = []
+
+    async with get_async_session() as db:
+        stmt = select(Images)
+        if sample:
+            stmt = stmt.order_by(Images.image_id.desc()).limit(sample)
+        result = await db.execute(stmt)
+        rows = list(result.scalars())
+
+    for image in rows:
+        variants = ["fullsize", "thumbs"]
+        if image.medium == VariantStatus.READY:
+            variants.append("medium")
+        if image.large == VariantStatus.READY:
+            variants.append("large")
+
+        for variant in variants:
+            ext = "webp" if variant == "thumbs" else image.ext
+            key = f"{variant}/{image.filename}.{ext}"
+            in_public = await r2.object_exists(
+                bucket=settings.R2_PUBLIC_BUCKET, key=key
+            )
+            in_private = await r2.object_exists(
+                bucket=settings.R2_PRIVATE_BUCKET, key=key
+            )
+            if image.r2_location == R2Location.NONE:
+                if in_public or in_private:
+                    discrepancies.append({
+                        "kind": "unexpected",
+                        "image_id": image.image_id,
+                        "key": key,
+                        "found_in_public": in_public,
+                        "found_in_private": in_private,
+                    })
+                continue
+            expected_bucket = (
+                settings.R2_PUBLIC_BUCKET
+                if image.r2_location == R2Location.PUBLIC
+                else settings.R2_PRIVATE_BUCKET
+            )
+            found_expected = (
+                in_public if image.r2_location == R2Location.PUBLIC else in_private
+            )
+            found_other = (
+                in_private if image.r2_location == R2Location.PUBLIC else in_public
+            )
+            if not found_expected:
+                discrepancies.append({
+                    "kind": "missing",
+                    "image_id": image.image_id,
+                    "bucket": expected_bucket,
+                    "key": key,
+                })
+            if found_other:
+                discrepancies.append({
+                    "kind": "wrong_bucket",
+                    "image_id": image.image_id,
+                    "key": key,
+                    "r2_location": int(image.r2_location),
+                    "found_in_public": in_public,
+                    "found_in_private": in_private,
+                })
+
+    report = {"checked": len(rows), "discrepancies": discrepancies}
+    print(f"checked {report['checked']} rows, {len(discrepancies)} discrepancies")
+    for d in discrepancies[:20]:
+        print(f"  {d['kind']}: {d.get('bucket', '')}{d['key']} (image_id={d['image_id']})")
+    return report
+
+
+async def purge_cache_command(*, image_id: int) -> None:
+    """Manually invoke Cloudflare purge for one image's CDN URLs."""
+    async with get_async_session() as db:
+        result = await db.execute(select(Images).where(Images.image_id == image_id))
+        image = result.scalar_one_or_none()
+    if image is None:
+        print(f"image {image_id} not found")
+        return
+    variants = ["fullsize", "thumbs"]
+    if image.medium == VariantStatus.READY:
+        variants.append("medium")
+    if image.large == VariantStatus.READY:
+        variants.append("large")
+    urls = []
+    for variant in variants:
+        ext = "webp" if variant == "thumbs" else image.ext
+        urls.append(f"{settings.R2_PUBLIC_CDN_URL}/{variant}/{image.filename}.{ext}")
+    await purge_cache_by_urls(urls)
+    print(f"purged {len(urls)} URLs for image {image_id}")
+
+
+async def health(*, output_json: bool = False) -> dict[str, Any]:
+    """Read-only health report for monitoring wiring."""
+    import asyncio as _asyncio
+    import subprocess
+    from datetime import UTC, datetime
+
+    from sqlalchemy import func
+
+    async with get_async_session() as db:
+        count_result = await db.execute(
+            select(func.count()).select_from(Images).where(Images.r2_location == R2Location.NONE)
+        )
+        unsynced_count = count_result.scalar_one()
+
+        oldest_result = await db.execute(
+            select(func.min(Images.date_added)).where(Images.r2_location == R2Location.NONE)
+        )
+        oldest = oldest_result.scalar_one_or_none()
+        oldest_age = (
+            int((datetime.now(UTC).replace(tzinfo=None) - oldest).total_seconds())
+            if oldest
+            else 0
+        )
+
+    try:
+        du_output = await _asyncio.to_thread(
+            subprocess.check_output, ["du", "-sb", settings.STORAGE_PATH], text=True
+        )
+        local_bytes = int(du_output.split()[0])
+    except Exception:
+        local_bytes = -1
+
+    report = {
+        "unsynced_count": unsynced_count,
+        "oldest_unsynced_age_seconds": oldest_age,
+        "local_storage_used_bytes": local_bytes,
+        "local_storage_path": settings.STORAGE_PATH,
+    }
+    if output_json:
+        import json
+
+        print(json.dumps(report))
+    else:
+        for k, v in report.items():
+            print(f"{k}: {v}")
+    return report
+
+
 async def _dispatch(args: argparse.Namespace) -> int:
     require_r2_enabled()
 
     if args.command == "split-existing":
         await split_existing(dry_run=args.dry_run)
-        return 0
-    if args.command == "backfill-locations":
+    elif args.command == "backfill-locations":
         await backfill_locations()
-        return 0
-
-    raise NotImplementedError(
-        f"Subcommand '{args.command}' is not yet implemented."
-    )
+    elif args.command == "reconcile":
+        await reconcile(stale_after=args.stale_after)
+    elif args.command == "image":
+        await resync_image(args.image_id)
+    elif args.command == "verify":
+        await verify(sample=args.sample)
+    elif args.command == "purge-cache":
+        await purge_cache_command(image_id=args.image_id)
+    elif args.command == "health":
+        await health(output_json=args.json)
+    else:
+        raise ValueError(f"unknown command: {args.command}")
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -1,0 +1,98 @@
+"""R2 operational tooling.
+
+Subcommands:
+    split-existing       — one-time move protected images from public bucket to private
+    backfill-locations   — one-shot flip r2_location for existing rows (gated)
+    reconcile            — heal: upload missing R2 objects from local FS (gated)
+    image                — inspect/re-sync a single image
+    verify               — audit R2 vs DB state (read-only)
+    purge-cache          — manually purge CDN for one image
+    health               — report unsynced counts and storage usage (read-only)
+
+Guarded by R2_ENABLED=true (all commands). backfill-locations and reconcile
+additionally require R2_ALLOW_BULK_BACKFILL=true to prevent staging from
+mass-uploading prod-imported images to its small staging bucket.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from app.config import settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class R2SyncError(Exception):
+    """Base for r2_sync CLI errors."""
+
+
+class R2DisabledError(R2SyncError):
+    """Raised when R2_ENABLED=false."""
+
+
+class BulkBackfillDisallowedError(R2SyncError):
+    """Raised when R2_ALLOW_BULK_BACKFILL=false."""
+
+
+def require_r2_enabled() -> None:
+    if not settings.R2_ENABLED:
+        raise R2DisabledError(
+            "R2_ENABLED=false. Enable R2 in config before running r2_sync commands."
+        )
+
+
+def require_bulk_backfill() -> None:
+    require_r2_enabled()
+    if not settings.R2_ALLOW_BULK_BACKFILL:
+        raise BulkBackfillDisallowedError(
+            "R2_ALLOW_BULK_BACKFILL=false. This command walks the DB for "
+            "unsynced rows and uploads local files to R2; on staging this "
+            "would mass-upload the prod dataset. Set the flag true only in "
+            "prod's steady-state config."
+        )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="R2 operational tooling")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    se = sub.add_parser("split-existing")
+    se.add_argument("--dry-run", action="store_true")
+    sub.add_parser("backfill-locations")
+    rec = sub.add_parser("reconcile")
+    rec.add_argument("--stale-after", type=int, default=600)
+    img = sub.add_parser("image")
+    img.add_argument("image_id", type=int)
+    ver = sub.add_parser("verify")
+    ver.add_argument("--sample", type=int, default=None)
+    pc = sub.add_parser("purge-cache")
+    pc.add_argument("image_id", type=int)
+    h = sub.add_parser("health")
+    h.add_argument("--json", action="store_true")
+
+    return parser
+
+
+async def _dispatch(args: argparse.Namespace) -> int:
+    require_r2_enabled()
+    raise NotImplementedError(
+        f"Subcommand '{args.command}' is not yet implemented in this chunk."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return asyncio.run(_dispatch(args))
+    except R2SyncError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reconcile_variant_status.py
+++ b/scripts/reconcile_variant_status.py
@@ -1,0 +1,124 @@
+"""Flip medium/large status from PENDING (2) to READY (1) when the variant file exists on disk.
+
+Repairs rows left stuck at PENDING by a pre-PR #173 worker that never flipped the
+status after generating the file (see 2026-03-07 through worker-restart window).
+
+Walks images where medium=PENDING or large=PENDING, checks the expected file on
+disk, and issues batched UPDATEs only for rows whose file is present. Rows with
+missing files are logged (they need a real regen via generate_variants.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+from sqlalchemy import select, update
+
+from app.config import settings
+from app.core.database import engine, get_async_session
+from app.core.logging import get_logger
+from app.models.image import Images, VariantStatus
+
+logger = get_logger(__name__)
+
+
+async def reconcile(*, variant: str, dry_run: bool, batch_size: int = 500) -> None:
+    """Flip `variant` column from PENDING to READY for rows whose file is on disk.
+
+    variant: 'medium' or 'large'.
+    """
+    column = getattr(Images, variant)
+    variant_dir = Path(settings.STORAGE_PATH) / variant
+
+    last_image_id = 0
+    scanned = 0
+    flipped = 0
+    missing = 0
+
+    while True:
+        async with get_async_session() as db:
+            stmt = (
+                select(Images)
+                .where(column == VariantStatus.PENDING.value)
+                .where(Images.image_id > last_image_id)  # type: ignore[arg-type,operator]
+                .order_by(Images.image_id)  # type: ignore[arg-type]
+                .limit(batch_size)
+            )
+            result = await db.execute(stmt)
+            rows = list(result.scalars())
+
+        if not rows:
+            break
+
+        last_image_id = rows[-1].image_id  # type: ignore[assignment]
+
+        flip_ids: list[int] = []
+        for image in rows:
+            scanned += 1
+            path = variant_dir / f"{image.filename}.{image.ext}"
+            if path.exists():
+                flip_ids.append(image.image_id)  # type: ignore[arg-type]
+            else:
+                missing += 1
+                logger.warning(
+                    "variant_file_missing_on_disk",
+                    variant=variant,
+                    image_id=image.image_id,
+                    path=str(path),
+                )
+
+        if flip_ids:
+            if dry_run:
+                for image_id in flip_ids:
+                    print(f"DRY_RUN flip image_id={image_id} {variant}=PENDING -> READY")
+            else:
+                async with get_async_session() as db:
+                    await db.execute(
+                        update(Images)
+                        .where(Images.image_id.in_(flip_ids))  # type: ignore[union-attr]
+                        .where(column == VariantStatus.PENDING.value)
+                        .values(**{variant: VariantStatus.READY.value})
+                    )
+                    await db.commit()
+            flipped += len(flip_ids)
+
+        logger.info(
+            "reconcile_progress",
+            variant=variant,
+            scanned=scanned,
+            flipped=flipped,
+            missing=missing,
+            last_image_id=last_image_id,
+        )
+
+    print(
+        f"{'[dry-run] ' if dry_run else ''}{variant}: flipped {flipped}"
+        f" ({missing} missing on disk) across {scanned} scanned"
+    )
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--variant",
+        choices=("medium", "large", "both"),
+        default="both",
+        help="Which column to reconcile (default: both).",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        variants = ("medium", "large") if args.variant == "both" else (args.variant,)
+        for variant in variants:
+            await reconcile(variant=variant, dry_run=args.dry_run)
+    finally:
+        await engine.dispose()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/api/v1/test_image_delete_r2.py
+++ b/tests/api/v1/test_image_delete_r2.py
@@ -1,0 +1,125 @@
+"""Tests for r2_delete_image_job enqueued on hard delete."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+from app.core.security import create_access_token, get_password_hash
+from app.models.image import Images, VariantStatus
+from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
+from app.models.user import Users
+
+
+async def _create_admin_with_delete(db_session: AsyncSession) -> Users:
+    user = Users(
+        username="r2deleter",
+        password=get_password_hash("TestPassword123!"),
+        password_type="bcrypt",
+        salt="saltsalt12345678",
+        email="r2deleter@example.com",
+        active=1,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    perm = Perms(title="image_delete", desc="Delete images")
+    db_session.add(perm)
+    await db_session.flush()
+
+    group = Groups(title="r2_delete_test_group", desc="R2 delete test group")
+    db_session.add(group)
+    await db_session.flush()
+
+    db_session.add(GroupPerms(group_id=group.group_id, perm_id=perm.perm_id, permvalue=1))
+    db_session.add(UserGroups(user_id=user.user_id, group_id=group.group_id))
+    await db_session.commit()
+    return user
+
+
+@pytest.mark.api
+class TestDeleteEnqueuesR2:
+    async def test_enqueues_delete_with_prior_location(
+        self, client: AsyncClient, db_session: AsyncSession, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        admin = await _create_admin_with_delete(db_session)
+        token = create_access_token(admin.user_id)
+
+        image = Images(
+            user_id=admin.user_id,
+            filename="r2-delete-test-1",
+            ext="jpg",
+            md5_hash="r2deletetest1hash0000001",
+            status=ImageStatus.ACTIVE,
+            r2_location=R2Location.PUBLIC,
+            medium=VariantStatus.READY,
+            large=VariantStatus.NONE,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        image_id = image.image_id
+
+        with patch(
+            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue, patch(
+            "app.api.v1.images.remove_from_iqdb", return_value=True
+        ):
+            response = await client.delete(
+                f"/api/v1/images/{image_id}?reason=test",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert response.status_code == 204
+        delete_calls = [
+            c
+            for c in mock_enqueue.await_args_list
+            if c.args[0] == "r2_delete_image_job"
+        ]
+        assert len(delete_calls) == 1
+        assert delete_calls[0].kwargs["r2_location"] == int(R2Location.PUBLIC)
+        assert delete_calls[0].kwargs["filename"] == "r2-delete-test-1"
+        assert delete_calls[0].kwargs["ext"] == "jpg"
+        assert "fullsize" in delete_calls[0].kwargs["variants"]
+        assert "thumbs" in delete_calls[0].kwargs["variants"]
+        assert "medium" in delete_calls[0].kwargs["variants"]
+        assert "large" not in delete_calls[0].kwargs["variants"]
+
+    async def test_no_enqueue_when_r2_disabled(
+        self, client: AsyncClient, db_session: AsyncSession, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        admin = await _create_admin_with_delete(db_session)
+        token = create_access_token(admin.user_id)
+
+        image = Images(
+            user_id=admin.user_id,
+            filename="r2-delete-test-2",
+            ext="jpg",
+            md5_hash="r2deletetest2hash0000002",
+            status=ImageStatus.ACTIVE,
+            r2_location=R2Location.PUBLIC,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        with patch(
+            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue, patch(
+            "app.api.v1.images.remove_from_iqdb", return_value=True
+        ):
+            await client.delete(
+                f"/api/v1/images/{image.image_id}?reason=test",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        delete_calls = [
+            c
+            for c in mock_enqueue.await_args_list
+            if c.args[0] == "r2_delete_image_job"
+        ]
+        assert delete_calls == []

--- a/tests/api/v1/test_image_status_r2.py
+++ b/tests/api/v1/test_image_status_r2.py
@@ -1,0 +1,220 @@
+"""Tests for sync_image_status_job enqueued on status change."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, settings
+from app.core.security import create_access_token, get_password_hash
+from app.models.image import Images
+from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
+from app.models.user import Users
+
+
+async def _create_user(
+    db_session: AsyncSession,
+    username: str = "statususer",
+    email: str = "status@example.com",
+) -> Users:
+    user = Users(
+        username=username,
+        password=get_password_hash("TestPassword123!"),
+        password_type="bcrypt",
+        salt="saltsalt12345678",
+        email=email,
+        active=1,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+async def _grant_permission(db_session: AsyncSession, user_id: int, perm_title: str):
+    result = await db_session.execute(select(Perms).where(Perms.title == perm_title))
+    perm = result.scalar_one_or_none()
+    if not perm:
+        perm = Perms(title=perm_title, desc=f"Test {perm_title}")
+        db_session.add(perm)
+        await db_session.flush()
+
+    result = await db_session.execute(
+        select(Groups).where(Groups.title == "r2_status_test_group")
+    )
+    group = result.scalar_one_or_none()
+    if not group:
+        group = Groups(title="r2_status_test_group", desc="R2 status test group")
+        db_session.add(group)
+        await db_session.flush()
+
+    result = await db_session.execute(
+        select(GroupPerms).where(
+            GroupPerms.group_id == group.group_id, GroupPerms.perm_id == perm.perm_id
+        )
+    )
+    if not result.scalar_one_or_none():
+        db_session.add(GroupPerms(group_id=group.group_id, perm_id=perm.perm_id, permvalue=1))
+        await db_session.flush()
+
+    result = await db_session.execute(
+        select(UserGroups).where(
+            UserGroups.user_id == user_id, UserGroups.group_id == group.group_id
+        )
+    )
+    if not result.scalar_one_or_none():
+        db_session.add(UserGroups(user_id=user_id, group_id=group.group_id))
+
+    await db_session.commit()
+
+
+@pytest.mark.api
+class TestStatusChangeEnqueuesSync:
+    """Test sync_image_status_job enqueue on admin status change."""
+
+    async def test_enqueues_sync_when_status_changes_and_r2_enabled(
+        self, client: AsyncClient, db_session: AsyncSession, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        admin = await _create_user(db_session, "r2admin1", "r2admin1@test.com")
+        await _grant_permission(db_session, admin.user_id, "image_edit")
+        token = create_access_token(admin.user_id)
+
+        image = Images(
+            user_id=admin.user_id,
+            filename="r2-status-test-1",
+            ext="jpg",
+            md5_hash="r2statustest1hash00000000001",
+            status=ImageStatus.ACTIVE,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        with patch(
+            "app.api.v1.admin.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            response = await client.patch(
+                f"/api/v1/admin/images/{image.image_id}",
+                json={"status": ImageStatus.REVIEW},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert response.status_code == 200
+        sync_calls = [
+            c
+            for c in mock_enqueue.await_args_list
+            if c.args[0] == "sync_image_status_job"
+        ]
+        assert len(sync_calls) == 1
+        assert sync_calls[0].kwargs["image_id"] == image.image_id
+        assert sync_calls[0].kwargs["old_status"] == ImageStatus.ACTIVE
+        assert sync_calls[0].kwargs["new_status"] == ImageStatus.REVIEW
+
+    async def test_no_enqueue_when_status_unchanged(
+        self, client: AsyncClient, db_session: AsyncSession, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        admin = await _create_user(db_session, "r2admin2", "r2admin2@test.com")
+        await _grant_permission(db_session, admin.user_id, "image_edit")
+        token = create_access_token(admin.user_id)
+
+        image = Images(
+            user_id=admin.user_id,
+            filename="r2-status-test-2",
+            ext="jpg",
+            md5_hash="r2statustest2hash00000000002",
+            status=ImageStatus.ACTIVE,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        with patch(
+            "app.api.v1.admin.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            response = await client.patch(
+                f"/api/v1/admin/images/{image.image_id}",
+                json={"locked": True},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert response.status_code == 200
+        sync_calls = [
+            c
+            for c in mock_enqueue.await_args_list
+            if c.args[0] == "sync_image_status_job"
+        ]
+        assert sync_calls == []
+
+    async def test_no_enqueue_when_r2_disabled(
+        self, client: AsyncClient, db_session: AsyncSession, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        admin = await _create_user(db_session, "r2admin3", "r2admin3@test.com")
+        await _grant_permission(db_session, admin.user_id, "image_edit")
+        token = create_access_token(admin.user_id)
+
+        image = Images(
+            user_id=admin.user_id,
+            filename="r2-status-test-3",
+            ext="jpg",
+            md5_hash="r2statustest3hash00000000003",
+            status=ImageStatus.ACTIVE,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        with patch(
+            "app.api.v1.admin.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            response = await client.patch(
+                f"/api/v1/admin/images/{image.image_id}",
+                json={"status": ImageStatus.REVIEW},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert response.status_code == 200
+        sync_calls = [
+            c
+            for c in mock_enqueue.await_args_list
+            if c.args[0] == "sync_image_status_job"
+        ]
+        assert sync_calls == []
+
+    async def test_owner_spoiler_enqueues_sync(
+        self, client: AsyncClient, db_session: AsyncSession, monkeypatch
+    ):
+        """Owner marking ACTIVE→SPOILER via PATCH /api/v1/images/ also enqueues."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        owner = await _create_user(db_session, "r2owner", "r2owner@test.com")
+        token = create_access_token(owner.user_id)
+
+        image = Images(
+            user_id=owner.user_id,
+            filename="r2-status-test-4",
+            ext="jpg",
+            md5_hash="r2statustest4hash00000000004",
+            status=ImageStatus.ACTIVE,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        with patch(
+            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            response = await client.patch(
+                f"/api/v1/images/{image.image_id}",
+                json={"status": ImageStatus.SPOILER},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert response.status_code == 200
+        sync_calls = [
+            c
+            for c in mock_enqueue.await_args_list
+            if c.args[0] == "sync_image_status_job"
+        ]
+        assert len(sync_calls) == 1
+        assert sync_calls[0].kwargs["old_status"] == ImageStatus.ACTIVE
+        assert sync_calls[0].kwargs["new_status"] == ImageStatus.SPOILER

--- a/tests/api/v1/test_image_status_r2.py
+++ b/tests/api/v1/test_image_status_r2.py
@@ -182,10 +182,16 @@ class TestStatusChangeEnqueuesSync:
         ]
         assert sync_calls == []
 
-    async def test_owner_spoiler_enqueues_sync(
+    async def test_owner_spoiler_does_not_enqueue_same_side(
         self, client: AsyncClient, db_session: AsyncSession, monkeypatch
     ):
-        """Owner marking ACTIVE→SPOILER via PATCH /api/v1/images/ also enqueues."""
+        """Owner marking ACTIVE→SPOILER via PATCH /api/v1/images/ skips enqueue.
+
+        ACTIVE and SPOILER are both in PUBLIC_IMAGE_STATUSES_FOR_R2, so the
+        object stays in the public bucket. `enqueue_r2_sync_on_status_change`
+        short-circuits to avoid an enqueue + worker wake for a no-op move —
+        all owner-path transitions (ACTIVE → {SPOILER, REPOST}) land here.
+        """
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         owner = await _create_user(db_session, "r2owner", "r2owner@test.com")
         token = create_access_token(owner.user_id)
@@ -215,6 +221,4 @@ class TestStatusChangeEnqueuesSync:
             for c in mock_enqueue.await_args_list
             if c.args[0] == "sync_image_status_job"
         ]
-        assert len(sync_calls) == 1
-        assert sync_calls[0].kwargs["old_status"] == ImageStatus.ACTIVE
-        assert sync_calls[0].kwargs["new_status"] == ImageStatus.SPOILER
+        assert sync_calls == []

--- a/tests/api/v1/test_image_status_r2.py
+++ b/tests/api/v1/test_image_status_r2.py
@@ -94,7 +94,7 @@ class TestStatusChangeEnqueuesSync:
         await db_session.refresh(image)
 
         with patch(
-            "app.api.v1.admin.enqueue_job", new_callable=AsyncMock
+            "app.services.image_status.enqueue_job", new_callable=AsyncMock
         ) as mock_enqueue:
             response = await client.patch(
                 f"/api/v1/admin/images/{image.image_id}",
@@ -132,7 +132,7 @@ class TestStatusChangeEnqueuesSync:
         await db_session.refresh(image)
 
         with patch(
-            "app.api.v1.admin.enqueue_job", new_callable=AsyncMock
+            "app.services.image_status.enqueue_job", new_callable=AsyncMock
         ) as mock_enqueue:
             response = await client.patch(
                 f"/api/v1/admin/images/{image.image_id}",
@@ -167,7 +167,7 @@ class TestStatusChangeEnqueuesSync:
         await db_session.refresh(image)
 
         with patch(
-            "app.api.v1.admin.enqueue_job", new_callable=AsyncMock
+            "app.services.image_status.enqueue_job", new_callable=AsyncMock
         ) as mock_enqueue:
             response = await client.patch(
                 f"/api/v1/admin/images/{image.image_id}",
@@ -202,7 +202,7 @@ class TestStatusChangeEnqueuesSync:
         await db_session.refresh(image)
 
         with patch(
-            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+            "app.services.image_status.enqueue_job", new_callable=AsyncMock
         ) as mock_enqueue:
             response = await client.patch(
                 f"/api/v1/images/{image.image_id}",

--- a/tests/api/v1/test_image_upload_r2.py
+++ b/tests/api/v1/test_image_upload_r2.py
@@ -42,9 +42,10 @@ async def uploader(db_session: AsyncSession) -> Users:
 @pytest.mark.api
 class TestUploadEnqueuesR2Finalize:
     async def test_enqueues_finalize_when_r2_enabled(
-        self, client: AsyncClient, uploader: Users, monkeypatch
+        self, client: AsyncClient, uploader: Users, monkeypatch, tmp_path
     ):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
         token = create_access_token(uploader.user_id)
 
         with patch(
@@ -65,9 +66,10 @@ class TestUploadEnqueuesR2Finalize:
         assert finalize_calls[0].kwargs.get("_defer_by", 0) >= 60
 
     async def test_no_finalize_when_r2_disabled(
-        self, client: AsyncClient, uploader: Users, monkeypatch
+        self, client: AsyncClient, uploader: Users, monkeypatch, tmp_path
     ):
         monkeypatch.setattr(settings, "R2_ENABLED", False)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
         token = create_access_token(uploader.user_id)
 
         with patch(

--- a/tests/api/v1/test_image_upload_r2.py
+++ b/tests/api/v1/test_image_upload_r2.py
@@ -1,0 +1,86 @@
+"""Tests for R2 finalize job enqueued after upload."""
+
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.core.security import create_access_token, get_password_hash
+from app.models.user import Users
+
+
+def _fake_image_bytes() -> bytes:
+    """Create a minimal valid JPEG for upload tests."""
+    from PIL import Image
+
+    img = Image.new("RGB", (100, 100), color="red")
+    buf = BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+async def uploader(db_session: AsyncSession) -> Users:
+    user = Users(
+        username="r2uploader",
+        password=get_password_hash("TestPassword123!"),
+        password_type="bcrypt",
+        salt="saltsalt12345678",
+        email="r2uploader@example.com",
+        active=1,
+        email_verified=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest.mark.api
+class TestUploadEnqueuesR2Finalize:
+    async def test_enqueues_finalize_when_r2_enabled(
+        self, client: AsyncClient, uploader: Users, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        token = create_access_token(uploader.user_id)
+
+        with patch(
+            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            response = await client.post(
+                "/api/v1/images/upload",
+                files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert response.status_code in (200, 201)
+        finalize_calls = [
+            c
+            for c in mock_enqueue.await_args_list
+            if c.args[0] == "r2_finalize_upload_job"
+        ]
+        assert len(finalize_calls) == 1
+        assert finalize_calls[0].kwargs.get("_defer_by", 0) >= 60
+
+    async def test_no_finalize_when_r2_disabled(
+        self, client: AsyncClient, uploader: Users, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        token = create_access_token(uploader.user_id)
+
+        with patch(
+            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            await client.post(
+                "/api/v1/images/upload",
+                files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        finalize_calls = [
+            c
+            for c in mock_enqueue.await_args_list
+            if c.args[0] == "r2_finalize_upload_job"
+        ]
+        assert finalize_calls == []

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -2536,7 +2536,7 @@ class TestShowAllImagesFilter:
         db_session.add(user)
         await db_session.flush()
 
-        # Create images with different statuses (excluding LOW_QUALITY which isn't valid)
+        # Create images with different statuses (LOW_QUALITY omitted — same visibility as REVIEW)
         statuses = [
             (ImageStatus.REVIEW, "review_img"),  # -4, hidden
             (ImageStatus.INAPPROPRIATE, "inapp_img"),  # -2, hidden
@@ -2676,7 +2676,7 @@ class TestShowAllImagesFilter:
         db_session.add(other_user)
         await db_session.flush()
 
-        # All valid statuses (excluding LOW_QUALITY which isn't in the validator)
+        # All valid statuses (LOW_QUALITY omitted — same visibility as REVIEW)
         statuses = [
             (ImageStatus.REVIEW, "review_img"),
             (ImageStatus.INAPPROPRIATE, "inapp_img"),

--- a/tests/api/v1/test_media_serving.py
+++ b/tests/api/v1/test_media_serving.py
@@ -1,0 +1,165 @@
+"""Tests for /images/* media-serving endpoint R2 branches."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, settings
+from app.core.r2_client import reset_r2_storage
+from app.core.r2_constants import R2Location
+from app.core.security import create_access_token
+from app.models.image import Images
+from app.models.user import Users
+
+
+@pytest.mark.api
+class TestMediaServingR2:
+    @pytest.fixture(autouse=True)
+    def _reset_r2(self):
+        reset_r2_storage()
+        yield
+        reset_r2_storage()
+
+    @pytest.fixture
+    async def public_r2_image(self, db_session: AsyncSession):
+        """ACTIVE image in the public R2 bucket."""
+        image = Images(
+            image_id=701,
+            filename="2026-04-18-701",
+            ext="jpg",
+            md5_hash="r2public701hash",
+            filesize=1000,
+            width=800,
+            height=600,
+            user_id=1,
+            status=ImageStatus.ACTIVE,
+            r2_location=R2Location.PUBLIC,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    @pytest.fixture
+    async def private_r2_image(self, db_session: AsyncSession):
+        """REVIEW image in the private R2 bucket (protected status + PRIVATE location)."""
+        image = Images(
+            image_id=702,
+            filename="2026-04-18-702",
+            ext="jpg",
+            md5_hash="r2private702hash",
+            filesize=1000,
+            width=800,
+            height=600,
+            user_id=1,
+            status=ImageStatus.REVIEW,
+            r2_location=R2Location.PRIVATE,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    @pytest.fixture
+    async def local_image(self, db_session: AsyncSession):
+        """ACTIVE image not yet synced to R2 (r2_location=NONE)."""
+        image = Images(
+            image_id=703,
+            filename="2026-04-18-703",
+            ext="jpg",
+            md5_hash="r2local703hash",
+            filesize=1000,
+            width=800,
+            height=600,
+            user_id=1,
+            status=ImageStatus.ACTIVE,
+            r2_location=R2Location.NONE,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        return image
+
+    async def test_public_bucket_302s_to_cdn(
+        self, client: AsyncClient, public_r2_image: Images, monkeypatch
+    ):
+        """status=ACTIVE, r2_location=PUBLIC, R2 on → 302 to CDN URL with no-store."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+
+        response = await client.get(
+            f"/images/2026-04-18-{public_r2_image.image_id}.jpg",
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.headers["Location"].startswith("https://cdn.example.com/fullsize/")
+        assert response.headers["Cache-Control"] == "no-store"
+
+    async def test_private_bucket_302s_to_presigned(
+        self, client: AsyncClient, private_r2_image: Images, db_session: AsyncSession, monkeypatch
+    ):
+        """Protected status + PRIVATE location → 302 to presigned URL for owner."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+        owner = await db_session.get(Users, 1)
+        owner.active = 1
+        await db_session.commit()
+        token = create_access_token(owner.user_id)
+
+        mock_r2 = AsyncMock()
+        mock_r2.generate_presigned_url = AsyncMock(
+            return_value="https://presigned.example.com/foo?sig=xxx"
+        )
+        with patch("app.api.v1.media.get_r2_storage", return_value=mock_r2):
+            response = await client.get(
+                f"/images/2026-04-18-{private_r2_image.image_id}.jpg",
+                follow_redirects=False,
+                cookies={"access_token": token},
+            )
+        assert response.status_code == 302
+        assert response.headers["Cache-Control"] == "no-store"
+        assert response.headers.get("Location")
+        # Verify routing wired up the correct bucket, key, and TTL.
+        mock_r2.generate_presigned_url.assert_awaited_once_with(
+            bucket=settings.R2_PRIVATE_BUCKET,
+            key=f"fullsize/{private_r2_image.filename}.{private_r2_image.ext}",
+            ttl=settings.R2_PRESIGN_TTL_SECONDS,
+        )
+
+    async def test_location_none_falls_back_to_xaccel(
+        self, client: AsyncClient, local_image: Images, monkeypatch
+    ):
+        """r2_location=NONE → X-Accel-Redirect to /internal/ (unchanged behaviour)."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+        response = await client.get(
+            f"/images/2026-04-18-{local_image.image_id}.jpg",
+            follow_redirects=False,
+        )
+        assert response.status_code == 200
+        assert response.headers["X-Accel-Redirect"].startswith("/internal/fullsize/")
+
+    async def test_r2_disabled_always_xaccel(
+        self, client: AsyncClient, public_r2_image: Images, monkeypatch
+    ):
+        """R2_ENABLED=false → X-Accel-Redirect regardless of r2_location."""
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+
+        response = await client.get(
+            f"/images/2026-04-18-{public_r2_image.image_id}.jpg",
+            follow_redirects=False,
+        )
+        assert response.status_code == 200
+        assert response.headers["X-Accel-Redirect"].startswith("/internal/")
+
+    async def test_permission_check_still_runs(
+        self, client: AsyncClient, private_r2_image: Images, monkeypatch
+    ):
+        """Anonymous request for a protected image returns 404 before any R2 logic."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        response = await client.get(
+            f"/images/2026-04-18-{private_r2_image.image_id}.jpg",
+        )
+        assert response.status_code == 404

--- a/tests/integration/test_r2_sync_backfill.py
+++ b/tests/integration/test_r2_sync_backfill.py
@@ -1,0 +1,80 @@
+"""Integration test: backfill-locations fills r2_location based on current status."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+from app.models.image import Images
+from scripts.r2_sync import BulkBackfillDisallowedError, backfill_locations
+
+
+def _mock_session_cm(db_session):
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=db_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    return mock_cm
+
+
+@pytest.mark.integration
+class TestBackfillLocations:
+    @pytest.fixture(autouse=True)
+    def _patch_get_session(self, db_session):
+        with patch(
+            "scripts.r2_sync.get_async_session",
+            return_value=_mock_session_cm(db_session),
+        ):
+            yield
+
+    async def test_respects_r2_allow_bulk_backfill_flag(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", False)
+
+        with pytest.raises(BulkBackfillDisallowedError):
+            await backfill_locations()
+
+    async def test_flips_public_and_private(self, db_session, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", True)
+
+        db_session.add(
+            Images(user_id=1, filename="a", ext="jpg", status=ImageStatus.ACTIVE)
+        )
+        db_session.add(
+            Images(user_id=1, filename="b", ext="jpg", status=ImageStatus.REVIEW)
+        )
+        db_session.add(
+            Images(user_id=1, filename="c", ext="jpg", status=ImageStatus.REPOST)
+        )
+        await db_session.commit()
+
+        await backfill_locations(batch_size=2)
+
+        result = await db_session.execute(select(Images))
+        images = {img.filename: img for img in result.scalars()}
+        assert images["a"].r2_location == R2Location.PUBLIC
+        assert images["b"].r2_location == R2Location.PRIVATE
+        assert images["c"].r2_location == R2Location.PUBLIC
+
+    async def test_skips_already_set_rows(self, db_session, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", True)
+
+        db_session.add(
+            Images(
+                user_id=1,
+                filename="d",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        await backfill_locations()
+
+        result = await db_session.execute(select(Images))
+        img = result.scalar_one()
+        assert img.r2_location == R2Location.PUBLIC

--- a/tests/integration/test_r2_sync_split.py
+++ b/tests/integration/test_r2_sync_split.py
@@ -1,0 +1,128 @@
+"""Integration test: split-existing moves protected images to private bucket."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+from app.models.image import Images, VariantStatus
+from scripts.r2_sync import split_existing
+
+
+def _mock_session_cm(db_session):
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=db_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    return mock_cm
+
+
+@pytest.mark.integration
+class TestSplitExisting:
+    @pytest.fixture(autouse=True)
+    def _patch_get_session(self, db_session):
+        with patch(
+            "scripts.r2_sync.get_async_session",
+            return_value=_mock_session_cm(db_session),
+        ):
+            yield
+
+    async def test_moves_protected_images_only(
+        self, db_session: AsyncSession, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+        db_session.add(
+            Images(
+                user_id=1,
+                filename="2026-04-17-1",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        db_session.add(
+            Images(
+                user_id=1,
+                filename="2026-04-17-2",
+                ext="jpg",
+                status=ImageStatus.REVIEW,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        db_session.add(
+            Images(
+                user_id=1,
+                filename="2026-04-17-3",
+                ext="jpg",
+                status=ImageStatus.REPOST,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=True)
+
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            await split_existing(dry_run=False)
+
+        # Only image 2 (REVIEW) should be moved — 2 variants (fullsize + thumbs)
+        assert mock_r2.copy_object.await_count == 2
+        assert mock_r2.delete_object.await_count == 2
+
+        copied_keys = {c.kwargs["key"] for c in mock_r2.copy_object.await_args_list}
+        assert "fullsize/2026-04-17-2.jpg" in copied_keys
+        assert "thumbs/2026-04-17-2.webp" in copied_keys
+        assert "fullsize/2026-04-17-1.jpg" not in copied_keys
+        assert "fullsize/2026-04-17-3.jpg" not in copied_keys
+
+    async def test_dry_run_does_not_copy(
+        self, db_session: AsyncSession, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+        db_session.add(
+            Images(
+                user_id=1,
+                filename="2026-04-17-5",
+                ext="jpg",
+                status=ImageStatus.REVIEW,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=True)
+
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            await split_existing(dry_run=True)
+
+        mock_r2.copy_object.assert_not_awaited()
+        mock_r2.delete_object.assert_not_awaited()
+
+    async def test_skips_missing_objects(
+        self, db_session: AsyncSession, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+        db_session.add(
+            Images(
+                user_id=1,
+                filename="2026-04-17-6",
+                ext="jpg",
+                status=ImageStatus.REVIEW,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=False)
+
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            await split_existing(dry_run=False)
+
+        mock_r2.copy_object.assert_not_awaited()

--- a/tests/integration/test_r2_sync_split.py
+++ b/tests/integration/test_r2_sync_split.py
@@ -1,6 +1,6 @@
 """Integration test: split-existing moves protected images to private bucket."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -16,6 +16,17 @@ def _mock_session_cm(db_session):
     mock_cm.__aenter__ = AsyncMock(return_value=db_session)
     mock_cm.__aexit__ = AsyncMock(return_value=False)
     return mock_cm
+
+
+def _make_mock_r2(*, object_exists: bool) -> AsyncMock:
+    """AsyncMock for R2Storage with bulk_session() returning a no-op async CM."""
+    mock_r2 = AsyncMock()
+    mock_r2.object_exists = AsyncMock(return_value=object_exists)
+    bulk_cm = AsyncMock()
+    bulk_cm.__aenter__ = AsyncMock(return_value=mock_r2)
+    bulk_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_r2.bulk_session = Mock(return_value=bulk_cm)
+    return mock_r2
 
 
 @pytest.mark.integration
@@ -62,8 +73,7 @@ class TestSplitExisting:
         )
         await db_session.commit()
 
-        mock_r2 = AsyncMock()
-        mock_r2.object_exists = AsyncMock(return_value=True)
+        mock_r2 = _make_mock_r2(object_exists=True)
 
         with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
             await split_existing(dry_run=False)
@@ -94,8 +104,7 @@ class TestSplitExisting:
         )
         await db_session.commit()
 
-        mock_r2 = AsyncMock()
-        mock_r2.object_exists = AsyncMock(return_value=True)
+        mock_r2 = _make_mock_r2(object_exists=True)
 
         with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
             await split_existing(dry_run=True)
@@ -119,8 +128,7 @@ class TestSplitExisting:
         )
         await db_session.commit()
 
-        mock_r2 = AsyncMock()
-        mock_r2.object_exists = AsyncMock(return_value=False)
+        mock_r2 = _make_mock_r2(object_exists=False)
 
         with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
             await split_existing(dry_run=False)

--- a/tests/unit/test_cloudflare_purge.py
+++ b/tests/unit/test_cloudflare_purge.py
@@ -1,0 +1,100 @@
+"""Tests for Cloudflare cache purge service."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.config import settings
+from app.services.cloudflare import purge_cache_by_urls
+
+
+def _make_mock_client(raise_for_status=None):
+    """Build a mock httpx.AsyncClient for use in tests.
+
+    httpx.Response is sync — MagicMock, not AsyncMock, so .text/.json
+    don't become coroutines.
+    """
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.text = ""
+    mock_response.json = lambda: {"success": True, "errors": []}
+    mock_response.raise_for_status = raise_for_status or (lambda: None)
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = False
+    return mock_client
+
+
+@pytest.mark.unit
+class TestPurgeCacheByUrls:
+    async def test_no_op_when_urls_empty(self):
+        """Empty URL list is a no-op (no HTTP calls)."""
+        with patch("app.services.cloudflare.httpx.AsyncClient") as client_cls:
+            await purge_cache_by_urls([])
+            client_cls.assert_not_called()
+
+    async def test_raises_when_credentials_missing(self, monkeypatch):
+        """Missing Cloudflare config is a misconfiguration — raise, don't silently no-op."""
+        monkeypatch.setattr(settings, "CLOUDFLARE_API_TOKEN", "")
+        monkeypatch.setattr(settings, "CLOUDFLARE_ZONE_ID", "")
+        with pytest.raises(RuntimeError, match="CLOUDFLARE_ZONE_ID"):
+            await purge_cache_by_urls(["https://cdn.example.com/x.jpg"])
+
+    async def test_posts_to_cloudflare_api(self, monkeypatch):
+        monkeypatch.setattr(settings, "CLOUDFLARE_API_TOKEN", "tok")
+        monkeypatch.setattr(settings, "CLOUDFLARE_ZONE_ID", "zone")
+
+        mock_client = _make_mock_client()
+        with patch("app.services.cloudflare.httpx.AsyncClient", return_value=mock_client):
+            await purge_cache_by_urls(["https://cdn.example.com/x.jpg"])
+
+        mock_client.post.assert_awaited_once()
+        call = mock_client.post.await_args
+        assert "zones/zone/purge_cache" in call.args[0]
+        assert call.kwargs["json"] == {"files": ["https://cdn.example.com/x.jpg"]}
+        assert call.kwargs["headers"]["Authorization"] == "Bearer tok"
+
+    async def test_batches_urls_in_groups_of_30(self, monkeypatch):
+        """Cloudflare free plan accepts max 30 URLs per call — we chunk accordingly."""
+        monkeypatch.setattr(settings, "CLOUDFLARE_API_TOKEN", "tok")
+        monkeypatch.setattr(settings, "CLOUDFLARE_ZONE_ID", "zone")
+
+        mock_client = _make_mock_client()
+        urls = [f"https://cdn.example.com/{i}.jpg" for i in range(65)]
+        with patch("app.services.cloudflare.httpx.AsyncClient", return_value=mock_client):
+            await purge_cache_by_urls(urls)
+
+        # 65 URLs → 30 + 30 + 5 = 3 calls
+        assert mock_client.post.await_count == 3
+        first_batch = mock_client.post.await_args_list[0].kwargs["json"]["files"]
+        last_batch = mock_client.post.await_args_list[2].kwargs["json"]["files"]
+        assert len(first_batch) == 30
+        assert len(last_batch) == 5
+
+    async def test_logs_and_raises_on_cloudflare_error(self, monkeypatch, caplog):
+        monkeypatch.setattr(settings, "CLOUDFLARE_API_TOKEN", "tok")
+        monkeypatch.setattr(settings, "CLOUDFLARE_ZONE_ID", "zone")
+
+        # httpx.HTTPStatusError requires a real Request object — passing None
+        # TypeErrors at construction time on httpx ≥0.24.
+        fake_request = httpx.Request("POST", "https://api.cloudflare.com/")
+        fake_response = MagicMock(spec=httpx.Response)
+        fake_response.status_code = 400
+        fake_response.text = '{"success": false, "errors": [{"message": "bad"}]}'
+
+        def raise_for_status():
+            raise httpx.HTTPStatusError("400", request=fake_request, response=fake_response)
+
+        mock_client = _make_mock_client(raise_for_status=raise_for_status)
+
+        with caplog.at_level(logging.ERROR), patch(
+            "app.services.cloudflare.httpx.AsyncClient", return_value=mock_client
+        ):
+            with pytest.raises(httpx.HTTPStatusError):
+                await purge_cache_by_urls(["https://cdn.example.com/x.jpg"])
+
+        assert any("r2_cdn_purge_failed" in r.message for r in caplog.records)

--- a/tests/unit/test_cloudflare_purge.py
+++ b/tests/unit/test_cloudflare_purge.py
@@ -98,3 +98,27 @@ class TestPurgeCacheByUrls:
                 await purge_cache_by_urls(["https://cdn.example.com/x.jpg"])
 
         assert any("r2_cdn_purge_failed" in r.message for r in caplog.records)
+
+    async def test_raises_on_logical_failure(self, monkeypatch, caplog):
+        """Cloudflare can return 200 with success=false — must raise."""
+        monkeypatch.setattr(settings, "CLOUDFLARE_API_TOKEN", "tok")
+        monkeypatch.setattr(settings, "CLOUDFLARE_ZONE_ID", "zone")
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.text = ""
+        mock_response.json = lambda: {"success": False, "errors": [{"message": "bad token"}]}
+        mock_response.raise_for_status = lambda: None
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = False
+
+        with caplog.at_level(logging.ERROR), patch(
+            "app.services.cloudflare.httpx.AsyncClient", return_value=mock_client
+        ):
+            with pytest.raises(RuntimeError, match="success=false"):
+                await purge_cache_by_urls(["https://cdn.example.com/x.jpg"])
+
+        assert any("r2_cdn_purge_logical_failure" in r.message for r in caplog.records)

--- a/tests/unit/test_config_r2.py
+++ b/tests/unit/test_config_r2.py
@@ -1,0 +1,43 @@
+"""Tests for R2 config validation."""
+
+import pytest
+
+from app.config import Settings
+
+
+@pytest.mark.unit
+class TestR2ConfigValidation:
+    """R2_ENABLED requires all R2_* and CLOUDFLARE_* credentials."""
+
+    def test_r2_disabled_requires_no_credentials(self):
+        """When R2_ENABLED=false, empty R2/Cloudflare fields are fine."""
+        s = Settings(_env_file=None, R2_ENABLED=False)
+        assert s.R2_ENABLED is False
+
+    def test_r2_enabled_requires_all_credentials(self):
+        """When R2_ENABLED=true, missing credentials fail validation."""
+        with pytest.raises(ValueError, match="R2_ACCESS_KEY_ID"):
+            Settings(
+                _env_file=None,
+                R2_ENABLED=True,
+                R2_ACCESS_KEY_ID="",
+                R2_SECRET_ACCESS_KEY="sk",
+                R2_ENDPOINT="https://example.r2.cloudflarestorage.com",
+                R2_PUBLIC_CDN_URL="https://cdn.example.com",
+                CLOUDFLARE_API_TOKEN="tok",
+                CLOUDFLARE_ZONE_ID="zone",
+            )
+
+    def test_r2_enabled_with_all_credentials_passes(self):
+        """Full credentials pass validation."""
+        s = Settings(
+            _env_file=None,
+            R2_ENABLED=True,
+            R2_ACCESS_KEY_ID="ak",
+            R2_SECRET_ACCESS_KEY="sk",
+            R2_ENDPOINT="https://example.r2.cloudflarestorage.com",
+            R2_PUBLIC_CDN_URL="https://cdn.example.com",
+            CLOUDFLARE_API_TOKEN="tok",
+            CLOUDFLARE_ZONE_ID="zone",
+        )
+        assert s.R2_ENABLED is True

--- a/tests/unit/test_config_r2.py
+++ b/tests/unit/test_config_r2.py
@@ -7,7 +7,7 @@ from app.config import Settings
 
 @pytest.mark.unit
 class TestR2ConfigValidation:
-    """R2_ENABLED requires all R2_* and CLOUDFLARE_* credentials."""
+    """R2_ENABLED requires R2_* credentials; CLOUDFLARE_* are optional."""
 
     def test_r2_disabled_requires_no_credentials(self):
         """When R2_ENABLED=false, empty R2/Cloudflare fields are fine."""

--- a/tests/unit/test_image_r2_location.py
+++ b/tests/unit/test_image_r2_location.py
@@ -1,0 +1,22 @@
+"""Test r2_location field on Images model."""
+
+import pytest
+
+from app.core.r2_constants import R2Location
+from app.models.image import Images
+
+
+@pytest.mark.unit
+class TestImageR2Location:
+    def test_default_is_none(self):
+        """New image instances default r2_location to NONE=0."""
+        img = Images(ext="jpg", user_id=1)
+        assert img.r2_location == R2Location.NONE == 0
+
+    def test_can_set_public(self):
+        img = Images(ext="jpg", user_id=1, r2_location=R2Location.PUBLIC)
+        assert img.r2_location == 1
+
+    def test_can_set_private(self):
+        img = Images(ext="jpg", user_id=1, r2_location=R2Location.PRIVATE)
+        assert img.r2_location == 2

--- a/tests/unit/test_image_status_helper.py
+++ b/tests/unit/test_image_status_helper.py
@@ -55,3 +55,29 @@ class TestEnqueueR2SyncOnStatusChange:
                 new_status=ImageStatus.REVIEW,
             )
         mock_enqueue.assert_not_awaited()
+
+    async def test_noop_when_transition_stays_on_public_side(self, monkeypatch):
+        """ACTIVE→SPOILER: both public — worker would early-return, don't enqueue."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        with patch(
+            "app.services.image_status.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            await enqueue_r2_sync_on_status_change(
+                image_id=123,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.SPOILER,
+            )
+        mock_enqueue.assert_not_awaited()
+
+    async def test_noop_when_transition_stays_on_protected_side(self, monkeypatch):
+        """REVIEW→INAPPROPRIATE: both protected — worker would early-return, don't enqueue."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        with patch(
+            "app.services.image_status.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            await enqueue_r2_sync_on_status_change(
+                image_id=123,
+                old_status=ImageStatus.REVIEW,
+                new_status=ImageStatus.INAPPROPRIATE,
+            )
+        mock_enqueue.assert_not_awaited()

--- a/tests/unit/test_image_status_helper.py
+++ b/tests/unit/test_image_status_helper.py
@@ -1,0 +1,57 @@
+"""Tests for enqueue_r2_sync_on_status_change.
+
+These guard the enqueue gating logic so none of the ~7 status-mutation call
+sites can silently regress (they all go through this helper).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import ImageStatus, settings
+from app.services.image_status import enqueue_r2_sync_on_status_change
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestEnqueueR2SyncOnStatusChange:
+    async def test_enqueues_when_status_changed_and_r2_enabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        with patch(
+            "app.services.image_status.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            await enqueue_r2_sync_on_status_change(
+                image_id=123,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.REVIEW,
+            )
+        mock_enqueue.assert_awaited_once_with(
+            "sync_image_status_job",
+            image_id=123,
+            old_status=ImageStatus.ACTIVE,
+            new_status=ImageStatus.REVIEW,
+        )
+
+    async def test_noop_when_status_unchanged(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        with patch(
+            "app.services.image_status.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            await enqueue_r2_sync_on_status_change(
+                image_id=123,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.ACTIVE,
+            )
+        mock_enqueue.assert_not_awaited()
+
+    async def test_noop_when_r2_disabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        with patch(
+            "app.services.image_status.enqueue_job", new_callable=AsyncMock
+        ) as mock_enqueue:
+            await enqueue_r2_sync_on_status_change(
+                image_id=123,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.REVIEW,
+            )
+        mock_enqueue.assert_not_awaited()

--- a/tests/unit/test_image_url_generation.py
+++ b/tests/unit/test_image_url_generation.py
@@ -1,0 +1,135 @@
+"""Tests for status-aware image URL generation.
+
+Matrix: 7 statuses × 3 r2_location values × 2 R2_ENABLED values. A direct-CDN
+URL must be emitted only when R2_ENABLED=true AND status is public AND
+r2_location=PUBLIC. Every other combination falls back to the /images/ path.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+from app.schemas.image import ImageResponse
+
+ALL_STATUSES = [
+    ImageStatus.REVIEW,
+    ImageStatus.LOW_QUALITY,
+    ImageStatus.INAPPROPRIATE,
+    ImageStatus.REPOST,
+    ImageStatus.OTHER,
+    ImageStatus.ACTIVE,
+    ImageStatus.SPOILER,
+]
+PUBLIC_STATUSES = [ImageStatus.ACTIVE, ImageStatus.SPOILER, ImageStatus.REPOST]
+
+
+def _make_image(status: int, r2_location: int, medium: int = 0, large: int = 0) -> ImageResponse:
+    return ImageResponse(
+        image_id=1,
+        user_id=1,
+        filename="2026-04-17-1",
+        ext="jpg",
+        status=status,
+        r2_location=r2_location,
+        date_added=datetime(2026, 4, 17),
+        locked=0,
+        posts=0,
+        favorites=0,
+        bayesian_rating=0.0,
+        num_ratings=0,
+        medium=medium,
+        large=large,
+    )
+
+
+@pytest.fixture
+def r2_on(monkeypatch):
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://localhost:3000")
+
+
+@pytest.fixture
+def r2_off(monkeypatch):
+    monkeypatch.setattr(settings, "R2_ENABLED", False)
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://localhost:3000")
+
+
+@pytest.mark.unit
+class TestUrlGenerationR2Off:
+    """With R2 disabled, everything goes through /images/ — no exceptions."""
+
+    @pytest.mark.parametrize("status", ALL_STATUSES)
+    @pytest.mark.parametrize(
+        "location", [R2Location.NONE, R2Location.PUBLIC, R2Location.PRIVATE]
+    )
+    def test_url_fallback(self, r2_off, status, location):
+        img = _make_image(status=status, r2_location=location)
+        assert img.url == "http://localhost:3000/images/2026-04-17-1.jpg"
+        assert img.thumbnail_url == "http://localhost:3000/thumbs/2026-04-17-1.webp"
+
+
+@pytest.mark.unit
+class TestUrlGenerationR2On:
+    @pytest.mark.parametrize("status", PUBLIC_STATUSES)
+    def test_cdn_direct_for_public_status_public_location(self, r2_on, status):
+        img = _make_image(status=status, r2_location=R2Location.PUBLIC)
+        assert img.url == "https://cdn.example.com/fullsize/2026-04-17-1.jpg"
+        assert img.thumbnail_url == "https://cdn.example.com/thumbs/2026-04-17-1.webp"
+
+    @pytest.mark.parametrize("status", PUBLIC_STATUSES)
+    def test_fallback_when_location_none(self, r2_on, status):
+        img = _make_image(status=status, r2_location=R2Location.NONE)
+        assert img.url.startswith("http://localhost:3000/images/")
+        assert img.thumbnail_url.startswith("http://localhost:3000/thumbs/")
+
+    @pytest.mark.parametrize("status", PUBLIC_STATUSES)
+    def test_fallback_when_location_private(self, r2_on, status):
+        """Public status with PRIVATE location means a transition is in flight."""
+        img = _make_image(status=status, r2_location=R2Location.PRIVATE)
+        assert img.url.startswith("http://localhost:3000/images/")
+        assert img.thumbnail_url.startswith("http://localhost:3000/thumbs/")
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            ImageStatus.REVIEW,
+            ImageStatus.LOW_QUALITY,
+            ImageStatus.INAPPROPRIATE,
+            ImageStatus.OTHER,
+        ],
+    )
+    @pytest.mark.parametrize(
+        "location", [R2Location.NONE, R2Location.PUBLIC, R2Location.PRIVATE]
+    )
+    def test_protected_never_direct_cdn(self, r2_on, status, location):
+        """Protected statuses must never emit a CDN URL, regardless of location."""
+        img = _make_image(status=status, r2_location=location)
+        assert "cdn.example.com" not in img.url
+        assert img.url.startswith("http://localhost:3000/images/")
+
+
+@pytest.mark.unit
+class TestMediumLargeUrls:
+    def test_medium_none_returns_none(self, r2_on):
+        img = _make_image(
+            status=ImageStatus.ACTIVE, r2_location=R2Location.PUBLIC, medium=0, large=0
+        )
+        assert img.medium_url is None
+        assert img.large_url is None
+
+    def test_medium_ready_uses_cdn(self, r2_on):
+        img = _make_image(
+            status=ImageStatus.ACTIVE, r2_location=R2Location.PUBLIC, medium=1, large=1
+        )
+        assert img.medium_url == "https://cdn.example.com/medium/2026-04-17-1.jpg"
+        assert img.large_url == "https://cdn.example.com/large/2026-04-17-1.jpg"
+
+    def test_medium_ready_fallback_when_none_location(self, r2_on):
+        img = _make_image(
+            status=ImageStatus.ACTIVE, r2_location=R2Location.NONE, medium=1, large=1
+        )
+        assert img.medium_url == "http://localhost:3000/medium/2026-04-17-1.jpg"
+        assert img.large_url == "http://localhost:3000/large/2026-04-17-1.jpg"

--- a/tests/unit/test_r2_client.py
+++ b/tests/unit/test_r2_client.py
@@ -1,0 +1,41 @@
+"""Tests for the R2 client singleton accessor."""
+
+import pytest
+
+from app.config import settings
+from app.core.r2_client import get_r2_storage, reset_r2_storage
+from app.services.r2_storage import DummyR2Storage, R2Storage
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_r2_storage()
+    yield
+    reset_r2_storage()
+
+
+@pytest.mark.unit
+class TestGetR2Storage:
+    def test_returns_dummy_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        storage = get_r2_storage()
+        assert isinstance(storage, DummyR2Storage)
+
+    def test_returns_real_when_enabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ACCESS_KEY_ID", "ak")
+        monkeypatch.setattr(settings, "R2_SECRET_ACCESS_KEY", "sk")
+        monkeypatch.setattr(
+            settings, "R2_ENDPOINT", "https://example.r2.cloudflarestorage.com"
+        )
+        storage = get_r2_storage()
+        assert isinstance(storage, R2Storage)
+
+    def test_singleton_stable_within_mode(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        assert get_r2_storage() is get_r2_storage()
+
+    async def test_dummy_methods_raise(self):
+        storage = DummyR2Storage()
+        with pytest.raises(RuntimeError, match="R2 is disabled"):
+            await storage.object_exists(bucket="b", key="k")

--- a/tests/unit/test_r2_constants.py
+++ b/tests/unit/test_r2_constants.py
@@ -1,0 +1,47 @@
+"""Tests for R2 shared constants."""
+
+import pytest
+
+from app.config import ImageStatus
+from app.core.r2_constants import (
+    PUBLIC_IMAGE_STATUSES_FOR_R2,
+    R2_VARIANTS,
+    R2Location,
+)
+
+
+@pytest.mark.unit
+class TestR2Location:
+    """R2Location enum values."""
+
+    def test_values(self):
+        assert R2Location.NONE == 0
+        assert R2Location.PUBLIC == 1
+        assert R2Location.PRIVATE == 2
+
+    def test_int_comparison(self):
+        """Enum is IntEnum so it compares to ints directly."""
+        assert R2Location.NONE == 0
+        assert int(R2Location.PUBLIC) == 1
+
+
+@pytest.mark.unit
+class TestPublicStatuses:
+    """The set of statuses that map to the public bucket."""
+
+    def test_members(self):
+        assert PUBLIC_IMAGE_STATUSES_FOR_R2 == frozenset(
+            {ImageStatus.ACTIVE, ImageStatus.SPOILER, ImageStatus.REPOST}
+        )
+
+    def test_is_frozen(self):
+        with pytest.raises(AttributeError):
+            PUBLIC_IMAGE_STATUSES_FOR_R2.add(999)  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
+class TestR2Variants:
+    """The canonical list of variant prefixes used as R2 key prefixes."""
+
+    def test_list(self):
+        assert R2_VARIANTS == ("fullsize", "thumbs", "medium", "large")

--- a/tests/unit/test_r2_delete_job.py
+++ b/tests/unit/test_r2_delete_job.py
@@ -1,0 +1,81 @@
+"""Tests for r2_delete_image_job — full delete from R2 and CDN purge."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import settings
+from app.core.r2_constants import R2Location
+from app.tasks.r2_jobs import r2_delete_image_job
+
+
+@pytest.mark.unit
+class TestR2DeleteImageJob:
+    async def test_deletes_all_four_variants_from_public_and_purges(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
+            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await r2_delete_image_job(
+                {},
+                image_id=42,
+                r2_location=int(R2Location.PUBLIC),
+                filename="2026-04-17-42",
+                ext="jpg",
+                variants=["fullsize", "thumbs", "medium", "large"],
+            )
+        assert mock_r2.delete_object.await_count == 4
+        for c in mock_r2.delete_object.await_args_list:
+            assert c.kwargs["bucket"] == settings.R2_PUBLIC_BUCKET
+        mock_purge.assert_awaited_once()
+        assert len(mock_purge.await_args.args[0]) == 4
+
+    async def test_deletes_from_private_no_purge(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
+            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await r2_delete_image_job(
+                {},
+                image_id=42,
+                r2_location=int(R2Location.PRIVATE),
+                filename="2026-04-17-42",
+                ext="jpg",
+                variants=["fullsize", "thumbs"],
+            )
+        assert mock_r2.delete_object.await_count == 2
+        for c in mock_r2.delete_object.await_args_list:
+            assert c.kwargs["bucket"] == settings.R2_PRIVATE_BUCKET
+        mock_purge.assert_not_awaited()
+
+    async def test_no_op_when_location_none(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_delete_image_job(
+                {},
+                image_id=42,
+                r2_location=int(R2Location.NONE),
+                filename="2026-04-17-42",
+                ext="jpg",
+                variants=["fullsize", "thumbs"],
+            )
+        mock_r2.delete_object.assert_not_awaited()
+
+    async def test_no_op_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_delete_image_job(
+                {},
+                image_id=42,
+                r2_location=int(R2Location.PUBLIC),
+                filename="2026-04-17-42",
+                ext="jpg",
+                variants=["fullsize", "thumbs"],
+            )
+        mock_r2.delete_object.assert_not_awaited()

--- a/tests/unit/test_r2_finalize_job.py
+++ b/tests/unit/test_r2_finalize_job.py
@@ -1,0 +1,166 @@
+"""Tests for r2_finalize_upload_job — first-sync of a newly uploaded image."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+from app.models.image import Images, VariantStatus
+from app.tasks.r2_jobs import r2_finalize_upload_job
+
+
+def _mock_session_cm(db_session):
+    """Return an async context manager that yields db_session.
+
+    r2_finalize_upload_job opens `async with get_async_session() as db:`, which
+    bypasses the test's SAVEPOINT isolation.  This helper routes that call back
+    to the test's db_session so the job sees the fixture data and its updates
+    stay inside the same transaction.
+    """
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=db_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    return mock_cm
+
+
+@pytest.fixture
+async def fresh_image(db_session):
+    img = Images(
+        user_id=1,
+        filename="2026-04-17-42",
+        ext="jpg",
+        status=ImageStatus.ACTIVE,
+        medium=VariantStatus.NONE,
+        large=VariantStatus.NONE,
+        r2_location=R2Location.NONE,
+    )
+    db_session.add(img)
+    await db_session.commit()
+    await db_session.refresh(img)
+    return img
+
+
+@pytest.mark.unit
+class TestR2FinalizeUploadJob:
+    @pytest.fixture(autouse=True)
+    def _patch_get_session(self, db_session):
+        """Route get_async_session() to the test's db_session."""
+        with patch(
+            "app.tasks.r2_jobs.get_async_session",
+            return_value=_mock_session_cm(db_session),
+        ):
+            yield
+
+    async def test_uploads_two_variants_and_flips_public(self, fresh_image, db_session, monkeypatch, tmp_path):
+        """Image with no medium/large: uploads fullsize+thumbs to public bucket."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        # Create the local files that the finalizer expects
+        (tmp_path / "fullsize").mkdir()
+        (tmp_path / "thumbs").mkdir()
+        (tmp_path / "fullsize" / "2026-04-17-42.jpg").write_bytes(b"x")
+        (tmp_path / "thumbs" / "2026-04-17-42.webp").write_bytes(b"x")
+
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
+
+        assert mock_r2.upload_file.await_count == 2
+        calls = {
+            (c.kwargs["bucket"], c.kwargs["key"])
+            for c in mock_r2.upload_file.await_args_list
+        }
+        assert (settings.R2_PUBLIC_BUCKET, "fullsize/2026-04-17-42.jpg") in calls
+        assert (settings.R2_PUBLIC_BUCKET, "thumbs/2026-04-17-42.webp") in calls
+
+        # Flip happened
+        await db_session.refresh(fresh_image)
+        assert fresh_image.r2_location == R2Location.PUBLIC
+
+    async def test_protected_status_goes_to_private_bucket(
+        self, fresh_image, db_session, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        (tmp_path / "fullsize").mkdir()
+        (tmp_path / "thumbs").mkdir()
+        (tmp_path / "fullsize" / "2026-04-17-42.jpg").write_bytes(b"x")
+        (tmp_path / "thumbs" / "2026-04-17-42.webp").write_bytes(b"x")
+
+        fresh_image.status = ImageStatus.REVIEW
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
+
+        for c in mock_r2.upload_file.await_args_list:
+            assert c.kwargs["bucket"] == settings.R2_PRIVATE_BUCKET
+
+        await db_session.refresh(fresh_image)
+        assert fresh_image.r2_location == R2Location.PRIVATE
+
+    async def test_uploads_medium_and_large_when_ready(
+        self, fresh_image, db_session, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        for sub in ("fullsize", "thumbs", "medium", "large"):
+            (tmp_path / sub).mkdir()
+            suffix = "webp" if sub == "thumbs" else "jpg"
+            (tmp_path / sub / f"2026-04-17-42.{suffix}").write_bytes(b"x")
+
+        fresh_image.medium = VariantStatus.READY
+        fresh_image.large = VariantStatus.READY
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
+
+        assert mock_r2.upload_file.await_count == 4
+
+    async def test_retries_when_expected_variant_file_missing(
+        self, fresh_image, db_session, monkeypatch, tmp_path
+    ):
+        """If medium=READY but file is missing on disk, the finalizer must retry."""
+        from arq import Retry
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        (tmp_path / "fullsize").mkdir()
+        (tmp_path / "thumbs").mkdir()
+        (tmp_path / "medium").mkdir()
+        (tmp_path / "fullsize" / "2026-04-17-42.jpg").write_bytes(b"x")
+        (tmp_path / "thumbs" / "2026-04-17-42.webp").write_bytes(b"x")
+        # medium dir exists but file does not
+
+        fresh_image.medium = VariantStatus.READY
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            with pytest.raises(Retry):
+                await r2_finalize_upload_job(
+                    {"job_try": 1}, image_id=fresh_image.image_id
+                )
+
+        await db_session.refresh(fresh_image)
+        assert fresh_image.r2_location == R2Location.NONE  # no flip on retry
+
+    async def test_no_op_when_r2_disabled(self, fresh_image, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
+        mock_r2.upload_file.assert_not_awaited()
+
+    async def test_no_op_when_already_synced(self, fresh_image, db_session, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        fresh_image.r2_location = R2Location.PUBLIC
+        await db_session.commit()
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
+        mock_r2.upload_file.assert_not_awaited()

--- a/tests/unit/test_r2_finalize_job.py
+++ b/tests/unit/test_r2_finalize_job.py
@@ -63,6 +63,7 @@ class TestR2FinalizeUploadJob:
         (tmp_path / "thumbs" / "2026-04-17-42.webp").write_bytes(b"x")
 
         mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=False)
         with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
             await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
 
@@ -92,6 +93,7 @@ class TestR2FinalizeUploadJob:
         await db_session.commit()
 
         mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=False)
         with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
             await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
 
@@ -116,6 +118,7 @@ class TestR2FinalizeUploadJob:
         await db_session.commit()
 
         mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=False)
         with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
             await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
 

--- a/tests/unit/test_r2_status_sync_job.py
+++ b/tests/unit/test_r2_status_sync_job.py
@@ -82,10 +82,25 @@ class TestSyncImageStatusJob:
         mock_r2.copy_object.assert_not_awaited()
 
     async def test_public_to_protected_copies_deletes_and_purges(
-        self, synced_public_image, db_session, monkeypatch
+        self, db_session, monkeypatch
     ):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+        # Simulate post-commit state: status already changed to REVIEW,
+        # but r2_location still PUBLIC (job hasn't moved objects yet).
+        img = Images(
+            user_id=1,
+            filename="2026-04-17-7",
+            ext="jpg",
+            status=ImageStatus.REVIEW,
+            r2_location=R2Location.PUBLIC,
+            medium=VariantStatus.READY,
+            large=VariantStatus.NONE,
+        )
+        db_session.add(img)
+        await db_session.commit()
+        await db_session.refresh(img)
+
         mock_r2 = AsyncMock()
         mock_r2.object_exists = AsyncMock(return_value=True)
 
@@ -94,15 +109,15 @@ class TestSyncImageStatusJob:
         ) as mock_purge:
             await sync_image_status_job(
                 {},
-                image_id=synced_public_image.image_id,
+                image_id=img.image_id,
                 old_status=ImageStatus.ACTIVE,
                 new_status=ImageStatus.REVIEW,
             )
 
         assert mock_r2.copy_object.await_count == 3
         assert mock_r2.delete_object.await_count == 3
-        await db_session.refresh(synced_public_image)
-        assert synced_public_image.r2_location == R2Location.PRIVATE
+        await db_session.refresh(img)
+        assert img.r2_location == R2Location.PRIVATE
         mock_purge.assert_awaited_once()
         urls = mock_purge.await_args.args[0]
         assert all(u.startswith("https://cdn.example.com/") for u in urls)
@@ -141,12 +156,22 @@ class TestSyncImageStatusJob:
         await db_session.refresh(img)
         assert img.r2_location == R2Location.PUBLIC
 
-    async def test_skips_missing_source_objects(
-        self, synced_public_image, db_session, monkeypatch
-    ):
+    async def test_skips_missing_source_objects(self, db_session, monkeypatch):
         """All source objects missing → no copies, no DB flip."""
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+        # Post-commit state: status=REVIEW, r2_location=PUBLIC.
+        img = Images(
+            user_id=1,
+            filename="2026-04-17-missing",
+            ext="jpg",
+            status=ImageStatus.REVIEW,
+            r2_location=R2Location.PUBLIC,
+        )
+        db_session.add(img)
+        await db_session.commit()
+        await db_session.refresh(img)
+
         mock_r2 = AsyncMock()
         mock_r2.object_exists = AsyncMock(return_value=False)
 
@@ -155,15 +180,15 @@ class TestSyncImageStatusJob:
         ):
             result = await sync_image_status_job(
                 {},
-                image_id=synced_public_image.image_id,
+                image_id=img.image_id,
                 old_status=ImageStatus.ACTIVE,
                 new_status=ImageStatus.REVIEW,
             )
         mock_r2.copy_object.assert_not_awaited()
         mock_r2.delete_object.assert_not_awaited()
         assert result == {"skipped": "no_objects_moved"}
-        await db_session.refresh(synced_public_image)
-        assert synced_public_image.r2_location == R2Location.PUBLIC
+        await db_session.refresh(img)
+        assert img.r2_location == R2Location.PUBLIC
 
     async def test_no_op_when_r2_disabled(self, synced_public_image, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", False)

--- a/tests/unit/test_r2_status_sync_job.py
+++ b/tests/unit/test_r2_status_sync_job.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from arq import Retry
 
 from app.config import ImageStatus, settings
 from app.core.r2_constants import R2Location
@@ -45,7 +46,7 @@ class TestSyncImageStatusJob:
         ):
             yield
 
-    async def test_early_return_when_location_none(self, db_session, monkeypatch):
+    async def test_retries_when_location_none(self, db_session, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         img = Images(
             user_id=1,
@@ -60,12 +61,13 @@ class TestSyncImageStatusJob:
 
         mock_r2 = AsyncMock()
         with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
-            await sync_image_status_job(
-                {},
-                image_id=img.image_id,
-                old_status=ImageStatus.ACTIVE,
-                new_status=ImageStatus.REVIEW,
-            )
+            with pytest.raises(Retry):
+                await sync_image_status_job(
+                    {},
+                    image_id=img.image_id,
+                    old_status=ImageStatus.ACTIVE,
+                    new_status=ImageStatus.REVIEW,
+                )
         mock_r2.copy_object.assert_not_awaited()
         mock_r2.delete_object.assert_not_awaited()
 

--- a/tests/unit/test_r2_status_sync_job.py
+++ b/tests/unit/test_r2_status_sync_job.py
@@ -192,6 +192,54 @@ class TestSyncImageStatusJob:
         await db_session.refresh(img)
         assert img.r2_location == R2Location.PUBLIC
 
+    async def test_replay_when_src_missing_but_dst_exists_flips_db(
+        self, db_session, monkeypatch
+    ):
+        """Replay after prior run moved objects but failed before DB flip.
+
+        Source is empty, destination has all variants → treat as already moved,
+        still commit DB flip and purge CDN (purge is idempotent).
+        """
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+        img = Images(
+            user_id=1,
+            filename="2026-04-17-replay",
+            ext="jpg",
+            status=ImageStatus.REVIEW,
+            r2_location=R2Location.PUBLIC,
+        )
+        db_session.add(img)
+        await db_session.commit()
+        await db_session.refresh(img)
+
+        mock_r2 = AsyncMock()
+
+        async def object_exists(*, bucket: str, key: str) -> bool:
+            return bucket == settings.R2_PRIVATE_BUCKET
+
+        mock_r2.object_exists = AsyncMock(side_effect=object_exists)
+
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
+            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            result = await sync_image_status_job(
+                {},
+                image_id=img.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.REVIEW,
+            )
+
+        mock_r2.copy_object.assert_not_awaited()
+        mock_r2.delete_object.assert_not_awaited()
+        assert result["r2_location"] == int(R2Location.PRIVATE)
+        assert result["moved_variants"] == []
+        await db_session.refresh(img)
+        assert img.r2_location == R2Location.PRIVATE
+        mock_purge.assert_awaited_once()
+        urls = mock_purge.await_args.args[0]
+        assert len(urls) == 2
+
     async def test_no_op_when_r2_disabled(self, synced_public_image, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", False)
         mock_r2 = AsyncMock()

--- a/tests/unit/test_r2_status_sync_job.py
+++ b/tests/unit/test_r2_status_sync_job.py
@@ -1,0 +1,173 @@
+"""Tests for sync_image_status_job — bucket move on status change."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+from app.models.image import Images, VariantStatus
+from app.tasks.r2_jobs import sync_image_status_job
+
+
+def _mock_session_cm(db_session):
+    """Route get_async_session() back to the test's SAVEPOINT-isolated session."""
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=db_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    return mock_cm
+
+
+@pytest.fixture
+async def synced_public_image(db_session):
+    img = Images(
+        user_id=1,
+        filename="2026-04-17-7",
+        ext="jpg",
+        status=ImageStatus.ACTIVE,
+        r2_location=R2Location.PUBLIC,
+        medium=VariantStatus.READY,
+        large=VariantStatus.NONE,
+    )
+    db_session.add(img)
+    await db_session.commit()
+    await db_session.refresh(img)
+    return img
+
+
+@pytest.mark.unit
+class TestSyncImageStatusJob:
+    @pytest.fixture(autouse=True)
+    def _patch_get_session(self, db_session):
+        with patch(
+            "app.tasks.r2_jobs.get_async_session",
+            return_value=_mock_session_cm(db_session),
+        ):
+            yield
+
+    async def test_early_return_when_location_none(self, db_session, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        img = Images(
+            user_id=1,
+            filename="2026-04-17-8",
+            ext="jpg",
+            status=ImageStatus.REVIEW,
+            r2_location=R2Location.NONE,
+        )
+        db_session.add(img)
+        await db_session.commit()
+        await db_session.refresh(img)
+
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await sync_image_status_job(
+                {},
+                image_id=img.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.REVIEW,
+            )
+        mock_r2.copy_object.assert_not_awaited()
+        mock_r2.delete_object.assert_not_awaited()
+
+    async def test_no_op_when_public_to_public(self, synced_public_image, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await sync_image_status_job(
+                {},
+                image_id=synced_public_image.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.SPOILER,
+            )
+        mock_r2.copy_object.assert_not_awaited()
+
+    async def test_public_to_protected_copies_deletes_and_purges(
+        self, synced_public_image, db_session, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=True)
+
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
+            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await sync_image_status_job(
+                {},
+                image_id=synced_public_image.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.REVIEW,
+            )
+
+        assert mock_r2.copy_object.await_count == 3
+        assert mock_r2.delete_object.await_count == 3
+        await db_session.refresh(synced_public_image)
+        assert synced_public_image.r2_location == R2Location.PRIVATE
+        mock_purge.assert_awaited_once()
+        urls = mock_purge.await_args.args[0]
+        assert all(u.startswith("https://cdn.example.com/") for u in urls)
+        assert len(urls) == 3
+
+    async def test_protected_to_public_copies_deletes_no_purge(
+        self, db_session, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        img = Images(
+            user_id=1,
+            filename="2026-04-17-9",
+            ext="jpg",
+            status=ImageStatus.ACTIVE,
+            r2_location=R2Location.PRIVATE,
+        )
+        db_session.add(img)
+        await db_session.commit()
+        await db_session.refresh(img)
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=True)
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
+            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await sync_image_status_job(
+                {},
+                image_id=img.image_id,
+                old_status=ImageStatus.REVIEW,
+                new_status=ImageStatus.ACTIVE,
+            )
+
+        assert mock_r2.copy_object.await_count == 2
+        assert mock_r2.delete_object.await_count == 2
+        mock_purge.assert_not_awaited()
+        await db_session.refresh(img)
+        assert img.r2_location == R2Location.PUBLIC
+
+    async def test_skips_missing_source_objects(self, synced_public_image, monkeypatch):
+        """Missing source objects don't crash — the variant is skipped."""
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=False)
+
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
+            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
+        ):
+            await sync_image_status_job(
+                {},
+                image_id=synced_public_image.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.REVIEW,
+            )
+        mock_r2.copy_object.assert_not_awaited()
+        mock_r2.delete_object.assert_not_awaited()
+
+    async def test_no_op_when_r2_disabled(self, synced_public_image, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        mock_r2 = AsyncMock()
+        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
+            await sync_image_status_job(
+                {},
+                image_id=synced_public_image.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.REVIEW,
+            )
+        mock_r2.copy_object.assert_not_awaited()

--- a/tests/unit/test_r2_status_sync_job.py
+++ b/tests/unit/test_r2_status_sync_job.py
@@ -141,8 +141,10 @@ class TestSyncImageStatusJob:
         await db_session.refresh(img)
         assert img.r2_location == R2Location.PUBLIC
 
-    async def test_skips_missing_source_objects(self, synced_public_image, monkeypatch):
-        """Missing source objects don't crash — the variant is skipped."""
+    async def test_skips_missing_source_objects(
+        self, synced_public_image, db_session, monkeypatch
+    ):
+        """All source objects missing → no copies, no DB flip."""
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
         mock_r2 = AsyncMock()
@@ -151,7 +153,7 @@ class TestSyncImageStatusJob:
         with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
             "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
         ):
-            await sync_image_status_job(
+            result = await sync_image_status_job(
                 {},
                 image_id=synced_public_image.image_id,
                 old_status=ImageStatus.ACTIVE,
@@ -159,6 +161,9 @@ class TestSyncImageStatusJob:
             )
         mock_r2.copy_object.assert_not_awaited()
         mock_r2.delete_object.assert_not_awaited()
+        assert result == {"skipped": "no_objects_moved"}
+        await db_session.refresh(synced_public_image)
+        assert synced_public_image.r2_location == R2Location.PUBLIC
 
     async def test_no_op_when_r2_disabled(self, synced_public_image, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", False)

--- a/tests/unit/test_r2_storage.py
+++ b/tests/unit/test_r2_storage.py
@@ -1,0 +1,108 @@
+"""Tests for R2Storage adapter (backed by moto ThreadedMotoServer).
+
+Note: mock_aws() patches the sync botocore HTTP layer but aiobotocore 2.x
+awaits async HTTP responses — incompatible on this stack. ThreadedMotoServer
+starts a real Flask-based HTTP server so aiobotocore can make genuine async
+HTTP calls against a local mock endpoint.
+"""
+
+import time
+from pathlib import Path
+
+import aioboto3
+import pytest
+from moto.server import ThreadedMotoServer
+
+from app.services.r2_storage import R2Storage
+
+_CREDS = {
+    "aws_access_key_id": "test",
+    "aws_secret_access_key": "test",
+    "region_name": "us-east-1",
+}
+
+
+@pytest.fixture(scope="module")
+def moto_server():
+    """Start a ThreadedMotoServer for the duration of this test module."""
+    server = ThreadedMotoServer(port=0)
+    server.start()
+    time.sleep(0.2)  # let the server come up
+    host, port = server.get_host_and_port()
+    yield f"http://{host}:{port}"
+    server.stop()
+
+
+@pytest.fixture
+def moto_session(moto_server):
+    """aioboto3 session pointed at the moto server."""
+    return aioboto3.Session(**_CREDS)
+
+
+@pytest.fixture
+async def storage(moto_session, moto_server):
+    """R2Storage instance wired to the moto server endpoint."""
+    return R2Storage(session=moto_session, endpoint_url=moto_server)
+
+
+@pytest.fixture
+async def setup_buckets(storage, moto_session, moto_server):
+    async with moto_session.client("s3", endpoint_url=moto_server) as s3:
+        await s3.create_bucket(Bucket="public")
+        await s3.create_bucket(Bucket="private")
+    yield storage
+    # Cleanup: empty and delete buckets so tests are isolated
+    async with moto_session.client("s3", endpoint_url=moto_server) as s3:
+        for bucket in ("public", "private"):
+            try:
+                resp = await s3.list_objects_v2(Bucket=bucket)
+                for obj in resp.get("Contents", []):
+                    await s3.delete_object(Bucket=bucket, Key=obj["Key"])
+                await s3.delete_bucket(Bucket=bucket)
+            except Exception:
+                pass
+
+
+@pytest.mark.unit
+class TestR2Storage:
+    async def test_upload_and_exists(self, setup_buckets, tmp_path: Path):
+        storage = setup_buckets
+        src = tmp_path / "a.bin"
+        src.write_bytes(b"hello")
+        await storage.upload_file(bucket="public", key="fullsize/a.bin", path=src)
+        assert await storage.object_exists(bucket="public", key="fullsize/a.bin") is True
+        assert await storage.object_exists(bucket="public", key="fullsize/missing.bin") is False
+
+    async def test_copy_object(self, setup_buckets, tmp_path: Path):
+        storage = setup_buckets
+        src = tmp_path / "a.bin"
+        src.write_bytes(b"data")
+        await storage.upload_file(bucket="public", key="fullsize/a.bin", path=src)
+        await storage.copy_object(
+            src_bucket="public", dst_bucket="private", key="fullsize/a.bin"
+        )
+        assert await storage.object_exists(bucket="private", key="fullsize/a.bin") is True
+
+    async def test_delete_object(self, setup_buckets, tmp_path: Path):
+        storage = setup_buckets
+        src = tmp_path / "a.bin"
+        src.write_bytes(b"data")
+        await storage.upload_file(bucket="public", key="fullsize/a.bin", path=src)
+        await storage.delete_object(bucket="public", key="fullsize/a.bin")
+        assert await storage.object_exists(bucket="public", key="fullsize/a.bin") is False
+
+    async def test_delete_missing_is_idempotent(self, setup_buckets):
+        storage = setup_buckets
+        # Deleting a key that doesn't exist must not raise — S3 returns 204.
+        await storage.delete_object(bucket="public", key="fullsize/missing.bin")
+
+    async def test_generate_presigned_url(self, setup_buckets, tmp_path: Path):
+        storage = setup_buckets
+        src = tmp_path / "a.bin"
+        src.write_bytes(b"data")
+        await storage.upload_file(bucket="private", key="fullsize/a.bin", path=src)
+        url = await storage.generate_presigned_url(
+            bucket="private", key="fullsize/a.bin", ttl=60
+        )
+        assert "a.bin" in url
+        assert "Signature" in url or "X-Amz-Signature" in url

--- a/tests/unit/test_r2_storage.py
+++ b/tests/unit/test_r2_storage.py
@@ -106,3 +106,73 @@ class TestR2Storage:
         )
         assert "a.bin" in url
         assert "Signature" in url or "X-Amz-Signature" in url
+
+    async def test_bulk_session_operations_work(self, setup_buckets, tmp_path: Path):
+        """Every R2Storage op works correctly while a bulk_session is active."""
+        storage = setup_buckets
+        src = tmp_path / "a.bin"
+        src.write_bytes(b"data")
+        async with storage.bulk_session():
+            await storage.upload_file(bucket="public", key="fullsize/a.bin", path=src)
+            assert (
+                await storage.object_exists(bucket="public", key="fullsize/a.bin")
+                is True
+            )
+            await storage.copy_object(
+                src_bucket="public", dst_bucket="private", key="fullsize/a.bin"
+            )
+            await storage.delete_object(bucket="public", key="fullsize/a.bin")
+            assert (
+                await storage.object_exists(bucket="public", key="fullsize/a.bin")
+                is False
+            )
+            assert (
+                await storage.object_exists(bucket="private", key="fullsize/a.bin")
+                is True
+            )
+
+    async def test_bulk_session_reuses_single_client(
+        self, setup_buckets, tmp_path: Path, monkeypatch
+    ):
+        """Inside bulk_session, all ops share one client; outside, each op opens a fresh one."""
+        storage = setup_buckets
+        src = tmp_path / "a.bin"
+        src.write_bytes(b"data")
+
+        call_count = 0
+        original_client = storage._client
+
+        def counting_client():
+            nonlocal call_count
+            call_count += 1
+            return original_client()
+
+        monkeypatch.setattr(storage, "_client", counting_client)
+
+        await storage.upload_file(bucket="public", key="one", path=src)
+        await storage.object_exists(bucket="public", key="one")
+        assert call_count == 2, "without bulk_session, each op opens its own client"
+
+        call_count = 0
+        async with storage.bulk_session():
+            await storage.upload_file(bucket="public", key="two", path=src)
+            await storage.object_exists(bucket="public", key="two")
+            await storage.copy_object(
+                src_bucket="public", dst_bucket="private", key="two"
+            )
+            await storage.delete_object(bucket="public", key="two")
+        assert call_count == 1, "bulk_session opens one client for all ops inside"
+
+    async def test_bulk_session_nests(self, setup_buckets, tmp_path: Path):
+        """Nested bulk_session blocks don't break — inner reuses outer's client."""
+        storage = setup_buckets
+        src = tmp_path / "a.bin"
+        src.write_bytes(b"x")
+        async with storage.bulk_session():
+            await storage.upload_file(bucket="public", key="nested", path=src)
+            async with storage.bulk_session():
+                assert (
+                    await storage.object_exists(bucket="public", key="nested") is True
+                )
+            # outer client still usable after inner exits
+            await storage.delete_object(bucket="public", key="nested")

--- a/tests/unit/test_r2_sync_cli_guards.py
+++ b/tests/unit/test_r2_sync_cli_guards.py
@@ -1,0 +1,37 @@
+"""Tests for r2_sync.py CLI guards (R2_ENABLED, R2_ALLOW_BULK_BACKFILL)."""
+
+import pytest
+
+from app.config import settings
+from scripts.r2_sync import (
+    BulkBackfillDisallowedError,
+    R2DisabledError,
+    require_bulk_backfill,
+    require_r2_enabled,
+)
+
+
+@pytest.mark.unit
+class TestRequireR2Enabled:
+    def test_passes_when_enabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        require_r2_enabled()
+
+    def test_raises_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", False)
+        with pytest.raises(R2DisabledError):
+            require_r2_enabled()
+
+
+@pytest.mark.unit
+class TestRequireBulkBackfill:
+    def test_passes_when_allowed(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", True)
+        require_bulk_backfill()
+
+    def test_raises_when_disallowed(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", False)
+        with pytest.raises(BulkBackfillDisallowedError):
+            require_bulk_backfill()

--- a/tests/unit/test_r2_sync_remaining.py
+++ b/tests/unit/test_r2_sync_remaining.py
@@ -1,0 +1,275 @@
+"""Tests for the remaining r2_sync.py subcommands."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import ImageStatus, settings
+from app.core.r2_constants import R2Location
+from scripts.r2_sync import (
+    BulkBackfillDisallowedError,
+    health,
+    purge_cache_command,
+    reconcile,
+    resync_image,
+    verify,
+)
+
+
+def _mock_session_cm(db_session):
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=db_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    return mock_cm
+
+
+@pytest.mark.unit
+class TestReconcileGuard:
+    async def test_requires_bulk_backfill_flag(self, monkeypatch):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", False)
+        with pytest.raises(BulkBackfillDisallowedError):
+            await reconcile(stale_after=60)
+
+
+@pytest.mark.unit
+class TestHealth:
+    @pytest.fixture(autouse=True)
+    def _patch_get_session(self, db_session):
+        with patch(
+            "scripts.r2_sync.get_async_session",
+            return_value=_mock_session_cm(db_session),
+        ):
+            yield
+
+    async def test_reports_unsynced_count_and_oldest_age(
+        self, db_session, monkeypatch, tmp_path
+    ):
+        from app.models.image import Images
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        db_session.add(
+            Images(
+                user_id=1,
+                filename="a",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                r2_location=R2Location.NONE,
+            )
+        )
+        db_session.add(
+            Images(
+                user_id=1,
+                filename="b",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        result = await health(output_json=True)
+        assert result["unsynced_count"] == 1
+        assert result["local_storage_path"] == str(tmp_path)
+
+
+@pytest.mark.unit
+class TestPurgeCacheCommand:
+    @pytest.fixture(autouse=True)
+    def _patch_get_session(self, db_session):
+        with patch(
+            "scripts.r2_sync.get_async_session",
+            return_value=_mock_session_cm(db_session),
+        ):
+            yield
+
+    async def test_calls_cloudflare_with_all_variant_urls(
+        self, db_session, monkeypatch
+    ):
+        from app.models.image import Images, VariantStatus
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
+        db_session.add(
+            Images(
+                image_id=42,
+                user_id=1,
+                filename="2026-04-17-42",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                medium=VariantStatus.READY,
+                large=VariantStatus.READY,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        with patch(
+            "scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await purge_cache_command(image_id=42)
+        mock_purge.assert_awaited_once()
+        urls = mock_purge.await_args.args[0]
+        assert len(urls) == 4
+
+
+@pytest.mark.unit
+class TestResyncImage:
+    @pytest.fixture(autouse=True)
+    def _patch_get_session(self, db_session):
+        with patch(
+            "scripts.r2_sync.get_async_session",
+            return_value=_mock_session_cm(db_session),
+        ):
+            yield
+
+    async def test_prints_state_for_known_image(
+        self, db_session, monkeypatch, capsys
+    ):
+        from app.models.image import Images
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_BUCKET", "public")
+        db_session.add(
+            Images(
+                image_id=99,
+                user_id=1,
+                filename="a",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=True)
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            await resync_image(99)
+
+        out = capsys.readouterr().out
+        assert "image 99" in out
+        assert "fullsize" in out and "thumbs" in out
+
+    async def test_prints_not_found_for_missing_image(
+        self, db_session, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        await resync_image(99999999)
+        assert "not found" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+class TestVerify:
+    """verify must implement the spec's full discrepancy rules."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_get_session(self, db_session):
+        with patch(
+            "scripts.r2_sync.get_async_session",
+            return_value=_mock_session_cm(db_session),
+        ):
+            yield
+
+    async def test_none_with_no_object_is_clean(self, db_session, monkeypatch):
+        """NONE + no object is a legitimate state (spec Operational tooling)."""
+        from app.models.image import Images
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        db_session.add(
+            Images(
+                user_id=1,
+                filename="x",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                r2_location=R2Location.NONE,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=False)
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            report = await verify(sample=None)
+        assert report["discrepancies"] == []
+
+    async def test_none_with_unexpected_object_reports_unexpected(
+        self, db_session, monkeypatch
+    ):
+        """NONE row + object present in either bucket -> leaked upload."""
+        from app.models.image import Images
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        db_session.add(
+            Images(
+                image_id=10,
+                user_id=1,
+                filename="orphan",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                r2_location=R2Location.NONE,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(
+            side_effect=lambda bucket, key: bucket == settings.R2_PUBLIC_BUCKET
+        )
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            report = await verify(sample=None)
+        kinds = {d["kind"] for d in report["discrepancies"]}
+        assert "unexpected" in kinds
+
+    async def test_cross_bucket_orphan_reports_wrong_bucket(
+        self, db_session, monkeypatch
+    ):
+        """PUBLIC row with copy also in private bucket -> incomplete move."""
+        from app.models.image import Images
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        db_session.add(
+            Images(
+                image_id=11,
+                user_id=1,
+                filename="moved",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=True)
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            report = await verify(sample=None)
+        kinds = {d["kind"] for d in report["discrepancies"]}
+        assert "wrong_bucket" in kinds
+
+    async def test_missing_from_expected_bucket_reports_missing(
+        self, db_session, monkeypatch
+    ):
+        """PUBLIC row with object missing from public bucket -> report missing."""
+        from app.models.image import Images
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        db_session.add(
+            Images(
+                image_id=12,
+                user_id=1,
+                filename="gone",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = AsyncMock()
+        mock_r2.object_exists = AsyncMock(return_value=False)
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            report = await verify(sample=None)
+        kinds = {d["kind"] for d in report["discrepancies"]}
+        assert "missing" in kinds

--- a/tests/unit/test_r2_sync_remaining.py
+++ b/tests/unit/test_r2_sync_remaining.py
@@ -8,6 +8,7 @@ from app.config import ImageStatus, settings
 from app.core.r2_constants import R2Location
 from scripts.r2_sync import (
     BulkBackfillDisallowedError,
+    force_reupload_image,
     health,
     purge_cache_command,
     reconcile,
@@ -166,6 +167,180 @@ class TestResyncImage:
     ):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         await resync_image(99999999)
+        assert "not found" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+class TestForceReuploadImage:
+    @pytest.fixture(autouse=True)
+    def _patch_get_session(self, db_session):
+        with patch(
+            "scripts.r2_sync.get_async_session",
+            return_value=_mock_session_cm(db_session),
+        ):
+            yield
+
+    def _seed_local_files(self, tmp_path, filename: str, ext: str) -> None:
+        for variant in ("fullsize", "thumbs", "medium", "large"):
+            variant_ext = "webp" if variant == "thumbs" else ext
+            (tmp_path / variant).mkdir(parents=True, exist_ok=True)
+            (tmp_path / variant / f"{filename}.{variant_ext}").write_bytes(b"x")
+
+    async def test_deletes_and_reuploads_each_ready_variant(
+        self, db_session, monkeypatch, tmp_path
+    ):
+        from app.models.image import Images, VariantStatus
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        monkeypatch.setattr(settings, "R2_PUBLIC_BUCKET", "pub")
+        self._seed_local_files(tmp_path, "force-reup", "jpg")
+        db_session.add(
+            Images(
+                image_id=50,
+                user_id=1,
+                filename="force-reup",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                medium=VariantStatus.READY,
+                large=VariantStatus.READY,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = _attach_bulk_session(AsyncMock())
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2), patch(
+            "scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await force_reupload_image(image_id=50, dry_run=False)
+
+        assert mock_r2.delete_object.await_count == 4
+        assert mock_r2.upload_file.await_count == 4
+        # Public bucket -> purge CDN after reupload.
+        mock_purge.assert_awaited_once()
+
+    async def test_private_bucket_does_not_purge(
+        self, db_session, monkeypatch, tmp_path
+    ):
+        from app.models.image import Images
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        self._seed_local_files(tmp_path, "private-reup", "jpg")
+        db_session.add(
+            Images(
+                image_id=51,
+                user_id=1,
+                filename="private-reup",
+                ext="jpg",
+                status=ImageStatus.REVIEW,
+                r2_location=R2Location.PRIVATE,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = _attach_bulk_session(AsyncMock())
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2), patch(
+            "scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await force_reupload_image(image_id=51, dry_run=False)
+
+        assert mock_r2.upload_file.await_count == 2  # fullsize + thumbs only
+        mock_purge.assert_not_awaited()
+
+    async def test_dry_run_does_not_touch_r2(
+        self, db_session, monkeypatch, tmp_path
+    ):
+        from app.models.image import Images
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        self._seed_local_files(tmp_path, "dry-reup", "jpg")
+        db_session.add(
+            Images(
+                image_id=52,
+                user_id=1,
+                filename="dry-reup",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = _attach_bulk_session(AsyncMock())
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2), patch(
+            "scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock
+        ) as mock_purge:
+            await force_reupload_image(image_id=52, dry_run=True)
+
+        mock_r2.delete_object.assert_not_awaited()
+        mock_r2.upload_file.assert_not_awaited()
+        mock_purge.assert_not_awaited()
+
+    async def test_r2_location_none_refuses(
+        self, db_session, monkeypatch, tmp_path, capsys
+    ):
+        from app.models.image import Images
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        self._seed_local_files(tmp_path, "none-reup", "jpg")
+        db_session.add(
+            Images(
+                image_id=53,
+                user_id=1,
+                filename="none-reup",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                r2_location=R2Location.NONE,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = _attach_bulk_session(AsyncMock())
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
+            await force_reupload_image(image_id=53, dry_run=False)
+
+        mock_r2.upload_file.assert_not_awaited()
+        assert "reconcile" in capsys.readouterr().out
+
+    async def test_missing_local_file_skips_variant(
+        self, db_session, monkeypatch, tmp_path
+    ):
+        from app.models.image import Images
+
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+        # Seed only fullsize; leave thumbs missing on disk.
+        (tmp_path / "fullsize").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "fullsize" / "partial-reup.jpg").write_bytes(b"x")
+        db_session.add(
+            Images(
+                image_id=54,
+                user_id=1,
+                filename="partial-reup",
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                r2_location=R2Location.PUBLIC,
+            )
+        )
+        await db_session.commit()
+
+        mock_r2 = _attach_bulk_session(AsyncMock())
+        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2), patch(
+            "scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock
+        ):
+            await force_reupload_image(image_id=54, dry_run=False)
+
+        assert mock_r2.upload_file.await_count == 1  # fullsize only
+
+    async def test_prints_not_found_for_missing_image(
+        self, db_session, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        await force_reupload_image(image_id=99999999, dry_run=False)
         assert "not found" in capsys.readouterr().out
 
 

--- a/tests/unit/test_r2_sync_remaining.py
+++ b/tests/unit/test_r2_sync_remaining.py
@@ -1,6 +1,6 @@
 """Tests for the remaining r2_sync.py subcommands."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -21,6 +21,15 @@ def _mock_session_cm(db_session):
     mock_cm.__aenter__ = AsyncMock(return_value=db_session)
     mock_cm.__aexit__ = AsyncMock(return_value=False)
     return mock_cm
+
+
+def _attach_bulk_session(mock_r2: AsyncMock) -> AsyncMock:
+    """Wire a no-op bulk_session() async CM onto an existing r2 mock."""
+    bulk_cm = AsyncMock()
+    bulk_cm.__aenter__ = AsyncMock(return_value=mock_r2)
+    bulk_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_r2.bulk_session = Mock(return_value=bulk_cm)
+    return mock_r2
 
 
 @pytest.mark.unit
@@ -188,7 +197,7 @@ class TestVerify:
         )
         await db_session.commit()
 
-        mock_r2 = AsyncMock()
+        mock_r2 = _attach_bulk_session(AsyncMock())
         mock_r2.object_exists = AsyncMock(return_value=False)
         with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
             report = await verify(sample=None)
@@ -213,7 +222,7 @@ class TestVerify:
         )
         await db_session.commit()
 
-        mock_r2 = AsyncMock()
+        mock_r2 = _attach_bulk_session(AsyncMock())
         mock_r2.object_exists = AsyncMock(
             side_effect=lambda bucket, key: bucket == settings.R2_PUBLIC_BUCKET
         )
@@ -241,7 +250,7 @@ class TestVerify:
         )
         await db_session.commit()
 
-        mock_r2 = AsyncMock()
+        mock_r2 = _attach_bulk_session(AsyncMock())
         mock_r2.object_exists = AsyncMock(return_value=True)
         with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
             report = await verify(sample=None)
@@ -267,7 +276,7 @@ class TestVerify:
         )
         await db_session.commit()
 
-        mock_r2 = AsyncMock()
+        mock_r2 = _attach_bulk_session(AsyncMock())
         mock_r2.object_exists = AsyncMock(return_value=False)
         with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2):
             report = await verify(sample=None)

--- a/tests/unit/test_review_deadline_job.py
+++ b/tests/unit/test_review_deadline_job.py
@@ -508,7 +508,7 @@ class TestEarlyClose:
         await db_session.refresh(review)
         await db_session.refresh(image)
 
-        assert closed is True
+        assert closed is not None
         assert review.status == ReviewStatus.CLOSED
         assert review.outcome == ReviewOutcome.KEEP
         assert image.status == ImageStatus.ACTIVE
@@ -527,7 +527,7 @@ class TestEarlyClose:
         await db_session.refresh(review)
         await db_session.refresh(image)
 
-        assert closed is True
+        assert closed is not None
         assert review.status == ReviewStatus.CLOSED
         assert review.outcome == ReviewOutcome.REMOVE
         assert image.status == ImageStatus.INAPPROPRIATE
@@ -544,7 +544,7 @@ class TestEarlyClose:
 
         await db_session.refresh(review)
 
-        assert closed is False
+        assert closed is None
         assert review.status == ReviewStatus.OPEN
 
     async def test_early_close_tie(self, db_session: AsyncSession):
@@ -559,7 +559,7 @@ class TestEarlyClose:
 
         await db_session.refresh(review)
 
-        assert closed is False
+        assert closed is None
         assert review.status == ReviewStatus.OPEN
 
     async def test_early_close_large_margin_keep(self, db_session: AsyncSession):
@@ -576,7 +576,7 @@ class TestEarlyClose:
         await db_session.refresh(review)
         await db_session.refresh(image)
 
-        assert closed is True
+        assert closed is not None
         assert review.outcome == ReviewOutcome.KEEP
         assert image.status == ImageStatus.ACTIVE
 
@@ -615,5 +615,5 @@ class TestEarlyClose:
 
         await db_session.refresh(review)
 
-        assert closed is False
+        assert closed is None
         assert review.status == ReviewStatus.OPEN

--- a/uv.lock
+++ b/uv.lock
@@ -182,6 +182,15 @@ wheels = [
 ]
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/5f/2cdf6f7aca3b20d3f316e9f505292e1f256a32089bd702034c29ebde6242/antlr4_python3_runtime-4.13.2.tar.gz", hash = "sha256:909b647e1d2fc2b70180ac586df3933e38919c85f98ccc656a96cd3f25ef3916", size = 117467, upload-time = "2024-08-03T19:00:12.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl", hash = "sha256:fe3835eb8d33daece0e799090eda89719dbccee7aa39ef94eed3818cafa5a7e8", size = 144462, upload-time = "2024-08-03T19:00:11.134Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -213,6 +222,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "aws-sam-translator"
+version = "1.103.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e3/82cc7240504b1c0d2d7ed7028b05ccceedb02932b8638c61a8372a5d875f/aws_sam_translator-1.103.0.tar.gz", hash = "sha256:8317b72ef412db581dc7846932a44dfc1729adea578d9307a3e6ece46a7882ca", size = 344881, upload-time = "2025-11-21T19:50:51.818Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/86/6414c215ff0a10b33bf89622951e7d4413106320657535d2ba0e4f634661/aws_sam_translator-1.103.0-py3-none-any.whl", hash = "sha256:d4eb4a1efa62f00b253ee5f8c0084bd4b7687186c6a12338f900ebe07ff74dad", size = 403100, upload-time = "2025-11-21T19:50:50.528Z" },
+]
+
+[[package]]
+name = "aws-xray-sdk"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/25/0cbd7a440080def5e6f063720c3b190a25f8aa2938c1e34415dc18241596/aws_xray_sdk-2.15.0.tar.gz", hash = "sha256:794381b96e835314345068ae1dd3b9120bd8b4e21295066c37e8814dbb341365", size = 76315, upload-time = "2025-10-29T20:59:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/c3/f30a7a63e664acc7c2545ca0491b6ce8264536e0e5cad3965f1d1b91e960/aws_xray_sdk-2.15.0-py2.py3-none-any.whl", hash = "sha256:422d62ad7d52e373eebb90b642eb1bb24657afe03b22a8df4a8b2e5108e278a3", size = 103228, upload-time = "2025-10-29T21:00:24.12Z" },
 ]
 
 [[package]]
@@ -264,6 +301,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
     { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
     { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
 ]
 
 [[package]]
@@ -382,6 +428,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "cfn-lint"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aws-sam-translator" },
+    { name = "jsonpatch" },
+    { name = "networkx" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/b5/436c192cdf8dbddd8e09a591384f126c5a47937c14953d87b1dacacd0543/cfn_lint-1.41.0.tar.gz", hash = "sha256:6feca1cf57f9ed2833bab68d9b1d38c8033611e571fa792e45ab4a39e2b8ab57", size = 3408534, upload-time = "2025-11-18T20:03:33.431Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/5e/81ef8f87894543210d783a495c8880cfb0b5baa0ee3bcc6d852f1b343863/cfn_lint-1.41.0-py3-none-any.whl", hash = "sha256:cd43f76f59a664b2bad580840827849fac0d56a3b80e9a41315d8ab5ff6b563a", size = 5674429, upload-time = "2025-11-18T20:03:31.083Z" },
 ]
 
 [[package]]
@@ -561,6 +625,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -685,6 +763,36 @@ wheels = [
 ]
 
 [[package]]
+name = "flask"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
+]
+
+[[package]]
+name = "flask-cors"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/74/0fc0fa68d62f21daef41017dafab19ef4b36551521260987eb3a5394c7ba/flask_cors-6.0.2.tar.gz", hash = "sha256:6e118f3698249ae33e429760db98ce032a8bf9913638d085ca0f4c5534ad2423", size = 13472, upload-time = "2025-12-12T20:31:42.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/af/72ad54402e599152de6d067324c46fe6a4f531c7c65baf7e96c63db55eaf/flask_cors-6.0.2-py3-none-any.whl", hash = "sha256:e57544d415dfd7da89a9564e1e3a9e515042df76e12130641ca6f3f2f03b699a", size = 13257, upload-time = "2025-12-12T20:31:41.3Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -723,6 +831,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "graphql-core"
+version = "3.2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/c5/36aa96205c3ecbb3d34c7c24189e4553c7ca2ebc7e1dd07432339b980272/graphql_core-3.2.8.tar.gz", hash = "sha256:015457da5d996c924ddf57a43f4e959b0b94fb695b85ed4c29446e508ed65cf3", size = 513181, upload-time = "2026-03-05T19:55:37.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/41/cb887d9afc5dabd78feefe6ccbaf83ff423c206a7a1b7aeeac05120b2125/graphql_core-3.2.8-py3-none-any.whl", hash = "sha256:cbee07bee1b3ed5e531723685369039f32ff815ef60166686e0162f540f1520c", size = 207349, upload-time = "2026-03-05T19:55:35.911Z" },
 ]
 
 [[package]]
@@ -856,6 +973,15 @@ wheels = [
 ]
 
 [[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -874,6 +1000,103 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpath-ng"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/58/250751940d75c8019659e15482d548a4aa3b6ce122c515102a4bfdac50e3/jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3", size = 74513, upload-time = "2026-02-24T14:42:06.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/99/33c7d78a3fb70d545fd5411ac67a651c81602cc09c9cf0df383733f068c5/jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138", size = 67844, upload-time = "2026-02-28T00:53:19.637Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/6e/35174c1d3f30560848c82d3c233c01420e047d70925c897a4d6e932b4898/jsonschema-4.24.1.tar.gz", hash = "sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d", size = 356635, upload-time = "2025-07-17T14:40:01.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/7f/ea48ffb58f9791f9d97ccb35e42fea1ebc81c67ce36dc4b8b2eee60e8661/jsonschema-4.24.1-py3-none-any.whl", hash = "sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627", size = 89060, upload-time = "2025-07-17T14:39:59.471Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/8a/7e6102f2b8bdc6705a9eb5294f8f6f9ccd3a8420e8e8e19671d1dd773251/jsonschema_path-0.4.5.tar.gz", hash = "sha256:c6cd7d577ae290c7defd4f4029e86fdb248ca1bd41a07557795b3c95e5144918", size = 15113, upload-time = "2026-03-03T09:56:46.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/d5/4e96c44f6c1ea3d812cf5391d81a4f5abaa540abf8d04ecd7f66e0ed11df/jsonschema_path-0.4.5-py3-none-any.whl", hash = "sha256:7d77a2c3f3ec569a40efe5c5f942c44c1af2a6f96fe0866794c9ef5b8f87fd65", size = 19368, upload-time = "2026-03-03T09:56:45.39Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a2/69df9c6ba6d316cfd81fe2381e464db3e6de5db45f8c43c6a23504abf8cb/lazy_object_proxy-1.12.0.tar.gz", hash = "sha256:1f5a462d92fd0cfb82f1fab28b51bfb209fabbe6aabf7f0d51472c0c124c0c61", size = 43681, upload-time = "2025-08-22T13:50:06.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3a/277857b51ae419a1574557c0b12e0d06bf327b758ba94cafc664cb1e2f66/lazy_object_proxy-1.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c9defba70ab943f1df98a656247966d7729da2fe9c2d5d85346464bf320820a3", size = 26582, upload-time = "2025-08-22T13:49:49.366Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b6/c5e0fa43535bb9c87880e0ba037cdb1c50e01850b0831e80eb4f4762f270/lazy_object_proxy-1.12.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6763941dbf97eea6b90f5b06eb4da9418cc088fce0e3883f5816090f9afcde4a", size = 71059, upload-time = "2025-08-22T13:49:50.488Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8a/7dcad19c685963c652624702f1a968ff10220b16bfcc442257038216bf55/lazy_object_proxy-1.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdc70d81235fc586b9e3d1aeef7d1553259b62ecaae9db2167a5d2550dcc391a", size = 71034, upload-time = "2025-08-22T13:49:54.224Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ac/34cbfb433a10e28c7fd830f91c5a348462ba748413cbb950c7f259e67aa7/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0a83c6f7a6b2bfc11ef3ed67f8cbe99f8ff500b05655d8e7df9aab993a6abc95", size = 69529, upload-time = "2025-08-22T13:49:55.29Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6a/11ad7e349307c3ca4c0175db7a77d60ce42a41c60bcb11800aabd6a8acb8/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:256262384ebd2a77b023ad02fbcc9326282bcfd16484d5531154b02bc304f4c5", size = 70391, upload-time = "2025-08-22T13:49:56.35Z" },
+    { url = "https://files.pythonhosted.org/packages/59/97/9b410ed8fbc6e79c1ee8b13f8777a80137d4bc189caf2c6202358e66192c/lazy_object_proxy-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7601ec171c7e8584f8ff3f4e440aa2eebf93e854f04639263875b8c2971f819f", size = 26988, upload-time = "2025-08-22T13:49:57.302Z" },
 ]
 
 [[package]]
@@ -1006,6 +1229,33 @@ s3 = [
     { name = "py-partiql-parser" },
     { name = "pyyaml" },
 ]
+server = [
+    { name = "antlr4-python3-runtime" },
+    { name = "aws-sam-translator" },
+    { name = "aws-xray-sdk" },
+    { name = "cfn-lint" },
+    { name = "docker" },
+    { name = "flask" },
+    { name = "flask-cors" },
+    { name = "graphql-core" },
+    { name = "joserfc" },
+    { name = "jsonpath-ng" },
+    { name = "openapi-spec-validator" },
+    { name = "py-partiql-parser" },
+    { name = "pydantic" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
 
 [[package]]
 name = "msgpack"
@@ -1109,12 +1359,55 @@ wheels = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
+name = "openapi-schema-validator"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-specifications" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/4b/67b24b2b23d96ea862be2cca3632a546f67a22461200831213e80c3c6011/openapi_schema_validator-0.8.1.tar.gz", hash = "sha256:4c57266ce8cbfa37bb4eb4d62cdb7d19356c3a468e3535743c4562863e1790da", size = 23134, upload-time = "2026-03-02T08:46:29.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/87/e9f29f463b230d4b47d65e17858c595153a8ca8c1775f16e406aa82d455d/openapi_schema_validator-0.8.1-py3-none-any.whl", hash = "sha256:0f5859794c5bfa433d478dc5ac5e5768d50adc56b14380c8a6fd3a8113e89c9b", size = 19211, upload-time = "2026-03-02T08:46:28.154Z" },
+]
+
+[[package]]
+name = "openapi-spec-validator"
+version = "0.8.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "lazy-object-proxy" },
+    { name = "openapi-schema-validator" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/de/0199b15f5dde3ca61df6e6b3987420bfd424db077998f0162e8ffe12e4f5/openapi_spec_validator-0.8.4.tar.gz", hash = "sha256:8bb324b9b08b9b368b1359dec14610c60a8f3a3dd63237184eb04456d4546f49", size = 1756847, upload-time = "2026-03-01T15:48:19.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/70/52310f9ece5f4eb02e0b31d538b51f729169517767a8d0100a25db31d67f/openapi_spec_validator-0.8.4-py3-none-any.whl", hash = "sha256:cf905117063d7c4d495c8a5a167a1f2a8006da6ffa8ba234a7ed0d0f11454d51", size = 50330, upload-time = "2026-03-01T15:48:17.668Z" },
 ]
 
 [[package]]
@@ -1133,6 +1426,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
 ]
 
 [[package]]
@@ -1337,7 +1639,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.12.5"
+version = "2.12.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -1345,9 +1647,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/ad/a17bc283d7d81837c061c49e3eaa27a45991759a1b7eae1031921c6bd924/pydantic-2.12.4.tar.gz", hash = "sha256:0f8cb9555000a4b5b617f66bfd2566264c4984b27589d3b845685983e8ea85ac", size = 821038, upload-time = "2025-11-05T10:50:08.59Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/e68750da9b04856e2a7ec56fc6f034a5a79775e9b9a81882252789873798/pydantic-2.12.4-py3-none-any.whl", hash = "sha256:92d3d202a745d46f9be6df459ac5a064fdaa3c1c4cd8adcfa332ccf3c05f871e", size = 463400, upload-time = "2025-11-05T10:50:06.732Z" },
 ]
 
 [package.optional-dependencies]
@@ -1538,6 +1840,16 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1581,6 +1893,59 @@ hiredis = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000, upload-time = "2026-04-03T20:56:28.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f5/ed97c2dc47b5fbd4b73c0d7d75f9ebc8eca139f2bbef476bba35f28c0a77/regex-2026.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2da82d643fa698e5e5210e54af90181603d5853cf469f5eedf9bfc8f59b4b8c7", size = 490343, upload-time = "2026-04-03T20:55:15.241Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/de4828a7385ec166d673a5790ad06ac48cdaa98bc0960108dd4b9cc1aef7/regex-2026.4.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:54a1189ad9d9357760557c91103d5e421f0a2dabe68a5cdf9103d0dcf4e00752", size = 291909, upload-time = "2026-04-03T20:55:17.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d6/5cfbfc97f3201a4d24b596a77957e092030dcc4205894bc035cedcfce62f/regex-2026.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:76d67d5afb1fe402d10a6403bae668d000441e2ab115191a804287d53b772951", size = 289692, upload-time = "2026-04-03T20:55:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/f2212d9fd56fe897e36d0110ba30ba2d247bd6410c5bd98499c7e5a1e1f2/regex-2026.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7cd3e4ee8d80447a83bbc9ab0c8459781fa77087f856c3e740d7763be0df27f", size = 796979, upload-time = "2026-04-03T20:55:22.56Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e3/a016c12675fbac988a60c7e1c16e67823ff0bc016beb27bd7a001dbdabc6/regex-2026.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e19e18c568d2866d8b6a6dfad823db86193503f90823a8f66689315ba28fbe8", size = 866744, upload-time = "2026-04-03T20:55:24.646Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a4/0b90ca4cf17adc3cb43de80ec71018c37c88ad64987e8d0d481a95ca60b5/regex-2026.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7698a6f38730fd1385d390d1ed07bb13dce39aa616aca6a6d89bea178464b9a4", size = 911613, upload-time = "2026-04-03T20:55:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3b/2b3dac0b82d41ab43aa87c6ecde63d71189d03fe8854b8ca455a315edac3/regex-2026.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:173a66f3651cdb761018078e2d9487f4cf971232c990035ec0eb1cdc6bf929a9", size = 800551, upload-time = "2026-04-03T20:55:29.532Z" },
+    { url = "https://files.pythonhosted.org/packages/25/fe/5365eb7aa0e753c4b5957815c321519ecab033c279c60e1b1ae2367fa810/regex-2026.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa7922bbb2cc84fa062d37723f199d4c0cd200245ce269c05db82d904db66b83", size = 776911, upload-time = "2026-04-03T20:55:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b3/7fb0072156bba065e3b778a7bc7b0a6328212be5dd6a86fd207e0c4f2dab/regex-2026.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:59f67cd0a0acaf0e564c20bbd7f767286f23e91e2572c5703bf3e56ea7557edb", size = 785751, upload-time = "2026-04-03T20:55:33.797Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1a/9f83677eb699273e56e858f7bd95acdbee376d42f59e8bfca2fd80d79df3/regex-2026.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:475e50f3f73f73614f7cba5524d6de49dee269df00272a1b85e3d19f6d498465", size = 860484, upload-time = "2026-04-03T20:55:35.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/7a/93937507b61cfcff8b4c5857f1b452852b09f741daa9acae15c971d8554e/regex-2026.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:a1c0c7d67b64d85ac2e1879923bad2f08a08f3004055f2f406ef73c850114bd4", size = 765939, upload-time = "2026-04-03T20:55:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ea/81a7f968a351c6552b1670ead861e2a385be730ee28402233020c67f9e0f/regex-2026.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:1371c2ccbb744d66ee63631cc9ca12aa233d5749972626b68fe1a649dd98e566", size = 851417, upload-time = "2026-04-03T20:55:39.92Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7e/323c18ce4b5b8f44517a36342961a0306e931e499febbd876bb149d900f0/regex-2026.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:59968142787042db793348a3f5b918cf24ced1f23247328530e063f89c128a95", size = 789056, upload-time = "2026-04-03T20:55:42.303Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/af/e7510f9b11b1913b0cd44eddb784b2d650b2af6515bfce4cffcc5bfd1d38/regex-2026.4.4-cp314-cp314-win32.whl", hash = "sha256:59efe72d37fd5a91e373e5146f187f921f365f4abc1249a5ab446a60f30dd5f8", size = 272130, upload-time = "2026-04-03T20:55:44.995Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/51/57dae534c915e2d3a21490e88836fa2ae79dde3b66255ecc0c0a155d2c10/regex-2026.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:e0aab3ff447845049d676827d2ff714aab4f73f340e155b7de7458cf53baa5a4", size = 280992, upload-time = "2026-04-03T20:55:47.316Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5e/abaf9f4c3792e34edb1434f06717fae2b07888d85cb5cec29f9204931bf8/regex-2026.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:a7a5bb6aa0cf62208bb4fa079b0c756734f8ad0e333b425732e8609bd51ee22f", size = 273563, upload-time = "2026-04-03T20:55:49.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/06/35da85f9f217b9538b99cbb170738993bcc3b23784322decb77619f11502/regex-2026.4.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:97850d0638391bdc7d35dc1c1039974dcb921eaafa8cc935ae4d7f272b1d60b3", size = 494191, upload-time = "2026-04-03T20:55:51.258Z" },
+    { url = "https://files.pythonhosted.org/packages/54/5b/1bc35f479eef8285c4baf88d8c002023efdeebb7b44a8735b36195486ae7/regex-2026.4.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ee7337f88f2a580679f7bbfe69dc86c043954f9f9c541012f49abc554a962f2e", size = 293877, upload-time = "2026-04-03T20:55:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5b/f53b9ad17480b3ddd14c90da04bfb55ac6894b129e5dea87bcaf7d00e336/regex-2026.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7429f4e6192c11d659900c0648ba8776243bf396ab95558b8c51a345afeddde6", size = 292410, upload-time = "2026-04-03T20:55:55.736Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/56/52377f59f60a7c51aa4161eecf0b6032c20b461805aca051250da435ffc9/regex-2026.4.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4f10fbd5dd13dcf4265b4cc07d69ca70280742870c97ae10093e3d66000359", size = 811831, upload-time = "2026-04-03T20:55:57.802Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/63/8026310bf066f702a9c361f83a8c9658f3fe4edb349f9c1e5d5273b7c40c/regex-2026.4.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a152560af4f9742b96f3827090f866eeec5becd4765c8e0d3473d9d280e76a5a", size = 871199, upload-time = "2026-04-03T20:56:00.333Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9f/a514bbb00a466dbb506d43f187a04047f7be1505f10a9a15615ead5080ee/regex-2026.4.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54170b3e95339f415d54651f97df3bff7434a663912f9358237941bbf9143f55", size = 917649, upload-time = "2026-04-03T20:56:02.445Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6b/8399f68dd41a2030218839b9b18360d79b86d22b9fab5ef477c7f23ca67c/regex-2026.4.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:07f190d65f5a72dcb9cf7106bfc3d21e7a49dd2879eda2207b683f32165e4d99", size = 816388, upload-time = "2026-04-03T20:56:04.595Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/9c/103963f47c24339a483b05edd568594c2be486188f688c0170fd504b2948/regex-2026.4.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9a2741ce5a29d3c84b0b94261ba630ab459a1b847a0d6beca7d62d188175c790", size = 785746, upload-time = "2026-04-03T20:56:07.13Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ee/7f6054c0dec0cee3463c304405e4ff42e27cff05bf36fcb34be549ab17bd/regex-2026.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b26c30df3a28fd9793113dac7385a4deb7294a06c0f760dd2b008bd49a9139bc", size = 801483, upload-time = "2026-04-03T20:56:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c2/51d3d941cf6070dc00c3338ecf138615fc3cce0421c3df6abe97a08af61a/regex-2026.4.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:421439d1bee44b19f4583ccf42670ca464ffb90e9fdc38d37f39d1ddd1e44f1f", size = 866331, upload-time = "2026-04-03T20:56:12.039Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e8/76d50dcc122ac33927d939f350eebcfe3dbcbda96913e03433fc36de5e63/regex-2026.4.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b40379b53ecbc747fd9bdf4a0ea14eb8188ca1bd0f54f78893a39024b28f4863", size = 772673, upload-time = "2026-04-03T20:56:14.558Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/5f6bf75e20ea6873d05ba4ec78378c375cbe08cdec571c83fbb01606e563/regex-2026.4.4-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:08c55c13d2eef54f73eeadc33146fb0baaa49e7335eb1aff6ae1324bf0ddbe4a", size = 857146, upload-time = "2026-04-03T20:56:16.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/33/3c76d9962949e487ebba353a18e89399f292287204ac8f2f4cfc3a51c233/regex-2026.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9776b85f510062f5a75ef112afe5f494ef1635607bf1cc220c1391e9ac2f5e81", size = 803463, upload-time = "2026-04-03T20:56:18.923Z" },
+    { url = "https://files.pythonhosted.org/packages/19/eb/ef32dcd2cb69b69bc0c3e55205bce94a7def48d495358946bc42186dcccc/regex-2026.4.4-cp314-cp314t-win32.whl", hash = "sha256:385edaebde5db5be103577afc8699fea73a0e36a734ba24870be7ffa61119d74", size = 275709, upload-time = "2026-04-03T20:56:20.996Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/86/c291bf740945acbf35ed7dbebf8e2eea2f3f78041f6bd7cdab80cb274dc0/regex-2026.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:5d354b18839328927832e2fa5f7c95b7a3ccc39e7a681529e1685898e6436d45", size = 285622, upload-time = "2026-04-03T20:56:23.641Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/ec846d560ae6a597115153c02ca6138a7877a1748b2072d9521c10a93e58/regex-2026.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:af0384cb01a33600c49505c27c6c57ab0b27bf84a74e28524c92ca897ebdac9d", size = 275773, upload-time = "2026-04-03T20:56:26.07Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1607,6 +1972,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
 ]
 
 [[package]]
@@ -1675,6 +2052,43 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1726,6 +2140,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1762,7 +2185,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "moto", extra = ["s3"] },
+    { name = "moto", extra = ["s3", "server"] },
     { name = "mypy" },
     { name = "pip-audit" },
     { name = "pre-commit" },
@@ -1800,7 +2223,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
+    { name = "moto", extras = ["s3", "server"], specifier = ">=5.0.0" },
     { name = "mypy", specifier = ">=1.11.0" },
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pre-commit", specifier = ">=3.5.0" },
@@ -1881,6 +2304,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,120 @@ revision = 3
 requires-python = ">=3.14"
 
 [[package]]
+name = "aioboto3"
+version = "15.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiobotocore", extra = ["boto3"] },
+    { name = "aiofiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/01/92e9ab00f36e2899315f49eefcd5b4685fbb19016c7f19a9edf06da80bb0/aioboto3-15.5.0.tar.gz", hash = "sha256:ea8d8787d315594842fbfcf2c4dce3bac2ad61be275bc8584b2ce9a3402a6979", size = 255069, upload-time = "2025-10-30T13:37:16.122Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/3e/e8f5b665bca646d43b916763c901e00a07e40f7746c9128bdc912a089424/aioboto3-15.5.0-py3-none-any.whl", hash = "sha256:cc880c4d6a8481dd7e05da89f41c384dbd841454fc1998ae25ca9c39201437a6", size = 35913, upload-time = "2025-10-30T13:37:14.549Z" },
+]
+
+[[package]]
+name = "aiobotocore"
+version = "2.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aioitertools" },
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "multidict" },
+    { name = "python-dateutil" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/94/2e4ec48cf1abb89971cb2612d86f979a6240520f0a659b53a43116d344dc/aiobotocore-2.25.1.tar.gz", hash = "sha256:ea9be739bfd7ece8864f072ec99bb9ed5c7e78ebb2b0b15f29781fbe02daedbc", size = 120560, upload-time = "2025-10-28T22:33:21.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/2a/d275ec4ce5cd0096665043995a7d76f5d0524853c76a3d04656de49f8808/aiobotocore-2.25.1-py3-none-any.whl", hash = "sha256:eb6daebe3cbef5b39a0bb2a97cffbe9c7cb46b2fcc399ad141f369f3c2134b1f", size = 86039, upload-time = "2025-10-28T22:33:19.949Z" },
+]
+
+[package.optional-dependencies]
+boto3 = [
+    { name = "boto3" },
+]
+
+[[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/ce/46572759afc859e867a5bc8ec3487315869013f59281ce61764f76d879de/aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c", size = 745721, upload-time = "2026-03-31T21:58:50.229Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fe/8a2efd7626dbe6049b2ef8ace18ffda8a4dfcbe1bcff3ac30c0c7575c20b/aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be", size = 497663, upload-time = "2026-03-31T21:58:52.232Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25", size = 499094, upload-time = "2026-03-31T21:58:54.566Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56", size = 1726701, upload-time = "2026-03-31T21:58:56.864Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0c/c091ac5c3a17114bd76cbf85d674650969ddf93387876cf67f754204bd77/aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2", size = 1683360, upload-time = "2026-03-31T21:58:59.072Z" },
+    { url = "https://files.pythonhosted.org/packages/23/73/bcee1c2b79bc275e964d1446c55c54441a461938e70267c86afaae6fba27/aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a", size = 1773023, upload-time = "2026-03-31T21:59:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ef/720e639df03004fee2d869f771799d8c23046dec47d5b81e396c7cda583a/aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be", size = 1853795, upload-time = "2026-03-31T21:59:04.568Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b", size = 1730405, upload-time = "2026-03-31T21:59:07.221Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/75/ee1fd286ca7dc599d824b5651dad7b3be7ff8d9a7e7b3fe9820d9180f7db/aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94", size = 1558082, upload-time = "2026-03-31T21:59:09.484Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/20/1e9e6650dfc436340116b7aa89ff8cb2bbdf0abc11dfaceaad8f74273a10/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d", size = 1692346, upload-time = "2026-03-31T21:59:12.068Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/40/8ebc6658d48ea630ac7903912fe0dd4e262f0e16825aa4c833c56c9f1f56/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7", size = 1698891, upload-time = "2026-03-31T21:59:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/78/ea0ae5ec8ba7a5c10bdd6e318f1ba5e76fcde17db8275188772afc7917a4/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772", size = 1742113, upload-time = "2026-03-31T21:59:17.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/66/9d308ed71e3f2491be1acb8769d96c6f0c47d92099f3bc9119cada27b357/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5", size = 1553088, upload-time = "2026-03-31T21:59:19.541Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a6/6cc25ed8dfc6e00c90f5c6d126a98e2cf28957ad06fa1036bd34b6f24a2c/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1", size = 1757976, upload-time = "2026-03-31T21:59:22.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2b/cce5b0ffe0de99c83e5e36d8f828e4161e415660a9f3e58339d07cce3006/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b", size = 1712444, upload-time = "2026-03-31T21:59:24.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/cf/9e1795b4160c58d29421eafd1a69c6ce351e2f7c8d3c6b7e4ca44aea1a5b/aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3", size = 438128, upload-time = "2026-03-31T21:59:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4d/eaedff67fc805aeba4ba746aec891b4b24cebb1a7d078084b6300f79d063/aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162", size = 464029, upload-time = "2026-03-31T21:59:29.429Z" },
+    { url = "https://files.pythonhosted.org/packages/79/11/c27d9332ee20d68dd164dc12a6ecdef2e2e35ecc97ed6cf0d2442844624b/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a", size = 778758, upload-time = "2026-03-31T21:59:31.547Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fb/377aead2e0a3ba5f09b7624f702a964bdf4f08b5b6728a9799830c80041e/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254", size = 512883, upload-time = "2026-03-31T21:59:34.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a6/aa109a33671f7a5d3bd78b46da9d852797c5e665bfda7d6b373f56bff2ec/aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36", size = 516668, upload-time = "2026-03-31T21:59:36.497Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b3/ca078f9f2fa9563c36fb8ef89053ea2bb146d6f792c5104574d49d8acb63/aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f", size = 1883461, upload-time = "2026-03-31T21:59:38.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e3/a7ad633ca1ca497b852233a3cce6906a56c3225fb6d9217b5e5e60b7419d/aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800", size = 1747661, upload-time = "2026-03-31T21:59:41.187Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b9/cd6fe579bed34a906d3d783fe60f2fa297ef55b27bb4538438ee49d4dc41/aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf", size = 1863800, upload-time = "2026-03-31T21:59:43.84Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3f/2c1e2f5144cefa889c8afd5cf431994c32f3b29da9961698ff4e3811b79a/aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b", size = 1958382, upload-time = "2026-03-31T21:59:46.187Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/f31ec3f1013723b3babe3609e7f119c2c2fb6ef33da90061a705ef3e1bc8/aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a", size = 1803724, upload-time = "2026-03-31T21:59:48.656Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b4/57712dfc6f1542f067daa81eb61da282fab3e6f1966fca25db06c4fc62d5/aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8", size = 1640027, upload-time = "2026-03-31T21:59:51.284Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3c/734c878fb43ec083d8e31bf029daae1beafeae582d1b35da234739e82ee7/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be", size = 1806644, upload-time = "2026-03-31T21:59:53.753Z" },
+    { url = "https://files.pythonhosted.org/packages/20/a5/f671e5cbec1c21d044ff3078223f949748f3a7f86b14e34a365d74a5d21f/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b", size = 1791630, upload-time = "2026-03-31T21:59:56.239Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/fb8d0ad63a0b8a99be97deac8c04dacf0785721c158bdf23d679a87aa99e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6", size = 1809403, upload-time = "2026-03-31T21:59:59.103Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0c/bfed7f30662fcf12206481c2aac57dedee43fe1c49275e85b3a1e1742294/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037", size = 1634924, upload-time = "2026-03-31T22:00:02.116Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d6/fd518d668a09fd5a3319ae5e984d4d80b9a4b3df4e21c52f02251ef5a32e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500", size = 1836119, upload-time = "2026-03-31T22:00:04.756Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+]
+
+[[package]]
+name = "aioitertools"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/53c4a17a05fb9ea2313ee1777ff53f5e001aefd5cc85aa2f4c2d982e1e38/aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c", size = 19322, upload-time = "2025-11-06T22:17:07.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be", size = 24182, upload-time = "2025-11-06T22:17:06.502Z" },
+]
+
+[[package]]
 name = "aiomysql"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -12,6 +126,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/29/e0/302aeffe8d90853556f47f3106b89c16cc2ec2a4d269bdfd82e3f4ae12cc/aiomysql-0.3.2.tar.gz", hash = "sha256:72d15ef5cfc34c03468eb41e1b90adb9fd9347b0b589114bd23ead569a02ac1a", size = 108311, upload-time = "2025-10-22T00:15:21.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/af/aae0153c3e28712adaf462328f6c7a3c196a1c1c27b491de4377dd3e6b52/aiomysql-0.3.2-py3-none-any.whl", hash = "sha256:c82c5ba04137d7afd5c693a258bea8ead2aad77101668044143a991e04632eb2", size = 71834, upload-time = "2025-10-22T00:15:15.905Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
 ]
 
 [[package]]
@@ -81,6 +207,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -138,6 +273,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.40.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/f9/6ef8feb52c3cce5ec3967a535a6114b57ac7949fd166b0f3090c2b06e4e5/boto3-1.40.61.tar.gz", hash = "sha256:d6c56277251adf6c2bdd25249feae625abe4966831676689ff23b4694dea5b12", size = 111535, upload-time = "2025-10-28T19:26:57.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/24/3bf865b07d15fea85b63504856e137029b6acbc73762496064219cdb265d/boto3-1.40.61-py3-none-any.whl", hash = "sha256:6b9c57b2a922b5d8c17766e29ed792586a818098efe84def27c8f582b33f898c", size = 139321, upload-time = "2025-10-28T19:26:55.007Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.40.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/a3/81d3a47c2dbfd76f185d3b894f2ad01a75096c006a2dd91f237dca182188/botocore-1.40.61.tar.gz", hash = "sha256:a2487ad69b090f9cccd64cf07c7021cd80ee9c0655ad974f87045b02f3ef52cd", size = 14393956, upload-time = "2025-10-28T19:26:46.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/c5/f6ce561004db45f0b847c2cd9b19c67c6bf348a82018a48cb718be6b58b0/botocore-1.40.61-py3-none-any.whl", hash = "sha256:17ebae412692fd4824f99cde0f08d50126dc97954008e5ba2b522eb049238aa7", size = 14055973, upload-time = "2025-10-28T19:26:42.15Z" },
+]
+
+[[package]]
+name = "botocore-stubs"
+version = "1.42.41"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-awscrt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/a8/a26608ff39e3a5866c6c79eda10133490205cbddd45074190becece3ff2a/botocore_stubs-1.42.41.tar.gz", hash = "sha256:dbeac2f744df6b814ce83ec3f3777b299a015cbea57a2efc41c33b8c38265825", size = 42411, upload-time = "2026-02-03T20:46:14.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/76/cab7af7f16c0b09347f2ebe7ffda7101132f786acb767666dce43055faab/botocore_stubs-1.42.41-py3-none-any.whl", hash = "sha256:9423110fb0e391834bd2ed44ae5f879d8cb370a444703d966d30842ce2bcb5f0", size = 66759, upload-time = "2026-02-03T20:46:13.02Z" },
 ]
 
 [[package]]
@@ -510,6 +685,47 @@ wheels = [
 ]
 
 [[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/c8/85da824b7e7b9b6e7f7705b2ecaf9591ba6f79c1177f324c2735e41d36a2/frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0", size = 86127, upload-time = "2025-10-06T05:37:08.438Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f", size = 49698, upload-time = "2025-10-06T05:37:09.48Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c", size = 49749, upload-time = "2025-10-06T05:37:10.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2", size = 231298, upload-time = "2025-10-06T05:37:11.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8", size = 232015, upload-time = "2025-10-06T05:37:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/be719d2766c1138148564a3960fc2c06eb688da592bdc25adcf856101be7/frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686", size = 225038, upload-time = "2025-10-06T05:37:14.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/09/6712b6c5465f083f52f50cf74167b92d4ea2f50e46a9eea0523d658454ae/frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e", size = 240130, upload-time = "2025-10-06T05:37:15.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d4/cd065cdcf21550b54f3ce6a22e143ac9e4836ca42a0de1022da8498eac89/frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a", size = 242845, upload-time = "2025-10-06T05:37:17.037Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/f57a5c8c70cd1ead3d5d5f776f89d33110b1addae0ab010ad774d9a44fb9/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128", size = 229131, upload-time = "2025-10-06T05:37:18.221Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/52/232476fe9cb64f0742f3fde2b7d26c1dac18b6d62071c74d4ded55e0ef94/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f", size = 240542, upload-time = "2025-10-06T05:37:19.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/07bf3f5d0fb5414aee5f47d33c6f5c77bfe49aac680bfece33d4fdf6a246/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7", size = 237308, upload-time = "2025-10-06T05:37:20.969Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/ae3a33d5befd41ac0ca2cc7fd3aa707c9c324de2e89db0e0f45db9a64c26/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30", size = 238210, upload-time = "2025-10-06T05:37:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/60/b1d2da22f4970e7a155f0adde9b1435712ece01b3cd45ba63702aea33938/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7", size = 231972, upload-time = "2025-10-06T05:37:23.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ab/945b2f32de889993b9c9133216c068b7fcf257d8595a0ac420ac8677cab0/frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806", size = 40536, upload-time = "2025-10-06T05:37:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0", size = 44330, upload-time = "2025-10-06T05:37:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/82/13/e6950121764f2676f43534c555249f57030150260aee9dcf7d64efda11dd/frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b", size = 40627, upload-time = "2025-10-06T05:37:28.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/43200656ecc4e02d3f8bc248df68256cd9572b3f0017f0a0c4e93440ae23/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d", size = 89238, upload-time = "2025-10-06T05:37:29.373Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/55c5f0689b9c0fb765055629f472c0de484dcaf0acee2f7707266ae3583c/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed", size = 50738, upload-time = "2025-10-06T05:37:30.792Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7d/b7282a445956506fa11da8c2db7d276adcbf2b17d8bb8407a47685263f90/frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930", size = 51739, upload-time = "2025-10-06T05:37:32.127Z" },
+    { url = "https://files.pythonhosted.org/packages/62/1c/3d8622e60d0b767a5510d1d3cf21065b9db874696a51ea6d7a43180a259c/frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c", size = 284186, upload-time = "2025-10-06T05:37:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/14/aa36d5f85a89679a85a1d44cd7a6657e0b1c75f61e7cad987b203d2daca8/frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24", size = 292196, upload-time = "2025-10-06T05:37:36.107Z" },
+    { url = "https://files.pythonhosted.org/packages/05/23/6bde59eb55abd407d34f77d39a5126fb7b4f109a3f611d3929f14b700c66/frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37", size = 273830, upload-time = "2025-10-06T05:37:37.663Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3f/22cff331bfad7a8afa616289000ba793347fcd7bc275f3b28ecea2a27909/frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a", size = 294289, upload-time = "2025-10-06T05:37:39.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/89/5b057c799de4838b6c69aa82b79705f2027615e01be996d2486a69ca99c4/frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2", size = 300318, upload-time = "2025-10-06T05:37:43.213Z" },
+    { url = "https://files.pythonhosted.org/packages/30/de/2c22ab3eb2a8af6d69dc799e48455813bab3690c760de58e1bf43b36da3e/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef", size = 282814, upload-time = "2025-10-06T05:37:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f7/970141a6a8dbd7f556d94977858cfb36fa9b66e0892c6dd780d2219d8cd8/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe", size = 291762, upload-time = "2025-10-06T05:37:46.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/15/ca1adae83a719f82df9116d66f5bb28bb95557b3951903d39135620ef157/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8", size = 289470, upload-time = "2025-10-06T05:37:47.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/83/dca6dc53bf657d371fbc88ddeb21b79891e747189c5de990b9dfff2ccba1/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a", size = 289042, upload-time = "2025-10-06T05:37:49.499Z" },
+    { url = "https://files.pythonhosted.org/packages/96/52/abddd34ca99be142f354398700536c5bd315880ed0a213812bc491cff5e4/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e", size = 283148, upload-time = "2025-10-06T05:37:50.745Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
+    { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -652,6 +868,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -757,6 +982,32 @@ wheels = [
 ]
 
 [[package]]
+name = "moto"
+version = "5.1.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/3d/1765accbf753dc1ae52f26a2e2ed2881d78c2eb9322c178e45312472e4a0/moto-5.1.22.tar.gz", hash = "sha256:e5b2c378296e4da50ce5a3c355a1743c8d6d396ea41122f5bb2a40f9b9a8cc0e", size = 8547792, upload-time = "2026-03-08T21:06:43.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/4f/8812a01e3e0bd6be3e13b90432fb5c696af9a720af3f00e6eba5ad748345/moto-5.1.22-py3-none-any.whl", hash = "sha256:d9f20ae3cf29c44f93c1f8f06c8f48d5560e5dc027816ef1d0d2059741ffcfbe", size = 6617400, upload-time = "2026-03-08T21:06:41.093Z" },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "msgpack"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -780,6 +1031,51 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
     { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
     { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/cc/db74228a8be41884a567e88a62fd589a913708fcf180d029898c17a9a371/multidict-6.7.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8f333ec9c5eb1b7105e3b84b53141e66ca05a19a605368c55450b6ba208cb9ee", size = 75190, upload-time = "2026-01-26T02:45:10.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a407f13c188f804c759fc6a9f88286a565c242a76b27626594c133b82883b5c2", size = 44486, upload-time = "2026-01-26T02:45:11.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1", size = 43219, upload-time = "2026-01-26T02:45:14.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bb/2c0c2287963f4259c85e8bcbba9182ced8d7fca65c780c38e99e61629d11/multidict-6.7.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1e3a8bb24342a8201d178c3b4984c26ba81a577c80d4d525727427460a50c22d", size = 245132, upload-time = "2026-01-26T02:45:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31", size = 252420, upload-time = "2026-01-26T02:45:17.293Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/78f7275e73fa17b24c9a51b0bd9d73ba64bb32d0ed51b02a746eb876abe7/multidict-6.7.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b10359683bd8806a200fd2909e7c8ca3a7b24ec1d8132e483d58e791d881048", size = 233510, upload-time = "2026-01-26T02:45:19.356Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/8167187f62ae3cbd52da7893f58cb036b47ea3fb67138787c76800158982/multidict-6.7.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:283ddac99f7ac25a4acadbf004cb5ae34480bbeb063520f70ce397b281859362", size = 264094, upload-time = "2026-01-26T02:45:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e7/69a3a83b7b030cf283fb06ce074a05a02322359783424d7edf0f15fe5022/multidict-6.7.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:538cec1e18c067d0e6103aa9a74f9e832904c957adc260e61cd9d8cf0c3b3d37", size = 260786, upload-time = "2026-01-26T02:45:22.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709", size = 248483, upload-time = "2026-01-26T02:45:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/d5a99e3acbca0e29c5d9cba8f92ceb15dce78bab963b308ae692981e3a5d/multidict-6.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa263a02f4f2dd2d11a7b1bb4362aa7cb1049f84a9235d31adf63f30143469a0", size = 248403, upload-time = "2026-01-26T02:45:25.982Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/e58cd31f6c7d5102f2a4bf89f96b9cf7e00b6c6f3d04ecc44417c00a5a3c/multidict-6.7.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2e1425e2f99ec5bd36c15a01b690a1a2456209c5deed58f95469ffb46039ccbb", size = 240315, upload-time = "2026-01-26T02:45:27.487Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/1cd210229559cb90b6786c30676bb0c58249ff42f942765f88793b41fdce/multidict-6.7.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:497394b3239fc6f0e13a78a3e1b61296e72bf1c5f94b4c4eb80b265c37a131cd", size = 245528, upload-time = "2026-01-26T02:45:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/6e1107d226278c876c783056b7db43d800bb64c6131cec9c8dfb6903698e/multidict-6.7.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:233b398c29d3f1b9676b4b6f75c518a06fcb2ea0b925119fb2c1bc35c05e1601", size = 258784, upload-time = "2026-01-26T02:45:30.503Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c1/11f664f14d525e4a1b5327a82d4de61a1db604ab34c6603bb3c2cc63ad34/multidict-6.7.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:93b1818e4a6e0930454f0f2af7dfce69307ca03cdcfb3739bf4d91241967b6c1", size = 251980, upload-time = "2026-01-26T02:45:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9f/75a9ac888121d0c5bbd4ecf4eead45668b1766f6baabfb3b7f66a410e231/multidict-6.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f33dc2a3abe9249ea5d8360f969ec7f4142e7ac45ee7014d8f8d5acddf178b7b", size = 243602, upload-time = "2026-01-26T02:45:34.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e7/50bf7b004cc8525d80dbbbedfdc7aed3e4c323810890be4413e589074032/multidict-6.7.1-cp314-cp314-win32.whl", hash = "sha256:3ab8b9d8b75aef9df299595d5388b14530839f6422333357af1339443cff777d", size = 40930, upload-time = "2026-01-26T02:45:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:5e01429a929600e7dab7b166062d9bb54a5eed752384c7384c968c2afab8f50f", size = 45074, upload-time = "2026-01-26T02:45:37.546Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ab/22803b03285fa3a525f48217963da3a65ae40f6a1b6f6cf2768879e208f9/multidict-6.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:4885cb0e817aef5d00a2e8451d4665c1808378dc27c2705f1bf4ef8505c0d2e5", size = 42471, upload-time = "2026-01-26T02:45:38.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6d/f9293baa6146ba9507e360ea0292b6422b016907c393e2f63fc40ab7b7b5/multidict-6.7.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0458c978acd8e6ea53c81eefaddbbee9c6c5e591f41b3f5e8e194780fe026581", size = 82401, upload-time = "2026-01-26T02:45:40.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/53b5494738d83558d87c3c71a486504d8373421c3e0dbb6d0db48ad42ee0/multidict-6.7.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c0abd12629b0af3cf590982c0b413b1e7395cd4ec026f30986818ab95bfaa94a", size = 48143, upload-time = "2026-01-26T02:45:41.635Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e8/5284c53310dcdc99ce5d66563f6e5773531a9b9fe9ec7a615e9bc306b05f/multidict-6.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:14525a5f61d7d0c94b368a42cff4c9a4e7ba2d52e2672a7b23d84dc86fb02b0c", size = 46507, upload-time = "2026-01-26T02:45:42.99Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/fc/6800d0e5b3875568b4083ecf5f310dcf91d86d52573160834fb4bfcf5e4f/multidict-6.7.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17307b22c217b4cf05033dabefe68255a534d637c6c9b0cc8382718f87be4262", size = 239358, upload-time = "2026-01-26T02:45:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/41/75/4ad0973179361cdf3a113905e6e088173198349131be2b390f9fa4da5fc6/multidict-6.7.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a7e590ff876a3eaf1c02a4dfe0724b6e69a9e9de6d8f556816f29c496046e59", size = 246884, upload-time = "2026-01-26T02:45:47.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/095bb28b5da139bd41fb9a5d5caff412584f377914bd8787c2aa98717130/multidict-6.7.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5fa6a95dfee63893d80a34758cd0e0c118a30b8dcb46372bf75106c591b77889", size = 225878, upload-time = "2026-01-26T02:45:48.698Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d0/c0a72000243756e8f5a277b6b514fa005f2c73d481b7d9e47cd4568aa2e4/multidict-6.7.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a0543217a6a017692aa6ae5cc39adb75e587af0f3a82288b1492eb73dd6cc2a4", size = 253542, upload-time = "2026-01-26T02:45:50.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6b/f69da15289e384ecf2a68837ec8b5ad8c33e973aa18b266f50fe55f24b8c/multidict-6.7.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f99fe611c312b3c1c0ace793f92464d8cd263cc3b26b5721950d977b006b6c4d", size = 252403, upload-time = "2026-01-26T02:45:51.779Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/76/b9669547afa5a1a25cd93eaca91c0da1c095b06b6d2d8ec25b713588d3a1/multidict-6.7.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9004d8386d133b7e6135679424c91b0b854d2d164af6ea3f289f8f2761064609", size = 244889, upload-time = "2026-01-26T02:45:53.27Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a9/a50d2669e506dad33cfc45b5d574a205587b7b8a5f426f2fbb2e90882588/multidict-6.7.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e628ef0e6859ffd8273c69412a2465c4be4a9517d07261b33334b5ec6f3c7489", size = 241982, upload-time = "2026-01-26T02:45:54.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bb/1609558ad8b456b4827d3c5a5b775c93b87878fd3117ed3db3423dfbce1b/multidict-6.7.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:841189848ba629c3552035a6a7f5bf3b02eb304e9fea7492ca220a8eda6b0e5c", size = 232415, upload-time = "2026-01-26T02:45:56.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/59/6f61039d2aa9261871e03ab9dc058a550d240f25859b05b67fd70f80d4b3/multidict-6.7.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce1bbd7d780bb5a0da032e095c951f7014d6b0a205f8318308140f1a6aba159e", size = 240337, upload-time = "2026-01-26T02:45:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/29/fdc6a43c203890dc2ae9249971ecd0c41deaedfe00d25cb6564b2edd99eb/multidict-6.7.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b26684587228afed0d50cf804cc71062cc9c1cdf55051c4c6345d372947b268c", size = 248788, upload-time = "2026-01-26T02:46:00.862Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/14/a153a06101323e4cf086ecee3faadba52ff71633d471f9685c42e3736163/multidict-6.7.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9f9af11306994335398293f9958071019e3ab95e9a707dc1383a35613f6abcb9", size = 242842, upload-time = "2026-01-26T02:46:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/604ae839e64a4a6efc80db94465348d3b328ee955e37acb24badbcd24d83/multidict-6.7.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b4938326284c4f1224178a560987b6cf8b4d38458b113d9b8c1db1a836e640a2", size = 240237, upload-time = "2026-01-26T02:46:05.898Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/c3a5187bf66f6fb546ff4ab8fb5a077cbdd832d7b1908d4365c7f74a1917/multidict-6.7.1-cp314-cp314t-win32.whl", hash = "sha256:98655c737850c064a65e006a3df7c997cd3b220be4ec8fe26215760b9697d4d7", size = 48008, upload-time = "2026-01-26T02:46:07.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
 ]
 
 [[package]]
@@ -971,6 +1267,54 @@ wheels = [
 ]
 
 [[package]]
+name = "propcache"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/5c/bca52d654a896f831b8256683457ceddd490ec18d9ec50e97dfd8fc726a8/propcache-0.4.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3f7124c9d820ba5548d431afb4632301acf965db49e666aa21c305cbe8c6de12", size = 78152, upload-time = "2025-10-08T19:47:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/65/9b/03b04e7d82a5f54fb16113d839f5ea1ede58a61e90edf515f6577c66fa8f/propcache-0.4.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:c0d4b719b7da33599dfe3b22d3db1ef789210a0597bc650b7cee9c77c2be8c5c", size = 44869, upload-time = "2025-10-08T19:47:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f302f4783709a78240ebc311b793f123328716a60911d667e0c036bc5dcbded", size = 46596, upload-time = "2025-10-08T19:47:54.073Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/47816020d337f4a746edc42fe8d53669965138f39ee117414c7d7a340cfe/propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c80ee5802e3fb9ea37938e7eecc307fb984837091d5fd262bb37238b1ae97641", size = 206981, upload-time = "2025-10-08T19:47:55.715Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f6/c5fa1357cc9748510ee55f37173eb31bfde6d94e98ccd9e6f033f2fc06e1/propcache-0.4.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ed5a841e8bb29a55fb8159ed526b26adc5bdd7e8bd7bf793ce647cb08656cdf4", size = 211490, upload-time = "2025-10-08T19:47:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/80/1e/e5889652a7c4a3846683401a48f0f2e5083ce0ec1a8a5221d8058fbd1adf/propcache-0.4.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:55c72fd6ea2da4c318e74ffdf93c4fe4e926051133657459131a95c846d16d44", size = 215371, upload-time = "2025-10-08T19:47:59.317Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8326e144341460402713f91df60ade3c999d601e7eb5ff8f6f7862d54de0610d", size = 201424, upload-time = "2025-10-08T19:48:00.67Z" },
+    { url = "https://files.pythonhosted.org/packages/27/73/033d63069b57b0812c8bd19f311faebeceb6ba31b8f32b73432d12a0b826/propcache-0.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:060b16ae65bc098da7f6d25bf359f1f31f688384858204fe5d652979e0015e5b", size = 197566, upload-time = "2025-10-08T19:48:02.604Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/89/ce24f3dc182630b4e07aa6d15f0ff4b14ed4b9955fae95a0b54c58d66c05/propcache-0.4.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:89eb3fa9524f7bec9de6e83cf3faed9d79bffa560672c118a96a171a6f55831e", size = 193130, upload-time = "2025-10-08T19:48:04.499Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/24/ef0d5fd1a811fb5c609278d0209c9f10c35f20581fcc16f818da959fc5b4/propcache-0.4.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dee69d7015dc235f526fe80a9c90d65eb0039103fe565776250881731f06349f", size = 202625, upload-time = "2025-10-08T19:48:06.213Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/02/98ec20ff5546f68d673df2f7a69e8c0d076b5abd05ca882dc7ee3a83653d/propcache-0.4.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5558992a00dfd54ccbc64a32726a3357ec93825a418a401f5cc67df0ac5d9e49", size = 204209, upload-time = "2025-10-08T19:48:08.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/87/492694f76759b15f0467a2a93ab68d32859672b646aa8a04ce4864e7932d/propcache-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c9b822a577f560fbd9554812526831712c1436d2c046cedee4c3796d3543b144", size = 197797, upload-time = "2025-10-08T19:48:09.968Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/36/66367de3575db1d2d3f3d177432bd14ee577a39d3f5d1b3d5df8afe3b6e2/propcache-0.4.1-cp314-cp314-win32.whl", hash = "sha256:ab4c29b49d560fe48b696cdcb127dd36e0bc2472548f3bf56cc5cb3da2b2984f", size = 38140, upload-time = "2025-10-08T19:48:11.232Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2a/a758b47de253636e1b8aef181c0b4f4f204bf0dd964914fb2af90a95b49b/propcache-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:5a103c3eb905fcea0ab98be99c3a9a5ab2de60228aa5aceedc614c0281cf6153", size = 41257, upload-time = "2025-10-08T19:48:12.707Z" },
+    { url = "https://files.pythonhosted.org/packages/34/5e/63bd5896c3fec12edcbd6f12508d4890d23c265df28c74b175e1ef9f4f3b/propcache-0.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:74c1fb26515153e482e00177a1ad654721bf9207da8a494a0c05e797ad27b992", size = 38097, upload-time = "2025-10-08T19:48:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/9ff785d787ccf9bbb3f3106f79884a130951436f58392000231b4c737c80/propcache-0.4.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:824e908bce90fb2743bd6b59db36eb4f45cd350a39637c9f73b1c1ea66f5b75f", size = 81455, upload-time = "2025-10-08T19:48:15.16Z" },
+    { url = "https://files.pythonhosted.org/packages/90/85/2431c10c8e7ddb1445c1f7c4b54d886e8ad20e3c6307e7218f05922cad67/propcache-0.4.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2b5e7db5328427c57c8e8831abda175421b709672f6cfc3d630c3b7e2146393", size = 46372, upload-time = "2025-10-08T19:48:16.424Z" },
+    { url = "https://files.pythonhosted.org/packages/01/20/b0972d902472da9bcb683fa595099911f4d2e86e5683bcc45de60dd05dc3/propcache-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6f6ff873ed40292cd4969ef5310179afd5db59fdf055897e282485043fc80ad0", size = 48411, upload-time = "2025-10-08T19:48:17.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e3/7dc89f4f21e8f99bad3d5ddb3a3389afcf9da4ac69e3deb2dcdc96e74169/propcache-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49a2dc67c154db2c1463013594c458881a069fcf98940e61a0569016a583020a", size = 275712, upload-time = "2025-10-08T19:48:18.901Z" },
+    { url = "https://files.pythonhosted.org/packages/20/67/89800c8352489b21a8047c773067644e3897f02ecbbd610f4d46b7f08612/propcache-0.4.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:005f08e6a0529984491e37d8dbc3dd86f84bd78a8ceb5fa9a021f4c48d4984be", size = 273557, upload-time = "2025-10-08T19:48:20.762Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a1/b52b055c766a54ce6d9c16d9aca0cad8059acd9637cdf8aa0222f4a026ef/propcache-0.4.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5c3310452e0d31390da9035c348633b43d7e7feb2e37be252be6da45abd1abcc", size = 280015, upload-time = "2025-10-08T19:48:22.592Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c8/33cee30bd890672c63743049f3c9e4be087e6780906bfc3ec58528be59c1/propcache-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c3c70630930447f9ef1caac7728c8ad1c56bc5015338b20fed0d08ea2480b3a", size = 262880, upload-time = "2025-10-08T19:48:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b1/8f08a143b204b418285c88b83d00edbd61afbc2c6415ffafc8905da7038b/propcache-0.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e57061305815dfc910a3634dcf584f08168a8836e6999983569f51a8544cd89", size = 260938, upload-time = "2025-10-08T19:48:25.656Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/12/96e4664c82ca2f31e1c8dff86afb867348979eb78d3cb8546a680287a1e9/propcache-0.4.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:521a463429ef54143092c11a77e04056dd00636f72e8c45b70aaa3140d639726", size = 247641, upload-time = "2025-10-08T19:48:27.207Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ed/e7a9cfca28133386ba52278136d42209d3125db08d0a6395f0cba0c0285c/propcache-0.4.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:120c964da3fdc75e3731aa392527136d4ad35868cc556fd09bb6d09172d9a367", size = 262510, upload-time = "2025-10-08T19:48:28.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/16d8bf65e8845dd62b4e2b57444ab81f07f40caa5652b8969b87ddcf2ef6/propcache-0.4.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:d8f353eb14ee3441ee844ade4277d560cdd68288838673273b978e3d6d2c8f36", size = 263161, upload-time = "2025-10-08T19:48:30.133Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/70/c99e9edb5d91d5ad8a49fa3c1e8285ba64f1476782fed10ab251ff413ba1/propcache-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ab2943be7c652f09638800905ee1bab2c544e537edb57d527997a24c13dc1455", size = 257393, upload-time = "2025-10-08T19:48:31.567Z" },
+    { url = "https://files.pythonhosted.org/packages/08/02/87b25304249a35c0915d236575bc3574a323f60b47939a2262b77632a3ee/propcache-0.4.1-cp314-cp314t-win32.whl", hash = "sha256:05674a162469f31358c30bcaa8883cb7829fa3110bf9c0991fe27d7896c42d85", size = 42546, upload-time = "2025-10-08T19:48:32.872Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
 name = "py-serializable"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1155,6 +1499,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1237,6 +1593,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
 ]
 
 [[package]]
@@ -1331,6 +1701,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
+]
+
+[[package]]
 name = "sentry-sdk"
 version = "2.47.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1357,6 +1739,7 @@ name = "shuushuu-api"
 version = "2.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aioboto3" },
     { name = "aiomysql" },
     { name = "aiosmtplib" },
     { name = "alembic" },
@@ -1379,6 +1762,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "moto", extra = ["s3"] },
     { name = "mypy" },
     { name = "pip-audit" },
     { name = "pre-commit" },
@@ -1387,11 +1771,13 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "types-aioboto3" },
     { name = "types-redis" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "aioboto3", specifier = ">=13.0.0" },
     { name = "aiomysql", specifier = ">=0.2.0" },
     { name = "aiosmtplib", specifier = ">=5.0.0" },
     { name = "alembic", specifier = ">=1.13.0" },
@@ -1414,6 +1800,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "mypy", specifier = ">=1.11.0" },
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pre-commit", specifier = ">=3.5.0" },
@@ -1422,7 +1809,17 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "ruff", specifier = ">=0.5.0" },
+    { name = "types-aioboto3", specifier = ">=13.0.0" },
     { name = "types-redis", specifier = ">=4.6.0" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -1538,6 +1935,41 @@ wheels = [
 ]
 
 [[package]]
+name = "types-aioboto3"
+version = "15.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-aiobotocore" },
+    { name = "types-s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/76/e162ea2ef8d414d4f36f28a6e0b6078ccef3f2f9d5f957859f303995c528/types_aioboto3-15.5.0.tar.gz", hash = "sha256:5769a1c3df7ca1abedf3656ddf0b970c9b0436d0f88cf4686040b55cd2a02925", size = 81059, upload-time = "2025-10-31T01:11:54.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/1d/e187fbe9771dffb5f0801e315ac23a6c383c14d1cbb90da6ca3ad1ea9b06/types_aioboto3-15.5.0-py3-none-any.whl", hash = "sha256:8aed7c9b6fe9b59e6ce74f7a6db7b8a9912a34c8f80ed639fac1fa59d6b20aa1", size = 42521, upload-time = "2025-10-31T01:11:47.832Z" },
+]
+
+[[package]]
+name = "types-aiobotocore"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/95/349d980d5e7da4e3f300bba5f09de71ffd70f3d96ad70b260420a4f4ff89/types_aiobotocore-3.4.0.tar.gz", hash = "sha256:010fa82ddc8aba6084e18edbf22981e541b7efc1f85e49e2320501c22913ef35", size = 87621, upload-time = "2026-04-08T02:46:37.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/e2/f2e1baa388a1ef70522132c287b1d9b23c89b4d6a7ec2981fa2f2d65c1a4/types_aiobotocore-3.4.0-py3-none-any.whl", hash = "sha256:17a52c57d879d5f9fbf7b69671dae8d8f593544a89a6f794b9bed4680e7fd334", size = 54653, upload-time = "2026-04-08T02:46:34.185Z" },
+]
+
+[[package]]
+name = "types-awscrt"
+version = "0.31.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/26/0aa563e229c269c528a3b8c709fc671ac2a5c564732fab0852ac6ee006cf/types_awscrt-0.31.3.tar.gz", hash = "sha256:09d3eaf00231e0f47e101bd9867e430873bc57040050e2a3bd8305cb4fc30865", size = 18178, upload-time = "2026-03-08T02:31:14.569Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/e5/47a573bbbd0a790f8f9fe452f7188ea72b212d21c9be57d5fc0cbc442075/types_awscrt-0.31.3-py3-none-any.whl", hash = "sha256:e5ce65a00a2ab4f35eacc1e3d700d792338d56e4823ee7b4dbe017f94cfc4458", size = 43340, upload-time = "2026-03-08T02:31:13.38Z" },
+]
+
+[[package]]
 name = "types-cffi"
 version = "1.17.0.20250915"
 source = { registry = "https://pypi.org/simple" }
@@ -1573,6 +2005,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/95/c054d3ac940e8bac4ca216470c80c26688a0e79e09f520a942bb27da3386/types-redis-4.6.0.20241004.tar.gz", hash = "sha256:5f17d2b3f9091ab75384153bfa276619ffa1cf6a38da60e10d5e6749cc5b902e", size = 49679, upload-time = "2024-10-04T02:43:59.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/82/7d25dce10aad92d2226b269bce2f85cfd843b4477cd50245d7d40ecf8f89/types_redis-4.6.0.20241004-py3-none-any.whl", hash = "sha256:ef5da68cb827e5f606c8f9c0b49eeee4c2669d6d97122f301d3a55dc6a63f6ed", size = 58737, upload-time = "2024-10-04T02:43:57.968Z" },
+]
+
+[[package]]
+name = "types-s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
 ]
 
 [[package]]
@@ -1713,4 +2154,104 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/98/b85a038d65d1b92c3903ab89444f48d3cee490a883477b716d7a24b1a78c/yarl-1.23.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:21d1b7305a71a15b4794b5ff22e8eef96ff4a6d7f9657155e5aa419444b28912", size = 124455, upload-time = "2026-03-01T22:06:43.615Z" },
+    { url = "https://files.pythonhosted.org/packages/39/54/bc2b45559f86543d163b6e294417a107bb87557609007c007ad889afec18/yarl-1.23.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:85610b4f27f69984932a7abbe52703688de3724d9f72bceb1cca667deff27474", size = 86752, upload-time = "2026-03-01T22:06:45.425Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f9/e8242b68362bffe6fb536c8db5076861466fc780f0f1b479fc4ffbebb128/yarl-1.23.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23f371bd662cf44a7630d4d113101eafc0cfa7518a2760d20760b26021454719", size = 86291, upload-time = "2026-03-01T22:06:46.974Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/d8/d1cb2378c81dd729e98c716582b1ccb08357e8488e4c24714658cc6630e8/yarl-1.23.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4a80f77dc1acaaa61f0934176fccca7096d9b1ff08c8ba9cddf5ae034a24319", size = 99026, upload-time = "2026-03-01T22:06:48.459Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ff/7196790538f31debe3341283b5b0707e7feb947620fc5e8236ef28d44f72/yarl-1.23.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:bd654fad46d8d9e823afbb4f87c79160b5a374ed1ff5bde24e542e6ba8f41434", size = 92355, upload-time = "2026-03-01T22:06:50.306Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/56/25d58c3eddde825890a5fe6aa1866228377354a3c39262235234ab5f616b/yarl-1.23.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:682bae25f0a0dd23a056739f23a134db9f52a63e2afd6bfb37ddc76292bbd723", size = 106417, upload-time = "2026-03-01T22:06:52.1Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8a/882c0e7bc8277eb895b31bce0138f51a1ba551fc2e1ec6753ffc1e7c1377/yarl-1.23.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a82836cab5f197a0514235aaf7ffccdc886ccdaa2324bc0aafdd4ae898103039", size = 106422, upload-time = "2026-03-01T22:06:54.424Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2b/fef67d616931055bf3d6764885990a3ac647d68734a2d6a9e1d13de437a2/yarl-1.23.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c57676bdedc94cd3bc37724cf6f8cd2779f02f6aba48de45feca073e714fe52", size = 101915, upload-time = "2026-03-01T22:06:55.895Z" },
+    { url = "https://files.pythonhosted.org/packages/18/6a/530e16aebce27c5937920f3431c628a29a4b6b430fab3fd1c117b26ff3f6/yarl-1.23.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c7f8dc16c498ff06497c015642333219871effba93e4a2e8604a06264aca5c5c", size = 100690, upload-time = "2026-03-01T22:06:58.21Z" },
+    { url = "https://files.pythonhosted.org/packages/88/08/93749219179a45e27b036e03260fda05190b911de8e18225c294ac95bbc9/yarl-1.23.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5ee586fb17ff8f90c91cf73c6108a434b02d69925f44f5f8e0d7f2f260607eae", size = 98750, upload-time = "2026-03-01T22:06:59.794Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cf/ea424a004969f5d81a362110a6ac1496d79efdc6d50c2c4b2e3ea0fc2519/yarl-1.23.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:17235362f580149742739cc3828b80e24029d08cbb9c4bda0242c7b5bc610a8e", size = 94685, upload-time = "2026-03-01T22:07:01.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/b7/14341481fe568e2b0408bcf1484c652accafe06a0ade9387b5d3fd9df446/yarl-1.23.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:0793e2bd0cf14234983bbb371591e6bea9e876ddf6896cdcc93450996b0b5c85", size = 106009, upload-time = "2026-03-01T22:07:03.151Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/5c744a9b54f4e8007ad35bce96fbc9218338e84812d36f3390cea616881a/yarl-1.23.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3650dc2480f94f7116c364096bc84b1d602f44224ef7d5c7208425915c0475dd", size = 100033, upload-time = "2026-03-01T22:07:04.701Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/23/e3bfc188d0b400f025bc49d99793d02c9abe15752138dcc27e4eaf0c4a9e/yarl-1.23.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f40e782d49630ad384db66d4d8b73ff4f1b8955dc12e26b09a3e3af064b3b9d6", size = 106483, upload-time = "2026-03-01T22:07:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/72/42/f0505f949a90b3f8b7a363d6cbdf398f6e6c58946d85c6d3a3bc70595b26/yarl-1.23.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94f8575fbdf81749008d980c17796097e645574a3b8c28ee313931068dad14fe", size = 102175, upload-time = "2026-03-01T22:07:08.4Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/65/b39290f1d892a9dd671d1c722014ca062a9c35d60885d57e5375db0404b5/yarl-1.23.0-cp314-cp314-win32.whl", hash = "sha256:c8aa34a5c864db1087d911a0b902d60d203ea3607d91f615acd3f3108ac32169", size = 83871, upload-time = "2026-03-01T22:07:09.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5b/9b92f54c784c26e2a422e55a8d2607ab15b7ea3349e28359282f84f01d43/yarl-1.23.0-cp314-cp314-win_amd64.whl", hash = "sha256:63e92247f383c85ab00dd0091e8c3fa331a96e865459f5ee80353c70a4a42d70", size = 89093, upload-time = "2026-03-01T22:07:11.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/7d/8a84dc9381fd4412d5e7ff04926f9865f6372b4c2fd91e10092e65d29eb8/yarl-1.23.0-cp314-cp314-win_arm64.whl", hash = "sha256:70efd20be968c76ece7baa8dafe04c5be06abc57f754d6f36f3741f7aa7a208e", size = 83384, upload-time = "2026-03-01T22:07:13.069Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8d/d2fad34b1c08aa161b74394183daa7d800141aaaee207317e82c790b418d/yarl-1.23.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9a18d6f9359e45722c064c97464ec883eb0e0366d33eda61cb19a244bf222679", size = 131019, upload-time = "2026-03-01T22:07:14.903Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ff/33009a39d3ccf4b94d7d7880dfe17fb5816c5a4fe0096d9b56abceea9ac7/yarl-1.23.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2803ed8b21ca47a43da80a6fd1ed3019d30061f7061daa35ac54f63933409412", size = 89894, upload-time = "2026-03-01T22:07:17.372Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f1/dab7ac5e7306fb79c0190766a3c00b4cb8d09a1f390ded68c85a5934faf5/yarl-1.23.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:394906945aa8b19fc14a61cf69743a868bb8c465efe85eee687109cc540b98f4", size = 89979, upload-time = "2026-03-01T22:07:19.361Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b1/08e95f3caee1fad6e65017b9f26c1d79877b502622d60e517de01e72f95d/yarl-1.23.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:71d006bee8397a4a89f469b8deb22469fe7508132d3c17fa6ed871e79832691c", size = 95943, upload-time = "2026-03-01T22:07:21.266Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/6409f9018864a6aa186c61175b977131f373f1988e198e031236916e87e4/yarl-1.23.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:62694e275c93d54f7ccedcfef57d42761b2aad5234b6be1f3e3026cae4001cd4", size = 88786, upload-time = "2026-03-01T22:07:23.129Z" },
+    { url = "https://files.pythonhosted.org/packages/76/40/cc22d1d7714b717fde2006fad2ced5efe5580606cb059ae42117542122f3/yarl-1.23.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a31de1613658308efdb21ada98cbc86a97c181aa050ba22a808120bb5be3ab94", size = 101307, upload-time = "2026-03-01T22:07:24.689Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/0d/476c38e85ddb4c6ec6b20b815bdd779aa386a013f3d8b85516feee55c8dc/yarl-1.23.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb1e8b8d66c278b21d13b0a7ca22c41dd757a7c209c6b12c313e445c31dd3b28", size = 100904, upload-time = "2026-03-01T22:07:26.287Z" },
+    { url = "https://files.pythonhosted.org/packages/72/32/0abe4a76d59adf2081dcb0397168553ece4616ada1c54d1c49d8936c74f8/yarl-1.23.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50f9d8d531dfb767c565f348f33dd5139a6c43f5cbdf3f67da40d54241df93f6", size = 97728, upload-time = "2026-03-01T22:07:27.906Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/35/7b30f4810fba112f60f5a43237545867504e15b1c7647a785fbaf588fac2/yarl-1.23.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575aa4405a656e61a540f4a80eaa5260f2a38fff7bfdc4b5f611840d76e9e277", size = 95964, upload-time = "2026-03-01T22:07:30.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/86/ed7a73ab85ef00e8bb70b0cb5421d8a2a625b81a333941a469a6f4022828/yarl-1.23.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:041b1a4cefacf65840b4e295c6985f334ba83c30607441ae3cf206a0eed1a2e4", size = 95882, upload-time = "2026-03-01T22:07:32.132Z" },
+    { url = "https://files.pythonhosted.org/packages/19/90/d56967f61a29d8498efb7afb651e0b2b422a1e9b47b0ab5f4e40a19b699b/yarl-1.23.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:d38c1e8231722c4ce40d7593f28d92b5fc72f3e9774fe73d7e800ec32299f63a", size = 90797, upload-time = "2026-03-01T22:07:34.404Z" },
+    { url = "https://files.pythonhosted.org/packages/72/00/8b8f76909259f56647adb1011d7ed8b321bcf97e464515c65016a47ecdf0/yarl-1.23.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:d53834e23c015ee83a99377db6e5e37d8484f333edb03bd15b4bc312cc7254fb", size = 101023, upload-time = "2026-03-01T22:07:35.953Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e2/cab11b126fb7d440281b7df8e9ddbe4851e70a4dde47a202b6642586b8d9/yarl-1.23.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2e27c8841126e017dd2a054a95771569e6070b9ee1b133366d8b31beb5018a41", size = 96227, upload-time = "2026-03-01T22:07:37.594Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/9b/2c893e16bfc50e6b2edf76c1a9eb6cb0c744346197e74c65e99ad8d634d0/yarl-1.23.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:76855800ac56f878847a09ce6dba727c93ca2d89c9e9d63002d26b916810b0a2", size = 100302, upload-time = "2026-03-01T22:07:39.334Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ec/5498c4e3a6d5f1003beb23405671c2eb9cdbf3067d1c80f15eeafe301010/yarl-1.23.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e09fd068c2e169a7070d83d3bde728a4d48de0549f975290be3c108c02e499b4", size = 98202, upload-time = "2026-03-01T22:07:41.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c3/cd737e2d45e70717907f83e146f6949f20cc23cd4bf7b2688727763aa458/yarl-1.23.0-cp314-cp314t-win32.whl", hash = "sha256:73309162a6a571d4cbd3b6a1dcc703c7311843ae0d1578df6f09be4e98df38d4", size = 90558, upload-time = "2026-03-01T22:07:43.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
+    { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
 ]


### PR DESCRIPTION
## Summary

- Add Cloudflare R2 image serving behind `R2_ENABLED` feature flag (defaults to `false`, zero impact on current behavior)
- Public images (ACTIVE, SPOILER, REPOST) served via CDN 302 redirects; protected images (REVIEW, etc.) via short-lived presigned URLs; unsynced images fall back to local filesystem via X-Accel-Redirect
- Three ARQ jobs handle the lifecycle: `r2_finalize_upload_job` (first sync after upload), `sync_image_status_job` (bucket moves on status change), `r2_delete_image_job` (cleanup after hard delete)
- Cloudflare CDN cache purge on public→protected transitions and deletions
- `scripts/r2_sync.py` CLI with 7 subcommands for one-time migration and ongoing operations: `split-existing`, `backfill-locations`, `reconcile`, `image`, `verify`, `purge-cache`, `health`
- Operator runbook with env var matrix, cutover checklist, rollback procedure, and alerting thresholds

## Implementation (22 tasks, 7 chunks)

1. **Foundation** — `aioboto3` dependency, R2 config settings, `r2_location` column + migration, `R2Location` enum
2. **Storage layer** — `R2Storage` adapter over aioboto3, `DummyR2Storage` for disabled mode, Cloudflare cache purge service
3. **URL generation** — Status-aware CDN/presigned/local URL routing in `/images/*` endpoints
4. **ARQ jobs** — Finalize, status-sync (with copy-verify-delete and CDN purge), and delete jobs
5. **Endpoint wiring** — Enqueue jobs on upload, owner/admin status change, and hard delete
6. **Operational CLI** — `r2_sync.py` with guards (`R2_ALLOW_BULK_BACKFILL` prevents staging mass-uploads)
7. **Cleanup** — Removed unused `STORAGE_TYPE`/`S3_*` config, wrote docs

## Key design decisions

- **Two buckets** (public CDN + private presigned) rather than one with mixed access
- **`r2_location` tri-state** (NONE/PUBLIC/PRIVATE) on each image row drives URL generation and tracks sync state
- **Deferred finalize** (`_defer_by=90s`) gives variant processing jobs time to complete before R2 upload
- **`R2_ALLOW_BULK_BACKFILL`** gate prevents staging (which has a prod DB copy) from mass-uploading to its small R2 bucket
- **Feature flag** — `R2_ENABLED=false` makes all R2 code no-op; safe to merge and enable per-environment

## Test plan

- [x] 9 new unit test files covering all R2 jobs, CLI guards, subcommands, storage adapter, URL generation, and endpoint wiring
- [x] 3 integration test files for split-existing, backfill-locations, and schema sync
- [x] Full test suite passes (1376 tests)
- [x] Docker images rebuilt, dev site verified working with `R2_ENABLED=false`
- [ ] Staging: enable R2, run `split-existing --dry-run`, `verify --sample 1000`
- [ ] Prod: follow cutover checklist in `docs/r2-operations.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)