### PR TITLE
ci: enable inline comments for Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,5 +25,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
           prompt: "Review this pull request for code quality, correctness, and security. Follow the project conventions in AGENTS.md. Leave inline comments for concrete issues; skip nitpicks."
-          claude_args: "--max-turns 10"
+          claude_args: |
+            --max-turns 10
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- Adds `--allowedTools` list including `mcp__github_inline_comment__create_inline_comment` so Claude can actually post inline review comments (the previous workflow had 11 permission denials and produced no output).
- Enables `track_progress: true` for a progress-tracking comment during reviews.

## Context
First run on #192 finished "successfully" but posted nothing because Claude lacked the inline-comment MCP tool. Matches the pattern from the official [`pr-review-comprehensive.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) example.

## Test plan
- [ ] After merge, re-merge main into #192 to retrigger review — verify inline comments appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)