### PR TITLE
chore(deps): bump pip 26.0.1 -> 26.1 (CVE-2026-3219)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1493,11 +1493,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Resolves the only open Dependabot alert (#13, medium):
**GHSA-58qw-9mgm-455v / CVE-2026-3219** — pip handles concatenated tar+ZIP files as ZIP regardless of filename, which can cause incorrect contents to be installed from a hybrid sdist.

Fixed in **pip 26.1** (released 2026-04-26):
> Bug Fixes — Fix installing `.tar.gz` source distributions that look like a zip file. (#13867)

The Dependabot DB still shows "no patched version" because the GHSA entry hasn't been updated yet; this lock bump should auto-resolve the alert once 26.1 is recognized as patched, or it can be manually dismissed as fixed.

## Risk
- `pip` is a **transitive dev-only dep** (pulled in via `pip-audit` in the `dev` dependency group).
- Production uses **uv** as the installer — pip is never invoked at runtime.
- Effective production exposure: nil. This is purely to clear the alert and tidy dev tooling.

## Test plan
- [x] `uv lock --upgrade-package pip` → `pip 26.0.1 -> 26.1`, no other packages changed
- [x] `uv sync` succeeds
- [x] `uv run pytest tests/api/v1/test_images.py::TestGetImageRatings` — 11 passed (smoke check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)