### PR TITLE
fix(auth): unbreak login when lockout_until exists

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -284,8 +284,12 @@ async def login(
 
     # Check if account is locked
     if user.lockout_until:
-        if user.lockout_until > datetime.now(UTC):
-            remaining_minutes = int((user.lockout_until - datetime.now(UTC)).total_seconds() / 60)
+        # MySQL DATETIME is timezone-naive, so lockout_until comes back without
+        # tzinfo. Drop tzinfo from `now` to match — comparing aware vs. naive
+        # raises TypeError, which previously locked users out indefinitely.
+        now_naive = datetime.now(UTC).replace(tzinfo=None)
+        if user.lockout_until > now_naive:
+            remaining_minutes = int((user.lockout_until - now_naive).total_seconds() / 60)
             raise HTTPException(
                 status_code=status.HTTP_423_LOCKED,
                 detail=f"Account locked due to too many failed login attempts. Try again in {remaining_minutes} minutes.",

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -258,6 +258,65 @@ class TestLogin:
         await db_session.refresh(user)
         assert user.failed_login_attempts == 1
 
+    async def test_login_with_expired_lockout_clears_and_succeeds(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Login must succeed when an existing lockout_until has already expired.
+
+        MySQL DATETIME is timezone-naive, so user.lockout_until comes back from the
+        DB without tzinfo. Comparing it against datetime.now(UTC) (tz-aware) raises
+        TypeError, which silently 500s the login and locks users out indefinitely.
+        """
+        user = Users(
+            username="expiredlockuser",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="expiredlock@example.com",
+            active=1,
+            failed_login_attempts=5,
+            lockout_until=datetime.now(UTC) - timedelta(days=30),
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "expiredlockuser", "password": "TestPassword123!"},
+        )
+
+        assert response.status_code == 200
+        await db_session.refresh(user)
+        assert user.lockout_until is None
+        assert user.failed_login_attempts == 0
+
+    async def test_login_with_active_lockout_returns_423(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """An unexpired lockout_until must produce 423, not crash on tz comparison."""
+        user = Users(
+            username="activelockuser",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="activelock@example.com",
+            active=1,
+            failed_login_attempts=5,
+            lockout_until=datetime.now(UTC) + timedelta(minutes=10),
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "activelockuser", "password": "TestPassword123!"},
+        )
+
+        assert response.status_code == 423
+        assert "locked" in response.json()["detail"].lower()
+
 
 @pytest.mark.api
 class TestRefresh:


### PR DESCRIPTION
## Summary

- `user.lockout_until` (naive, from MySQL DATETIME) was compared against `datetime.now(UTC)` (tz-aware), raising `TypeError: can't compare offset-naive and offset-aware datetimes`.
- The exception bubbled up as a 500 with a non-JSON body, which SvelteKit's login action couldn't parse and surfaced as the generic `"Login failed"` toast.
- Net effect: **any user who ever hit the 5-failed-attempts threshold could not log in again, ever** — even after the lockout window expired and even after a full password reset (the comparison crashed before either path could clear `lockout_until`).
- Match the existing codebase pattern (suspension check at `auth.py:91`, refresh-token expiry at `auth.py:405`, email verification at `auth.py:685`) — drop tzinfo from `now` to compare against the naive DB value.

## Discovery

Found via centralized logging (Loki) while investigating a user report ("can't log in after password reset"). The 92-byte response in nginx access logs decoded to gzipped `'Login failed'` — the SvelteKit fallback when the api response isn't parseable as JSON. Loki traceback pointed directly at `auth.py:288`.

10 production accounts were stuck (1–63 days) by this; cleared manually as part of this fix.

## Test plan

- [x] `tests/api/v1/test_auth.py::TestLogin::test_login_with_expired_lockout_clears_and_succeeds` — reproduces the bug, passes after fix
- [x] `tests/api/v1/test_auth.py::TestLogin::test_login_with_active_lockout_returns_423` — verifies the 423 path still works
- [x] All existing TestLogin tests still pass (11/11)
- [ ] Deploy and verify previously-stuck users can log in

🤖 Generated with [Claude Code](https://claude.com/claude-code)