### PR TITLE
ci: drop --max-turns cap from Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,5 +28,4 @@ jobs:
           track_progress: true
           prompt: "Review this pull request for code quality, correctness, and security. Follow the project conventions in AGENTS.md. Leave inline comments for concrete issues; skip nitpicks."
           claude_args: |
-            --max-turns 10
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- Removes `--max-turns 10` from `claude_args`.
- With `track_progress: true`, Claude uses turns to update the tracking comment, so 10 wasn't enough for a real review — PR #192's run exited with `error_max_turns` at turn 11 before posting any inline comments.

## Test plan
- [ ] After merge, re-merge main into #192 — verify inline comments appear and review completes without hitting the turn cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)