### PR TITLE
feat(tags): raise tag title max length from 150 to 255

### DIFF
--- a/alembic/versions/c25a53d7e1e6_increase_tags_title_length_to_255.py
+++ b/alembic/versions/c25a53d7e1e6_increase_tags_title_length_to_255.py
@@ -1,0 +1,43 @@
+"""increase tags_title length to 255
+
+Revision ID: c25a53d7e1e6
+Revises: 6ad847e3bc00
+Create Date: 2026-04-23 20:21:33.478986
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c25a53d7e1e6'
+down_revision: str | Sequence[str] | None = '6ad847e3bc00'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Increase tags.title from VARCHAR(150) to VARCHAR(255)."""
+    op.alter_column(
+        'tags',
+        'title',
+        existing_type=sa.String(length=150),
+        type_=sa.String(length=255),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Revert tags.title to VARCHAR(150).
+
+    Note: this will fail if any existing rows have title > 150 chars.
+    """
+    op.alter_column(
+        'tags',
+        'title',
+        existing_type=sa.String(length=255),
+        type_=sa.String(length=150),
+        existing_nullable=True,
+    )

--- a/app/models/tag.py
+++ b/app/models/tag.py
@@ -31,7 +31,7 @@ class TagBase(SQLModel):
     """
 
     # Basic information
-    title: str | None = Field(default=None, max_length=150)
+    title: str | None = Field(default=None, max_length=255)
     desc: str | None = Field(default=None, max_length=200)
     type: int = Field(
         default=TagType.THEME,

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -13,7 +13,7 @@ from app.schemas.common import UserSummary
 
 # Tag name validation constants
 TAG_NAME_MIN_LENGTH = 2
-TAG_NAME_MAX_LENGTH = 150
+TAG_NAME_MAX_LENGTH = 255
 
 # Regex pattern for allowed characters in tag names:
 # All printable ASCII (U+0020 through U+007E) except backtick (`).
@@ -27,7 +27,7 @@ def validate_tag_name(title: str) -> str:
 
     Rules:
     - Minimum length: 2 characters
-    - Maximum length: 150 characters
+    - Maximum length: 255 characters
     - Consecutive spaces normalized to single space
     - Only printable ASCII characters (no backticks, cannot start with ! or -)
 

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -4970,7 +4970,7 @@ class TestTagNameValidation:
 
     Additionally:
     - Minimum length: 2 characters
-    - Maximum length: 150 characters
+    - Maximum length: 255 characters
     - Consecutive spaces are normalized to single space
     """
 
@@ -5393,7 +5393,7 @@ class TestTagNameValidation:
     async def test_maximum_length_validation(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Test that tag names cannot exceed 150 characters."""
+        """Test that tag names cannot exceed 255 characters."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)
         await db_session.commit()
@@ -5422,18 +5422,18 @@ class TestTagNameValidation:
         )
         access_token = login_response.json()["access_token"]
 
-        # 151 characters should be rejected
+        # 256 characters should be rejected
         response = await client.post(
             "/api/v1/tags",
-            json={"title": "A" * 151, "type": TagType.THEME},
+            json={"title": "A" * 256, "type": TagType.THEME},
             headers={"Authorization": f"Bearer {access_token}"},
         )
         assert response.status_code == 422
 
-        # 150 characters should be allowed
+        # 255 characters should be allowed
         response = await client.post(
             "/api/v1/tags",
-            json={"title": "A" * 150, "type": TagType.THEME},
+            json={"title": "A" * 255, "type": TagType.THEME},
             headers={"Authorization": f"Bearer {access_token}"},
         )
         assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Raises the tag title max length from 150 → 255 in the model (`app/models/tag.py`), the `TAG_NAME_MAX_LENGTH` validation constant (`app/schemas/tag.py`), and the matching boundary tests.
- Adds alembic migration `c25a53d7e1e6` to widen `tags.title` from `VARCHAR(150)` to `VARCHAR(255)`.

## Index safety note
The `idx_tags_title` index stays well within InnoDB's 3072-byte key prefix limit — 255 × 4 bytes (utf8mb4) = 1020 bytes.

## Test plan
- [x] `uv run pytest tests/api/v1/test_tags.py` — 132 passed
- [x] Migration applies cleanly (`uv run alembic upgrade head`)
- [ ] Migration `downgrade` path only works if no rows exceed 150 chars at rollback time (documented in the migration docstring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)