### PR TITLE
fix(images): include user groups in favorites/ratings user lists

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1377,8 +1377,15 @@ async def get_image_favorites(
     if not image:
         raise HTTPException(status_code=404, detail="Image not found")
 
-    # Get users who favorited the image
-    query = select(Users).join(Favorites).where(Favorites.image_id == image_id)  # type: ignore[arg-type]
+    # Get users who favorited the image; eager-load groups so UserResponse.groups is populated
+    query = (
+        select(Users)
+        .join(Favorites)
+        .where(Favorites.image_id == image_id)  # type: ignore[arg-type]
+        .options(
+            selectinload(Users.user_groups).selectinload(UserGroups.group),  # type: ignore[arg-type]
+        )
+    )
 
     # Count total
     count_query = select(func.count()).select_from(query.subquery())
@@ -1426,7 +1433,8 @@ async def get_image_ratings_users(
     count_query = select(func.count()).where(ImageRatings.image_id == image_id)  # type: ignore[arg-type]
     total = (await db.execute(count_query)).scalar() or 0
 
-    # Join Users with their ImageRatings row for this image
+    # Join Users with their ImageRatings row for this image; eager-load groups so
+    # UserResponse.groups is populated for each rater.
     query = (
         select(
             Users,
@@ -1435,6 +1443,9 @@ async def get_image_ratings_users(
         )
         .join(ImageRatings, ImageRatings.user_id == Users.user_id)  # type: ignore[arg-type]
         .where(ImageRatings.image_id == image_id)  # type: ignore[arg-type]
+        .options(
+            selectinload(Users.user_groups).selectinload(UserGroups.group),  # type: ignore[arg-type]
+        )
     )
 
     # Resolve sort column from the requested field (some live on Users, some on ImageRatings)

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import TagType, settings
 from app.models import Favorites, ImageRatings, Images, TagLinks, Tags, Users
+from app.models.permissions import Groups, UserGroups
 
 
 @pytest.mark.api
@@ -3530,3 +3531,78 @@ class TestGetImageRatings:
         assert response.status_code == 200
         ids_in_order = [u["user_id"] for u in response.json()["users"]]
         assert ids_in_order == sorted(ids_in_order, reverse=True)
+
+
+@pytest.mark.api
+class TestImageUserListsIncludeGroups:
+    """User lists for an image must surface group memberships (for username coloring etc.)."""
+
+    async def _create_user_in_group(
+        self, db_session: AsyncSession, username: str, group_title: str
+    ) -> Users:
+        user = Users(
+            username=username,
+            password="hashed",
+            password_type="bcrypt",
+            salt="x" * 16,
+            email=f"{username}@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        group = Groups(title=group_title, desc=f"{group_title} group")
+        db_session.add(group)
+        await db_session.commit()
+        await db_session.refresh(group)
+
+        db_session.add(UserGroups(user_id=user.user_id, group_id=group.group_id))
+        await db_session.commit()
+        return user
+
+    async def test_image_favorites_includes_groups(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """GET /api/v1/images/{id}/favorites must include groups for each user."""
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        user = await self._create_user_in_group(db_session, "fav_grp_user", "Mods")
+        db_session.add(Favorites(user_id=user.user_id, image_id=image.image_id))
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{image.image_id}/favorites")
+        assert response.status_code == 200
+
+        entry = next(
+            u for u in response.json()["users"] if u["username"] == "fav_grp_user"
+        )
+        assert "groups" in entry
+        assert "Mods" in entry["groups"]
+
+    async def test_image_ratings_includes_groups(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """GET /api/v1/images/{id}/ratings must include groups for each user."""
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        user = await self._create_user_in_group(db_session, "rate_grp_user", "Admins")
+        db_session.add(
+            ImageRatings(user_id=user.user_id, image_id=image.image_id, rating=8)
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{image.image_id}/ratings")
+        assert response.status_code == 200
+
+        entry = next(
+            u for u in response.json()["users"] if u["username"] == "rate_grp_user"
+        )
+        assert "groups" in entry
+        assert "Admins" in entry["groups"]


### PR DESCRIPTION
## Summary
- Both `GET /api/v1/images/{image_id}/favorites` and `GET /api/v1/images/{image_id}/ratings` serialize each entry as `UserResponse`, which has a `groups: list[str]` field used for username coloring / mod & admin badges.
- `Users.user_groups` is declared with `lazy="raise"` to prevent accidental lazy-loading in async, and the `Users.groups` property returns `[]` when the relationship isn't loaded. Neither endpoint was eager-loading it, so `groups` was silently coming back empty for every user.
- Add `selectinload(Users.user_groups).selectinload(UserGroups.group)` to both queries.

## Test plan
- [x] New `TestImageUserListsIncludeGroups` covers both endpoints (creates a user in a group, hits the endpoint, asserts `groups` contains the group title) — both fail without the fix, both pass with it.
- [x] `uv run pytest tests/api/v1/test_images.py tests/api/v1/test_favorites.py` — 100 passed, 1 skipped, no regressions.
- [x] `uv run mypy app/api/v1/images.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)