### PR TITLE
feat(images): list users who rated an image

### DIFF
--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -65,6 +65,19 @@ class UserSortParams(BaseModel):
     sort_order: SortOrder = Field(default="DESC", description="Sort order")
 
 
+class ImageRatingsSortParams(BaseModel):
+    """Sorting parameters for the per-image ratings list."""
+
+    sort_by: Literal[
+        "rating",
+        "date",
+        "user_id",
+        "username",
+        "date_joined",
+    ] = Field(default="rating", description="Sort field")
+    sort_order: SortOrder = Field(default="DESC", description="Sort order")
+
+
 class TagSortParams(BaseModel):
     """Common sorting parameters for tag queries."""
 

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1443,11 +1443,13 @@ async def get_image_ratings_users(
     }
     sort_column = sort_columns[sorting.sort_by]
     primary = desc(sort_column) if sorting.sort_order == "DESC" else asc(sort_column)
-    # Tiebreaker on user_id keeps order stable when sorting by a non-unique column
+    # Tiebreaker on user_id keeps order stable when sorting by a non-unique column.
+    # Skip it when the primary sort is already user_id (which is unique).
+    tiebreaker: list[Any] = (
+        [] if sorting.sort_by == "user_id" else [asc(Users.user_id)]  # type: ignore[arg-type]
+    )
     query = (
-        query.order_by(primary, asc(Users.user_id))  # type: ignore[arg-type]
-        .offset(pagination.offset)
-        .limit(pagination.per_page)
+        query.order_by(primary, *tiebreaker).offset(pagination.offset).limit(pagination.per_page)
     )
 
     result = await db.execute(query)

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -93,7 +93,12 @@ from app.schemas.image import (
 )
 from app.schemas.report import ReportCreate, ReportResponse, SkippedTagsInfo, TagSuggestion
 from app.schemas.tag import LinkedTag
-from app.schemas.user import UserListResponse, UserResponse
+from app.schemas.user import (
+    ImageRatingsListResponse,
+    UserListResponse,
+    UserResponse,
+    UserWithRatingResponse,
+)
 from app.services.image_processing import (
     create_thumbnail,
     get_image_dimensions,
@@ -1394,6 +1399,56 @@ async def get_image_favorites(
         page=pagination.page,
         per_page=pagination.per_page,
         users=[UserResponse.model_validate(user) for user in users],
+    )
+
+
+@router.get("/{image_id}/ratings", response_model=ImageRatingsListResponse)
+async def get_image_ratings_users(
+    image_id: int,
+    pagination: Annotated[PaginationParams, Depends()],
+    db: AsyncSession = Depends(get_db),
+) -> ImageRatingsListResponse:
+    """
+    Get all users who have rated a specific image, along with their rating values.
+    """
+    # Verify image exists
+    image_result = await db.execute(select(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
+    if not image_result.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    # Join Users with their ImageRatings row for this image
+    query = (
+        select(Users, ImageRatings.rating.label("rating_value"))  # type: ignore[attr-defined]
+        .join(ImageRatings, ImageRatings.user_id == Users.user_id)  # type: ignore[arg-type]
+        .where(ImageRatings.image_id == image_id)  # type: ignore[arg-type]
+    )
+
+    # Count total
+    count_query = select(func.count()).select_from(query.subquery())
+    total = (await db.execute(count_query)).scalar() or 0
+
+    # Order by rating descending, then user_id for stability; paginate
+    query = (
+        query.order_by(desc(ImageRatings.rating), asc(Users.user_id))  # type: ignore[arg-type]
+        .offset(pagination.offset)
+        .limit(pagination.per_page)
+    )
+
+    result = await db.execute(query)
+    rows = result.all()
+
+    users_with_ratings = [
+        UserWithRatingResponse.model_validate(
+            {**UserResponse.model_validate(user).model_dump(), "rating": rating}
+        )
+        for user, rating in rows
+    ]
+
+    return ImageRatingsListResponse(
+        total=total,
+        page=pagination.page,
+        per_page=pagination.per_page,
+        users=users_with_ratings,
     )
 
 

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1428,7 +1428,11 @@ async def get_image_ratings_users(
 
     # Join Users with their ImageRatings row for this image
     query = (
-        select(Users, ImageRatings.rating.label("rating_value"))  # type: ignore[attr-defined]
+        select(
+            Users,
+            ImageRatings.rating.label("rating_value"),  # type: ignore[attr-defined]
+            ImageRatings.date.label("rated_at"),  # type: ignore[union-attr]
+        )
         .join(ImageRatings, ImageRatings.user_id == Users.user_id)  # type: ignore[arg-type]
         .where(ImageRatings.image_id == image_id)  # type: ignore[arg-type]
     )
@@ -1456,8 +1460,12 @@ async def get_image_ratings_users(
     rows = result.all()
 
     users_with_ratings = [
-        UserWithRatingResponse(**UserResponse.model_validate(user).model_dump(), rating=rating)
-        for user, rating in rows
+        UserWithRatingResponse(
+            **UserResponse.model_validate(user).model_dump(),
+            rating=rating,
+            rated_at=rated_at,
+        )
+        for user, rating, rated_at in rows
     ]
 
     return ImageRatingsListResponse(

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -9,7 +9,7 @@ import tempfile
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path as FilePath
-from typing import Annotated
+from typing import Annotated, Any
 
 import redis.asyncio as redis
 from fastapi import (
@@ -30,7 +30,12 @@ from sqlalchemy import text as sql_text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
-from app.api.dependencies import ImageSortParams, PaginationParams, UserSortParams
+from app.api.dependencies import (
+    ImageRatingsSortParams,
+    ImageSortParams,
+    PaginationParams,
+    UserSortParams,
+)
 from app.api.v1.tags import get_tag_hierarchy, resolve_tag_alias
 from app.config import (
     AdminActionType,
@@ -1406,6 +1411,7 @@ async def get_image_favorites(
 async def get_image_ratings_users(
     image_id: int,
     pagination: Annotated[PaginationParams, Depends()],
+    sorting: Annotated[ImageRatingsSortParams, Depends()],
     db: AsyncSession = Depends(get_db),
 ) -> ImageRatingsListResponse:
     """
@@ -1416,6 +1422,10 @@ async def get_image_ratings_users(
     if not image_result.scalar_one_or_none():
         raise HTTPException(status_code=404, detail="Image not found")
 
+    # Count is independent of the user join — hits the fk_image_ratings_image_id index directly
+    count_query = select(func.count()).where(ImageRatings.image_id == image_id)  # type: ignore[arg-type]
+    total = (await db.execute(count_query)).scalar() or 0
+
     # Join Users with their ImageRatings row for this image
     query = (
         select(Users, ImageRatings.rating.label("rating_value"))  # type: ignore[attr-defined]
@@ -1423,13 +1433,19 @@ async def get_image_ratings_users(
         .where(ImageRatings.image_id == image_id)  # type: ignore[arg-type]
     )
 
-    # Count total
-    count_query = select(func.count()).select_from(query.subquery())
-    total = (await db.execute(count_query)).scalar() or 0
-
-    # Order by rating descending, then user_id for stability; paginate
+    # Resolve sort column from the requested field (some live on Users, some on ImageRatings)
+    sort_columns: dict[str, Any] = {
+        "rating": ImageRatings.rating,
+        "date": ImageRatings.date,
+        "user_id": Users.user_id,
+        "username": Users.username,
+        "date_joined": Users.date_joined,
+    }
+    sort_column = sort_columns[sorting.sort_by]
+    primary = desc(sort_column) if sorting.sort_order == "DESC" else asc(sort_column)
+    # Tiebreaker on user_id keeps order stable when sorting by a non-unique column
     query = (
-        query.order_by(desc(ImageRatings.rating), asc(Users.user_id))  # type: ignore[arg-type]
+        query.order_by(primary, asc(Users.user_id))  # type: ignore[arg-type]
         .offset(pagination.offset)
         .limit(pagination.per_page)
     )
@@ -1438,9 +1454,7 @@ async def get_image_ratings_users(
     rows = result.all()
 
     users_with_ratings = [
-        UserWithRatingResponse.model_validate(
-            {**UserResponse.model_validate(user).model_dump(), "rating": rating}
-        )
+        UserWithRatingResponse(**UserResponse.model_validate(user).model_dump(), rating=rating)
         for user, rating in rows
     ]
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -241,6 +241,7 @@ class UserWithRatingResponse(UserResponse):
     """User profile with the rating they assigned to a specific image."""
 
     rating: int
+    rated_at: UTCDatetimeOptional = None
 
 
 class ImageRatingsListResponse(BaseModel):

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -237,6 +237,21 @@ class UserListResponse(BaseModel):
     users: list[UserResponse]
 
 
+class UserWithRatingResponse(UserResponse):
+    """User profile with the rating they assigned to a specific image."""
+
+    rating: int
+
+
+class ImageRatingsListResponse(BaseModel):
+    """Schema for paginated list of users who rated an image, including their rating values."""
+
+    total: int
+    page: int
+    per_page: int
+    users: list[UserWithRatingResponse]
+
+
 # ===== User Warnings Schemas =====
 
 

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -3237,6 +3237,9 @@ class TestGetImageRatings:
         assert rating_by_username["rater_1"] == 8
         assert rating_by_username["rater_2"] == 10
 
+        # Default order is rating DESC
+        assert [u["rating"] for u in data["users"]] == [10, 8, 5]
+
         # Should also include core user fields
         first = data["users"][0]
         assert "user_id" in first
@@ -3300,3 +3303,124 @@ class TestGetImageRatings:
         assert data["page"] == 1
         assert data["per_page"] == 2
         assert len(data["users"]) == 2
+
+    async def test_sort_by_rating_asc(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Sorting by rating ASC returns lowest ratings first."""
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        users = []
+        for i in range(3):
+            user = Users(
+                username=f"sort_rate_{i}",
+                password="hashed",
+                password_type="bcrypt",
+                salt="x" * 16,
+                email=f"sortrate{i}@example.com",
+                active=1,
+            )
+            db_session.add(user)
+            users.append(user)
+        await db_session.commit()
+        for u, rating_value in zip(users, [9, 3, 6], strict=True):
+            await db_session.refresh(u)
+            db_session.add(
+                ImageRatings(user_id=u.user_id, image_id=image.image_id, rating=rating_value)
+            )
+        await db_session.commit()
+
+        response = await client.get(
+            f"/api/v1/images/{image.image_id}/ratings?sort_by=rating&sort_order=ASC"
+        )
+        assert response.status_code == 200
+        ratings_in_order = [u["rating"] for u in response.json()["users"]]
+        assert ratings_in_order == [3, 6, 9]
+
+    async def test_sort_by_rating_desc_default(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Default sort is by rating DESC."""
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        users = []
+        for i in range(3):
+            user = Users(
+                username=f"sort_def_{i}",
+                password="hashed",
+                password_type="bcrypt",
+                salt="x" * 16,
+                email=f"sortdef{i}@example.com",
+                active=1,
+            )
+            db_session.add(user)
+            users.append(user)
+        await db_session.commit()
+        for u, rating_value in zip(users, [4, 9, 6], strict=True):
+            await db_session.refresh(u)
+            db_session.add(
+                ImageRatings(user_id=u.user_id, image_id=image.image_id, rating=rating_value)
+            )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{image.image_id}/ratings")
+        assert response.status_code == 200
+        ratings_in_order = [u["rating"] for u in response.json()["users"]]
+        assert ratings_in_order == [9, 6, 4]
+
+    async def test_sort_by_username_asc(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Sorting by username ASC orders alphabetically."""
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        usernames = ["zeta_user", "alpha_user", "mike_user"]
+        users = []
+        for name in usernames:
+            user = Users(
+                username=name,
+                password="hashed",
+                password_type="bcrypt",
+                salt="x" * 16,
+                email=f"{name}@example.com",
+                active=1,
+            )
+            db_session.add(user)
+            users.append(user)
+        await db_session.commit()
+        for u in users:
+            await db_session.refresh(u)
+            db_session.add(
+                ImageRatings(user_id=u.user_id, image_id=image.image_id, rating=5)
+            )
+        await db_session.commit()
+
+        response = await client.get(
+            f"/api/v1/images/{image.image_id}/ratings?sort_by=username&sort_order=ASC"
+        )
+        assert response.status_code == 200
+        usernames_in_order = [u["username"] for u in response.json()["users"]]
+        assert usernames_in_order == ["alpha_user", "mike_user", "zeta_user"]
+
+    async def test_invalid_sort_by_rejected(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Unsupported sort_by values return 422."""
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        response = await client.get(
+            f"/api/v1/images/{image.image_id}/ratings?sort_by=email"
+        )
+        assert response.status_code == 422

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -3424,3 +3424,74 @@ class TestGetImageRatings:
             f"/api/v1/images/{image.image_id}/ratings?sort_by=email"
         )
         assert response.status_code == 422
+
+    async def test_sort_by_date_asc(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Sorting by date ASC returns 200 and handles all rating rows."""
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        users = []
+        for i in range(2):
+            user = Users(
+                username=f"sort_date_{i}",
+                password="hashed",
+                password_type="bcrypt",
+                salt="x" * 16,
+                email=f"sortdate{i}@example.com",
+                active=1,
+            )
+            db_session.add(user)
+            users.append(user)
+        await db_session.commit()
+        for u in users:
+            await db_session.refresh(u)
+            db_session.add(
+                ImageRatings(user_id=u.user_id, image_id=image.image_id, rating=5)
+            )
+        await db_session.commit()
+
+        response = await client.get(
+            f"/api/v1/images/{image.image_id}/ratings?sort_by=date&sort_order=ASC"
+        )
+        assert response.status_code == 200
+        assert len(response.json()["users"]) == 2
+
+    async def test_sort_by_user_id_desc_no_redundant_tiebreaker(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Sorting by user_id DESC orders by user_id descending without redundant tiebreak."""
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        users = []
+        for i in range(3):
+            user = Users(
+                username=f"sort_uid_{i}",
+                password="hashed",
+                password_type="bcrypt",
+                salt="x" * 16,
+                email=f"sortuid{i}@example.com",
+                active=1,
+            )
+            db_session.add(user)
+            users.append(user)
+        await db_session.commit()
+        for u in users:
+            await db_session.refresh(u)
+            db_session.add(
+                ImageRatings(user_id=u.user_id, image_id=image.image_id, rating=5)
+            )
+        await db_session.commit()
+
+        response = await client.get(
+            f"/api/v1/images/{image.image_id}/ratings?sort_by=user_id&sort_order=DESC"
+        )
+        assert response.status_code == 200
+        ids_in_order = [u["user_id"] for u in response.json()["users"]]
+        assert ids_in_order == sorted(ids_in_order, reverse=True)

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -3186,3 +3186,117 @@ class TestRateImage:
         data = response.json()
         assert data["average_rating"] == 10.0
         assert data["num_ratings"] == 1
+
+
+@pytest.mark.api
+class TestGetImageRatings:
+    """Tests for GET /api/v1/images/{image_id}/ratings endpoint."""
+
+    async def test_get_image_ratings(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Returns list of users with their ratings for an image."""
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        # Create ratings from multiple users
+        users = []
+        for i, rating_value in enumerate([5, 8, 10]):
+            user = Users(
+                username=f"rater_{i}",
+                password="hashed",
+                password_type="bcrypt",
+                salt="x" * 16,
+                email=f"rater{i}@example.com",
+                active=1,
+            )
+            db_session.add(user)
+            users.append(user)
+        await db_session.commit()
+        for u in users:
+            await db_session.refresh(u)
+
+        for user, rating_value in zip(users, [5, 8, 10], strict=True):
+            db_session.add(
+                ImageRatings(user_id=user.user_id, image_id=image.image_id, rating=rating_value)
+            )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{image.image_id}/ratings")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["total"] == 3
+        assert len(data["users"]) == 3
+
+        # Each entry should include the user fields plus a rating value
+        rating_by_username = {u["username"]: u["rating"] for u in data["users"]}
+        assert rating_by_username["rater_0"] == 5
+        assert rating_by_username["rater_1"] == 8
+        assert rating_by_username["rater_2"] == 10
+
+        # Should also include core user fields
+        first = data["users"][0]
+        assert "user_id" in first
+        assert "username" in first
+
+    async def test_get_image_ratings_nonexistent_image(self, client: AsyncClient):
+        """Returns 404 for an image that doesn't exist."""
+        response = await client.get("/api/v1/images/999999/ratings")
+        assert response.status_code == 404
+
+    async def test_get_image_ratings_empty(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Returns empty list when image has no ratings."""
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        response = await client.get(f"/api/v1/images/{image.image_id}/ratings")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 0
+        assert data["users"] == []
+
+    async def test_get_image_ratings_pagination(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Pagination limits how many ratings come back per page."""
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        users = []
+        for i in range(5):
+            user = Users(
+                username=f"pager_{i}",
+                password="hashed",
+                password_type="bcrypt",
+                salt="x" * 16,
+                email=f"pager{i}@example.com",
+                active=1,
+            )
+            db_session.add(user)
+            users.append(user)
+        await db_session.commit()
+        for u in users:
+            await db_session.refresh(u)
+            db_session.add(
+                ImageRatings(user_id=u.user_id, image_id=image.image_id, rating=7)
+            )
+        await db_session.commit()
+
+        response = await client.get(
+            f"/api/v1/images/{image.image_id}/ratings?page=1&per_page=2"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 5
+        assert data["page"] == 1
+        assert data["per_page"] == 2
+        assert len(data["users"]) == 2

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -3425,6 +3425,41 @@ class TestGetImageRatings:
         )
         assert response.status_code == 422
 
+    async def test_response_includes_rated_at_timestamp(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Each user entry includes the timestamp when the rating was recorded."""
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        user = Users(
+            username="dated_rater",
+            password="hashed",
+            password_type="bcrypt",
+            salt="x" * 16,
+            email="datedrater@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        db_session.add(
+            ImageRatings(user_id=user.user_id, image_id=image.image_id, rating=7)
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{image.image_id}/ratings")
+        assert response.status_code == 200
+
+        entry = response.json()["users"][0]
+        assert "rated_at" in entry
+        # Should be a non-empty ISO 8601 timestamp ending in Z (UTC), per UTCDatetime serializer
+        assert isinstance(entry["rated_at"], str)
+        assert entry["rated_at"].endswith("Z")
+
     async def test_sort_by_date_asc(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
     ):


### PR DESCRIPTION
## Summary
- New `GET /api/v1/images/{image_id}/ratings` endpoint mirroring `/favorites`, returning users who rated an image and the rating each user gave.
- Adds `UserWithRatingResponse` (extends `UserResponse` + `rating: int`) and `ImageRatingsListResponse` so client code that already parses the favorites users list can read this with the same shape, plus `rating` on each entry.
- Ordered by rating desc, then user_id asc; standard pagination (`page` / `per_page`).

## Test plan
- [x] `uv run pytest tests/api/v1/test_images.py::TestGetImageRatings` — 4 new tests pass (happy path, 404, empty, pagination)
- [x] `uv run pytest tests/api/v1/test_images.py tests/api/v1/test_favorites.py` — 91 passed, no regressions
- [x] `uv run mypy app/api/v1/images.py app/schemas/user.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)