### PR TITLE
feat: Atom feeds for images and tags

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -11,6 +11,7 @@ from app.api.v1 import (
     comments,
     donations,
     favorites,
+    feeds,
     history,
     images,
     meta,
@@ -29,6 +30,7 @@ router.include_router(admin.router)
 router.include_router(auth.router)
 router.include_router(banners.router)
 router.include_router(donations.router)
+router.include_router(feeds.router)
 router.include_router(images.router)
 router.include_router(tags.router)
 router.include_router(character_source_links_router)

--- a/app/api/v1/feeds.py
+++ b/app/api/v1/feeds.py
@@ -4,9 +4,10 @@ from datetime import UTC, datetime
 from email.utils import format_datetime, parsedate_to_datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.v1.tags import get_tag_hierarchy, resolve_tag_alias
 from app.config import settings
 from app.core.database import get_db
 from app.services.feeds import (
@@ -87,6 +88,39 @@ async def list_images_atom(
         title="Shuushuu — latest images",
         self_url=_self_url(request),
         alternate_url=_frontend(),
+    )
+    xml = build_atom_feed(meta, entries)
+
+    return Response(content=xml, media_type=ATOM_CONTENT_TYPE, headers=headers)
+
+
+@router.get("/tags/{tag_id}/images.atom")
+async def list_tag_images_atom(
+    request: Request,
+    tag_id: Annotated[int, Path(ge=1)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Response:
+    """Latest 50 active images tagged with `tag_id`. Follows alias + hierarchy."""
+    tag, resolved_id = await resolve_tag_alias(db, tag_id)
+    if tag is None:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    effective_ids = await get_tag_hierarchy(db, resolved_id)
+
+    sentinel = await fetch_feed_sentinel(db, tag_ids=effective_ids, limit=50)
+    etag = compute_feed_etag(sentinel)
+    last_mod = newest_timestamp(sentinel)
+    headers = _cacheable_headers(etag, last_mod)
+
+    if _is_not_modified(request, etag, last_mod):
+        return Response(status_code=304, headers=headers)
+
+    entries = await fetch_feed_entries(db, tag_ids=effective_ids, limit=50)
+    meta = FeedMeta(
+        feed_id=f"tag:e-shuushuu.net,2005:feed:tags:{resolved_id}",
+        title=f"Shuushuu — tag: {tag.title}",
+        self_url=_self_url(request),
+        alternate_url=_frontend("tags", str(resolved_id)),
     )
     xml = build_atom_feed(meta, entries)
 

--- a/app/api/v1/feeds.py
+++ b/app/api/v1/feeds.py
@@ -43,10 +43,19 @@ def _ensure_utc(dt: datetime) -> datetime:
 
 
 def _is_not_modified(request: Request, etag: str, last_mod: datetime | None) -> bool:
-    """Conditional-request evaluation."""
+    """Conditional-request evaluation.
+
+    Handles If-None-Match per RFC 7232 §3.2: '*' or a comma-separated list of
+    ETags. Feed readers occasionally send their previous and current ETags
+    together; we 304 as long as ours appears anywhere in the list.
+    """
     inm = request.headers.get("if-none-match", "").strip()
-    if inm == "*" or (inm and inm == etag):
+    if inm == "*":
         return True
+    if inm:
+        candidates = {token.strip() for token in inm.split(",") if token.strip()}
+        if etag in candidates:
+            return True
 
     if last_mod is not None:
         ims = request.headers.get("if-modified-since")

--- a/app/api/v1/feeds.py
+++ b/app/api/v1/feeds.py
@@ -1,5 +1,93 @@
 """Atom feed endpoints."""
 
-from fastapi import APIRouter
+from datetime import UTC, datetime
+from email.utils import format_datetime, parsedate_to_datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.core.database import get_db
+from app.services.feeds import (
+    FeedMeta,
+    build_atom_feed,
+    compute_feed_etag,
+    fetch_feed_entries,
+    fetch_feed_sentinel,
+    newest_timestamp,
+)
 
 router = APIRouter(tags=["feeds"])
+
+CACHE_CONTROL = "public, max-age=300"
+ATOM_CONTENT_TYPE = "application/atom+xml; charset=utf-8"
+
+
+def _frontend(*parts: str) -> str:
+    base = settings.FRONTEND_URL.rstrip("/")
+    return "/".join([base, *parts])
+
+
+def _self_url(request: Request) -> str:
+    """Absolute URL of the current request — used for feed <link rel='self'>."""
+    return str(request.url).split("?")[0]
+
+
+def _ensure_utc(dt: datetime) -> datetime:
+    """Treat naive datetimes as UTC — the DB stores naive timestamps for date_added."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _is_not_modified(request: Request, etag: str, last_mod: datetime | None) -> bool:
+    """Conditional-request evaluation."""
+    inm = request.headers.get("if-none-match", "").strip()
+    if inm == "*" or (inm and inm == etag):
+        return True
+
+    if last_mod is not None:
+        ims = request.headers.get("if-modified-since")
+        if ims:
+            try:
+                ims_dt = parsedate_to_datetime(ims)
+            except (TypeError, ValueError):
+                ims_dt = None
+            if ims_dt is not None and ims_dt >= _ensure_utc(last_mod):
+                return True
+
+    return False
+
+
+def _cacheable_headers(etag: str, last_mod: datetime | None) -> dict[str, str]:
+    headers = {"Cache-Control": CACHE_CONTROL, "ETag": etag}
+    if last_mod is not None:
+        headers["Last-Modified"] = format_datetime(_ensure_utc(last_mod), usegmt=True)
+    return headers
+
+
+@router.get("/images.atom")
+async def list_images_atom(
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Response:
+    """Latest 50 active images, newest first."""
+    sentinel = await fetch_feed_sentinel(db, tag_ids=None, limit=50)
+    etag = compute_feed_etag(sentinel)
+    last_mod = newest_timestamp(sentinel)
+    headers = _cacheable_headers(etag, last_mod)
+
+    if _is_not_modified(request, etag, last_mod):
+        return Response(status_code=304, headers=headers)
+
+    entries = await fetch_feed_entries(db, tag_ids=None, limit=50)
+    meta = FeedMeta(
+        feed_id="tag:e-shuushuu.net,2005:feed:images",
+        title="Shuushuu — latest images",
+        self_url=_self_url(request),
+        alternate_url=_frontend(),
+    )
+    xml = build_atom_feed(meta, entries)
+
+    return Response(content=xml, media_type=ATOM_CONTENT_TYPE, headers=headers)

--- a/app/api/v1/feeds.py
+++ b/app/api/v1/feeds.py
@@ -1,0 +1,5 @@
+"""Atom feed endpoints."""
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["feeds"])

--- a/app/main.py
+++ b/app/main.py
@@ -177,5 +177,9 @@ from app.api.v1.iqdb_feed import router as iqdb_feed_router  # noqa: E402
 # Mount iqdb feed at root level so iqdb.org can crawl /image/index.xml
 app.include_router(iqdb_feed_router)
 
+from app.api.v1 import feeds as feeds_router  # noqa: E402
+
+app.include_router(feeds_router.router, prefix="/api/v1")
+
 # Note: Static images are served directly by nginx for better performance
 # See docker/nginx/frontend.conf.template for configuration

--- a/app/main.py
+++ b/app/main.py
@@ -177,9 +177,5 @@ from app.api.v1.iqdb_feed import router as iqdb_feed_router  # noqa: E402
 # Mount iqdb feed at root level so iqdb.org can crawl /image/index.xml
 app.include_router(iqdb_feed_router)
 
-from app.api.v1 import feeds as feeds_router  # noqa: E402
-
-app.include_router(feeds_router.router, prefix="/api/v1")
-
 # Note: Static images are served directly by nginx for better performance
 # See docker/nginx/frontend.conf.template for configuration

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -27,6 +27,7 @@ class TagSummary(BaseModel):
     tag_id: int
     tag: str = Field(alias="title")  # Maps from Tags.title
     type_id: int = Field(alias="type")  # Maps from Tags.type
+    usage_count: int = 0  # Needed by feed title composer; non-breaking.
 
     # Allow Pydantic to read from SQLAlchemy model attributes (not just dicts)
     model_config = {"from_attributes": True, "populate_by_name": True}

--- a/app/services/feeds.py
+++ b/app/services/feeds.py
@@ -6,10 +6,12 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.config import ImageStatus, TagType
 from app.models.image import Images
 from app.models.tag_link import TagLinks
+from app.schemas.image import ImageDetailedResponse
 
 SentinelRow = tuple[int, datetime | None]
 
@@ -129,3 +131,39 @@ async def fetch_feed_sentinel(
 
     result = await db.execute(query)
     return [(row.image_id, row.date_added) for row in result]
+
+
+async def fetch_feed_entries(
+    db: AsyncSession,
+    tag_ids: list[int] | None,
+    limit: int = 50,
+) -> list[ImageDetailedResponse]:
+    """Full hydration query for feed rendering.
+
+    Eager-loads the uploader and every linked tag (plus the tag row itself for
+    title/type). Converts results via ImageDetailedResponse.from_db_model, which
+    handles the tag_links -> tags mapping that from_attributes cannot do.
+    """
+    if tag_ids == []:
+        return []
+
+    query = (
+        select(Images)
+        .options(
+            selectinload(Images.user),
+            selectinload(Images.tag_links).selectinload(TagLinks.tag),
+        )
+        .where(Images.status == ImageStatus.ACTIVE)
+        .order_by(Images.image_id.desc())
+        .limit(limit)
+    )
+
+    if tag_ids is not None:
+        tag_subquery = (
+            select(TagLinks.image_id).where(TagLinks.tag_id.in_(tag_ids)).distinct().subquery()
+        )
+        query = query.where(Images.image_id.in_(select(tag_subquery)))
+
+    result = await db.execute(query)
+    images = result.scalars().all()
+    return [ImageDetailedResponse.from_db_model(image) for image in images]

--- a/app/services/feeds.py
+++ b/app/services/feeds.py
@@ -1,1 +1,18 @@
 """Atom feed rendering and query helpers."""
+
+_MIME_BY_EXT: dict[str, str] = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "gif": "image/gif",
+    "webp": "image/webp",
+}
+
+
+def mime_type_for_ext(ext: str) -> str:
+    """Map a file extension (case-insensitive, no leading dot) to its MIME type.
+
+    Returns 'application/octet-stream' for unknown or empty extensions — Atom
+    validators accept this and feed readers handle it gracefully.
+    """
+    return _MIME_BY_EXT.get(ext.lower(), "application/octet-stream")

--- a/app/services/feeds.py
+++ b/app/services/feeds.py
@@ -135,13 +135,13 @@ async def fetch_feed_sentinel(
     )
 
     if tag_ids is not None:
-        tag_subquery = (
-            select(TagLinks.image_id)  # type: ignore[call-overload]
-            .where(TagLinks.tag_id.in_(tag_ids))  # type: ignore[attr-defined]
-            .distinct()
-            .subquery()
+        query = query.where(
+            Images.image_id.in_(  # type: ignore[union-attr]
+                select(TagLinks.image_id)  # type: ignore[call-overload]
+                .where(TagLinks.tag_id.in_(tag_ids))  # type: ignore[attr-defined]
+                .distinct()
+            )
         )
-        query = query.where(Images.image_id.in_(select(tag_subquery)))  # type: ignore[union-attr]
 
     result = await db.execute(query)
     return [(row.image_id, row.date_added) for row in result]
@@ -173,13 +173,13 @@ async def fetch_feed_entries(
     )
 
     if tag_ids is not None:
-        tag_subquery = (
-            select(TagLinks.image_id)  # type: ignore[call-overload]
-            .where(TagLinks.tag_id.in_(tag_ids))  # type: ignore[attr-defined]
-            .distinct()
-            .subquery()
+        query = query.where(
+            Images.image_id.in_(  # type: ignore[union-attr]
+                select(TagLinks.image_id)  # type: ignore[call-overload]
+                .where(TagLinks.tag_id.in_(tag_ids))  # type: ignore[attr-defined]
+                .distinct()
+            )
         )
-        query = query.where(Images.image_id.in_(select(tag_subquery)))  # type: ignore[union-attr]
 
     result = await db.execute(query)
     images = result.scalars().all()
@@ -222,7 +222,7 @@ def build_atom_feed(
     feed = _ShuushuuAtom1Feed(
         title=meta.title,
         link=meta.alternate_url,
-        description="",  # empty → no <subtitle>
+        description=None,  # explicit: no <subtitle>
         feed_url=meta.self_url,
         language="en",
     )
@@ -236,7 +236,10 @@ def build_atom_feed(
         author_name = (
             image.user.username if image.user and image.user.username else "[deleted user]"
         )
-        entry_dt = image.date_added or datetime.now(UTC)
+        # date_added is NOT NULL at the DB level; this fallback is for the
+        # impossible case only. Use a fixed epoch rather than wall-clock time so
+        # a misconfigured row doesn't churn the entry's timestamp on every poll.
+        entry_dt = image.date_added or datetime(1970, 1, 1, tzinfo=UTC)
 
         content_html: str | None = escape(image.caption) if image.caption else None
 

--- a/app/services/feeds.py
+++ b/app/services/feeds.py
@@ -1,0 +1,1 @@
+"""Atom feed rendering and query helpers."""

--- a/app/services/feeds.py
+++ b/app/services/feeds.py
@@ -1,5 +1,9 @@
 """Atom feed rendering and query helpers."""
 
+from typing import Any
+
+from app.config import TagType
+
 _MIME_BY_EXT: dict[str, str] = {
     "jpg": "image/jpeg",
     "jpeg": "image/jpeg",
@@ -16,3 +20,40 @@ def mime_type_for_ext(ext: str) -> str:
     validators accept this and feed readers handle it gracefully.
     """
     return _MIME_BY_EXT.get(ext.lower(), "application/octet-stream")
+
+
+def _pick_representative(tags: list[Any], type_value: int) -> str | None:
+    """Return the title of the highest-usage tag of the given type, or None."""
+    candidates = [t for t in tags if t.type_id == type_value]
+    if not candidates:
+        return None
+    # Stable sort: usage_count DESC, then tag_id ASC for determinism on ties.
+    candidates.sort(key=lambda t: (-t.usage_count, t.tag_id))
+    return candidates[0].tag
+
+
+def compose_entry_title(image_id: int, tags: list[Any]) -> str:
+    """Build the Atom entry <title> per the design spec.
+
+    Format: '{characters} ({sources}) by {artists}' — single representative tag
+    per category (highest usage_count). Empty sections are skipped. Falls back
+    to 'Image #{image_id}' if no character, source, or artist tags are present.
+
+    `tags` is a sequence of TagSummary-shaped objects with `.tag` (title),
+    `.type_id` (int, matching TagType constants), `.tag_id`, and `.usage_count`.
+    """
+    char = _pick_representative(tags, TagType.CHARACTER)
+    src = _pick_representative(tags, TagType.SOURCE)
+    artist = _pick_representative(tags, TagType.ARTIST)
+
+    parts: list[str] = []
+    if char:
+        parts.append(char)
+    if src:
+        parts.append(f"({src})")
+    if artist:
+        parts.append(f"by {artist}")
+
+    if not parts:
+        return f"Image #{image_id}"
+    return " ".join(parts)

--- a/app/services/feeds.py
+++ b/app/services/feeds.py
@@ -1,17 +1,28 @@
 """Atom feed rendering and query helpers."""
 
 import hashlib
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from html import escape
 from typing import Any
 
+from feedgenerator import Atom1Feed, Enclosure  # type: ignore[import-untyped]
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.config import ImageStatus, TagType
+from app.config import ImageStatus, TagType, settings
 from app.models.image import Images
 from app.models.tag_link import TagLinks
 from app.schemas.image import ImageDetailedResponse
+
+TAG_TYPE_NAME: dict[int, str] = {
+    TagType.THEME: "Theme",
+    TagType.SOURCE: "Source",
+    TagType.ARTIST: "Artist",
+    TagType.CHARACTER: "Character",
+    # TagType.ALL is a filter pseudo-type; never on actual rows.
+}
 
 SentinelRow = tuple[int, datetime | None]
 
@@ -167,3 +178,82 @@ async def fetch_feed_entries(
     result = await db.execute(query)
     images = result.scalars().all()
     return [ImageDetailedResponse.from_db_model(image) for image in images]
+
+
+class _ShuushuuAtom1Feed(Atom1Feed):  # type: ignore[misc]
+    """Atom1Feed variant that emits <category term=... scheme=...> per RFC 4287.
+
+    The stock Atom1Feed.add_item_elements drops the scheme attribute, so we
+    append our own category elements from a 'shuu_categories' item attribute
+    (list of (term, scheme) tuples) passed through add_item's **kwargs.
+    """
+
+    def add_item_elements(self, handler, item):  # type: ignore[no-untyped-def]
+        super().add_item_elements(handler, item)
+        for term, scheme in item.get("shuu_categories", ()):
+            handler.addQuickElement("category", "", {"term": term, "scheme": scheme})
+
+
+@dataclass(frozen=True)
+class FeedMeta:
+    feed_id: str
+    title: str
+    self_url: str
+    alternate_url: str
+
+
+def _category_scheme(tag_type_id: int) -> str:
+    return (
+        f"{settings.FRONTEND_URL.rstrip('/')}/tag-type/{TAG_TYPE_NAME.get(tag_type_id, 'Unknown')}"
+    )
+
+
+def build_atom_feed(
+    meta: FeedMeta,
+    entries: list[ImageDetailedResponse],
+) -> str:
+    """Render an Atom 1.0 XML document."""
+    feed = _ShuushuuAtom1Feed(
+        title=meta.title,
+        link=meta.alternate_url,
+        description="",  # empty → no <subtitle>
+        feed_url=meta.self_url,
+        language="en",
+    )
+    # Override <id> and feed-level <author>. <updated> is auto-derived.
+    feed.feed["id"] = meta.feed_id
+    feed.feed["author_name"] = "Shuushuu"
+
+    frontend = settings.FRONTEND_URL.rstrip("/")
+
+    for image in entries:
+        author_name = (
+            image.user.username if image.user and image.user.username else "[deleted user]"
+        )
+        entry_dt = image.date_added or datetime.now(UTC)
+
+        content_html: str | None = escape(image.caption) if image.caption else None
+
+        shuu_categories = [(t.tag, _category_scheme(t.type_id)) for t in (image.tags or [])]
+
+        enclosure = Enclosure(
+            url=image.url,
+            length=str(image.filesize or 0),
+            mime_type=mime_type_for_ext(image.ext),
+        )
+
+        feed.add_item(
+            title=compose_entry_title(image_id=image.image_id, tags=image.tags or []),
+            link=f"{frontend}/images/{image.image_id}",
+            description=None,
+            content=content_html,
+            unique_id=f"tag:e-shuushuu.net,2005:image:{image.image_id}",
+            unique_id_is_permalink=False,
+            pubdate=entry_dt,
+            updateddate=entry_dt,
+            author_name=author_name,
+            enclosures=[enclosure],
+            shuu_categories=shuu_categories,
+        )
+
+    return feed.writeString("utf-8")  # type: ignore[no-any-return]

--- a/app/services/feeds.py
+++ b/app/services/feeds.py
@@ -1,8 +1,12 @@
 """Atom feed rendering and query helpers."""
 
+import hashlib
+from datetime import datetime
 from typing import Any
 
 from app.config import TagType
+
+SentinelRow = tuple[int, datetime | None]
 
 _MIME_BY_EXT: dict[str, str] = {
     "jpg": "image/jpeg",
@@ -57,3 +61,30 @@ def compose_entry_title(image_id: int, tags: list[Any]) -> str:
     if not parts:
         return f"Image #{image_id}"
     return " ".join(parts)
+
+
+def compute_feed_etag(sentinel: list[SentinelRow]) -> str:
+    """Derive a weak ETag from the sentinel query result.
+
+    Rows with NULL date_added are excluded from the hash (defensive per spec).
+    The hash is stable for identical input, which is all a conditional request
+    needs — we regenerate it from current DB state on every request and never
+    store it.
+    """
+    payload = ",".join(
+        f"{image_id}:{ts.isoformat()}" for image_id, ts in sentinel if ts is not None
+    )
+    digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()
+    return f'W/"{digest}"'
+
+
+def newest_timestamp(sentinel: list[SentinelRow]) -> datetime | None:
+    """Return the newest non-NULL date_added from the sentinel, floored to the second.
+
+    Returns None if the sentinel is empty or every row has NULL date_added —
+    callers should omit the Last-Modified header in that case.
+    """
+    non_null = [ts for _, ts in sentinel if ts is not None]
+    if not non_null:
+        return None
+    return max(non_null).replace(microsecond=0)

--- a/app/services/feeds.py
+++ b/app/services/feeds.py
@@ -51,7 +51,7 @@ def _pick_representative(tags: list[Any], type_value: int) -> str | None:
         return None
     # Stable sort: usage_count DESC, then tag_id ASC for determinism on ties.
     candidates.sort(key=lambda t: (-t.usage_count, t.tag_id))
-    return candidates[0].tag
+    return candidates[0].tag  # type: ignore[no-any-return]
 
 
 def compose_entry_title(image_id: int, tags: list[Any]) -> str:
@@ -128,17 +128,20 @@ async def fetch_feed_sentinel(
         return []
 
     query = (
-        select(Images.image_id, Images.date_added)
+        select(Images.image_id, Images.date_added)  # type: ignore[call-overload]
         .where(Images.status == ImageStatus.ACTIVE)
-        .order_by(Images.image_id.desc())
+        .order_by(Images.image_id.desc())  # type: ignore[union-attr]
         .limit(limit)
     )
 
     if tag_ids is not None:
         tag_subquery = (
-            select(TagLinks.image_id).where(TagLinks.tag_id.in_(tag_ids)).distinct().subquery()
+            select(TagLinks.image_id)  # type: ignore[call-overload]
+            .where(TagLinks.tag_id.in_(tag_ids))  # type: ignore[attr-defined]
+            .distinct()
+            .subquery()
         )
-        query = query.where(Images.image_id.in_(select(tag_subquery)))
+        query = query.where(Images.image_id.in_(select(tag_subquery)))  # type: ignore[union-attr]
 
     result = await db.execute(query)
     return [(row.image_id, row.date_added) for row in result]
@@ -161,19 +164,22 @@ async def fetch_feed_entries(
     query = (
         select(Images)
         .options(
-            selectinload(Images.user),
-            selectinload(Images.tag_links).selectinload(TagLinks.tag),
+            selectinload(Images.user),  # type: ignore[arg-type]
+            selectinload(Images.tag_links).selectinload(TagLinks.tag),  # type: ignore[arg-type]
         )
-        .where(Images.status == ImageStatus.ACTIVE)
-        .order_by(Images.image_id.desc())
+        .where(Images.status == ImageStatus.ACTIVE)  # type: ignore[arg-type]
+        .order_by(Images.image_id.desc())  # type: ignore[union-attr]
         .limit(limit)
     )
 
     if tag_ids is not None:
         tag_subquery = (
-            select(TagLinks.image_id).where(TagLinks.tag_id.in_(tag_ids)).distinct().subquery()
+            select(TagLinks.image_id)  # type: ignore[call-overload]
+            .where(TagLinks.tag_id.in_(tag_ids))  # type: ignore[attr-defined]
+            .distinct()
+            .subquery()
         )
-        query = query.where(Images.image_id.in_(select(tag_subquery)))
+        query = query.where(Images.image_id.in_(select(tag_subquery)))  # type: ignore[union-attr]
 
     result = await db.execute(query)
     images = result.scalars().all()

--- a/app/services/feeds.py
+++ b/app/services/feeds.py
@@ -4,7 +4,12 @@ import hashlib
 from datetime import datetime
 from typing import Any
 
-from app.config import TagType
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, TagType
+from app.models.image import Images
+from app.models.tag_link import TagLinks
 
 SentinelRow = tuple[int, datetime | None]
 
@@ -88,3 +93,39 @@ def newest_timestamp(sentinel: list[SentinelRow]) -> datetime | None:
     if not non_null:
         return None
     return max(non_null).replace(microsecond=0)
+
+
+async def fetch_feed_sentinel(
+    db: AsyncSession,
+    tag_ids: list[int] | None,
+    limit: int = 50,
+) -> list[SentinelRow]:
+    """Return [(image_id, date_added), ...] for the feed window.
+
+    Cheap query — indexed scan on (status, image_id DESC) only, no joins beyond
+    an optional IN subquery for per-tag filtering. Used for ETag derivation and
+    to short-circuit the full hydration query on conditional-request hits.
+
+    Args:
+        tag_ids: None for the global feed; a non-empty list (the already-resolved
+            alias + hierarchy-expanded tag IDs) for per-tag. An empty list returns
+            no rows.
+    """
+    if tag_ids == []:
+        return []
+
+    query = (
+        select(Images.image_id, Images.date_added)
+        .where(Images.status == ImageStatus.ACTIVE)
+        .order_by(Images.image_id.desc())
+        .limit(limit)
+    )
+
+    if tag_ids is not None:
+        tag_subquery = (
+            select(TagLinks.image_id).where(TagLinks.tag_id.in_(tag_ids)).distinct().subquery()
+        )
+        query = query.where(Images.image_id.in_(select(tag_subquery)))
+
+    result = await db.execute(query)
+    return [(row.image_id, row.date_added) for row in result]

--- a/docs/plans/2026-04-24-rss-feed-design.md
+++ b/docs/plans/2026-04-24-rss-feed-design.md
@@ -57,7 +57,7 @@ Modern booru convention is Atom 1.0 (verified: Danbooru serves `/posts.atom`, e6
 | `<id>` | `tag:e-shuushuu.net,2005:image:{image_id}`. Tag URI, stable, unique, independent of filename. |
 | `<title>` | See "Title composition" below. |
 | `<link rel="alternate">` | `https://e-shuushuu.net/images/{image_id}` (frontend detail page). |
-| `<link rel="enclosure">` | Full image URL, with `type="image/{ext}"` and `length="{image.filesize}"` in bytes. |
+| `<link rel="enclosure">` | Full image URL, with `length="{image.filesize}"` in bytes and `type` set via a small mapping (`jpg`/`jpeg` → `image/jpeg`, `png` → `image/png`, `gif` → `image/gif`, `webp` → `image/webp`). Naive `f"image/{ext}"` is wrong for `jpg`. |
 | `<updated>` | `image.date_added`. |
 | `<published>` | `image.date_added`. Same as `<updated>` until the model tracks edits separately. |
 | `<author><name>` | `image.user.username`. `"[deleted user]"` if `user` is NULL (soft-deleted uploader). |
@@ -160,7 +160,7 @@ app/
 - **Tag ID not found**: 404 with the repo's standard error shape.
 - **Tag is an alias** (`alias_of IS NOT NULL`): `resolve_tag_alias()` follows the alias to the canonical tag, then `get_tag_hierarchy()` expands to include child tags. The feed serves images in the full effective set. Matches `GET /api/v1/tags/{id}/images`. No redirect; the request URL remains the alias's ID, but the content is the canonical set. Readers that subscribe via alias continue to receive the correct content after the alias is established.
 - **Image with NULL `user_id`** (soft-deleted uploader): `<author><name>[deleted user]</name></author>`.
-- **NULL `date_added`**: `Images.date_added` is nullable in the model but has `server_default=current_timestamp()` at the DB level, so in practice it's always populated. Defensive handling: if a sentinel row has NULL `date_added`, exclude it from the ETag tuple and from `Last-Modified` derivation (fall back to current UTC for `<updated>` and omit `Last-Modified`).
+- **NULL `date_added`**: `Images.date_added` is nullable in the model but has `server_default=current_timestamp()` at the DB level, so in practice it's always populated. Defensive handling: if a sentinel row has NULL `date_added`, exclude it from the ETag tuple and from `Last-Modified` derivation (fall back to current UTC for feed-level `<updated>` and omit `Last-Modified`). For entry-level `<updated>` / `<published>` on such a row, fall back to current UTC — Atom requires `<updated>` on every entry, so dropping the entry from the feed would be more surprising than a slightly-wrong timestamp.
 - **Image with no tags**: title falls back to `"Image #{id}"`. Feed is valid.
 - **Caption contains HTML or XML specials**: library escapes as literal text inside `<content type="html">`. If we later want to render formatted captions, revisit the content type.
 - **Concurrent insert between sentinel and render**: feed's `<updated>` may lag the freshest entry by one request. Bounded by the 5-minute max-age; next poll resolves.

--- a/docs/plans/2026-04-24-rss-feed-design.md
+++ b/docs/plans/2026-04-24-rss-feed-design.md
@@ -152,7 +152,7 @@ app/
 
 ### Settings
 
-- `settings.FRONTEND_BASE_URL` (new) — used to construct detail-page links. Default to `"https://e-shuushuu.net"` in production, `"http://localhost:3000"` or similar in dev.
+- Reuse the existing `settings.FRONTEND_URL` (defined at `app/config.py:167`, defaults to `http://localhost:5173` in source; set to `https://e-shuushuu.net` in production via env). Used to construct detail-page links. No new setting.
 
 ## Edge cases
 

--- a/docs/plans/2026-04-24-rss-feed-design.md
+++ b/docs/plans/2026-04-24-rss-feed-design.md
@@ -66,10 +66,10 @@ Modern booru convention is Atom 1.0 (verified: Danbooru serves `/posts.atom`, e6
 
 ### Title composition
 
-Format: `"{characters} ({sources}) drawn by {artists}"` using a single representative tag per category, chosen by `ORDER BY usage_count DESC`. Empty sections are skipped:
+Format: `"{characters} ({sources}) by {artists}"` using a single representative tag per category, chosen by `ORDER BY usage_count DESC`. Empty sections are skipped:
 
-- No character tags: `"({sources}) drawn by {artists}"`.
-- No source tags: `"{characters} drawn by {artists}"`.
+- No character tags: `"({sources}) by {artists}"`.
+- No source tags: `"{characters} by {artists}"`.
 - No artist tags: `"{characters} ({sources})"`.
 - No tags of any used category: `"Image #{image_id}"` (final fallback).
 

--- a/docs/plans/2026-04-24-rss-feed-design.md
+++ b/docs/plans/2026-04-24-rss-feed-design.md
@@ -32,6 +32,7 @@ Modern booru convention is Atom 1.0 (verified: Danbooru serves `/posts.atom`, e6
 | `GET` | `/api/v1/tags/{id}/images.atom` | Latest 50 active images tagged with `{id}`. `{id}` is `tags.tag_id`. 404 if the tag does not exist. |
 
 - `{id}` is used instead of `{title}` to make URLs stable across tag renames.
+- The per-tag endpoint resolves aliases (`tags.alias_of`) via `resolve_tag_alias()` and expands the tag hierarchy via `get_tag_hierarchy()`, matching `GET /api/v1/tags/{id}/images` (see `app/api/v1/tags.py:167,201,695,703`). A reader subscribing to a tag feed sees the same image set the frontend tag page renders.
 - Content-Type: `application/atom+xml; charset=utf-8`.
 - Public (no auth).
 - Fixed window: 50 entries. No query parameters.
@@ -56,11 +57,11 @@ Modern booru convention is Atom 1.0 (verified: Danbooru serves `/posts.atom`, e6
 | `<id>` | `tag:e-shuushuu.net,2005:image:{image_id}`. Tag URI, stable, unique, independent of filename. |
 | `<title>` | See "Title composition" below. |
 | `<link rel="alternate">` | `https://e-shuushuu.net/images/{image_id}` (frontend detail page). |
-| `<link rel="enclosure">` | Full image URL, with `type="image/{ext}"`. `length` is omitted (we do not store file size per image). |
+| `<link rel="enclosure">` | Full image URL, with `type="image/{ext}"` and `length="{image.filesize}"` in bytes. |
 | `<updated>` | `image.date_added`. |
 | `<published>` | `image.date_added`. Same as `<updated>` until the model tracks edits separately. |
 | `<author><name>` | `image.user.username`. `"[deleted user]"` if `user` is NULL (soft-deleted uploader). |
-| `<category>` | One per tag linked to the image, via `tag_links`. `term="{tag.title}"`, `scheme="https://e-shuushuu.net/tag-type/{type_name}"` where `type_name` is one of `all`, `theme`, `source`, `artist`, `character` per `TagType`. No truncation. |
+| `<category>` | One per tag linked to the image, via `tag_links`. `term="{tag.title}"`, `scheme="https://e-shuushuu.net/tag-type/{type_name}"` where `type_name` is the value from `TagSummary.type_name` (title-cased: `All`, `Theme`, `Source`, `Artist`, `Character`). Reusing the existing schema value keeps feed and JSON-API representations aligned. No truncation. |
 | `<content type="html">` | `image.caption` if present, else empty string. HTML-escaped. |
 
 ### Title composition
@@ -79,7 +80,7 @@ Rationale: titles are the prominent field in feed-reader list views; keeping the
 ### Response headers
 
 - `Cache-Control: public, max-age=300` (5 minutes; matches PHP memcache TTL).
-- `Last-Modified: <HTTP-date>` — newest `date_added` in the feed window, in RFC 7232 §2.2 format.
+- `Last-Modified: <HTTP-date>` — newest `date_added` in the feed window, floored to whole seconds (RFC 7232 §2.2 HTTP-date has 1-second resolution) and formatted as e.g. `Wed, 24 Apr 2026 12:34:56 GMT`.
 - `ETag: W/"<hash>"` — weak ETag, content-derived (see below).
 
 ### ETag generation
@@ -87,9 +88,14 @@ Rationale: titles are the prominent field in feed-reader list views; keeping the
 Stateless. Server derives it on every request from current DB state; no storage of handed-out ETags.
 
 ```
+# Per-tag: resolve alias + expand hierarchy FIRST, then filter.
+# The sentinel's effective tag set MUST match the hydration query's effective tag set.
+effective_ids = get_tag_hierarchy(resolve_tag_alias(tag_id))  # per-tag feed only
+
 sentinel = SELECT image_id, date_added
            FROM images
-           WHERE status = 1 [AND image_id IN (SELECT image_id FROM tag_links WHERE tag_id = :tag_id)]
+           WHERE status = 1
+             [AND image_id IN (SELECT image_id FROM tag_links WHERE tag_id IN :effective_ids)]
            ORDER BY image_id DESC
            LIMIT 50;
 etag = 'W/"' + sha1(','.join(f"{id}:{ts.isoformat()}" for id, ts in sentinel)) + '"'
@@ -98,7 +104,8 @@ etag = 'W/"' + sha1(','.join(f"{id}:{ts.isoformat()}" for id, ts in sentinel)) +
 Properties:
 - New image uploaded → top-50 set changes → hash changes → cache busts.
 - Image in the window hidden / status-changed → window shifts → hash changes.
-- Older image (outside top 50) edited → hash unchanged, cache stays valid. Correct.
+- Image in the window *retagged* (tags added or removed without changing `date_added`) → hash unchanged, so the body may go stale. This is an accepted limitation bounded by the 5-minute `max-age`. Capturing tag mutations in the ETag would require hashing the tag set per entry, which is more joins per sentinel than it's worth for a 5-minute window.
+- Older image outside the top 50 edited → hash unchanged, cache stays valid. Correct.
 
 ### Conditional request handling
 
@@ -106,7 +113,9 @@ Properties:
 2. If the request has `If-None-Match` matching our current ETag, or `If-Modified-Since` at or after our `Last-Modified`: return `304 Not Modified` with no body and the ETag / Last-Modified headers.
 3. Otherwise: load full entry data (user + tag joins), render, return `200` with body + headers.
 
-Cost profile: repeat polls when nothing changed cost one indexed `SELECT ... LIMIT 50` and a SHA-1. Polls with new content add the full render path. No `Vary` header — no per-request variation to capture.
+Cost profile: repeat polls when nothing changed cost one indexed `SELECT ... LIMIT 50` and a SHA-1. Polls with new content add the full render path.
+
+The feed handler does not set a `Vary` header itself (no per-request variation in the rendered body). If a fronting proxy or FastAPI's `GZipMiddleware` applies `Content-Encoding: gzip`, the compression layer is responsible for setting `Vary: Accept-Encoding` so shared caches key the compressed and uncompressed responses correctly. This is standard proxy/middleware behavior and out of scope for the feed handler.
 
 ## Implementation
 
@@ -136,8 +145,8 @@ app/
 1. Handler receives request.
 2. Service runs the sentinel query and derives ETag + Last-Modified.
 3. If-None-Match / If-Modified-Since check → maybe return 304.
-4. Service runs the hydration query (joins `Users` via `selectinload`, joins `Tags` via `selectinload(Images.tag_links).selectinload(TagLinks.tag)`).
-5. Results converted to `ImageDetailedResponse` instances (`.model_validate(image)`).
+4. Service runs the hydration query, eager-loading relationships via `selectinload` (e.g. `Images.user`, `Images.tag_links.tag`) so no lazy-loads happen during rendering.
+5. Results converted to `ImageDetailedResponse` via `.model_validate(image)` directly. `ImageDetailedResponse.from_db_model()` is not used: its constructor-level kwargs (`is_favorited`, `user_rating`, `prev_image_id`, `next_image_id`) are request-context fields that do not apply in a public feed.
 6. `build_atom_feed(feed_meta, entries)` produces the XML string.
 7. Return `Response(content=..., media_type="application/atom+xml; charset=utf-8")` with headers.
 
@@ -149,7 +158,7 @@ app/
 
 - **Empty feed** (no matching active images): valid feed, zero `<entry>` elements, `<updated>` = current UTC. 200, not 404.
 - **Tag ID not found**: 404 with the repo's standard error shape.
-- **Tag is an alias** (`alias_of IS NOT NULL`): serve the alias's own images (no redirect, no alias-following). Matches existing tag-detail endpoint behavior. Revisit if users complain.
+- **Tag is an alias** (`alias_of IS NOT NULL`): `resolve_tag_alias()` follows the alias to the canonical tag, then `get_tag_hierarchy()` expands to include child tags. The feed serves images in the full effective set. Matches `GET /api/v1/tags/{id}/images`. No redirect; the request URL remains the alias's ID, but the content is the canonical set. Readers that subscribe via alias continue to receive the correct content after the alias is established.
 - **Image with NULL `user_id`** (soft-deleted uploader): `<author><name>[deleted user]</name></author>`.
 - **Image with no tags**: title falls back to `"Image #{id}"`. Feed is valid.
 - **Caption contains HTML or XML specials**: library escapes as literal text inside `<content type="html">`. If we later want to render formatted captions, revisit the content type.

--- a/docs/plans/2026-04-24-rss-feed-design.md
+++ b/docs/plans/2026-04-24-rss-feed-design.md
@@ -1,0 +1,199 @@
+# RSS / Atom feed design
+
+**Date:** 2026-04-24
+**Status:** Design approved, pending implementation
+**Supersedes:** legacy PHP `/index.rss` (RSS 1.0 / RDF)
+
+## Background
+
+The legacy PHP site shipped a single feed at `/index.rss` — latest 100 active images, RSS 1.0 (RDF), no parameters, no auth, 5-minute memcache TTL for anonymous requests. Items linked directly to the raw image file, not to a detail page. See `shuu-php/index.rss`.
+
+Modern booru convention is Atom 1.0 (verified: Danbooru serves `/posts.atom`, e621 serves `/posts.atom`, neither offers RSS 2.0). This design replaces the legacy feed with a spec-idiomatic Atom implementation on the FastAPI backend and adds per-tag feeds.
+
+## Goals
+
+- Serve an Atom 1.0 feed of the latest active images (parity with PHP).
+- Serve an Atom 1.0 feed of the latest active images for a given tag ID.
+- Present the same view of an image that the public JSON API does (reuse response schemas).
+- Support conditional requests (`ETag` / `Last-Modified`) so well-behaved readers cost only a sentinel query on polls.
+
+## Non-goals
+
+- No per-user / authenticated feeds (e.g. `/me/favorites.atom`). If needed later, the token-in-URL pattern can be bolted on.
+- No Redis-cached response bodies. HTTP caching is sufficient; if traffic forces it, escalating to Redis is a small future change.
+- No pagination (`?page=`, `?limit=`, RFC 5005). Fixed window is the convention and is sufficient given expected reader polling behavior.
+- No feed autodiscovery `<link>` tags in frontend HTML. Frontend's concern, not backend's.
+
+## Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/images.atom` | Latest 50 active images, newest first. |
+| `GET` | `/api/v1/tags/{id}/images.atom` | Latest 50 active images tagged with `{id}`. `{id}` is `tags.tag_id`. 404 if the tag does not exist. |
+
+- `{id}` is used instead of `{title}` to make URLs stable across tag renames.
+- Content-Type: `application/atom+xml; charset=utf-8`.
+- Public (no auth).
+- Fixed window: 50 entries. No query parameters.
+
+## Feed structure
+
+### Feed-level elements
+
+| Element | Value |
+|---|---|
+| `<id>` | `tag:e-shuushuu.net,2005:feed:images` (global) or `tag:e-shuushuu.net,2005:feed:tags:{id}` (per-tag). Tag URI (RFC 4151). |
+| `<title>` | `"Shuushuu — latest images"` (global) or `"Shuushuu — tag: {title}"` (per-tag). |
+| `<link rel="self">` | Absolute URL of the feed. |
+| `<link rel="alternate">` | `https://e-shuushuu.net/` (global) or `https://e-shuushuu.net/tags/{id}` (per-tag). |
+| `<updated>` | `date_added` of the newest entry, or current UTC time if feed is empty. |
+| `<author><name>` | `Shuushuu` (feed-level fallback; entries always emit their own). |
+
+### Entry-level elements
+
+| Element | Source |
+|---|---|
+| `<id>` | `tag:e-shuushuu.net,2005:image:{image_id}`. Tag URI, stable, unique, independent of filename. |
+| `<title>` | See "Title composition" below. |
+| `<link rel="alternate">` | `https://e-shuushuu.net/images/{image_id}` (frontend detail page). |
+| `<link rel="enclosure">` | Full image URL, with `type="image/{ext}"`. `length` is omitted (we do not store file size per image). |
+| `<updated>` | `image.date_added`. |
+| `<published>` | `image.date_added`. Same as `<updated>` until the model tracks edits separately. |
+| `<author><name>` | `image.user.username`. `"[deleted user]"` if `user` is NULL (soft-deleted uploader). |
+| `<category>` | One per tag linked to the image, via `tag_links`. `term="{tag.title}"`, `scheme="https://e-shuushuu.net/tag-type/{type_name}"` where `type_name` is one of `all`, `theme`, `source`, `artist`, `character` per `TagType`. No truncation. |
+| `<content type="html">` | `image.caption` if present, else empty string. HTML-escaped. |
+
+### Title composition
+
+Format: `"{characters} ({sources}) drawn by {artists}"` using a single representative tag per category, chosen by `ORDER BY usage_count DESC`. Empty sections are skipped:
+
+- No character tags: `"({sources}) drawn by {artists}"`.
+- No source tags: `"{characters} drawn by {artists}"`.
+- No artist tags: `"{characters} ({sources})"`.
+- No tags of any used category: `"Image #{image_id}"` (final fallback).
+
+Rationale: titles are the prominent field in feed-reader list views; keeping them short and human-readable is worth more than enumerating every tag. Full tag listing is available on each entry via `<category>` elements — the spec-canonical location.
+
+## Caching
+
+### Response headers
+
+- `Cache-Control: public, max-age=300` (5 minutes; matches PHP memcache TTL).
+- `Last-Modified: <HTTP-date>` — newest `date_added` in the feed window, in RFC 7232 §2.2 format.
+- `ETag: W/"<hash>"` — weak ETag, content-derived (see below).
+
+### ETag generation
+
+Stateless. Server derives it on every request from current DB state; no storage of handed-out ETags.
+
+```
+sentinel = SELECT image_id, date_added
+           FROM images
+           WHERE status = 1 [AND image_id IN (SELECT image_id FROM tag_links WHERE tag_id = :tag_id)]
+           ORDER BY image_id DESC
+           LIMIT 50;
+etag = 'W/"' + sha1(','.join(f"{id}:{ts.isoformat()}" for id, ts in sentinel)) + '"'
+```
+
+Properties:
+- New image uploaded → top-50 set changes → hash changes → cache busts.
+- Image in the window hidden / status-changed → window shifts → hash changes.
+- Older image (outside top 50) edited → hash unchanged, cache stays valid. Correct.
+
+### Conditional request handling
+
+1. Run sentinel query, derive ETag and `Last-Modified` (from the newest `date_added`).
+2. If the request has `If-None-Match` matching our current ETag, or `If-Modified-Since` at or after our `Last-Modified`: return `304 Not Modified` with no body and the ETag / Last-Modified headers.
+3. Otherwise: load full entry data (user + tag joins), render, return `200` with body + headers.
+
+Cost profile: repeat polls when nothing changed cost one indexed `SELECT ... LIMIT 50` and a SHA-1. Polls with new content add the full render path. No `Vary` header — no per-request variation to capture.
+
+## Implementation
+
+### File layout
+
+```
+app/
+├── api/v1/
+│   └── feeds.py           # New. Two thin route handlers.
+└── services/
+    └── feeds.py           # New. Query helpers + Atom rendering.
+```
+
+- `api/v1/feeds.py`: handlers under 30 lines each. Dependencies (db session), call service, set headers, return `Response`.
+- `services/feeds.py`: pure helpers — query builders returning `list[ImageDetailedResponse]`, an ETag deriver over the sentinel query, and `build_atom_feed(feed_meta, entries) -> str`.
+- Router registered in `app/main.py` alongside existing routers.
+- No Pydantic response schema (response is XML, not JSON).
+
+### Library
+
+- Add `feedgenerator` (the Django-extracted PyPI package, last release 2025-08) to `pyproject.toml`.
+- Use `feedgenerator.Atom1Feed` to assemble the document. Pass rendered strings in; the library handles namespace registration, date normalization (RFC 3339), XML escaping, and `<content type="html">` wrapping.
+- Rejected: `feedgen` (stale, last release 2023-12; pulls lxml); hand-rolled `ElementTree` (~7 validator footguns around RFC 3339 dates with tz, stable tag-URI `<id>`, `<link rel="self">`, `<link rel="enclosure">` vs RSS-style `<enclosure>`, per-entry `<author><name>`, namespace registration, content type).
+
+### Data flow
+
+1. Handler receives request.
+2. Service runs the sentinel query and derives ETag + Last-Modified.
+3. If-None-Match / If-Modified-Since check → maybe return 304.
+4. Service runs the hydration query (joins `Users` via `selectinload`, joins `Tags` via `selectinload(Images.tag_links).selectinload(TagLinks.tag)`).
+5. Results converted to `ImageDetailedResponse` instances (`.model_validate(image)`).
+6. `build_atom_feed(feed_meta, entries)` produces the XML string.
+7. Return `Response(content=..., media_type="application/atom+xml; charset=utf-8")` with headers.
+
+### Settings
+
+- `settings.FRONTEND_BASE_URL` (new) — used to construct detail-page links. Default to `"https://e-shuushuu.net"` in production, `"http://localhost:3000"` or similar in dev.
+
+## Edge cases
+
+- **Empty feed** (no matching active images): valid feed, zero `<entry>` elements, `<updated>` = current UTC. 200, not 404.
+- **Tag ID not found**: 404 with the repo's standard error shape.
+- **Tag is an alias** (`alias_of IS NOT NULL`): serve the alias's own images (no redirect, no alias-following). Matches existing tag-detail endpoint behavior. Revisit if users complain.
+- **Image with NULL `user_id`** (soft-deleted uploader): `<author><name>[deleted user]</name></author>`.
+- **Image with no tags**: title falls back to `"Image #{id}"`. Feed is valid.
+- **Caption contains HTML or XML specials**: library escapes as literal text inside `<content type="html">`. If we later want to render formatted captions, revisit the content type.
+- **Concurrent insert between sentinel and render**: feed's `<updated>` may lag the freshest entry by one request. Bounded by the 5-minute max-age; next poll resolves.
+- **DB error**: bubble up to 500 via standard FastAPI error handling.
+
+## Testing
+
+### Unit tests (`tests/unit/services/test_feeds.py`)
+
+- `build_atom_feed` produces well-formed Atom; feed-level `<id>`, `<title>`, `<link rel="self">`, `<updated>` present.
+- Entry `<id>` uses tag URI, is unique per image.
+- Entry `<title>` follows composition rules: all four sections populated, any one missing, none populated (falls back to `"Image #{id}"`).
+- `<category>` elements emitted once per tag, with the correct `scheme` per `TagType`.
+- `<link rel="enclosure">` has the correct MIME type per file extension.
+- Image with zero tags doesn't crash the builder.
+- ETag is deterministic for identical input; changes when any `image_id` or `date_added` in the input changes.
+
+### API tests (`tests/api/v1/test_feeds.py`)
+
+- `GET /api/v1/images.atom` returns 200, `application/atom+xml; charset=utf-8`.
+- Only `status=1` images appear; non-active images with other statuses excluded.
+- Ordering is newest first.
+- Capped at 50 entries when more than 50 eligible images exist.
+- `GET /api/v1/tags/{id}/images.atom` returns only images tagged with that tag.
+- `GET /api/v1/tags/{nonexistent_id}/images.atom` returns 404.
+- Conditional requests:
+  - First request returns 200 + ETag + Last-Modified.
+  - Same ETag in `If-None-Match` → 304 with empty body.
+  - After inserting a new image, repeat conditional request → 200 + new ETag.
+  - `If-Modified-Since` with a timestamp before newest → 200.
+  - `If-Modified-Since` with a timestamp at or after newest → 304.
+- Soft-deleted uploader (user NULL) → `<author>` shows `"[deleted user]"`, no crash.
+- `Cache-Control: public, max-age=300` present on 200 responses.
+- Atom XML parses under `xml.etree.ElementTree.fromstring`.
+
+### Out of scope
+
+- W3C feed validator in CI (would require network); acceptable as a one-time manual check during initial rollout.
+- Load or cache-hit-rate tests.
+
+## Open issues / future work
+
+- **Frontend `/tags/{id}` page**: feed-level `<link rel="alternate">` assumes this exists on the frontend. If it doesn't, either point to the global `/` or skip the alternate link.
+- **Autodiscovery `<link>` tags in HTML**: frontend concern. Once feeds ship, the frontend should emit `<link rel="alternate" type="application/atom+xml" ...>` in the `<head>` of pages where a feed applies.
+- **Per-user feeds**: not in this spec. If demand materializes, add `/api/v1/me/favorites.atom` etc. with a token-in-URL auth pattern (feed readers don't do cookies).
+- **Retagging affects `<updated>`?**: currently `<updated>` = `date_added`. If we want retags to bust caches and trigger reader updates, we'd need to track per-image "last touched" time. Deferred.

--- a/docs/plans/2026-04-24-rss-feed-design.md
+++ b/docs/plans/2026-04-24-rss-feed-design.md
@@ -61,7 +61,7 @@ Modern booru convention is Atom 1.0 (verified: Danbooru serves `/posts.atom`, e6
 | `<updated>` | `image.date_added`. |
 | `<published>` | `image.date_added`. Same as `<updated>` until the model tracks edits separately. |
 | `<author><name>` | `image.user.username`. `"[deleted user]"` if `user` is NULL (soft-deleted uploader). |
-| `<category>` | One per tag linked to the image, via `tag_links`. `term="{tag.title}"`, `scheme="https://e-shuushuu.net/tag-type/{type_name}"` where `type_name` is the value from `TagSummary.type_name` (title-cased: `All`, `Theme`, `Source`, `Artist`, `Character`). Reusing the existing schema value keeps feed and JSON-API representations aligned. No truncation. |
+| `<category>` | One per tag linked to the image, via `tag_links`. `term="{tag.title}"`, `scheme="https://e-shuushuu.net/tag-type/{type_name}"` where `type_name` is the value from `TagSummary.type_name` (title-cased: `Theme`, `Source`, `Artist`, `Character`; `All` exists as a pseudo-type in `TagType` but is a filter value only, not present on actual tag rows). Reusing the existing schema value keeps feed and JSON-API representations aligned. No truncation. |
 | `<content type="html">` | `image.caption` if present, else empty string. HTML-escaped. |
 
 ### Title composition
@@ -145,8 +145,8 @@ app/
 1. Handler receives request.
 2. Service runs the sentinel query and derives ETag + Last-Modified.
 3. If-None-Match / If-Modified-Since check → maybe return 304.
-4. Service runs the hydration query, eager-loading relationships via `selectinload` (e.g. `Images.user`, `Images.tag_links.tag`) so no lazy-loads happen during rendering.
-5. Results converted to `ImageDetailedResponse` via `.model_validate(image)` directly. `ImageDetailedResponse.from_db_model()` is not used: its constructor-level kwargs (`is_favorited`, `user_rating`, `prev_image_id`, `next_image_id`) are request-context fields that do not apply in a public feed.
+4. Service runs the hydration query, eager-loading relationships via the chained `selectinload` idiom used elsewhere in the codebase: `selectinload(Images.user)`, `selectinload(Images.tag_links).selectinload(TagLinks.tag)`. Dotted-attribute traversal in a single `selectinload(Images.tag_links.tag)` does not work in SQLAlchemy.
+5. Results converted to `ImageDetailedResponse` via `ImageDetailedResponse.from_db_model(image)` (defined in `app/schemas/image.py:167`). Using `from_db_model` (not `model_validate`) is required because the schema's `tags` field is populated by manually mapping from the `tag_links` relationship — Pydantic's `from_attributes` cannot cross the `tag_links` → `tags` name difference. The request-context kwargs (`is_favorited`, `user_rating`, `prev_image_id`, `next_image_id`) all have defaults and are left at their defaults for feed entries.
 6. `build_atom_feed(feed_meta, entries)` produces the XML string.
 7. Return `Response(content=..., media_type="application/atom+xml; charset=utf-8")` with headers.
 
@@ -156,10 +156,11 @@ app/
 
 ## Edge cases
 
-- **Empty feed** (no matching active images): valid feed, zero `<entry>` elements, `<updated>` = current UTC. 200, not 404.
+- **Empty feed** (no matching active images): valid feed, zero `<entry>` elements, `<updated>` = current UTC. `Last-Modified` header omitted (nothing to date); ETag falls out of the hash of an empty list, stable until content appears. 200, not 404.
 - **Tag ID not found**: 404 with the repo's standard error shape.
 - **Tag is an alias** (`alias_of IS NOT NULL`): `resolve_tag_alias()` follows the alias to the canonical tag, then `get_tag_hierarchy()` expands to include child tags. The feed serves images in the full effective set. Matches `GET /api/v1/tags/{id}/images`. No redirect; the request URL remains the alias's ID, but the content is the canonical set. Readers that subscribe via alias continue to receive the correct content after the alias is established.
 - **Image with NULL `user_id`** (soft-deleted uploader): `<author><name>[deleted user]</name></author>`.
+- **NULL `date_added`**: `Images.date_added` is nullable in the model but has `server_default=current_timestamp()` at the DB level, so in practice it's always populated. Defensive handling: if a sentinel row has NULL `date_added`, exclude it from the ETag tuple and from `Last-Modified` derivation (fall back to current UTC for `<updated>` and omit `Last-Modified`).
 - **Image with no tags**: title falls back to `"Image #{id}"`. Feed is valid.
 - **Caption contains HTML or XML specials**: library escapes as literal text inside `<content type="html">`. If we later want to render formatted captions, revisit the content type.
 - **Concurrent insert between sentinel and render**: feed's `<updated>` may lag the freshest entry by one request. Bounded by the 5-minute max-age; next poll resolves.

--- a/docs/plans/2026-04-24-rss-feed-impl.md
+++ b/docs/plans/2026-04-24-rss-feed-impl.md
@@ -644,9 +644,9 @@ class TestFetchFeedSentinelGlobal:
     ):
         user = await _make_user(db_session)
         active_a = await _make_image(db_session, user, "a")
-        hidden = await _make_image(db_session, user, "h", status=ImageStatus.DELETED)
+        hidden = await _make_image(db_session, user, "h", status=ImageStatus.INAPPROPRIATE)
         active_b = await _make_image(db_session, user, "b")
-        await _make_image(db_session, user, "c", status=ImageStatus.REPORTED)
+        await _make_image(db_session, user, "c", status=ImageStatus.REVIEW)
 
         sentinel = await fetch_feed_sentinel(db_session, tag_ids=None, limit=50)
 
@@ -813,7 +813,7 @@ class TestFetchFeedEntriesGlobal:
     async def test_only_active_images(self, db_session: AsyncSession):
         user = await _make_user(db_session, "activeonly")
         active = await _make_image(db_session, user, "a")
-        hidden = await _make_image(db_session, user, "h", status=ImageStatus.DELETED)
+        hidden = await _make_image(db_session, user, "h", status=ImageStatus.INAPPROPRIATE)
 
         entries = await fetch_feed_entries(db_session, tag_ids=None, limit=50)
         ids = [e.image_id for e in entries]
@@ -1218,7 +1218,7 @@ class TestGlobalImagesFeed:
         user = await _make_user(db_session, "actuser")
         active = await _make_image(db_session, user, "a1")
         hidden = await _make_image(
-            db_session, user, "h1", status=ImageStatus.DELETED
+            db_session, user, "h1", status=ImageStatus.INAPPROPRIATE
         )
 
         response = await client.get("/api/v1/images.atom")

--- a/docs/plans/2026-04-24-rss-feed-impl.md
+++ b/docs/plans/2026-04-24-rss-feed-impl.md
@@ -968,13 +968,19 @@ Expected: ImportError on `FeedMeta` / `build_atom_feed`.
 
 - [ ] **Step 3: Implement the builder**
 
+**API context (verified against feedgenerator 2.2.1 source):**
+- `add_item(...)` accepts `description` (emits `<summary type="html">`) **and** `content` (emits `<content type="html">`) as separate kwargs. We want `<content>`, not `<summary>`, so pass `content=...` and `description=None`.
+- `enclosures` kwarg iterates with attribute access (`enclosure.url`, `enclosure.length`, `enclosure.mime_type`). Must be a list of `Enclosure` instances, not dicts.
+- `categories` kwarg is stringified via `str(c)` and emitted as `<category term="...">` with no `scheme`. To get `<category term="..." scheme="...">` per our design spec, we subclass `Atom1Feed` and override `add_item_elements`. Extra item-level data rides through `add_item`'s `**kwargs` and is stored in the item dict.
+- `feed.feed["id"]`, `feed.feed["author_name"]` are read by `add_root_elements` directly — setting them on the feed dict works. `feed.feed["updated"]` is **not** read; `<updated>` is derived from `self.latest_post_date()` (newest `pubdate`/`updateddate` across items; falls back to `datetime.now()` on empty feeds, which matches our spec for the empty-feed case).
+
 Append to `app/services/feeds.py`:
 
 ```python
 from dataclasses import dataclass
 from html import escape
 
-from feedgenerator import Atom1Feed  # type: ignore[import-untyped]
+from feedgenerator import Atom1Feed, Enclosure  # type: ignore[import-untyped]
 
 from app.config import TagType, settings
 
@@ -987,26 +993,35 @@ TAG_TYPE_NAME: dict[int, str] = {
 }
 
 
+class _ShuushuuAtom1Feed(Atom1Feed):
+    """Atom1Feed variant that emits <category term=... scheme=...> per RFC 4287.
+
+    The stock Atom1Feed.add_item_elements drops the scheme attribute, so we
+    append our own category elements from a 'shuu_categories' item attribute
+    (list of (term, scheme) tuples) passed through add_item's **kwargs.
+    """
+
+    def add_item_elements(self, handler, item):  # type: ignore[no-untyped-def]
+        super().add_item_elements(handler, item)
+        for term, scheme in item.get("shuu_categories", ()):
+            handler.addQuickElement(
+                "category", "", {"term": term, "scheme": scheme}
+            )
+
+
 @dataclass(frozen=True)
 class FeedMeta:
     feed_id: str
     title: str
     self_url: str
     alternate_url: str
-    updated: datetime
 
 
-def _category_scheme(tag_type: int) -> str:
+def _category_scheme(tag_type_id: int) -> str:
     return (
         f"{settings.FRONTEND_URL.rstrip('/')}/tag-type/"
-        f"{TAG_TYPE_NAME.get(tag_type, 'Unknown')}"
+        f"{TAG_TYPE_NAME.get(tag_type_id, 'Unknown')}"
     )
-
-
-def _entry_content_html(caption: str | None) -> str:
-    if not caption:
-        return ""
-    return escape(caption)
 
 
 def build_atom_feed(
@@ -1015,80 +1030,61 @@ def build_atom_feed(
 ) -> str:
     """Render an Atom 1.0 XML document.
 
-    Uses feedgenerator.Atom1Feed which handles namespace registration, RFC 3339
-    date formatting, XML escaping, and well-formed output. We pass stringified
-    fields in; the library does the rest.
+    Uses our _ShuushuuAtom1Feed subclass to emit scheme-carrying <category>
+    elements. Item <content type="html"> comes from the image caption;
+    enclosure links use ImageResponse.url (CDN-aware).
     """
-    feed = Atom1Feed(
+    feed = _ShuushuuAtom1Feed(
         title=meta.title,
         link=meta.alternate_url,
-        description=meta.title,  # Atom1Feed requires description; mirrors title.
+        description="",  # empty → no <subtitle>
         feed_url=meta.self_url,
         language="en",
     )
-    # Override feed-level <id>, <updated>, <author> via subclassing-free attrs.
+    # Override <id> and feed-level <author>. <updated> is auto-derived.
     feed.feed["id"] = meta.feed_id
-    feed.feed["updated"] = meta.updated
     feed.feed["author_name"] = "Shuushuu"
 
     frontend = settings.FRONTEND_URL.rstrip("/")
 
     for image in entries:
-        entry_id = f"tag:e-shuushuu.net,2005:image:{image.image_id}"
-        alternate = f"{frontend}/images/{image.image_id}"
-
-        # Uploader name, with soft-delete fallback per spec.
         author_name = (
-            image.user.username if image.user and image.user.username
+            image.user.username
+            if image.user and image.user.username
             else "[deleted user]"
         )
-
-        # date_added fallback to current UTC if missing (defensive per spec).
         entry_dt = image.date_added or datetime.now(UTC)
 
-        # Title — delegate to the composer, passing tags as-is.
-        title = compose_entry_title(
-            image_id=image.image_id,
-            tags=image.tags or [],
-        )
+        content_html: str | None = escape(image.caption) if image.caption else None
 
-        # Build category kwargs: feedgenerator's add_item accepts categories
-        # as a list of tuples-or-dicts; we use the dict form to carry scheme.
-        categories = [
-            {"term": t.tag, "scheme": _category_scheme(t.type_id)}
-            for t in (image.tags or [])
+        shuu_categories = [
+            (t.tag, _category_scheme(t.type_id)) for t in (image.tags or [])
         ]
 
-        # Enclosure — full image URL using IMAGE_BASE_URL from settings.
-        enclosure_url = (
-            f"{settings.IMAGE_BASE_URL.rstrip('/')}/images/"
-            f"{image.filename}.{image.ext}"
+        enclosure = Enclosure(
+            url=image.url,  # CDN-aware computed field on ImageResponse.
+            length=str(image.filesize or 0),
+            mime_type=mime_type_for_ext(image.ext),
         )
-        enclosure_type = mime_type_for_ext(image.ext)
 
         feed.add_item(
-            title=title,
-            link=alternate,
-            description=_entry_content_html(image.caption),
-            unique_id=entry_id,
+            title=compose_entry_title(
+                image_id=image.image_id, tags=image.tags or []
+            ),
+            link=f"{frontend}/images/{image.image_id}",
+            description=None,  # skip <summary>; we emit <content> instead.
+            content=content_html,
+            unique_id=f"tag:e-shuushuu.net,2005:image:{image.image_id}",
             unique_id_is_permalink=False,
-            updateddate=entry_dt,
             pubdate=entry_dt,
+            updateddate=entry_dt,
             author_name=author_name,
-            categories=categories,
-            enclosures=[
-                {
-                    "url": enclosure_url,
-                    "length": str(image.filesize or 0),
-                    "mime_type": enclosure_type,
-                }
-            ],
+            enclosures=[enclosure],
+            shuu_categories=shuu_categories,  # via **kwargs → item dict
         )
 
     return feed.writeString("utf-8")
 ```
-
-NOTE: `feedgenerator.Atom1Feed.add_item` enclosure kwarg differs across versions — verify against installed version. If `enclosures=[{...}]` errors, fall back to `enclosure=Enclosure(...)` (older API). Run the test next step; if it fails on enclosure shape, `python -c "import feedgenerator; help(feedgenerator.Atom1Feed.add_item)"` to see the actual signature.
 
 - [ ] **Step 4: Run the tests and confirm pass**
 
@@ -1097,45 +1093,73 @@ Expected: all empty-feed tests pass. If enclosure-related attribute errors appea
 
 - [ ] **Step 5: Add tests for a non-empty feed**
 
+Rather than construct `ImageDetailedResponse` by hand (brittle — lots of required fields), build a minimal `Images` ORM instance with eager-loaded relationships set directly on the Python object, and funnel it through `from_db_model`. This exercises the exact code path the handler uses.
+
 Append to `tests/unit/test_feeds_service.py`:
 
 ```python
-class TestBuildAtomFeedWithEntries:
-    def _make_entry(self, image_id: int = 42):
-        """Minimal ImageDetailedResponse-shaped object for rendering."""
-        from app.schemas.common import UserSummary
-        from app.schemas.image import ImageDetailedResponse
+from types import SimpleNamespace
 
-        return ImageDetailedResponse(
-            image_id=image_id,
-            filename=f"abc{image_id}",
-            ext="png",
-            caption=None,
-            filesize=1024,
+from app.models.image import Images
+from app.models.tag import Tags
+from app.models.tag_link import TagLinks
+from app.models.user import Users
+from app.schemas.image import ImageDetailedResponse
+
+
+def _orm_image(
+    image_id: int = 42,
+    filename: str = "abc42",
+    ext: str = "png",
+    caption: str | None = None,
+    filesize: int = 1024,
+    date_added: datetime | None = None,
+    username: str | None = "alice",
+    tags: list[Tags] | None = None,
+) -> Images:
+    """Build an Images row with eager-loaded .user and .tag_links set in memory.
+
+    The schema's from_db_model reads image.user and iterates image.tag_links,
+    so we populate both directly. Returned object is ready for
+    ImageDetailedResponse.from_db_model(image).
+    """
+    user = None
+    if username is not None:
+        user = Users(
             user_id=1,
-            user=UserSummary(
-                user_id=1,
-                username="alice",
-                date_joined=datetime(2020, 1, 1, tzinfo=UTC),
-            ),
-            tags=[],
-            date_added=datetime(2026, 4, 24, 10, 0, 0, tzinfo=UTC),
-            locked=0,
-            posts=0,
-            favorites=0,
-            bayesian_rating=0.0,
-            num_ratings=0,
-            medium=0,
-            large=0,
-            is_favorited=False,
-            user_rating=None,
-            prev_image_id=None,
-            next_image_id=None,
+            username=username,
+            password="x",
+            password_type="bcrypt",
+            salt="",
+            email="a@b.c",
+            active=1,
         )
 
+    img = Images(
+        image_id=image_id,
+        filename=filename,
+        ext=ext,
+        caption=caption,
+        filesize=filesize,
+        user_id=1 if username else None,
+        status=1,
+        date_added=date_added or datetime(2026, 4, 24, 10, 0, 0, tzinfo=UTC),
+    )
+    # Directly attach relationships — avoids a DB round-trip for unit tests.
+    img.user = user  # type: ignore[assignment]
+    img.tag_links = [  # type: ignore[assignment]
+        SimpleNamespace(tag=t) for t in (tags or [])
+    ]
+    return img
+
+
+def _entry(**overrides) -> ImageDetailedResponse:
+    return ImageDetailedResponse.from_db_model(_orm_image(**overrides))
+
+
+class TestBuildAtomFeedWithEntries:
     def test_entry_has_tag_uri_id(self):
-        entry = self._make_entry(42)
-        xml = build_atom_feed(_feed_meta(), entries=[entry])
+        xml = build_atom_feed(_feed_meta(), entries=[_entry(image_id=42)])
         root = ET.fromstring(xml)
         entry_node = root.find(f"{ATOM_NS}entry")
         assert entry_node.find(f"{ATOM_NS}id").text == (
@@ -1143,38 +1167,82 @@ class TestBuildAtomFeedWithEntries:
         )
 
     def test_entry_alternate_link_points_to_detail_page(self):
-        entry = self._make_entry(42)
-        xml = build_atom_feed(_feed_meta(), entries=[entry])
+        xml = build_atom_feed(_feed_meta(), entries=[_entry(image_id=42)])
         root = ET.fromstring(xml)
-        entry_node = root.find(f"{ATOM_NS}entry")
-        alt = entry_node.find(f"{ATOM_NS}link[@rel='alternate']")
+        alt = root.find(f"{ATOM_NS}entry/{ATOM_NS}link[@rel='alternate']")
         assert alt is not None
         assert alt.get("href", "").endswith("/images/42")
 
     def test_entry_enclosure_has_mime_and_length(self):
-        entry = self._make_entry(42)
-        xml = build_atom_feed(_feed_meta(), entries=[entry])
+        xml = build_atom_feed(
+            _feed_meta(), entries=[_entry(image_id=42, ext="png", filesize=1024)]
+        )
         root = ET.fromstring(xml)
-        entry_node = root.find(f"{ATOM_NS}entry")
-        enc = entry_node.find(f"{ATOM_NS}link[@rel='enclosure']")
+        enc = root.find(f"{ATOM_NS}entry/{ATOM_NS}link[@rel='enclosure']")
         assert enc is not None
         assert enc.get("type") == "image/png"
         assert enc.get("length") == "1024"
 
     def test_entry_author_is_uploader(self):
-        entry = self._make_entry(42)
-        xml = build_atom_feed(_feed_meta(), entries=[entry])
-        root = ET.fromstring(xml)
-        entry_node = root.find(f"{ATOM_NS}entry")
-        assert (
-            entry_node.find(f"{ATOM_NS}author/{ATOM_NS}name").text == "alice"
+        xml = build_atom_feed(
+            _feed_meta(), entries=[_entry(username="alice")]
         )
+        root = ET.fromstring(xml)
+        assert (
+            root.find(
+                f"{ATOM_NS}entry/{ATOM_NS}author/{ATOM_NS}name"
+            ).text
+            == "alice"
+        )
+
+    def test_entry_author_falls_back_for_deleted_uploader(self):
+        xml = build_atom_feed(
+            _feed_meta(), entries=[_entry(username=None)]
+        )
+        root = ET.fromstring(xml)
+        assert (
+            root.find(
+                f"{ATOM_NS}entry/{ATOM_NS}author/{ATOM_NS}name"
+            ).text
+            == "[deleted user]"
+        )
+
+    def test_entry_content_is_html_escaped_caption(self):
+        xml = build_atom_feed(
+            _feed_meta(),
+            entries=[_entry(caption="a <b> caption & stuff")],
+        )
+        root = ET.fromstring(xml)
+        content = root.find(f"{ATOM_NS}entry/{ATOM_NS}content")
+        assert content is not None
+        assert content.get("type") == "html"
+        # ET.fromstring will have already un-escaped &amp; → &, &lt; → <
+        # so we check the .text rendered equals the original.
+        assert content.text == "a <b> caption & stuff"
+
+    def test_entry_with_no_caption_omits_content(self):
+        xml = build_atom_feed(_feed_meta(), entries=[_entry(caption=None)])
+        root = ET.fromstring(xml)
+        assert root.find(f"{ATOM_NS}entry/{ATOM_NS}content") is None
+
+    def test_entry_categories_carry_scheme(self):
+        tags = [
+            Tags(tag_id=1, title="hatsune miku", type=TagType.CHARACTER, usage_count=500),
+            Tags(tag_id=2, title="vocaloid", type=TagType.SOURCE, usage_count=1000),
+        ]
+        xml = build_atom_feed(_feed_meta(), entries=[_entry(tags=tags)])
+        root = ET.fromstring(xml)
+        cats = root.findall(f"{ATOM_NS}entry/{ATOM_NS}category")
+        assert len(cats) == 2
+        by_term = {c.get("term"): c.get("scheme") for c in cats}
+        assert by_term["hatsune miku"].endswith("/tag-type/Character")
+        assert by_term["vocaloid"].endswith("/tag-type/Source")
 ```
 
 - [ ] **Step 6: Run the tests**
 
 Run: `uv run pytest tests/unit/test_feeds_service.py::TestBuildAtomFeedWithEntries -v`
-Expected: all four tests pass. If the enclosure test fails with `<link rel="enclosure">` absent, inspect the generated XML via `print(xml)` inside the test and adapt the enclosure kwarg shape (see the NOTE in Step 3) until the link appears.
+Expected: all 8 tests pass.
 
 - [ ] **Step 7: Commit**
 
@@ -1292,14 +1360,30 @@ class TestGlobalImagesFeed:
         assert second.status_code == 200
         assert second.headers["etag"] != first_etag
 
+    async def test_if_modified_since_returns_304(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "imsuser")
+        await _make_image(db_session, user, "ims1")
+
+        first = await client.get("/api/v1/images.atom")
+        assert first.status_code == 200
+        last_mod = first.headers["last-modified"]
+
+        second = await client.get(
+            "/api/v1/images.atom",
+            headers={"If-Modified-Since": last_mod},
+        )
+        assert second.status_code == 304
+
     async def test_empty_feed_is_200(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        # No images in the DB for this test's isolated scope.
+        # Note: db_session may share rows across tests; we only assert feed
+        # validity and 200 status, not that there are zero entries.
         response = await client.get("/api/v1/images.atom")
 
         assert response.status_code == 200
-        # Feed is valid Atom even with no entries.
         assert "<feed" in response.text
 ```
 
@@ -1315,13 +1399,14 @@ Replace `app/api/v1/feeds.py` with:
 ```python
 """Atom feed endpoints."""
 
-from datetime import UTC, datetime
-from email.utils import format_datetime
+from datetime import datetime
+from email.utils import format_datetime, parsedate_to_datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.v1.tags import get_tag_hierarchy, resolve_tag_alias
 from app.config import settings
 from app.core.database import get_db
 from app.services.feeds import (
@@ -1349,6 +1434,42 @@ def _self_url(request: Request) -> str:
     return str(request.url).split("?")[0]
 
 
+def _is_not_modified(
+    request: Request, etag: str, last_mod: datetime | None
+) -> bool:
+    """Conditional-request evaluation.
+
+    A request is 'not modified' if either:
+    - Its If-None-Match matches our ETag (exact or '*'), or
+    - We know a Last-Modified and the request's If-Modified-Since is at/after it.
+
+    Both comparisons are best-effort: we accept weak-ETag equality and ignore
+    list/quote edge cases. Feed readers send simple values in practice.
+    """
+    inm = request.headers.get("if-none-match", "").strip()
+    if inm == "*" or (inm and inm == etag):
+        return True
+
+    if last_mod is not None:
+        ims = request.headers.get("if-modified-since")
+        if ims:
+            try:
+                ims_dt = parsedate_to_datetime(ims)
+            except (TypeError, ValueError):
+                ims_dt = None
+            if ims_dt is not None and ims_dt >= last_mod:
+                return True
+
+    return False
+
+
+def _cacheable_headers(etag: str, last_mod: datetime | None) -> dict[str, str]:
+    headers = {"Cache-Control": CACHE_CONTROL, "ETag": etag}
+    if last_mod is not None:
+        headers["Last-Modified"] = format_datetime(last_mod, usegmt=True)
+    return headers
+
+
 @router.get("/images.atom")
 async def list_images_atom(
     request: Request,
@@ -1358,11 +1479,10 @@ async def list_images_atom(
     sentinel = await fetch_feed_sentinel(db, tag_ids=None, limit=50)
     etag = compute_feed_etag(sentinel)
     last_mod = newest_timestamp(sentinel)
+    headers = _cacheable_headers(etag, last_mod)
 
-    # Conditional-request short-circuit
-    if_none_match = request.headers.get("if-none-match")
-    if if_none_match == etag:
-        return _not_modified(etag, last_mod)
+    if _is_not_modified(request, etag, last_mod):
+        return Response(status_code=304, headers=headers)
 
     entries = await fetch_feed_entries(db, tag_ids=None, limit=50)
     meta = FeedMeta(
@@ -1370,30 +1490,10 @@ async def list_images_atom(
         title="Shuushuu — latest images",
         self_url=_self_url(request),
         alternate_url=_frontend(),
-        updated=last_mod or datetime.now(UTC),
     )
     xml = build_atom_feed(meta, entries)
 
-    headers = {
-        "Cache-Control": CACHE_CONTROL,
-        "ETag": etag,
-    }
-    if last_mod:
-        headers["Last-Modified"] = format_datetime(last_mod, usegmt=True)
-
-    return Response(
-        content=xml, media_type=ATOM_CONTENT_TYPE, headers=headers
-    )
-
-
-def _not_modified(etag: str, last_mod: datetime | None) -> Response:
-    headers = {
-        "Cache-Control": CACHE_CONTROL,
-        "ETag": etag,
-    }
-    if last_mod:
-        headers["Last-Modified"] = format_datetime(last_mod, usegmt=True)
-    return Response(status_code=304, headers=headers)
+    return Response(content=xml, media_type=ATOM_CONTENT_TYPE, headers=headers)
 ```
 
 - [ ] **Step 4: Run the tests**
@@ -1503,14 +1603,9 @@ Expected: 404 on all (handler not registered yet).
 
 - [ ] **Step 3: Implement the per-tag handler**
 
-Add to `app/api/v1/feeds.py` (below the global handler):
+Add to `app/api/v1/feeds.py` immediately below the global handler (imports are already at the top of the file from Task 9):
 
 ```python
-from fastapi import HTTPException, Path
-
-from app.api.v1.tags import get_tag_hierarchy, resolve_tag_alias
-
-
 @router.get("/tags/{tag_id}/images.atom")
 async def list_tag_images_atom(
     request: Request,
@@ -1532,9 +1627,10 @@ async def list_tag_images_atom(
     sentinel = await fetch_feed_sentinel(db, tag_ids=effective_ids, limit=50)
     etag = compute_feed_etag(sentinel)
     last_mod = newest_timestamp(sentinel)
+    headers = _cacheable_headers(etag, last_mod)
 
-    if request.headers.get("if-none-match") == etag:
-        return _not_modified(etag, last_mod)
+    if _is_not_modified(request, etag, last_mod):
+        return Response(status_code=304, headers=headers)
 
     entries = await fetch_feed_entries(db, tag_ids=effective_ids, limit=50)
     meta = FeedMeta(
@@ -1542,23 +1638,13 @@ async def list_tag_images_atom(
         title=f"Shuushuu — tag: {tag.title}",
         self_url=_self_url(request),
         alternate_url=_frontend("tags", str(resolved_id)),
-        updated=last_mod or datetime.now(UTC),
     )
     xml = build_atom_feed(meta, entries)
 
-    headers = {
-        "Cache-Control": CACHE_CONTROL,
-        "ETag": etag,
-    }
-    if last_mod:
-        headers["Last-Modified"] = format_datetime(last_mod, usegmt=True)
-
-    return Response(
-        content=xml, media_type=ATOM_CONTENT_TYPE, headers=headers
-    )
+    return Response(content=xml, media_type=ATOM_CONTENT_TYPE, headers=headers)
 ```
 
-**Verify the signature of `resolve_tag_alias` before running.** It's defined at `app/api/v1/tags.py:167` and returns `tuple[Tags, int]` per usage at `app/api/v1/tags.py:695`. If it raises instead of returning `(None, ...)` on missing, convert that exception to a 404 explicitly; adjust the handler accordingly.
+**Verify `resolve_tag_alias`'s exact return contract before running.** It's defined at `app/api/v1/tags.py:167` and returns `tuple[Tags | None, int]` per existing call sites (e.g. `app/api/v1/tags.py:695`). `tag is None` on unknown id → our 404 branch fires. If the behavior differs in this repo's version, adjust the branch.
 
 - [ ] **Step 4: Run the tests**
 

--- a/docs/plans/2026-04-24-rss-feed-impl.md
+++ b/docs/plans/2026-04-24-rss-feed-impl.md
@@ -1,0 +1,1563 @@
+# RSS / Atom feed — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build two Atom 1.0 feed endpoints (`/api/v1/images.atom` and `/api/v1/tags/{id}/images.atom`) on the FastAPI backend, replacing the legacy PHP RSS 1.0 feed.
+
+**Architecture:** Thin route handlers in `app/api/v1/feeds.py` delegate to pure helpers in `app/services/feeds.py`. ETag/Last-Modified derived from a cheap sentinel query; full rendering happens only when conditional-request checks miss. Per-tag feeds reuse the existing `resolve_tag_alias()` + `get_tag_hierarchy()` helpers from `app/api/v1/tags.py` so the image set matches the JSON tag-images endpoint.
+
+**Tech Stack:** FastAPI, SQLModel/SQLAlchemy async, MariaDB, `feedgenerator` (PyPI, Django-extracted). Python 3.14+.
+
+**Reference:** full design at `docs/plans/2026-04-24-rss-feed-design.md`. Read it before starting — this plan assumes the reader has seen the spec's feed-structure tables, ETag rationale, and edge-case list.
+
+---
+
+## File Structure
+
+**Create:**
+- `app/api/v1/feeds.py` — two route handlers (`list_images_atom`, `list_tag_images_atom`). Thin; dependency injection, conditional-request check, call service, return `Response`.
+- `app/services/feeds.py` — pure helpers: MIME mapping, title composition, ETag/Last-Modified derivation, sentinel query, hydration query, Atom XML rendering.
+- `tests/unit/test_feeds_service.py` — unit tests for pure helpers (MIME, title, ETag).
+- `tests/api/v1/test_feeds.py` — API/integration tests hitting both endpoints.
+
+**Modify:**
+- `pyproject.toml` — add `feedgenerator>=2.2.1` to `dependencies`.
+- `app/main.py` — register the feeds router.
+
+**Do NOT modify:**
+- `app/config.py` (reuse existing `FRONTEND_URL`).
+- `app/schemas/image.py` (reuse `ImageDetailedResponse.from_db_model`).
+- Any DB schema or Alembic migration — pure read-only feature.
+
+---
+
+## Chunk 1: Setup + pure helpers
+
+Pure-function work. No DB, no HTTP. Every function in this chunk is unit-testable with plain Python input.
+
+### Task 1: Dependency, router wiring, and empty modules
+
+**Files:**
+- Modify: `pyproject.toml` (dependencies)
+- Create: `app/services/feeds.py` (empty module)
+- Create: `app/api/v1/feeds.py` (empty router)
+- Modify: `app/main.py` (register router)
+
+- [ ] **Step 1: Add `feedgenerator` to dependencies**
+
+Locate the `dependencies = [...]` block in `pyproject.toml` and append:
+
+```toml
+"feedgenerator>=2.2.1",
+```
+
+- [ ] **Step 2: Sync the environment**
+
+Run: `uv sync`
+Expected: no errors; `.venv/lib/.../feedgenerator/...` installed.
+
+- [ ] **Step 3: Create `app/services/feeds.py` as an empty module**
+
+```python
+"""Atom feed rendering and query helpers."""
+```
+
+- [ ] **Step 4: Create `app/api/v1/feeds.py` with an empty router**
+
+```python
+"""Atom feed endpoints."""
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["feeds"])
+```
+
+- [ ] **Step 5: Register the router in `app/main.py`**
+
+Find where other `app.include_router(...)` calls live. Add alongside them:
+
+```python
+from app.api.v1 import feeds as feeds_router
+# ...
+app.include_router(feeds_router.router, prefix="/api/v1")
+```
+
+- [ ] **Step 6: Verify the app still starts**
+
+Run: `uv run python -c "from app.main import app; print(sorted(r.path for r in app.routes if hasattr(r, 'path')))"`
+Expected: no import errors. No new routes yet — that's fine.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pyproject.toml uv.lock app/services/feeds.py app/api/v1/feeds.py app/main.py
+git commit -m "feat(feeds): scaffold feeds router and service module"
+```
+
+---
+
+### Task 2: MIME type mapping helper
+
+**Files:**
+- Modify: `app/services/feeds.py`
+- Create: `tests/unit/test_feeds_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_feeds_service.py
+"""Unit tests for app.services.feeds pure helpers."""
+
+import pytest
+
+from app.services.feeds import mime_type_for_ext
+
+
+class TestMimeTypeForExt:
+    @pytest.mark.parametrize(
+        "ext,expected",
+        [
+            ("jpg", "image/jpeg"),
+            ("jpeg", "image/jpeg"),
+            ("JPG", "image/jpeg"),
+            ("png", "image/png"),
+            ("gif", "image/gif"),
+            ("webp", "image/webp"),
+        ],
+    )
+    def test_known_extensions(self, ext: str, expected: str):
+        assert mime_type_for_ext(ext) == expected
+
+    def test_unknown_extension_falls_back_to_octet_stream(self):
+        assert mime_type_for_ext("xyz") == "application/octet-stream"
+
+    def test_empty_string_falls_back(self):
+        assert mime_type_for_ext("") == "application/octet-stream"
+```
+
+- [ ] **Step 2: Run the test and confirm failure**
+
+Run: `uv run pytest tests/unit/test_feeds_service.py::TestMimeTypeForExt -v`
+Expected: ImportError — `mime_type_for_ext` not defined yet.
+
+- [ ] **Step 3: Implement**
+
+Add to `app/services/feeds.py`:
+
+```python
+"""Atom feed rendering and query helpers."""
+
+_MIME_BY_EXT: dict[str, str] = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "gif": "image/gif",
+    "webp": "image/webp",
+}
+
+
+def mime_type_for_ext(ext: str) -> str:
+    """Map a file extension (case-insensitive, no leading dot) to its MIME type.
+
+    Returns 'application/octet-stream' for unknown or empty extensions — Atom
+    validators accept this and feed readers handle it gracefully.
+    """
+    return _MIME_BY_EXT.get(ext.lower(), "application/octet-stream")
+```
+
+- [ ] **Step 4: Run the tests and confirm pass**
+
+Run: `uv run pytest tests/unit/test_feeds_service.py::TestMimeTypeForExt -v`
+Expected: all 8 parametrize cases + 2 fallback cases PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/feeds.py tests/unit/test_feeds_service.py
+git commit -m "feat(feeds): MIME type mapping for enclosure links"
+```
+
+---
+
+### Task 3: Title composition helper
+
+Implements the spec's "Title composition" section. Picks one representative tag per category by `usage_count DESC` and formats `"{characters} ({sources}) by {artists}"` with empty sections skipped.
+
+**Files:**
+- Modify: `app/services/feeds.py`
+- Modify: `tests/unit/test_feeds_service.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_feeds_service.py`:
+
+```python
+from app.config import TagType
+from app.services.feeds import compose_entry_title
+
+
+def _tag(tag_id: int, title: str, type_: int, usage_count: int):
+    """Lightweight stand-in for TagSummary — just enough for the helper."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        tag_id=tag_id,
+        tag=title,  # TagSummary's alias for Tags.title
+        type=type_,
+        usage_count=usage_count,
+    )
+
+
+class TestComposeEntryTitle:
+    def test_all_three_sections(self):
+        tags = [
+            _tag(1, "hatsune miku", TagType.CHARACTER, 500),
+            _tag(2, "kagamine rin", TagType.CHARACTER, 100),
+            _tag(3, "vocaloid", TagType.SOURCE, 1000),
+            _tag(4, "cutesexyrobutts", TagType.ARTIST, 50),
+        ]
+        assert (
+            compose_entry_title(image_id=42, tags=tags)
+            == "hatsune miku (vocaloid) by cutesexyrobutts"
+        )
+
+    def test_no_character_tags(self):
+        tags = [
+            _tag(3, "vocaloid", TagType.SOURCE, 1000),
+            _tag(4, "cutesexyrobutts", TagType.ARTIST, 50),
+        ]
+        assert (
+            compose_entry_title(image_id=42, tags=tags)
+            == "(vocaloid) by cutesexyrobutts"
+        )
+
+    def test_no_source_tags(self):
+        tags = [
+            _tag(1, "hatsune miku", TagType.CHARACTER, 500),
+            _tag(4, "cutesexyrobutts", TagType.ARTIST, 50),
+        ]
+        assert (
+            compose_entry_title(image_id=42, tags=tags)
+            == "hatsune miku by cutesexyrobutts"
+        )
+
+    def test_no_artist_tags(self):
+        tags = [
+            _tag(1, "hatsune miku", TagType.CHARACTER, 500),
+            _tag(3, "vocaloid", TagType.SOURCE, 1000),
+        ]
+        assert (
+            compose_entry_title(image_id=42, tags=tags)
+            == "hatsune miku (vocaloid)"
+        )
+
+    def test_no_relevant_tags_falls_back(self):
+        tags = [_tag(5, "solo", TagType.THEME, 999)]
+        assert compose_entry_title(image_id=42, tags=tags) == "Image #42"
+
+    def test_no_tags_at_all_falls_back(self):
+        assert compose_entry_title(image_id=42, tags=[]) == "Image #42"
+
+    def test_picks_highest_usage_count_per_category(self):
+        tags = [
+            _tag(1, "low usage char", TagType.CHARACTER, 1),
+            _tag(2, "high usage char", TagType.CHARACTER, 9999),
+            _tag(3, "low usage artist", TagType.ARTIST, 1),
+            _tag(4, "high usage artist", TagType.ARTIST, 9999),
+        ]
+        assert (
+            compose_entry_title(image_id=42, tags=tags)
+            == "high usage char by high usage artist"
+        )
+```
+
+- [ ] **Step 2: Run tests and confirm failure**
+
+Run: `uv run pytest tests/unit/test_feeds_service.py::TestComposeEntryTitle -v`
+Expected: ImportError — `compose_entry_title` not defined.
+
+- [ ] **Step 3: Implement**
+
+Append to `app/services/feeds.py`:
+
+```python
+from typing import Any
+
+from app.config import TagType
+
+
+def _pick_representative(tags: list[Any], type_value: int) -> str | None:
+    """Return the title of the highest-usage tag of the given type, or None."""
+    candidates = [t for t in tags if t.type == type_value]
+    if not candidates:
+        return None
+    # Stable sort: usage_count DESC, then tag_id ASC for determinism on ties.
+    candidates.sort(key=lambda t: (-t.usage_count, t.tag_id))
+    return candidates[0].tag
+
+
+def compose_entry_title(image_id: int, tags: list[Any]) -> str:
+    """Build the Atom entry <title> per the design spec.
+
+    Format: '{characters} ({sources}) by {artists}' — single representative tag
+    per category (highest usage_count). Empty sections are skipped. Falls back
+    to 'Image #{image_id}' if no character, source, or artist tags are present.
+
+    `tags` is any sequence of objects with `.tag` (title), `.type` (int), `.tag_id`,
+    and `.usage_count` — e.g. TagSummary instances or SQLModel Tags rows.
+    """
+    char = _pick_representative(tags, TagType.CHARACTER)
+    src = _pick_representative(tags, TagType.SOURCE)
+    artist = _pick_representative(tags, TagType.ARTIST)
+
+    parts: list[str] = []
+    if char:
+        parts.append(char)
+    if src:
+        parts.append(f"({src})")
+    if artist:
+        parts.append(f"by {artist}")
+
+    if not parts:
+        return f"Image #{image_id}"
+    return " ".join(parts)
+```
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+Run: `uv run pytest tests/unit/test_feeds_service.py::TestComposeEntryTitle -v`
+Expected: all 7 cases PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/feeds.py tests/unit/test_feeds_service.py
+git commit -m "feat(feeds): compose Atom entry titles from image tags"
+```
+
+---
+
+### Task 4: ETag and Last-Modified helpers
+
+Pure functions operating on a list of `(image_id, date_added)` tuples (the sentinel result). No DB access here.
+
+**Files:**
+- Modify: `app/services/feeds.py`
+- Modify: `tests/unit/test_feeds_service.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_feeds_service.py`:
+
+```python
+from datetime import UTC, datetime
+
+from app.services.feeds import compute_feed_etag, newest_timestamp
+
+
+class TestComputeFeedEtag:
+    def _sentinel(self):
+        return [
+            (100, datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC)),
+            (99, datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)),
+        ]
+
+    def test_returns_weak_etag(self):
+        etag = compute_feed_etag(self._sentinel())
+        assert etag.startswith('W/"')
+        assert etag.endswith('"')
+
+    def test_deterministic_for_same_input(self):
+        s = self._sentinel()
+        assert compute_feed_etag(s) == compute_feed_etag(s)
+
+    def test_changes_when_image_id_changes(self):
+        a = self._sentinel()
+        b = self._sentinel()
+        b[0] = (101, b[0][1])
+        assert compute_feed_etag(a) != compute_feed_etag(b)
+
+    def test_changes_when_timestamp_changes(self):
+        a = self._sentinel()
+        b = self._sentinel()
+        b[0] = (b[0][0], datetime(2026, 4, 24, 13, 0, 0, tzinfo=UTC))
+        assert compute_feed_etag(a) != compute_feed_etag(b)
+
+    def test_empty_sentinel_still_returns_valid_etag(self):
+        etag = compute_feed_etag([])
+        assert etag.startswith('W/"') and etag.endswith('"')
+
+    def test_ignores_rows_with_null_date(self):
+        a = [(100, datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC))]
+        b = [
+            (100, datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC)),
+            (99, None),  # NULL date_added — defensive handling per spec
+        ]
+        # Null-date rows are excluded from the hash, so the result matches `a`.
+        assert compute_feed_etag(a) == compute_feed_etag(b)
+
+
+class TestNewestTimestamp:
+    def test_picks_newest_from_sentinel(self):
+        sentinel = [
+            (100, datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC)),
+            (99, datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)),
+        ]
+        assert newest_timestamp(sentinel) == datetime(
+            2026, 4, 24, 12, 0, 0, tzinfo=UTC
+        )
+
+    def test_empty_returns_none(self):
+        assert newest_timestamp([]) is None
+
+    def test_skips_none_timestamps(self):
+        sentinel = [
+            (100, None),
+            (99, datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)),
+        ]
+        assert newest_timestamp(sentinel) == datetime(
+            2026, 4, 23, 12, 0, 0, tzinfo=UTC
+        )
+
+    def test_all_none_returns_none(self):
+        assert newest_timestamp([(100, None), (99, None)]) is None
+
+    def test_result_is_floored_to_whole_seconds(self):
+        # Per spec: HTTP-date has 1-second resolution; we floor microseconds.
+        sentinel = [
+            (100, datetime(2026, 4, 24, 12, 0, 0, 999_999, tzinfo=UTC)),
+        ]
+        result = newest_timestamp(sentinel)
+        assert result is not None
+        assert result.microsecond == 0
+```
+
+- [ ] **Step 2: Run the tests and confirm failure**
+
+Run: `uv run pytest tests/unit/test_feeds_service.py::TestComputeFeedEtag tests/unit/test_feeds_service.py::TestNewestTimestamp -v`
+Expected: ImportError on `compute_feed_etag` / `newest_timestamp`.
+
+- [ ] **Step 3: Implement**
+
+Append to `app/services/feeds.py`:
+
+```python
+import hashlib
+from datetime import datetime
+
+
+SentinelRow = tuple[int, datetime | None]
+
+
+def compute_feed_etag(sentinel: list[SentinelRow]) -> str:
+    """Derive a weak ETag from the sentinel query result.
+
+    Rows with NULL date_added are excluded from the hash (defensive per spec).
+    The hash is stable for identical input, which is all a conditional request
+    needs — we regenerate it from current DB state on every request and never
+    store it.
+    """
+    payload = ",".join(
+        f"{image_id}:{ts.isoformat()}"
+        for image_id, ts in sentinel
+        if ts is not None
+    )
+    digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()
+    return f'W/"{digest}"'
+
+
+def newest_timestamp(sentinel: list[SentinelRow]) -> datetime | None:
+    """Return the newest non-NULL date_added from the sentinel, floored to the second.
+
+    Returns None if the sentinel is empty or every row has NULL date_added —
+    callers should omit the Last-Modified header in that case.
+    """
+    non_null = [ts for _, ts in sentinel if ts is not None]
+    if not non_null:
+        return None
+    return max(non_null).replace(microsecond=0)
+```
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+Run: `uv run pytest tests/unit/test_feeds_service.py -v`
+Expected: all tests in the file pass (MIME + title + ETag/LastMod = ~25 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/feeds.py tests/unit/test_feeds_service.py
+git commit -m "feat(feeds): ETag and Last-Modified derivation from sentinel query"
+```
+
+---
+
+## Chunk 2: DB query helpers
+
+Everything in this chunk touches the database. Tests here use the live test DB via `async_db_session` (see `tests/conftest.py`).
+
+### Task 5: Sentinel query (global + per-tag)
+
+Cheap query used for ETag/Last-Modified derivation and to short-circuit the hydration query on conditional hits.
+
+**Files:**
+- Modify: `app/services/feeds.py`
+- Modify: `tests/api/v1/test_feeds.py` (create if absent) — *integration-style* tests that exercise the query against a real DB.
+
+- [ ] **Step 1: Create `tests/api/v1/test_feeds.py` with sentinel tests**
+
+```python
+"""Integration tests for Atom feed endpoints and query helpers."""
+
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, TagType
+from app.models import Images, Tags, TagLinks, Users
+from app.services.feeds import fetch_feed_sentinel
+
+
+async def _make_user(db: AsyncSession, username: str = "feeder") -> Users:
+    user = Users(
+        username=username,
+        password="x",
+        password_type="bcrypt",
+        salt="",
+        email=f"{username}@example.com",
+        active=1,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _make_image(
+    db: AsyncSession,
+    user: Users,
+    filename: str,
+    status: int = ImageStatus.ACTIVE,
+) -> Images:
+    image = Images(
+        filename=filename,
+        ext="png",
+        status=status,
+        user_id=user.user_id,
+        filesize=1024,
+        date_added=datetime.now(UTC),
+    )
+    db.add(image)
+    await db.commit()
+    await db.refresh(image)
+    return image
+
+
+async def _make_tag(
+    db: AsyncSession, title: str, type_: int = TagType.THEME
+) -> Tags:
+    tag = Tags(title=title, type=type_, user_id=None)
+    db.add(tag)
+    await db.commit()
+    await db.refresh(tag)
+    return tag
+
+
+async def _link(db: AsyncSession, image: Images, tag: Tags) -> None:
+    db.add(TagLinks(image_id=image.image_id, tag_id=tag.tag_id))
+    await db.commit()
+
+
+class TestFetchFeedSentinelGlobal:
+    async def test_returns_only_active_images_newest_first(
+        self, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session)
+        active_a = await _make_image(db_session, user, "a")
+        hidden = await _make_image(db_session, user, "h", status=ImageStatus.DELETED)
+        active_b = await _make_image(db_session, user, "b")
+        await _make_image(db_session, user, "c", status=ImageStatus.REPORTED)
+
+        sentinel = await fetch_feed_sentinel(db_session, tag_ids=None, limit=50)
+
+        ids = [row[0] for row in sentinel]
+        assert active_b.image_id in ids
+        assert active_a.image_id in ids
+        assert hidden.image_id not in ids
+        # Newest first: active_b was inserted last, so should come first.
+        assert ids.index(active_b.image_id) < ids.index(active_a.image_id)
+
+    async def test_respects_limit(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "limituser")
+        for i in range(10):
+            await _make_image(db_session, user, f"lim{i}")
+
+        sentinel = await fetch_feed_sentinel(db_session, tag_ids=None, limit=3)
+        assert len(sentinel) == 3
+
+
+class TestFetchFeedSentinelPerTag:
+    async def test_filters_by_tag_id(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "tagfilter")
+        tag = await _make_tag(db_session, "filtertag")
+        img_with = await _make_image(db_session, user, "with")
+        img_without = await _make_image(db_session, user, "without")
+        await _link(db_session, img_with, tag)
+
+        sentinel = await fetch_feed_sentinel(
+            db_session, tag_ids=[tag.tag_id], limit=50
+        )
+
+        ids = [row[0] for row in sentinel]
+        assert img_with.image_id in ids
+        assert img_without.image_id not in ids
+
+    async def test_multiple_tag_ids_union(self, db_session: AsyncSession):
+        """tag_ids represents the already-expanded hierarchy set; any match qualifies."""
+        user = await _make_user(db_session, "multitag")
+        t1 = await _make_tag(db_session, "t1")
+        t2 = await _make_tag(db_session, "t2")
+        img_a = await _make_image(db_session, user, "a_t1")
+        img_b = await _make_image(db_session, user, "b_t2")
+        await _link(db_session, img_a, t1)
+        await _link(db_session, img_b, t2)
+
+        sentinel = await fetch_feed_sentinel(
+            db_session, tag_ids=[t1.tag_id, t2.tag_id], limit=50
+        )
+
+        ids = [row[0] for row in sentinel]
+        assert img_a.image_id in ids
+        assert img_b.image_id in ids
+
+    async def test_empty_tag_list_returns_no_rows(self, db_session: AsyncSession):
+        # Caller should never pass an empty list (should pass None for global),
+        # but guard the helper anyway.
+        sentinel = await fetch_feed_sentinel(db_session, tag_ids=[], limit=50)
+        assert sentinel == []
+```
+
+- [ ] **Step 2: Run tests and confirm failure**
+
+Run: `uv run pytest tests/api/v1/test_feeds.py -v`
+Expected: ImportError on `fetch_feed_sentinel`.
+
+- [ ] **Step 3: Implement the sentinel query**
+
+Append to `app/services/feeds.py`:
+
+```python
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus
+from app.models.image import Images
+from app.models.tag_link import TagLinks
+
+
+async def fetch_feed_sentinel(
+    db: AsyncSession,
+    tag_ids: list[int] | None,
+    limit: int = 50,
+) -> list[SentinelRow]:
+    """Return [(image_id, date_added), ...] for the feed window.
+
+    Cheap query — indexed scan on (status, image_id DESC) only, no joins beyond
+    an optional IN subquery for per-tag filtering. Used for ETag derivation and
+    to short-circuit the full hydration query on conditional-request hits.
+
+    Args:
+        tag_ids: None for the global feed; a non-empty list (the already-resolved
+            alias + hierarchy-expanded tag IDs) for per-tag. An empty list returns
+            no rows.
+    """
+    if tag_ids == []:
+        return []
+
+    query = (
+        select(Images.image_id, Images.date_added)
+        .where(Images.status == ImageStatus.ACTIVE)
+        .order_by(Images.image_id.desc())
+        .limit(limit)
+    )
+
+    if tag_ids is not None:
+        tag_subquery = (
+            select(TagLinks.image_id)
+            .where(TagLinks.tag_id.in_(tag_ids))
+            .distinct()
+            .subquery()
+        )
+        query = query.where(Images.image_id.in_(select(tag_subquery)))
+
+    result = await db.execute(query)
+    return [(row.image_id, row.date_added) for row in result]
+```
+
+- [ ] **Step 4: Run the tests and confirm pass**
+
+Run: `uv run pytest tests/api/v1/test_feeds.py -v`
+Expected: all sentinel tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/feeds.py tests/api/v1/test_feeds.py
+git commit -m "feat(feeds): sentinel query for ETag/Last-Modified derivation"
+```
+
+---
+
+### Task 6: Hydration query + schema conversion
+
+Full query with `selectinload` for user and tag relationships, converted to `ImageDetailedResponse` via `from_db_model` (see spec for why `model_validate` won't work here).
+
+**Files:**
+- Modify: `app/services/feeds.py`
+- Modify: `tests/api/v1/test_feeds.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/api/v1/test_feeds.py`:
+
+```python
+from app.services.feeds import fetch_feed_entries
+
+
+class TestFetchFeedEntriesGlobal:
+    async def test_returns_image_detailed_responses(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "hydrator")
+        tag = await _make_tag(db_session, "hydrator_tag", type_=TagType.ARTIST)
+        image = await _make_image(db_session, user, "h1")
+        await _link(db_session, image, tag)
+
+        entries = await fetch_feed_entries(db_session, tag_ids=None, limit=50)
+
+        assert len(entries) >= 1
+        entry = next(e for e in entries if e.image_id == image.image_id)
+        assert entry.user is not None
+        assert entry.user.username == "hydrator"
+        assert entry.tags is not None
+        assert any(t.tag == "hydrator_tag" for t in entry.tags)
+
+    async def test_only_active_images(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "activeonly")
+        active = await _make_image(db_session, user, "a")
+        hidden = await _make_image(db_session, user, "h", status=ImageStatus.DELETED)
+
+        entries = await fetch_feed_entries(db_session, tag_ids=None, limit=50)
+        ids = [e.image_id for e in entries]
+        assert active.image_id in ids
+        assert hidden.image_id not in ids
+
+    async def test_ordered_newest_first(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "orderer")
+        first = await _make_image(db_session, user, "o1")
+        second = await _make_image(db_session, user, "o2")
+
+        entries = await fetch_feed_entries(db_session, tag_ids=None, limit=50)
+        ids = [e.image_id for e in entries]
+        assert ids.index(second.image_id) < ids.index(first.image_id)
+```
+
+- [ ] **Step 2: Run the tests and confirm failure**
+
+Run: `uv run pytest tests/api/v1/test_feeds.py::TestFetchFeedEntriesGlobal -v`
+Expected: ImportError on `fetch_feed_entries`.
+
+- [ ] **Step 3: Implement**
+
+Append to `app/services/feeds.py`:
+
+```python
+from sqlalchemy.orm import selectinload
+
+from app.schemas.image import ImageDetailedResponse
+
+
+async def fetch_feed_entries(
+    db: AsyncSession,
+    tag_ids: list[int] | None,
+    limit: int = 50,
+) -> list[ImageDetailedResponse]:
+    """Full hydration query for feed rendering.
+
+    Eager-loads the uploader and every linked tag (plus the tag row itself for
+    title/type). Converts results via ImageDetailedResponse.from_db_model, which
+    handles the tag_links -> tags mapping that from_attributes cannot do.
+    """
+    if tag_ids == []:
+        return []
+
+    query = (
+        select(Images)
+        .options(
+            selectinload(Images.user),
+            selectinload(Images.tag_links).selectinload(TagLinks.tag),
+        )
+        .where(Images.status == ImageStatus.ACTIVE)
+        .order_by(Images.image_id.desc())
+        .limit(limit)
+    )
+
+    if tag_ids is not None:
+        tag_subquery = (
+            select(TagLinks.image_id)
+            .where(TagLinks.tag_id.in_(tag_ids))
+            .distinct()
+            .subquery()
+        )
+        query = query.where(Images.image_id.in_(select(tag_subquery)))
+
+    result = await db.execute(query)
+    images = result.scalars().all()
+    return [ImageDetailedResponse.from_db_model(image) for image in images]
+```
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+Run: `uv run pytest tests/api/v1/test_feeds.py -v`
+Expected: all sentinel + hydration tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/feeds.py tests/api/v1/test_feeds.py
+git commit -m "feat(feeds): hydration query returning ImageDetailedResponse list"
+```
+
+---
+
+## Chunk 3: Atom rendering + HTTP handlers
+
+Renders the feed XML and exposes the two routes with full conditional-request handling.
+
+### Task 7: Atom feed builder
+
+Uses `feedgenerator.Atom1Feed`. Takes a pre-computed `FeedMeta` dataclass (feed-level values) and the list of `ImageDetailedResponse` entries.
+
+**Files:**
+- Modify: `app/services/feeds.py`
+- Modify: `tests/unit/test_feeds_service.py`
+- Modify: `tests/api/v1/test_feeds.py`
+
+- [ ] **Step 1: Write unit tests for builder invariants**
+
+Append to `tests/unit/test_feeds_service.py`:
+
+```python
+from datetime import UTC, datetime
+import xml.etree.ElementTree as ET
+
+from app.services.feeds import FeedMeta, build_atom_feed
+
+
+ATOM_NS = "{http://www.w3.org/2005/Atom}"
+
+
+def _feed_meta() -> "FeedMeta":
+    return FeedMeta(
+        feed_id="tag:e-shuushuu.net,2005:feed:images",
+        title="Shuushuu — latest images",
+        self_url="https://e-shuushuu.net/api/v1/images.atom",
+        alternate_url="https://e-shuushuu.net/",
+        updated=datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC),
+    )
+
+
+class TestBuildAtomFeedEmpty:
+    def test_empty_feed_is_valid_atom(self):
+        xml = build_atom_feed(_feed_meta(), entries=[])
+        root = ET.fromstring(xml)
+        assert root.tag == f"{ATOM_NS}feed"
+
+    def test_empty_feed_has_id_title_self_link_updated(self):
+        xml = build_atom_feed(_feed_meta(), entries=[])
+        root = ET.fromstring(xml)
+        assert root.find(f"{ATOM_NS}id").text == (
+            "tag:e-shuushuu.net,2005:feed:images"
+        )
+        assert root.find(f"{ATOM_NS}title").text == "Shuushuu — latest images"
+        self_link = root.find(f"{ATOM_NS}link[@rel='self']")
+        assert self_link is not None
+        assert self_link.get("href") == (
+            "https://e-shuushuu.net/api/v1/images.atom"
+        )
+        assert root.find(f"{ATOM_NS}updated") is not None
+
+    def test_empty_feed_has_no_entries(self):
+        xml = build_atom_feed(_feed_meta(), entries=[])
+        root = ET.fromstring(xml)
+        assert root.findall(f"{ATOM_NS}entry") == []
+```
+
+- [ ] **Step 2: Run the tests and confirm failure**
+
+Run: `uv run pytest tests/unit/test_feeds_service.py -v -k "BuildAtomFeedEmpty"`
+Expected: ImportError on `FeedMeta` / `build_atom_feed`.
+
+- [ ] **Step 3: Implement the builder**
+
+Append to `app/services/feeds.py`:
+
+```python
+from dataclasses import dataclass
+from html import escape
+
+from feedgenerator import Atom1Feed  # type: ignore[import-untyped]
+
+from app.config import TagType, settings
+
+TAG_TYPE_NAME: dict[int, str] = {
+    TagType.THEME: "Theme",
+    TagType.SOURCE: "Source",
+    TagType.ARTIST: "Artist",
+    TagType.CHARACTER: "Character",
+    # TagType.ALL is a filter pseudo-type; never on actual rows.
+}
+
+
+@dataclass(frozen=True)
+class FeedMeta:
+    feed_id: str
+    title: str
+    self_url: str
+    alternate_url: str
+    updated: datetime
+
+
+def _category_scheme(tag_type: int) -> str:
+    return (
+        f"{settings.FRONTEND_URL.rstrip('/')}/tag-type/"
+        f"{TAG_TYPE_NAME.get(tag_type, 'Unknown')}"
+    )
+
+
+def _entry_content_html(caption: str | None) -> str:
+    if not caption:
+        return ""
+    return escape(caption)
+
+
+def build_atom_feed(
+    meta: FeedMeta,
+    entries: list[ImageDetailedResponse],
+) -> str:
+    """Render an Atom 1.0 XML document.
+
+    Uses feedgenerator.Atom1Feed which handles namespace registration, RFC 3339
+    date formatting, XML escaping, and well-formed output. We pass stringified
+    fields in; the library does the rest.
+    """
+    feed = Atom1Feed(
+        title=meta.title,
+        link=meta.alternate_url,
+        description=meta.title,  # Atom1Feed requires description; mirrors title.
+        feed_url=meta.self_url,
+        language="en",
+    )
+    # Override feed-level <id>, <updated>, <author> via subclassing-free attrs.
+    feed.feed["id"] = meta.feed_id
+    feed.feed["updated"] = meta.updated
+    feed.feed["author_name"] = "Shuushuu"
+
+    frontend = settings.FRONTEND_URL.rstrip("/")
+
+    for image in entries:
+        entry_id = f"tag:e-shuushuu.net,2005:image:{image.image_id}"
+        alternate = f"{frontend}/images/{image.image_id}"
+
+        # Uploader name, with soft-delete fallback per spec.
+        author_name = (
+            image.user.username if image.user and image.user.username
+            else "[deleted user]"
+        )
+
+        # date_added fallback to current UTC if missing (defensive per spec).
+        entry_dt = image.date_added or datetime.now(UTC)
+
+        # Title — delegate to the composer, passing tags as-is.
+        title = compose_entry_title(
+            image_id=image.image_id,
+            tags=image.tags or [],
+        )
+
+        # Build category kwargs: feedgenerator's add_item accepts categories
+        # as a list of tuples-or-dicts; we use the dict form to carry scheme.
+        categories = [
+            {"term": t.tag, "scheme": _category_scheme(t.type_id)}
+            for t in (image.tags or [])
+        ]
+
+        # Enclosure — full image URL using IMAGE_BASE_URL from settings.
+        enclosure_url = (
+            f"{settings.IMAGE_BASE_URL.rstrip('/')}/images/"
+            f"{image.filename}.{image.ext}"
+        )
+        enclosure_type = mime_type_for_ext(image.ext)
+
+        feed.add_item(
+            title=title,
+            link=alternate,
+            description=_entry_content_html(image.caption),
+            unique_id=entry_id,
+            unique_id_is_permalink=False,
+            updateddate=entry_dt,
+            pubdate=entry_dt,
+            author_name=author_name,
+            categories=categories,
+            enclosures=[
+                {
+                    "url": enclosure_url,
+                    "length": str(image.filesize or 0),
+                    "mime_type": enclosure_type,
+                }
+            ],
+        )
+
+    return feed.writeString("utf-8")
+```
+
+NOTE: `feedgenerator.Atom1Feed.add_item` enclosure kwarg differs across versions — verify against installed version. If `enclosures=[{...}]` errors, fall back to `enclosure=Enclosure(...)` (older API). Run the test next step; if it fails on enclosure shape, `python -c "import feedgenerator; help(feedgenerator.Atom1Feed.add_item)"` to see the actual signature.
+
+- [ ] **Step 4: Run the tests and confirm pass**
+
+Run: `uv run pytest tests/unit/test_feeds_service.py -v -k "BuildAtomFeedEmpty"`
+Expected: all empty-feed tests pass. If enclosure-related attribute errors appear at this step, adjust the enclosure-passing shape — the empty-feed test has no entries so won't hit that path yet.
+
+- [ ] **Step 5: Add tests for a non-empty feed**
+
+Append to `tests/unit/test_feeds_service.py`:
+
+```python
+class TestBuildAtomFeedWithEntries:
+    def _make_entry(self, image_id: int = 42):
+        """Minimal ImageDetailedResponse-shaped object for rendering."""
+        from app.schemas.common import UserSummary
+        from app.schemas.image import ImageDetailedResponse
+
+        return ImageDetailedResponse(
+            image_id=image_id,
+            filename=f"abc{image_id}",
+            ext="png",
+            caption=None,
+            filesize=1024,
+            user_id=1,
+            user=UserSummary(
+                user_id=1,
+                username="alice",
+                date_joined=datetime(2020, 1, 1, tzinfo=UTC),
+            ),
+            tags=[],
+            date_added=datetime(2026, 4, 24, 10, 0, 0, tzinfo=UTC),
+            locked=0,
+            posts=0,
+            favorites=0,
+            bayesian_rating=0.0,
+            num_ratings=0,
+            medium=0,
+            large=0,
+            is_favorited=False,
+            user_rating=None,
+            prev_image_id=None,
+            next_image_id=None,
+        )
+
+    def test_entry_has_tag_uri_id(self):
+        entry = self._make_entry(42)
+        xml = build_atom_feed(_feed_meta(), entries=[entry])
+        root = ET.fromstring(xml)
+        entry_node = root.find(f"{ATOM_NS}entry")
+        assert entry_node.find(f"{ATOM_NS}id").text == (
+            "tag:e-shuushuu.net,2005:image:42"
+        )
+
+    def test_entry_alternate_link_points_to_detail_page(self):
+        entry = self._make_entry(42)
+        xml = build_atom_feed(_feed_meta(), entries=[entry])
+        root = ET.fromstring(xml)
+        entry_node = root.find(f"{ATOM_NS}entry")
+        alt = entry_node.find(f"{ATOM_NS}link[@rel='alternate']")
+        assert alt is not None
+        assert alt.get("href", "").endswith("/images/42")
+
+    def test_entry_enclosure_has_mime_and_length(self):
+        entry = self._make_entry(42)
+        xml = build_atom_feed(_feed_meta(), entries=[entry])
+        root = ET.fromstring(xml)
+        entry_node = root.find(f"{ATOM_NS}entry")
+        enc = entry_node.find(f"{ATOM_NS}link[@rel='enclosure']")
+        assert enc is not None
+        assert enc.get("type") == "image/png"
+        assert enc.get("length") == "1024"
+
+    def test_entry_author_is_uploader(self):
+        entry = self._make_entry(42)
+        xml = build_atom_feed(_feed_meta(), entries=[entry])
+        root = ET.fromstring(xml)
+        entry_node = root.find(f"{ATOM_NS}entry")
+        assert (
+            entry_node.find(f"{ATOM_NS}author/{ATOM_NS}name").text == "alice"
+        )
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `uv run pytest tests/unit/test_feeds_service.py::TestBuildAtomFeedWithEntries -v`
+Expected: all four tests pass. If the enclosure test fails with `<link rel="enclosure">` absent, inspect the generated XML via `print(xml)` inside the test and adapt the enclosure kwarg shape (see the NOTE in Step 3) until the link appears.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/feeds.py tests/unit/test_feeds_service.py
+git commit -m "feat(feeds): Atom XML builder using feedgenerator"
+```
+
+---
+
+### Task 8: Global feed handler
+
+Route: `GET /api/v1/images.atom`. Includes full conditional-request handling.
+
+**Files:**
+- Modify: `app/api/v1/feeds.py`
+- Modify: `tests/api/v1/test_feeds.py`
+
+- [ ] **Step 1: Write the handler tests**
+
+Append to `tests/api/v1/test_feeds.py`:
+
+```python
+class TestGlobalImagesFeed:
+    async def test_returns_atom_content_type(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "ctuser")
+        await _make_image(db_session, user, "ct1")
+
+        response = await client.get("/api/v1/images.atom")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith(
+            "application/atom+xml"
+        )
+
+    async def test_includes_only_active_images(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "actuser")
+        active = await _make_image(db_session, user, "a1")
+        hidden = await _make_image(
+            db_session, user, "h1", status=ImageStatus.DELETED
+        )
+
+        response = await client.get("/api/v1/images.atom")
+
+        body = response.text
+        assert f"image:{active.image_id}" in body
+        assert f"image:{hidden.image_id}" not in body
+
+    async def test_caps_at_50_entries(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "capuser")
+        for i in range(55):
+            await _make_image(db_session, user, f"cap{i}")
+
+        response = await client.get("/api/v1/images.atom")
+        assert response.status_code == 200
+        assert response.text.count("<entry") <= 50
+
+    async def test_sets_cache_control_header(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "cacheuser")
+        await _make_image(db_session, user, "c1")
+
+        response = await client.get("/api/v1/images.atom")
+
+        assert "max-age=300" in response.headers["cache-control"]
+
+    async def test_sets_etag_and_last_modified(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "etaguser")
+        await _make_image(db_session, user, "e1")
+
+        response = await client.get("/api/v1/images.atom")
+
+        assert response.headers.get("etag", "").startswith('W/"')
+        assert "last-modified" in response.headers
+
+    async def test_conditional_if_none_match_returns_304(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "condetag")
+        await _make_image(db_session, user, "ce1")
+
+        first = await client.get("/api/v1/images.atom")
+        assert first.status_code == 200
+        etag = first.headers["etag"]
+
+        second = await client.get(
+            "/api/v1/images.atom", headers={"If-None-Match": etag}
+        )
+        assert second.status_code == 304
+        assert second.text == ""
+
+    async def test_new_image_busts_etag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "bustetag")
+        await _make_image(db_session, user, "be1")
+
+        first = await client.get("/api/v1/images.atom")
+        first_etag = first.headers["etag"]
+
+        await _make_image(db_session, user, "be2")
+
+        second = await client.get(
+            "/api/v1/images.atom", headers={"If-None-Match": first_etag}
+        )
+        assert second.status_code == 200
+        assert second.headers["etag"] != first_etag
+
+    async def test_empty_feed_is_200(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        # No images in the DB for this test's isolated scope.
+        response = await client.get("/api/v1/images.atom")
+
+        assert response.status_code == 200
+        # Feed is valid Atom even with no entries.
+        assert "<feed" in response.text
+```
+
+- [ ] **Step 2: Run the tests and confirm failure**
+
+Run: `uv run pytest tests/api/v1/test_feeds.py::TestGlobalImagesFeed -v`
+Expected: 404 on every request — handler not registered yet.
+
+- [ ] **Step 3: Implement the handler**
+
+Replace `app/api/v1/feeds.py` with:
+
+```python
+"""Atom feed endpoints."""
+
+from datetime import UTC, datetime
+from email.utils import format_datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.core.database import get_db
+from app.services.feeds import (
+    FeedMeta,
+    build_atom_feed,
+    compute_feed_etag,
+    fetch_feed_entries,
+    fetch_feed_sentinel,
+    newest_timestamp,
+)
+
+router = APIRouter(tags=["feeds"])
+
+CACHE_CONTROL = "public, max-age=300"
+ATOM_CONTENT_TYPE = "application/atom+xml; charset=utf-8"
+
+
+def _frontend(*parts: str) -> str:
+    base = settings.FRONTEND_URL.rstrip("/")
+    return "/".join([base, *parts])
+
+
+def _self_url(request: Request) -> str:
+    """Absolute URL of the current request — used for feed <link rel='self'>."""
+    return str(request.url).split("?")[0]
+
+
+@router.get("/images.atom")
+async def list_images_atom(
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Response:
+    """Latest 50 active images, newest first."""
+    sentinel = await fetch_feed_sentinel(db, tag_ids=None, limit=50)
+    etag = compute_feed_etag(sentinel)
+    last_mod = newest_timestamp(sentinel)
+
+    # Conditional-request short-circuit
+    if_none_match = request.headers.get("if-none-match")
+    if if_none_match == etag:
+        return _not_modified(etag, last_mod)
+
+    entries = await fetch_feed_entries(db, tag_ids=None, limit=50)
+    meta = FeedMeta(
+        feed_id="tag:e-shuushuu.net,2005:feed:images",
+        title="Shuushuu — latest images",
+        self_url=_self_url(request),
+        alternate_url=_frontend(),
+        updated=last_mod or datetime.now(UTC),
+    )
+    xml = build_atom_feed(meta, entries)
+
+    headers = {
+        "Cache-Control": CACHE_CONTROL,
+        "ETag": etag,
+    }
+    if last_mod:
+        headers["Last-Modified"] = format_datetime(last_mod, usegmt=True)
+
+    return Response(
+        content=xml, media_type=ATOM_CONTENT_TYPE, headers=headers
+    )
+
+
+def _not_modified(etag: str, last_mod: datetime | None) -> Response:
+    headers = {
+        "Cache-Control": CACHE_CONTROL,
+        "ETag": etag,
+    }
+    if last_mod:
+        headers["Last-Modified"] = format_datetime(last_mod, usegmt=True)
+    return Response(status_code=304, headers=headers)
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `uv run pytest tests/api/v1/test_feeds.py::TestGlobalImagesFeed -v`
+Expected: all 8 tests pass. If conditional-request tests fail, verify `request.headers.get("if-none-match")` returns the exact same string we handed out (case-insensitive header match is FastAPI/Starlette default).
+
+- [ ] **Step 5: Verify manually with a real request**
+
+Run: `uv run uvicorn app.main:app --port 8000 --reload` (in one terminal)
+In another: `curl -iD- http://localhost:8000/api/v1/images.atom | head -40`
+Expected: `200 OK`, `Content-Type: application/atom+xml; charset=utf-8`, valid XML body.
+Kill uvicorn when done.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/v1/feeds.py tests/api/v1/test_feeds.py
+git commit -m "feat(feeds): global images Atom feed handler with conditional requests"
+```
+
+---
+
+### Task 9: Per-tag feed handler
+
+Route: `GET /api/v1/tags/{tag_id}/images.atom`. Reuses `resolve_tag_alias()` and `get_tag_hierarchy()` from the tags module.
+
+**Files:**
+- Modify: `app/api/v1/feeds.py`
+- Modify: `tests/api/v1/test_feeds.py`
+
+- [ ] **Step 1: Write the handler tests**
+
+Append to `tests/api/v1/test_feeds.py`:
+
+```python
+class TestPerTagImagesFeed:
+    async def test_returns_only_images_with_tag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "ptuser")
+        tag = await _make_tag(db_session, "pt_tag")
+        with_tag = await _make_image(db_session, user, "pt_w")
+        without_tag = await _make_image(db_session, user, "pt_wo")
+        await _link(db_session, with_tag, tag)
+
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}/images.atom")
+
+        assert response.status_code == 200
+        body = response.text
+        assert f"image:{with_tag.image_id}" in body
+        assert f"image:{without_tag.image_id}" not in body
+
+    async def test_unknown_tag_id_returns_404(self, client: AsyncClient):
+        response = await client.get("/api/v1/tags/999999999/images.atom")
+        assert response.status_code == 404
+
+    async def test_alias_tag_serves_canonical_image_set(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """An alias tag should return the same images as its canonical target."""
+        user = await _make_user(db_session, "aliasuser")
+        canonical = await _make_tag(db_session, "canonical_tag")
+        # Build alias row by setting alias_of.
+        alias = Tags(
+            title="alias_tag",
+            type=TagType.THEME,
+            user_id=None,
+            alias_of=canonical.tag_id,
+        )
+        db_session.add(alias)
+        await db_session.commit()
+        await db_session.refresh(alias)
+
+        image = await _make_image(db_session, user, "aliasimg")
+        await _link(db_session, image, canonical)
+
+        # Fetch via alias ID — should still surface the image linked to canonical.
+        response = await client.get(f"/api/v1/tags/{alias.tag_id}/images.atom")
+
+        assert response.status_code == 200
+        assert f"image:{image.image_id}" in response.text
+
+    async def test_conditional_request_returns_304(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "pt_etag_user")
+        tag = await _make_tag(db_session, "pt_etag_tag")
+        image = await _make_image(db_session, user, "pt_e1")
+        await _link(db_session, image, tag)
+
+        first = await client.get(f"/api/v1/tags/{tag.tag_id}/images.atom")
+        assert first.status_code == 200
+        etag = first.headers["etag"]
+
+        second = await client.get(
+            f"/api/v1/tags/{tag.tag_id}/images.atom",
+            headers={"If-None-Match": etag},
+        )
+        assert second.status_code == 304
+```
+
+- [ ] **Step 2: Run the tests and confirm failure**
+
+Run: `uv run pytest tests/api/v1/test_feeds.py::TestPerTagImagesFeed -v`
+Expected: 404 on all (handler not registered yet).
+
+- [ ] **Step 3: Implement the per-tag handler**
+
+Add to `app/api/v1/feeds.py` (below the global handler):
+
+```python
+from fastapi import HTTPException, Path
+
+from app.api.v1.tags import get_tag_hierarchy, resolve_tag_alias
+
+
+@router.get("/tags/{tag_id}/images.atom")
+async def list_tag_images_atom(
+    request: Request,
+    tag_id: Annotated[int, Path(ge=1)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Response:
+    """Latest 50 active images tagged with `tag_id`.
+
+    Resolves aliases and expands the tag hierarchy, matching the behavior of
+    GET /api/v1/tags/{id}/images so readers see the same image set as the
+    frontend tag page.
+    """
+    tag, resolved_id = await resolve_tag_alias(db, tag_id)
+    if tag is None:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    effective_ids = await get_tag_hierarchy(db, resolved_id)
+
+    sentinel = await fetch_feed_sentinel(db, tag_ids=effective_ids, limit=50)
+    etag = compute_feed_etag(sentinel)
+    last_mod = newest_timestamp(sentinel)
+
+    if request.headers.get("if-none-match") == etag:
+        return _not_modified(etag, last_mod)
+
+    entries = await fetch_feed_entries(db, tag_ids=effective_ids, limit=50)
+    meta = FeedMeta(
+        feed_id=f"tag:e-shuushuu.net,2005:feed:tags:{resolved_id}",
+        title=f"Shuushuu — tag: {tag.title}",
+        self_url=_self_url(request),
+        alternate_url=_frontend("tags", str(resolved_id)),
+        updated=last_mod or datetime.now(UTC),
+    )
+    xml = build_atom_feed(meta, entries)
+
+    headers = {
+        "Cache-Control": CACHE_CONTROL,
+        "ETag": etag,
+    }
+    if last_mod:
+        headers["Last-Modified"] = format_datetime(last_mod, usegmt=True)
+
+    return Response(
+        content=xml, media_type=ATOM_CONTENT_TYPE, headers=headers
+    )
+```
+
+**Verify the signature of `resolve_tag_alias` before running.** It's defined at `app/api/v1/tags.py:167` and returns `tuple[Tags, int]` per usage at `app/api/v1/tags.py:695`. If it raises instead of returning `(None, ...)` on missing, convert that exception to a 404 explicitly; adjust the handler accordingly.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `uv run pytest tests/api/v1/test_feeds.py::TestPerTagImagesFeed -v`
+Expected: 4 tests pass. If the alias test fails, inspect `resolve_tag_alias` to confirm it follows alias chains and adjust test data accordingly.
+
+- [ ] **Step 5: Run the full feeds test suite for regressions**
+
+Run: `uv run pytest tests/api/v1/test_feeds.py tests/unit/test_feeds_service.py -v`
+Expected: every feeds test passes.
+
+- [ ] **Step 6: Run the full project test suite once**
+
+Run: `uv run pytest --tb=short`
+Expected: green. Any failure in a non-feeds test is a regression to fix before committing.
+
+- [ ] **Step 7: Manual smoke test**
+
+Run uvicorn as in Task 8, then:
+```bash
+curl -sD- http://localhost:8000/api/v1/tags/1/images.atom | head -40   # valid feed or 404
+curl -si http://localhost:8000/api/v1/tags/999999999/images.atom | head -5  # 404
+```
+
+Kill uvicorn.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/api/v1/feeds.py tests/api/v1/test_feeds.py
+git commit -m "feat(feeds): per-tag images Atom feed with alias and hierarchy support"
+```
+
+---
+
+## Wrap-up
+
+- [ ] **Verify no TODO/FIXME/`pass` stubs left in new files**
+
+Run: `grep -rnE "TODO|FIXME|^\s*pass\s*$" app/services/feeds.py app/api/v1/feeds.py`
+Expected: no output.
+
+- [ ] **Check formatting and lint**
+
+Run: `uv run ruff check app/services/feeds.py app/api/v1/feeds.py tests/unit/test_feeds_service.py tests/api/v1/test_feeds.py`
+Expected: no violations.
+
+Run: `uv run ruff format --check app/services/feeds.py app/api/v1/feeds.py tests/unit/test_feeds_service.py tests/api/v1/test_feeds.py`
+Expected: all files formatted.
+
+- [ ] **Type-check**
+
+Run: `uv run mypy app/services/feeds.py app/api/v1/feeds.py`
+Expected: no errors. If feedgenerator lacks type stubs, the `# type: ignore[import-untyped]` on its import is sufficient.
+
+- [ ] **Open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat: Atom feeds for images and tags" --body-file docs/plans/2026-04-24-rss-feed-design.md
+```
+
+---
+
+## Out of scope (deferred to later tasks)
+
+- Per-user / authenticated feeds (`/me/favorites.atom`).
+- Redis cache on the rendered XML.
+- Frontend HTML `<link rel="alternate" type="application/atom+xml">` tags — frontend's concern.
+- Retag-in-window cache busting — accepted 5-minute staleness per design doc.

--- a/docs/plans/2026-04-24-rss-feed-impl.md
+++ b/docs/plans/2026-04-24-rss-feed-impl.md
@@ -23,10 +23,10 @@
 **Modify:**
 - `pyproject.toml` — add `feedgenerator>=2.2.1` to `dependencies`.
 - `app/main.py` — register the feeds router.
+- `app/schemas/image.py` — add `usage_count: int = 0` to `TagSummary` (used for title-composition representative selection). Non-breaking addition; existing JSON API responses gain the field.
 
 **Do NOT modify:**
 - `app/config.py` (reuse existing `FRONTEND_URL`).
-- `app/schemas/image.py` (reuse `ImageDetailedResponse.from_db_model`).
 - Any DB schema or Alembic migration — pure read-only feature.
 
 ---
@@ -96,7 +96,75 @@ git commit -m "feat(feeds): scaffold feeds router and service module"
 
 ---
 
-### Task 2: MIME type mapping helper
+### Task 2: Extend `TagSummary` with `usage_count`
+
+`compose_entry_title` (next task) picks one representative tag per category by `usage_count DESC`. The existing `TagSummary` schema (`app/schemas/image.py:24`) exposes `.tag`, `.tag_id`, `.type_id`, `.type_name` — but **not** `.usage_count`, even though the underlying `Tags.usage_count` column exists (`app/models/tag.py:122`). Add it so `TagSummary` instances reaching the feed carry the data the title composer needs. Pydantic's `from_attributes=True` (already set on `TagSummary`) pulls the value automatically.
+
+**Files:**
+- Modify: `app/schemas/image.py`
+- Modify: `tests/unit/test_schemas.py` *(or similar — verify exact filename via `ls tests/unit/test_*schema*`; fall back to a new `tests/unit/test_tag_summary.py` if no tag-schema test file exists)*
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing tag-summary tests (or create a new `tests/unit/test_tag_summary.py` with this content):
+
+```python
+"""TagSummary schema tests — usage_count field."""
+
+from app.models.tag import Tags
+from app.schemas.image import TagSummary
+
+
+class TestTagSummaryUsageCount:
+    def test_usage_count_populated_from_orm(self):
+        tag = Tags(tag_id=1, title="t", type=1, usage_count=42)
+        summary = TagSummary.model_validate(tag)
+        assert summary.usage_count == 42
+
+    def test_usage_count_defaults_to_zero(self):
+        # Validate from a dict without usage_count — should default.
+        summary = TagSummary.model_validate(
+            {"tag_id": 1, "title": "t", "type": 1}
+        )
+        assert summary.usage_count == 0
+```
+
+- [ ] **Step 2: Run the test and confirm failure**
+
+Run: `uv run pytest tests/unit/test_tag_summary.py -v`  *(or whichever path you used in Step 1)*
+Expected: `AttributeError` or pydantic validation error — `usage_count` not on `TagSummary`.
+
+- [ ] **Step 3: Add the field**
+
+Edit `app/schemas/image.py`, in the `TagSummary` class definition, between `type_id` and the `model_config` line:
+
+```python
+    tag_id: int
+    tag: str = Field(alias="title")  # Maps from Tags.title
+    type_id: int = Field(alias="type")  # Maps from Tags.type
+    usage_count: int = 0  # NEW — needed by feed title composer; non-breaking.
+```
+
+- [ ] **Step 4: Run the test and confirm pass**
+
+Run: `uv run pytest tests/unit/test_tag_summary.py -v`
+Expected: both tests pass.
+
+- [ ] **Step 5: Run the full schema test suite for regressions**
+
+Run: `uv run pytest tests/unit/ -k "schema" -v`
+Expected: all pre-existing schema tests still pass (gaining a field is non-breaking).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/schemas/image.py tests/unit/test_tag_summary.py
+git commit -m "feat(schemas): expose usage_count on TagSummary for feed title composition"
+```
+
+---
+
+### Task 3: MIME type mapping helper
 
 **Files:**
 - Modify: `app/services/feeds.py`
@@ -179,7 +247,7 @@ git commit -m "feat(feeds): MIME type mapping for enclosure links"
 
 ---
 
-### Task 3: Title composition helper
+### Task 4: Title composition helper
 
 Implements the spec's "Title composition" section. Picks one representative tag per category by `usage_count DESC` and formats `"{characters} ({sources}) by {artists}"` with empty sections skipped.
 
@@ -197,13 +265,13 @@ from app.services.feeds import compose_entry_title
 
 
 def _tag(tag_id: int, title: str, type_: int, usage_count: int):
-    """Lightweight stand-in for TagSummary — just enough for the helper."""
+    """Lightweight stand-in for TagSummary — matches its attribute names."""
     from types import SimpleNamespace
 
     return SimpleNamespace(
         tag_id=tag_id,
-        tag=title,  # TagSummary's alias for Tags.title
-        type=type_,
+        tag=title,      # TagSummary's alias for Tags.title
+        type_id=type_,  # TagSummary's alias for Tags.type
         usage_count=usage_count,
     )
 
@@ -288,7 +356,7 @@ from app.config import TagType
 
 def _pick_representative(tags: list[Any], type_value: int) -> str | None:
     """Return the title of the highest-usage tag of the given type, or None."""
-    candidates = [t for t in tags if t.type == type_value]
+    candidates = [t for t in tags if t.type_id == type_value]
     if not candidates:
         return None
     # Stable sort: usage_count DESC, then tag_id ASC for determinism on ties.
@@ -303,8 +371,8 @@ def compose_entry_title(image_id: int, tags: list[Any]) -> str:
     per category (highest usage_count). Empty sections are skipped. Falls back
     to 'Image #{image_id}' if no character, source, or artist tags are present.
 
-    `tags` is any sequence of objects with `.tag` (title), `.type` (int), `.tag_id`,
-    and `.usage_count` — e.g. TagSummary instances or SQLModel Tags rows.
+    `tags` is a sequence of TagSummary-shaped objects with `.tag` (title),
+    `.type_id` (int, matching TagType constants), `.tag_id`, and `.usage_count`.
     """
     char = _pick_representative(tags, TagType.CHARACTER)
     src = _pick_representative(tags, TagType.SOURCE)
@@ -337,7 +405,7 @@ git commit -m "feat(feeds): compose Atom entry titles from image tags"
 
 ---
 
-### Task 4: ETag and Last-Modified helpers
+### Task 5: ETag and Last-Modified helpers
 
 Pure functions operating on a list of `(image_id, date_added)` tuples (the sentinel result). No DB access here.
 
@@ -496,7 +564,7 @@ git commit -m "feat(feeds): ETag and Last-Modified derivation from sentinel quer
 
 Everything in this chunk touches the database. Tests here use the live test DB via `async_db_session` (see `tests/conftest.py`).
 
-### Task 5: Sentinel query (global + per-tag)
+### Task 6: Sentinel query (global + per-tag)
 
 Cheap query used for ETag/Last-Modified derivation and to short-circuit the hydration query on conditional hits.
 
@@ -710,7 +778,7 @@ git commit -m "feat(feeds): sentinel query for ETag/Last-Modified derivation"
 
 ---
 
-### Task 6: Hydration query + schema conversion
+### Task 7: Hydration query + schema conversion
 
 Full query with `selectinload` for user and tag relationships, converted to `ImageDetailedResponse` via `from_db_model` (see spec for why `model_validate` won't work here).
 
@@ -834,7 +902,7 @@ git commit -m "feat(feeds): hydration query returning ImageDetailedResponse list
 
 Renders the feed XML and exposes the two routes with full conditional-request handling.
 
-### Task 7: Atom feed builder
+### Task 8: Atom feed builder
 
 Uses `feedgenerator.Atom1Feed`. Takes a pre-computed `FeedMeta` dataclass (feed-level values) and the list of `ImageDetailedResponse` entries.
 
@@ -1117,7 +1185,7 @@ git commit -m "feat(feeds): Atom XML builder using feedgenerator"
 
 ---
 
-### Task 8: Global feed handler
+### Task 9: Global feed handler
 
 Route: `GET /api/v1/images.atom`. Includes full conditional-request handling.
 
@@ -1349,7 +1417,7 @@ git commit -m "feat(feeds): global images Atom feed handler with conditional req
 
 ---
 
-### Task 9: Per-tag feed handler
+### Task 10: Per-tag feed handler
 
 Route: `GET /api/v1/tags/{tag_id}/images.atom`. Reuses `resolve_tag_alias()` and `get_tag_hierarchy()` from the tags module.
 
@@ -1509,7 +1577,7 @@ Expected: green. Any failure in a non-feeds test is a regression to fix before c
 
 - [ ] **Step 7: Manual smoke test**
 
-Run uvicorn as in Task 8, then:
+Run uvicorn as in Task 9, then:
 ```bash
 curl -sD- http://localhost:8000/api/v1/tags/1/images.atom | head -40   # valid feed or 404
 curl -si http://localhost:8000/api/v1/tags/999999999/images.atom | head -5  # 404

--- a/docs/plans/2026-04-24-rss-feed-impl.md
+++ b/docs/plans/2026-04-24-rss-feed-impl.md
@@ -511,7 +511,7 @@ Append to `app/services/feeds.py`:
 
 ```python
 import hashlib
-from datetime import datetime
+from datetime import UTC, datetime
 
 
 SentinelRow = tuple[int, datetime | None]
@@ -1216,9 +1216,11 @@ class TestBuildAtomFeedWithEntries:
         content = root.find(f"{ATOM_NS}entry/{ATOM_NS}content")
         assert content is not None
         assert content.get("type") == "html"
-        # ET.fromstring will have already un-escaped &amp; → &, &lt; → <
-        # so we check the .text rendered equals the original.
-        assert content.text == "a <b> caption & stuff"
+        # Two escape layers apply: html.escape (our code, so <b> is treated
+        # as plain text inside type="html") + XML-attribute escape (library).
+        # ET.fromstring reverses only the outer XML layer, so .text still
+        # shows the HTML-escaped form.
+        assert content.text == "a &lt;b&gt; caption &amp; stuff"
 
     def test_entry_with_no_caption_omits_content(self):
         xml = build_atom_feed(_feed_meta(), entries=[_entry(caption=None)])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     # Logging
     "structlog>=24.1.0",
     "python-json-logger>=2.0.7",
+    # Feed generation
+    "feedgenerator>=2.2.1",
     # Task queue
     "arq>=0.27.0", # Task queue for background jobs
     "aioboto3>=13.0.0",  # Async S3-compatible client for Cloudflare R2

--- a/tests/api/v1/test_feeds.py
+++ b/tests/api/v1/test_feeds.py
@@ -161,3 +161,88 @@ class TestFetchFeedEntriesGlobal:
         entries = await fetch_feed_entries(db_session, tag_ids=None, limit=50)
         ids = [e.image_id for e in entries]
         assert ids.index(second.image_id) < ids.index(first.image_id)
+
+
+class TestGlobalImagesFeed:
+    async def test_returns_atom_content_type(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "ctuser")
+        await _make_image(db_session, user, "ct1")
+        response = await client.get("/api/v1/images.atom")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/atom+xml")
+
+    async def test_includes_only_active_images(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "actuser")
+        active = await _make_image(db_session, user, "a1")
+        hidden = await _make_image(db_session, user, "h1", status=ImageStatus.INAPPROPRIATE)
+        response = await client.get("/api/v1/images.atom")
+        body = response.text
+        assert f"image:{active.image_id}" in body
+        assert f"image:{hidden.image_id}" not in body
+
+    async def test_caps_at_50_entries(self, client: AsyncClient, db_session: AsyncSession):
+        user = await _make_user(db_session, "capuser")
+        for i in range(55):
+            await _make_image(db_session, user, f"cap{i}")
+        response = await client.get("/api/v1/images.atom")
+        assert response.status_code == 200
+        assert response.text.count("<entry") <= 50
+
+    async def test_sets_cache_control_header(self, client: AsyncClient, db_session: AsyncSession):
+        user = await _make_user(db_session, "cacheuser")
+        await _make_image(db_session, user, "c1")
+        response = await client.get("/api/v1/images.atom")
+        assert "max-age=300" in response.headers["cache-control"]
+
+    async def test_sets_etag_and_last_modified(self, client: AsyncClient, db_session: AsyncSession):
+        user = await _make_user(db_session, "etaguser")
+        await _make_image(db_session, user, "e1")
+        response = await client.get("/api/v1/images.atom")
+        assert response.headers.get("etag", "").startswith('W/"')
+        assert "last-modified" in response.headers
+
+    async def test_conditional_if_none_match_returns_304(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "condetag")
+        await _make_image(db_session, user, "ce1")
+        first = await client.get("/api/v1/images.atom")
+        etag = first.headers["etag"]
+        second = await client.get(
+            "/api/v1/images.atom", headers={"If-None-Match": etag}
+        )
+        assert second.status_code == 304
+        assert second.text == ""
+
+    async def test_new_image_busts_etag(self, client: AsyncClient, db_session: AsyncSession):
+        user = await _make_user(db_session, "bustetag")
+        await _make_image(db_session, user, "be1")
+        first = await client.get("/api/v1/images.atom")
+        first_etag = first.headers["etag"]
+        await _make_image(db_session, user, "be2")
+        second = await client.get(
+            "/api/v1/images.atom", headers={"If-None-Match": first_etag}
+        )
+        assert second.status_code == 200
+        assert second.headers["etag"] != first_etag
+
+    async def test_if_modified_since_returns_304(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "imsuser")
+        await _make_image(db_session, user, "ims1")
+        first = await client.get("/api/v1/images.atom")
+        last_mod = first.headers["last-modified"]
+        second = await client.get(
+            "/api/v1/images.atom", headers={"If-Modified-Since": last_mod}
+        )
+        assert second.status_code == 304
+
+    async def test_empty_feed_is_200(self, client: AsyncClient, db_session: AsyncSession):
+        response = await client.get("/api/v1/images.atom")
+        assert response.status_code == 200
+        assert "<feed" in response.text

--- a/tests/api/v1/test_feeds.py
+++ b/tests/api/v1/test_feeds.py
@@ -246,3 +246,63 @@ class TestGlobalImagesFeed:
         response = await client.get("/api/v1/images.atom")
         assert response.status_code == 200
         assert "<feed" in response.text
+
+
+class TestPerTagImagesFeed:
+    async def test_returns_only_images_with_tag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "ptuser")
+        tag = await _make_tag(db_session, "pt_tag")
+        with_tag = await _make_image(db_session, user, "pt_w")
+        without_tag = await _make_image(db_session, user, "pt_wo")
+        await _link(db_session, with_tag, tag)
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}/images.atom")
+        assert response.status_code == 200
+        body = response.text
+        assert f"image:{with_tag.image_id}" in body
+        assert f"image:{without_tag.image_id}" not in body
+
+    async def test_unknown_tag_id_returns_404(self, client: AsyncClient):
+        response = await client.get("/api/v1/tags/999999999/images.atom")
+        assert response.status_code == 404
+
+    async def test_alias_tag_serves_canonical_image_set(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "aliasuser")
+        canonical = await _make_tag(db_session, "canonical_tag")
+        alias = Tags(
+            title="alias_tag",
+            type=TagType.THEME,
+            user_id=None,
+            alias_of=canonical.tag_id,
+        )
+        db_session.add(alias)
+        await db_session.commit()
+        await db_session.refresh(alias)
+
+        image = await _make_image(db_session, user, "aliasimg")
+        await _link(db_session, image, canonical)
+
+        response = await client.get(f"/api/v1/tags/{alias.tag_id}/images.atom")
+        assert response.status_code == 200
+        assert f"image:{image.image_id}" in response.text
+
+    async def test_conditional_request_returns_304(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "pt_etag_user")
+        tag = await _make_tag(db_session, "pt_etag_tag")
+        image = await _make_image(db_session, user, "pt_e1")
+        await _link(db_session, image, tag)
+
+        first = await client.get(f"/api/v1/tags/{tag.tag_id}/images.atom")
+        assert first.status_code == 200
+        etag = first.headers["etag"]
+
+        second = await client.get(
+            f"/api/v1/tags/{tag.tag_id}/images.atom",
+            headers={"If-None-Match": etag},
+        )
+        assert second.status_code == 304

--- a/tests/api/v1/test_feeds.py
+++ b/tests/api/v1/test_feeds.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import ImageStatus, TagType
 from app.models import Images, Tags, TagLinks, Users
-from app.services.feeds import fetch_feed_sentinel
+from app.services.feeds import fetch_feed_entries, fetch_feed_sentinel
 
 
 async def _make_user(db: AsyncSession, username: str = "feeder") -> Users:
@@ -125,3 +125,39 @@ class TestFetchFeedSentinelPerTag:
     async def test_empty_tag_list_returns_no_rows(self, db_session: AsyncSession):
         sentinel = await fetch_feed_sentinel(db_session, tag_ids=[], limit=50)
         assert sentinel == []
+
+
+class TestFetchFeedEntriesGlobal:
+    async def test_returns_image_detailed_responses(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "hydrator")
+        tag = await _make_tag(db_session, "hydrator_tag", type_=TagType.ARTIST)
+        image = await _make_image(db_session, user, "h1")
+        await _link(db_session, image, tag)
+
+        entries = await fetch_feed_entries(db_session, tag_ids=None, limit=50)
+
+        assert len(entries) >= 1
+        entry = next(e for e in entries if e.image_id == image.image_id)
+        assert entry.user is not None
+        assert entry.user.username == "hydrator"
+        assert entry.tags is not None
+        assert any(t.tag == "hydrator_tag" for t in entry.tags)
+
+    async def test_only_active_images(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "activeonly")
+        active = await _make_image(db_session, user, "a")
+        hidden = await _make_image(db_session, user, "h", status=ImageStatus.INAPPROPRIATE)
+
+        entries = await fetch_feed_entries(db_session, tag_ids=None, limit=50)
+        ids = [e.image_id for e in entries]
+        assert active.image_id in ids
+        assert hidden.image_id not in ids
+
+    async def test_ordered_newest_first(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "orderer")
+        first = await _make_image(db_session, user, "o1")
+        second = await _make_image(db_session, user, "o2")
+
+        entries = await fetch_feed_entries(db_session, tag_ids=None, limit=50)
+        ids = [e.image_id for e in entries]
+        assert ids.index(second.image_id) < ids.index(first.image_id)

--- a/tests/api/v1/test_feeds.py
+++ b/tests/api/v1/test_feeds.py
@@ -2,12 +2,11 @@
 
 from datetime import UTC, datetime
 
-import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import ImageStatus, TagType
-from app.models import Images, Tags, TagLinks, Users
+from app.models import Images, TagLinks, Tags, Users
 from app.services.feeds import fetch_feed_entries, fetch_feed_sentinel
 
 
@@ -46,9 +45,7 @@ async def _make_image(
     return image
 
 
-async def _make_tag(
-    db: AsyncSession, title: str, type_: int = TagType.THEME
-) -> Tags:
+async def _make_tag(db: AsyncSession, title: str, type_: int = TagType.THEME) -> Tags:
     tag = Tags(title=title, type=type_, user_id=None)
     db.add(tag)
     await db.commit()
@@ -62,9 +59,7 @@ async def _link(db: AsyncSession, image: Images, tag: Tags) -> None:
 
 
 class TestFetchFeedSentinelGlobal:
-    async def test_returns_only_active_images_newest_first(
-        self, db_session: AsyncSession
-    ):
+    async def test_returns_only_active_images_newest_first(self, db_session: AsyncSession):
         user = await _make_user(db_session)
         active_a = await _make_image(db_session, user, "a")
         hidden = await _make_image(db_session, user, "h", status=ImageStatus.INAPPROPRIATE)
@@ -96,9 +91,7 @@ class TestFetchFeedSentinelPerTag:
         img_without = await _make_image(db_session, user, "without")
         await _link(db_session, img_with, tag)
 
-        sentinel = await fetch_feed_sentinel(
-            db_session, tag_ids=[tag.tag_id], limit=50
-        )
+        sentinel = await fetch_feed_sentinel(db_session, tag_ids=[tag.tag_id], limit=50)
 
         ids = [row[0] for row in sentinel]
         assert img_with.image_id in ids
@@ -114,9 +107,7 @@ class TestFetchFeedSentinelPerTag:
         await _link(db_session, img_a, t1)
         await _link(db_session, img_b, t2)
 
-        sentinel = await fetch_feed_sentinel(
-            db_session, tag_ids=[t1.tag_id, t2.tag_id], limit=50
-        )
+        sentinel = await fetch_feed_sentinel(db_session, tag_ids=[t1.tag_id, t2.tag_id], limit=50)
 
         ids = [row[0] for row in sentinel]
         assert img_a.image_id in ids
@@ -164,18 +155,14 @@ class TestFetchFeedEntriesGlobal:
 
 
 class TestGlobalImagesFeed:
-    async def test_returns_atom_content_type(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_returns_atom_content_type(self, client: AsyncClient, db_session: AsyncSession):
         user = await _make_user(db_session, "ctuser")
         await _make_image(db_session, user, "ct1")
         response = await client.get("/api/v1/images.atom")
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("application/atom+xml")
 
-    async def test_includes_only_active_images(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_includes_only_active_images(self, client: AsyncClient, db_session: AsyncSession):
         user = await _make_user(db_session, "actuser")
         active = await _make_image(db_session, user, "a1")
         hidden = await _make_image(db_session, user, "h1", status=ImageStatus.INAPPROPRIATE)
@@ -212,9 +199,7 @@ class TestGlobalImagesFeed:
         await _make_image(db_session, user, "ce1")
         first = await client.get("/api/v1/images.atom")
         etag = first.headers["etag"]
-        second = await client.get(
-            "/api/v1/images.atom", headers={"If-None-Match": etag}
-        )
+        second = await client.get("/api/v1/images.atom", headers={"If-None-Match": etag})
         assert second.status_code == 304
         assert second.text == ""
 
@@ -224,9 +209,7 @@ class TestGlobalImagesFeed:
         first = await client.get("/api/v1/images.atom")
         first_etag = first.headers["etag"]
         await _make_image(db_session, user, "be2")
-        second = await client.get(
-            "/api/v1/images.atom", headers={"If-None-Match": first_etag}
-        )
+        second = await client.get("/api/v1/images.atom", headers={"If-None-Match": first_etag})
         assert second.status_code == 200
         assert second.headers["etag"] != first_etag
 
@@ -237,9 +220,7 @@ class TestGlobalImagesFeed:
         await _make_image(db_session, user, "ims1")
         first = await client.get("/api/v1/images.atom")
         last_mod = first.headers["last-modified"]
-        second = await client.get(
-            "/api/v1/images.atom", headers={"If-Modified-Since": last_mod}
-        )
+        second = await client.get("/api/v1/images.atom", headers={"If-Modified-Since": last_mod})
         assert second.status_code == 304
 
     async def test_empty_feed_is_200(self, client: AsyncClient, db_session: AsyncSession):

--- a/tests/api/v1/test_feeds.py
+++ b/tests/api/v1/test_feeds.py
@@ -203,6 +203,28 @@ class TestGlobalImagesFeed:
         assert second.status_code == 304
         assert second.text == ""
 
+    async def test_if_none_match_accepts_comma_separated_list(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """RFC 7232 §3.2: clients may send multiple ETags. We 304 if ours is in the set."""
+        user = await _make_user(db_session, "multietag")
+        await _make_image(db_session, user, "me1")
+        first = await client.get("/api/v1/images.atom")
+        etag = first.headers["etag"]
+        second = await client.get(
+            "/api/v1/images.atom",
+            headers={"If-None-Match": f'W/"stale-old-etag", {etag}, W/"another-old"'},
+        )
+        assert second.status_code == 304
+
+    async def test_if_none_match_star_returns_304(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "staretag")
+        await _make_image(db_session, user, "se1")
+        response = await client.get("/api/v1/images.atom", headers={"If-None-Match": "*"})
+        assert response.status_code == 304
+
     async def test_new_image_busts_etag(self, client: AsyncClient, db_session: AsyncSession):
         user = await _make_user(db_session, "bustetag")
         await _make_image(db_session, user, "be1")

--- a/tests/api/v1/test_feeds.py
+++ b/tests/api/v1/test_feeds.py
@@ -1,0 +1,127 @@
+"""Integration tests for Atom feed endpoints and query helpers."""
+
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, TagType
+from app.models import Images, Tags, TagLinks, Users
+from app.services.feeds import fetch_feed_sentinel
+
+
+async def _make_user(db: AsyncSession, username: str = "feeder") -> Users:
+    user = Users(
+        username=username,
+        password="x",
+        password_type="bcrypt",
+        salt="",
+        email=f"{username}@example.com",
+        active=1,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _make_image(
+    db: AsyncSession,
+    user: Users,
+    filename: str,
+    status: int = ImageStatus.ACTIVE,
+) -> Images:
+    image = Images(
+        filename=filename,
+        ext="png",
+        status=status,
+        user_id=user.user_id,
+        filesize=1024,
+        date_added=datetime.now(UTC),
+    )
+    db.add(image)
+    await db.commit()
+    await db.refresh(image)
+    return image
+
+
+async def _make_tag(
+    db: AsyncSession, title: str, type_: int = TagType.THEME
+) -> Tags:
+    tag = Tags(title=title, type=type_, user_id=None)
+    db.add(tag)
+    await db.commit()
+    await db.refresh(tag)
+    return tag
+
+
+async def _link(db: AsyncSession, image: Images, tag: Tags) -> None:
+    db.add(TagLinks(image_id=image.image_id, tag_id=tag.tag_id))
+    await db.commit()
+
+
+class TestFetchFeedSentinelGlobal:
+    async def test_returns_only_active_images_newest_first(
+        self, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session)
+        active_a = await _make_image(db_session, user, "a")
+        hidden = await _make_image(db_session, user, "h", status=ImageStatus.INAPPROPRIATE)
+        active_b = await _make_image(db_session, user, "b")
+        await _make_image(db_session, user, "c", status=ImageStatus.REVIEW)
+
+        sentinel = await fetch_feed_sentinel(db_session, tag_ids=None, limit=50)
+
+        ids = [row[0] for row in sentinel]
+        assert active_b.image_id in ids
+        assert active_a.image_id in ids
+        assert hidden.image_id not in ids
+        assert ids.index(active_b.image_id) < ids.index(active_a.image_id)
+
+    async def test_respects_limit(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "limituser")
+        for i in range(10):
+            await _make_image(db_session, user, f"lim{i}")
+
+        sentinel = await fetch_feed_sentinel(db_session, tag_ids=None, limit=3)
+        assert len(sentinel) == 3
+
+
+class TestFetchFeedSentinelPerTag:
+    async def test_filters_by_tag_id(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "tagfilter")
+        tag = await _make_tag(db_session, "filtertag")
+        img_with = await _make_image(db_session, user, "with")
+        img_without = await _make_image(db_session, user, "without")
+        await _link(db_session, img_with, tag)
+
+        sentinel = await fetch_feed_sentinel(
+            db_session, tag_ids=[tag.tag_id], limit=50
+        )
+
+        ids = [row[0] for row in sentinel]
+        assert img_with.image_id in ids
+        assert img_without.image_id not in ids
+
+    async def test_multiple_tag_ids_union(self, db_session: AsyncSession):
+        """tag_ids represents the already-expanded hierarchy set; any match qualifies."""
+        user = await _make_user(db_session, "multitag")
+        t1 = await _make_tag(db_session, "t1")
+        t2 = await _make_tag(db_session, "t2")
+        img_a = await _make_image(db_session, user, "a_t1")
+        img_b = await _make_image(db_session, user, "b_t2")
+        await _link(db_session, img_a, t1)
+        await _link(db_session, img_b, t2)
+
+        sentinel = await fetch_feed_sentinel(
+            db_session, tag_ids=[t1.tag_id, t2.tag_id], limit=50
+        )
+
+        ids = [row[0] for row in sentinel]
+        assert img_a.image_id in ids
+        assert img_b.image_id in ids
+
+    async def test_empty_tag_list_returns_no_rows(self, db_session: AsyncSession):
+        sentinel = await fetch_feed_sentinel(db_session, tag_ids=[], limit=50)
+        assert sentinel == []

--- a/tests/unit/test_feeds_service.py
+++ b/tests/unit/test_feeds_service.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from app.services.feeds import mime_type_for_ext
+from app.config import TagType
+from app.services.feeds import compose_entry_title, mime_type_for_ext
 
 
 class TestMimeTypeForExt:
@@ -25,3 +26,78 @@ class TestMimeTypeForExt:
 
     def test_empty_string_falls_back(self):
         assert mime_type_for_ext("") == "application/octet-stream"
+
+
+def _tag(tag_id: int, title: str, type_: int, usage_count: int):
+    """Lightweight stand-in for TagSummary — matches its attribute names."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        tag_id=tag_id,
+        tag=title,      # TagSummary's alias for Tags.title
+        type_id=type_,  # TagSummary's alias for Tags.type
+        usage_count=usage_count,
+    )
+
+
+class TestComposeEntryTitle:
+    def test_all_three_sections(self):
+        tags = [
+            _tag(1, "hatsune miku", TagType.CHARACTER, 500),
+            _tag(2, "kagamine rin", TagType.CHARACTER, 100),
+            _tag(3, "vocaloid", TagType.SOURCE, 1000),
+            _tag(4, "cutesexyrobutts", TagType.ARTIST, 50),
+        ]
+        assert (
+            compose_entry_title(image_id=42, tags=tags)
+            == "hatsune miku (vocaloid) by cutesexyrobutts"
+        )
+
+    def test_no_character_tags(self):
+        tags = [
+            _tag(3, "vocaloid", TagType.SOURCE, 1000),
+            _tag(4, "cutesexyrobutts", TagType.ARTIST, 50),
+        ]
+        assert (
+            compose_entry_title(image_id=42, tags=tags)
+            == "(vocaloid) by cutesexyrobutts"
+        )
+
+    def test_no_source_tags(self):
+        tags = [
+            _tag(1, "hatsune miku", TagType.CHARACTER, 500),
+            _tag(4, "cutesexyrobutts", TagType.ARTIST, 50),
+        ]
+        assert (
+            compose_entry_title(image_id=42, tags=tags)
+            == "hatsune miku by cutesexyrobutts"
+        )
+
+    def test_no_artist_tags(self):
+        tags = [
+            _tag(1, "hatsune miku", TagType.CHARACTER, 500),
+            _tag(3, "vocaloid", TagType.SOURCE, 1000),
+        ]
+        assert (
+            compose_entry_title(image_id=42, tags=tags)
+            == "hatsune miku (vocaloid)"
+        )
+
+    def test_no_relevant_tags_falls_back(self):
+        tags = [_tag(5, "solo", TagType.THEME, 999)]
+        assert compose_entry_title(image_id=42, tags=tags) == "Image #42"
+
+    def test_no_tags_at_all_falls_back(self):
+        assert compose_entry_title(image_id=42, tags=[]) == "Image #42"
+
+    def test_picks_highest_usage_count_per_category(self):
+        tags = [
+            _tag(1, "low usage char", TagType.CHARACTER, 1),
+            _tag(2, "high usage char", TagType.CHARACTER, 9999),
+            _tag(3, "low usage artist", TagType.ARTIST, 1),
+            _tag(4, "high usage artist", TagType.ARTIST, 9999),
+        ]
+        assert (
+            compose_entry_title(image_id=42, tags=tags)
+            == "high usage char by high usage artist"
+        )

--- a/tests/unit/test_feeds_service.py
+++ b/tests/unit/test_feeds_service.py
@@ -210,6 +210,13 @@ class TestBuildAtomFeedEmpty:
         root = ET.fromstring(xml)
         assert root.findall(f"{ATOM_NS}entry") == []
 
+    def test_empty_feed_has_no_subtitle(self):
+        # We pass description=None to suppress <subtitle>; this guards against
+        # a future feedgenerator change re-emitting an empty <subtitle/>.
+        xml = build_atom_feed(_feed_meta(), entries=[])
+        root = ET.fromstring(xml)
+        assert root.find(f"{ATOM_NS}subtitle") is None
+
 
 def _orm_image(
     image_id: int = 42,

--- a/tests/unit/test_feeds_service.py
+++ b/tests/unit/test_feeds_service.py
@@ -49,7 +49,7 @@ def _tag(tag_id: int, title: str, type_: int, usage_count: int):
 
     return SimpleNamespace(
         tag_id=tag_id,
-        tag=title,      # TagSummary's alias for Tags.title
+        tag=title,  # TagSummary's alias for Tags.title
         type_id=type_,  # TagSummary's alias for Tags.type
         usage_count=usage_count,
     )
@@ -73,30 +73,21 @@ class TestComposeEntryTitle:
             _tag(3, "vocaloid", TagType.SOURCE, 1000),
             _tag(4, "cutesexyrobutts", TagType.ARTIST, 50),
         ]
-        assert (
-            compose_entry_title(image_id=42, tags=tags)
-            == "(vocaloid) by cutesexyrobutts"
-        )
+        assert compose_entry_title(image_id=42, tags=tags) == "(vocaloid) by cutesexyrobutts"
 
     def test_no_source_tags(self):
         tags = [
             _tag(1, "hatsune miku", TagType.CHARACTER, 500),
             _tag(4, "cutesexyrobutts", TagType.ARTIST, 50),
         ]
-        assert (
-            compose_entry_title(image_id=42, tags=tags)
-            == "hatsune miku by cutesexyrobutts"
-        )
+        assert compose_entry_title(image_id=42, tags=tags) == "hatsune miku by cutesexyrobutts"
 
     def test_no_artist_tags(self):
         tags = [
             _tag(1, "hatsune miku", TagType.CHARACTER, 500),
             _tag(3, "vocaloid", TagType.SOURCE, 1000),
         ]
-        assert (
-            compose_entry_title(image_id=42, tags=tags)
-            == "hatsune miku (vocaloid)"
-        )
+        assert compose_entry_title(image_id=42, tags=tags) == "hatsune miku (vocaloid)"
 
     def test_no_relevant_tags_falls_back(self):
         tags = [_tag(5, "solo", TagType.THEME, 999)]
@@ -112,10 +103,7 @@ class TestComposeEntryTitle:
             _tag(3, "low usage artist", TagType.ARTIST, 1),
             _tag(4, "high usage artist", TagType.ARTIST, 9999),
         ]
-        assert (
-            compose_entry_title(image_id=42, tags=tags)
-            == "high usage char by high usage artist"
-        )
+        assert compose_entry_title(image_id=42, tags=tags) == "high usage char by high usage artist"
 
 
 class TestComputeFeedEtag:
@@ -165,9 +153,7 @@ class TestNewestTimestamp:
             (100, datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC)),
             (99, datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)),
         ]
-        assert newest_timestamp(sentinel) == datetime(
-            2026, 4, 24, 12, 0, 0, tzinfo=UTC
-        )
+        assert newest_timestamp(sentinel) == datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC)
 
     def test_empty_returns_none(self):
         assert newest_timestamp([]) is None
@@ -177,9 +163,7 @@ class TestNewestTimestamp:
             (100, None),
             (99, datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)),
         ]
-        assert newest_timestamp(sentinel) == datetime(
-            2026, 4, 23, 12, 0, 0, tzinfo=UTC
-        )
+        assert newest_timestamp(sentinel) == datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
 
     def test_all_none_returns_none(self):
         assert newest_timestamp([(100, None), (99, None)]) is None
@@ -214,15 +198,11 @@ class TestBuildAtomFeedEmpty:
     def test_empty_feed_has_id_title_self_link_updated(self):
         xml = build_atom_feed(_feed_meta(), entries=[])
         root = ET.fromstring(xml)
-        assert root.find(f"{ATOM_NS}id").text == (
-            "tag:e-shuushuu.net,2005:feed:images"
-        )
+        assert root.find(f"{ATOM_NS}id").text == ("tag:e-shuushuu.net,2005:feed:images")
         assert root.find(f"{ATOM_NS}title").text == "Shuushuu — latest images"
         self_link = root.find(f"{ATOM_NS}link[@rel='self']")
         assert self_link is not None
-        assert self_link.get("href") == (
-            "https://e-shuushuu.net/api/v1/images.atom"
-        )
+        assert self_link.get("href") == ("https://e-shuushuu.net/api/v1/images.atom")
         assert root.find(f"{ATOM_NS}updated") is not None
 
     def test_empty_feed_has_no_entries(self):
@@ -279,9 +259,7 @@ class TestBuildAtomFeedWithEntries:
         xml = build_atom_feed(_feed_meta(), entries=[_entry(image_id=42)])
         root = ET.fromstring(xml)
         entry_node = root.find(f"{ATOM_NS}entry")
-        assert entry_node.find(f"{ATOM_NS}id").text == (
-            "tag:e-shuushuu.net,2005:image:42"
-        )
+        assert entry_node.find(f"{ATOM_NS}id").text == ("tag:e-shuushuu.net,2005:image:42")
 
     def test_entry_alternate_link_points_to_detail_page(self):
         xml = build_atom_feed(_feed_meta(), entries=[_entry(image_id=42)])
@@ -291,9 +269,7 @@ class TestBuildAtomFeedWithEntries:
         assert alt.get("href", "").endswith("/images/42")
 
     def test_entry_enclosure_has_mime_and_length(self):
-        xml = build_atom_feed(
-            _feed_meta(), entries=[_entry(image_id=42, ext="png", filesize=1024)]
-        )
+        xml = build_atom_feed(_feed_meta(), entries=[_entry(image_id=42, ext="png", filesize=1024)])
         root = ET.fromstring(xml)
         enc = root.find(f"{ATOM_NS}entry/{ATOM_NS}link[@rel='enclosure']")
         assert enc is not None
@@ -303,18 +279,12 @@ class TestBuildAtomFeedWithEntries:
     def test_entry_author_is_uploader(self):
         xml = build_atom_feed(_feed_meta(), entries=[_entry(username="alice")])
         root = ET.fromstring(xml)
-        assert (
-            root.find(f"{ATOM_NS}entry/{ATOM_NS}author/{ATOM_NS}name").text
-            == "alice"
-        )
+        assert root.find(f"{ATOM_NS}entry/{ATOM_NS}author/{ATOM_NS}name").text == "alice"
 
     def test_entry_author_falls_back_for_deleted_uploader(self):
         xml = build_atom_feed(_feed_meta(), entries=[_entry(username=None)])
         root = ET.fromstring(xml)
-        assert (
-            root.find(f"{ATOM_NS}entry/{ATOM_NS}author/{ATOM_NS}name").text
-            == "[deleted user]"
-        )
+        assert root.find(f"{ATOM_NS}entry/{ATOM_NS}author/{ATOM_NS}name").text == "[deleted user]"
 
     def test_entry_content_is_html_escaped_caption(self):
         xml = build_atom_feed(

--- a/tests/unit/test_feeds_service.py
+++ b/tests/unit/test_feeds_service.py
@@ -1,9 +1,11 @@
 """Unit tests for app.services.feeds pure helpers."""
 
+from datetime import UTC, datetime
+
 import pytest
 
 from app.config import TagType
-from app.services.feeds import compose_entry_title, mime_type_for_ext
+from app.services.feeds import compose_entry_title, compute_feed_etag, mime_type_for_ext, newest_timestamp
 
 
 class TestMimeTypeForExt:
@@ -101,3 +103,78 @@ class TestComposeEntryTitle:
             compose_entry_title(image_id=42, tags=tags)
             == "high usage char by high usage artist"
         )
+
+
+class TestComputeFeedEtag:
+    def _sentinel(self):
+        return [
+            (100, datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC)),
+            (99, datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)),
+        ]
+
+    def test_returns_weak_etag(self):
+        etag = compute_feed_etag(self._sentinel())
+        assert etag.startswith('W/"')
+        assert etag.endswith('"')
+
+    def test_deterministic_for_same_input(self):
+        s = self._sentinel()
+        assert compute_feed_etag(s) == compute_feed_etag(s)
+
+    def test_changes_when_image_id_changes(self):
+        a = self._sentinel()
+        b = self._sentinel()
+        b[0] = (101, b[0][1])
+        assert compute_feed_etag(a) != compute_feed_etag(b)
+
+    def test_changes_when_timestamp_changes(self):
+        a = self._sentinel()
+        b = self._sentinel()
+        b[0] = (b[0][0], datetime(2026, 4, 24, 13, 0, 0, tzinfo=UTC))
+        assert compute_feed_etag(a) != compute_feed_etag(b)
+
+    def test_empty_sentinel_still_returns_valid_etag(self):
+        etag = compute_feed_etag([])
+        assert etag.startswith('W/"') and etag.endswith('"')
+
+    def test_ignores_rows_with_null_date(self):
+        a = [(100, datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC))]
+        b = [
+            (100, datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC)),
+            (99, None),
+        ]
+        assert compute_feed_etag(a) == compute_feed_etag(b)
+
+
+class TestNewestTimestamp:
+    def test_picks_newest_from_sentinel(self):
+        sentinel = [
+            (100, datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC)),
+            (99, datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)),
+        ]
+        assert newest_timestamp(sentinel) == datetime(
+            2026, 4, 24, 12, 0, 0, tzinfo=UTC
+        )
+
+    def test_empty_returns_none(self):
+        assert newest_timestamp([]) is None
+
+    def test_skips_none_timestamps(self):
+        sentinel = [
+            (100, None),
+            (99, datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)),
+        ]
+        assert newest_timestamp(sentinel) == datetime(
+            2026, 4, 23, 12, 0, 0, tzinfo=UTC
+        )
+
+    def test_all_none_returns_none(self):
+        assert newest_timestamp([(100, None), (99, None)]) is None
+
+    def test_result_is_floored_to_whole_seconds(self):
+        sentinel = [
+            (100, datetime(2026, 4, 24, 12, 0, 0, 999_999, tzinfo=UTC)),
+        ]
+        result = newest_timestamp(sentinel)
+        assert result is not None
+        assert result.microsecond == 0

--- a/tests/unit/test_feeds_service.py
+++ b/tests/unit/test_feeds_service.py
@@ -1,0 +1,27 @@
+"""Unit tests for app.services.feeds pure helpers."""
+
+import pytest
+
+from app.services.feeds import mime_type_for_ext
+
+
+class TestMimeTypeForExt:
+    @pytest.mark.parametrize(
+        "ext,expected",
+        [
+            ("jpg", "image/jpeg"),
+            ("jpeg", "image/jpeg"),
+            ("JPG", "image/jpeg"),
+            ("png", "image/png"),
+            ("gif", "image/gif"),
+            ("webp", "image/webp"),
+        ],
+    )
+    def test_known_extensions(self, ext: str, expected: str):
+        assert mime_type_for_ext(ext) == expected
+
+    def test_unknown_extension_falls_back_to_octet_stream(self):
+        assert mime_type_for_ext("xyz") == "application/octet-stream"
+
+    def test_empty_string_falls_back(self):
+        assert mime_type_for_ext("") == "application/octet-stream"

--- a/tests/unit/test_feeds_service.py
+++ b/tests/unit/test_feeds_service.py
@@ -1,11 +1,24 @@
 """Unit tests for app.services.feeds pure helpers."""
 
+import xml.etree.ElementTree as ET
 from datetime import UTC, datetime
+from types import SimpleNamespace
 
 import pytest
 
 from app.config import TagType
-from app.services.feeds import compose_entry_title, compute_feed_etag, mime_type_for_ext, newest_timestamp
+from app.models.image import Images
+from app.models.tag import Tags
+from app.models.user import Users
+from app.schemas.image import ImageDetailedResponse
+from app.services.feeds import (
+    FeedMeta,
+    build_atom_feed,
+    compose_entry_title,
+    compute_feed_etag,
+    mime_type_for_ext,
+    newest_timestamp,
+)
 
 
 class TestMimeTypeForExt:
@@ -178,3 +191,156 @@ class TestNewestTimestamp:
         result = newest_timestamp(sentinel)
         assert result is not None
         assert result.microsecond == 0
+
+
+ATOM_NS = "{http://www.w3.org/2005/Atom}"
+
+
+def _feed_meta() -> FeedMeta:
+    return FeedMeta(
+        feed_id="tag:e-shuushuu.net,2005:feed:images",
+        title="Shuushuu — latest images",
+        self_url="https://e-shuushuu.net/api/v1/images.atom",
+        alternate_url="https://e-shuushuu.net/",
+    )
+
+
+class TestBuildAtomFeedEmpty:
+    def test_empty_feed_is_valid_atom(self):
+        xml = build_atom_feed(_feed_meta(), entries=[])
+        root = ET.fromstring(xml)
+        assert root.tag == f"{ATOM_NS}feed"
+
+    def test_empty_feed_has_id_title_self_link_updated(self):
+        xml = build_atom_feed(_feed_meta(), entries=[])
+        root = ET.fromstring(xml)
+        assert root.find(f"{ATOM_NS}id").text == (
+            "tag:e-shuushuu.net,2005:feed:images"
+        )
+        assert root.find(f"{ATOM_NS}title").text == "Shuushuu — latest images"
+        self_link = root.find(f"{ATOM_NS}link[@rel='self']")
+        assert self_link is not None
+        assert self_link.get("href") == (
+            "https://e-shuushuu.net/api/v1/images.atom"
+        )
+        assert root.find(f"{ATOM_NS}updated") is not None
+
+    def test_empty_feed_has_no_entries(self):
+        xml = build_atom_feed(_feed_meta(), entries=[])
+        root = ET.fromstring(xml)
+        assert root.findall(f"{ATOM_NS}entry") == []
+
+
+def _orm_image(
+    image_id: int = 42,
+    filename: str = "abc42",
+    ext: str = "png",
+    caption: str | None = None,
+    filesize: int = 1024,
+    date_added: datetime | None = None,
+    username: str | None = "alice",
+    tags: list[Tags] | None = None,
+) -> Images:
+    user = None
+    if username is not None:
+        user = Users(
+            user_id=1,
+            username=username,
+            password="x",
+            password_type="bcrypt",
+            salt="",
+            email="a@b.c",
+            active=1,
+        )
+
+    img = Images(
+        image_id=image_id,
+        filename=filename,
+        ext=ext,
+        caption=caption or "",
+        filesize=filesize,
+        user_id=1,
+        status=1,
+        date_added=date_added or datetime(2026, 4, 24, 10, 0, 0, tzinfo=UTC),
+    )
+    # Bypass SQLAlchemy instrumentation — we're building a plain object graph
+    # for from_db_model to read, not persisting through a session.
+    img.__dict__["user"] = user
+    img.__dict__["tag_links"] = [SimpleNamespace(tag=t) for t in (tags or [])]
+    return img
+
+
+def _entry(**overrides) -> ImageDetailedResponse:
+    return ImageDetailedResponse.from_db_model(_orm_image(**overrides))
+
+
+class TestBuildAtomFeedWithEntries:
+    def test_entry_has_tag_uri_id(self):
+        xml = build_atom_feed(_feed_meta(), entries=[_entry(image_id=42)])
+        root = ET.fromstring(xml)
+        entry_node = root.find(f"{ATOM_NS}entry")
+        assert entry_node.find(f"{ATOM_NS}id").text == (
+            "tag:e-shuushuu.net,2005:image:42"
+        )
+
+    def test_entry_alternate_link_points_to_detail_page(self):
+        xml = build_atom_feed(_feed_meta(), entries=[_entry(image_id=42)])
+        root = ET.fromstring(xml)
+        alt = root.find(f"{ATOM_NS}entry/{ATOM_NS}link[@rel='alternate']")
+        assert alt is not None
+        assert alt.get("href", "").endswith("/images/42")
+
+    def test_entry_enclosure_has_mime_and_length(self):
+        xml = build_atom_feed(
+            _feed_meta(), entries=[_entry(image_id=42, ext="png", filesize=1024)]
+        )
+        root = ET.fromstring(xml)
+        enc = root.find(f"{ATOM_NS}entry/{ATOM_NS}link[@rel='enclosure']")
+        assert enc is not None
+        assert enc.get("type") == "image/png"
+        assert enc.get("length") == "1024"
+
+    def test_entry_author_is_uploader(self):
+        xml = build_atom_feed(_feed_meta(), entries=[_entry(username="alice")])
+        root = ET.fromstring(xml)
+        assert (
+            root.find(f"{ATOM_NS}entry/{ATOM_NS}author/{ATOM_NS}name").text
+            == "alice"
+        )
+
+    def test_entry_author_falls_back_for_deleted_uploader(self):
+        xml = build_atom_feed(_feed_meta(), entries=[_entry(username=None)])
+        root = ET.fromstring(xml)
+        assert (
+            root.find(f"{ATOM_NS}entry/{ATOM_NS}author/{ATOM_NS}name").text
+            == "[deleted user]"
+        )
+
+    def test_entry_content_is_html_escaped_caption(self):
+        xml = build_atom_feed(
+            _feed_meta(),
+            entries=[_entry(caption="a <b> caption & stuff")],
+        )
+        root = ET.fromstring(xml)
+        content = root.find(f"{ATOM_NS}entry/{ATOM_NS}content")
+        assert content is not None
+        assert content.get("type") == "html"
+        assert content.text == "a &lt;b&gt; caption &amp; stuff"
+
+    def test_entry_with_no_caption_omits_content(self):
+        xml = build_atom_feed(_feed_meta(), entries=[_entry(caption=None)])
+        root = ET.fromstring(xml)
+        assert root.find(f"{ATOM_NS}entry/{ATOM_NS}content") is None
+
+    def test_entry_categories_carry_scheme(self):
+        tags = [
+            Tags(tag_id=1, title="hatsune miku", type=TagType.CHARACTER, usage_count=500),
+            Tags(tag_id=2, title="vocaloid", type=TagType.SOURCE, usage_count=1000),
+        ]
+        xml = build_atom_feed(_feed_meta(), entries=[_entry(tags=tags)])
+        root = ET.fromstring(xml)
+        cats = root.findall(f"{ATOM_NS}entry/{ATOM_NS}category")
+        assert len(cats) == 2
+        by_term = {c.get("term"): c.get("scheme") for c in cats}
+        assert by_term["hatsune miku"].endswith("/tag-type/Character")
+        assert by_term["vocaloid"].endswith("/tag-type/Source")

--- a/tests/unit/test_tag_summary.py
+++ b/tests/unit/test_tag_summary.py
@@ -12,7 +12,5 @@ class TestTagSummaryUsageCount:
 
     def test_usage_count_defaults_to_zero(self):
         # Validate from a dict without usage_count — should default.
-        summary = TagSummary.model_validate(
-            {"tag_id": 1, "title": "t", "type": 1}
-        )
+        summary = TagSummary.model_validate({"tag_id": 1, "title": "t", "type": 1})
         assert summary.usage_count == 0

--- a/tests/unit/test_tag_summary.py
+++ b/tests/unit/test_tag_summary.py
@@ -1,0 +1,18 @@
+"""TagSummary schema tests — usage_count field."""
+
+from app.models.tag import Tags
+from app.schemas.image import TagSummary
+
+
+class TestTagSummaryUsageCount:
+    def test_usage_count_populated_from_orm(self):
+        tag = Tags(tag_id=1, title="t", type=1, usage_count=42)
+        summary = TagSummary.model_validate(tag)
+        assert summary.usage_count == 42
+
+    def test_usage_count_defaults_to_zero(self):
+        # Validate from a dict without usage_count — should default.
+        summary = TagSummary.model_validate(
+            {"tag_id": 1, "title": "t", "type": 1}
+        )
+        assert summary.usage_count == 0

--- a/uv.lock
+++ b/uv.lock
@@ -754,6 +754,18 @@ wheels = [
 ]
 
 [[package]]
+name = "feedgenerator"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/d2/f05e9f4628cb0df988de66f8a97dd52877490e6ebf8e7b41cd341bf2ad6b/feedgenerator-2.2.1.tar.gz", hash = "sha256:0eaa955f1f0bcb5b87ac195af740f06ff9fff4a40ed30b8a7c6bbebb264d4dd1", size = 20872, upload-time = "2025-08-17T19:36:53.48Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/08/6f74bef4663fb137fa10b493facce85bee8c055b67fbd9a7695d88e3d1a3/feedgenerator-2.2.1-py3-none-any.whl", hash = "sha256:0d8bb321e49dd43c916b659e137c1eab1b1c053dd4535a03ef8d47e5f3358ba5", size = 18495, upload-time = "2025-08-17T19:36:52.036Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2169,6 +2181,7 @@ dependencies = [
     { name = "arq" },
     { name = "bcrypt" },
     { name = "fastapi", extra = ["standard"] },
+    { name = "feedgenerator" },
     { name = "httpx" },
     { name = "pillow" },
     { name = "pydantic" },
@@ -2207,6 +2220,7 @@ requires-dist = [
     { name = "arq", specifier = ">=0.27.0" },
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0,<=0.122.0" },
+    { name = "feedgenerator", specifier = ">=2.2.1" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -2479,6 +2493,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replaces the legacy PHP `/index.rss` (RSS 1.0) feed with two Atom 1.0 endpoints on the FastAPI backend:

- `GET /api/v1/images.atom` — latest 50 active images, newest first
- `GET /api/v1/tags/{tag_id}/images.atom` — latest 50 active images for a tag (follows aliases + hierarchy, matching `/api/v1/tags/{id}/images`)

Both are public, cacheable, and respect `If-None-Match` / `If-Modified-Since` (304 on cache hits — sentinel-only DB cost).

## Design & plan

- **Design:** [`docs/plans/2026-04-24-rss-feed-design.md`](docs/plans/2026-04-24-rss-feed-design.md) — 3 rounds of spec review
- **Implementation plan:** [`docs/plans/2026-04-24-rss-feed-impl.md`](docs/plans/2026-04-24-rss-feed-impl.md) — 3 chunks, each reviewed

## Notable implementation details

- **Library:** `feedgenerator` 2.2.1 (Django-extracted, stdlib-only, maintained). Subclassed `Atom1Feed` with a minimal `add_item_elements` override (≈5 lines) so `<category>` elements carry `scheme` per RFC 4287 — the stock library drops it.
- **Schema reuse:** Entries flow through `ImageDetailedResponse.from_db_model`, so feed items present the same view as the JSON API. Added `usage_count` to `TagSummary` (non-breaking) since the title composer picks the representative tag per category by highest `usage_count`.
- **Title format:** `"{character} ({source}) by {artist}"`, one representative per category, empty sections skipped, falls back to `"Image #{id}"`.
- **ETag:** Weak, stateless, derived from a cheap sentinel query (`SELECT image_id, date_added ... LIMIT 50`) — no storage, regenerated from DB state on every request.
- **Naive datetime handling:** `Images.date_added` is naive in the DB; the handler treats it as UTC (matches the rest of the codebase's convention).

## Tests

- **Unit:** `tests/unit/test_feeds_service.py` (37 tests — MIME mapping, title composition, ETag/timestamp helpers, Atom builder, feed-level & entry-level invariants, category scheme, content-vs-summary, escaping)
- **Unit:** `tests/unit/test_tag_summary.py` (2 tests — new `usage_count` field)
- **Integration:** `tests/api/v1/test_feeds.py` (21 tests — sentinel query, hydration, both endpoints, conditional requests, alias/hierarchy expansion, 404s)
- **Full project suite:** `1454 passed, 9 skipped` (4m18s)
- **ruff + mypy:** clean

## Test plan

- [x] `uv run pytest tests/unit/test_feeds_service.py tests/unit/test_tag_summary.py tests/api/v1/test_feeds.py` — 60 passed
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy app/services/feeds.py app/api/v1/feeds.py` — clean
- [x] Full `uv run pytest` — 1454 passed
- [ ] Manual smoke: `curl -sD- http://localhost:8000/api/v1/images.atom` returns 200 + Atom XML
- [ ] Manual smoke: `curl -sD- http://localhost:8000/api/v1/tags/1/images.atom` returns 200 or 404 appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)