### PR TITLE
fix(reviews): record status history when image enters review

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -1774,6 +1774,15 @@ async def escalate_report(
     db.add(review)
     await db.flush()  # Get review_id
 
+    # Log to public status history
+    status_history = ImageStatusHistory(
+        image_id=report.image_id,
+        old_status=previous_status,
+        new_status=ImageStatus.REVIEW,
+        user_id=current_user.user_id,
+    )
+    db.add(status_history)
+
     # Log action
     action = AdminActions(
         user_id=current_user.user_id,
@@ -2024,6 +2033,15 @@ async def create_review(
     )
     db.add(review)
     await db.flush()
+
+    # Log to public status history
+    status_history = ImageStatusHistory(
+        image_id=image_id,
+        old_status=previous_status,
+        new_status=ImageStatus.REVIEW,
+        user_id=current_user.user_id,
+    )
+    db.add(status_history)
 
     # Log action
     action = AdminActions(

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -1774,14 +1774,16 @@ async def escalate_report(
     db.add(review)
     await db.flush()  # Get review_id
 
-    # Log to public status history
-    status_history = ImageStatusHistory(
-        image_id=report.image_id,
-        old_status=previous_status,
-        new_status=ImageStatus.REVIEW,
-        user_id=current_user.user_id,
-    )
-    db.add(status_history)
+    # Log to public status history (skip if image was already in REVIEW
+    # without an open review — orphaned state should not record a no-op transition)
+    if previous_status != ImageStatus.REVIEW:
+        status_history = ImageStatusHistory(
+            image_id=report.image_id,
+            old_status=previous_status,
+            new_status=ImageStatus.REVIEW,
+            user_id=current_user.user_id,
+        )
+        db.add(status_history)
 
     # Log action
     action = AdminActions(
@@ -2034,14 +2036,16 @@ async def create_review(
     db.add(review)
     await db.flush()
 
-    # Log to public status history
-    status_history = ImageStatusHistory(
-        image_id=image_id,
-        old_status=previous_status,
-        new_status=ImageStatus.REVIEW,
-        user_id=current_user.user_id,
-    )
-    db.add(status_history)
+    # Log to public status history (skip if image was already in REVIEW
+    # without an open review — orphaned state should not record a no-op transition)
+    if previous_status != ImageStatus.REVIEW:
+        status_history = ImageStatusHistory(
+            image_id=image_id,
+            old_status=previous_status,
+            new_status=ImageStatus.REVIEW,
+            user_id=current_user.user_id,
+        )
+        db.add(status_history)
 
     # Log action
     action = AdminActions(

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -10,12 +10,15 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sqlalchemy import select
+
 from app.config import ImageStatus, ReportStatus, ReviewStatus
 from app.core.security import get_password_hash
 from app.models.image import Images
 from app.models.image_report import ImageReports
 from app.models.image_report_tag_suggestion import ImageReportTagSuggestions
 from app.models.image_review import ImageReviews
+from app.models.image_status_history import ImageStatusHistory
 from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
 from app.models.tag import Tags
 from app.models.tag_link import TagLinks
@@ -992,6 +995,45 @@ class TestAdminReportEscalate:
         # Verify image status changed to REVIEW
         await db_session.refresh(image)
         assert image.status == ImageStatus.REVIEW
+
+    async def test_escalate_report_writes_status_history(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Escalating a report must record the ACTIVE -> REVIEW transition in status history."""
+        admin, password = await create_auth_user(db_session, username="admin", admin=True)
+        await grant_permission(db_session, admin.user_id, "report_manage")
+        await grant_permission(db_session, admin.user_id, "review_start")
+        token = await login_user(client, admin.username, password)
+
+        image = await create_test_image(db_session, admin.user_id)
+        report = ImageReports(
+            image_id=image.image_id,
+            user_id=admin.user_id,
+            category=2,
+            status=ReportStatus.PENDING,
+        )
+        db_session.add(report)
+        await db_session.commit()
+        await db_session.refresh(report)
+
+        response = await client.post(
+            f"/api/v1/admin/reports/{report.report_id}/escalate",
+            json={"deadline_days": 7},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+
+        result = await db_session.execute(
+            select(ImageStatusHistory).where(
+                ImageStatusHistory.image_id == image.image_id  # type: ignore[arg-type]
+            )
+        )
+        history_entries = result.scalars().all()
+        assert len(history_entries) == 1
+        entry = history_entries[0]
+        assert entry.old_status == ImageStatus.ACTIVE
+        assert entry.new_status == ImageStatus.REVIEW
+        assert entry.user_id == admin.user_id
 
     async def test_escalate_image_with_existing_review_fails(
         self, client: AsyncClient, db_session: AsyncSession

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -1035,6 +1035,44 @@ class TestAdminReportEscalate:
         assert entry.new_status == ImageStatus.REVIEW
         assert entry.user_id == admin.user_id
 
+    async def test_escalate_skips_history_when_already_in_review(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """No history row should be written when previous_status is already REVIEW."""
+        admin, password = await create_auth_user(db_session, username="admin", admin=True)
+        await grant_permission(db_session, admin.user_id, "report_manage")
+        await grant_permission(db_session, admin.user_id, "review_start")
+        token = await login_user(client, admin.username, password)
+
+        # Image already in REVIEW status with no open review (e.g. orphaned state)
+        image = await create_test_image(db_session, admin.user_id)
+        image.status = ImageStatus.REVIEW
+        await db_session.commit()
+
+        report = ImageReports(
+            image_id=image.image_id,
+            user_id=admin.user_id,
+            category=2,
+            status=ReportStatus.PENDING,
+        )
+        db_session.add(report)
+        await db_session.commit()
+        await db_session.refresh(report)
+
+        response = await client.post(
+            f"/api/v1/admin/reports/{report.report_id}/escalate",
+            json={"deadline_days": 7},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+
+        result = await db_session.execute(
+            select(ImageStatusHistory).where(
+                ImageStatusHistory.image_id == image.image_id  # type: ignore[arg-type]
+            )
+        )
+        assert result.scalars().all() == []
+
     async def test_escalate_image_with_existing_review_fails(
         self, client: AsyncClient, db_session: AsyncSession
     ):

--- a/tests/api/v1/test_reviews.py
+++ b/tests/api/v1/test_reviews.py
@@ -16,6 +16,7 @@ from app.config import ImageStatus, ReviewOutcome, ReviewStatus
 from app.core.security import get_password_hash
 from app.models.image import Images
 from app.models.image_review import ImageReviews
+from app.models.image_status_history import ImageStatusHistory
 from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
 from app.models.review_vote import ReviewVotes
 from app.models.user import Users
@@ -259,6 +260,35 @@ class TestCreateReview:
         assert response.status_code == 201
         data = response.json()
         assert data["reason"] is None
+
+    async def test_create_review_writes_status_history(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Creating a review must record the ACTIVE -> REVIEW transition in status history."""
+        admin, password = await create_auth_user(db_session, username="admin", admin=True)
+        await grant_permission(db_session, admin.user_id, "review_start")
+        token = await login_user(client, admin.username, password)
+
+        image = await create_test_image(db_session, admin.user_id)
+
+        response = await client.post(
+            f"/api/v1/admin/images/{image.image_id}/review",
+            json={"deadline_days": 7},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 201
+
+        result = await db_session.execute(
+            select(ImageStatusHistory).where(
+                ImageStatusHistory.image_id == image.image_id  # type: ignore[arg-type]
+            )
+        )
+        history_entries = result.scalars().all()
+        assert len(history_entries) == 1
+        entry = history_entries[0]
+        assert entry.old_status == ImageStatus.ACTIVE
+        assert entry.new_status == ImageStatus.REVIEW
+        assert entry.user_id == admin.user_id
 
     async def test_create_review_with_existing_open_review_fails(
         self, client: AsyncClient, db_session: AsyncSession

--- a/tests/api/v1/test_reviews.py
+++ b/tests/api/v1/test_reviews.py
@@ -290,6 +290,33 @@ class TestCreateReview:
         assert entry.new_status == ImageStatus.REVIEW
         assert entry.user_id == admin.user_id
 
+    async def test_create_review_skips_history_when_already_in_review(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """No history row should be written when previous_status is already REVIEW."""
+        admin, password = await create_auth_user(db_session, username="admin", admin=True)
+        await grant_permission(db_session, admin.user_id, "review_start")
+        token = await login_user(client, admin.username, password)
+
+        # Image already in REVIEW status with no open review (e.g. orphaned state)
+        image = await create_test_image(db_session, admin.user_id)
+        image.status = ImageStatus.REVIEW
+        await db_session.commit()
+
+        response = await client.post(
+            f"/api/v1/admin/images/{image.image_id}/review",
+            json={"deadline_days": 7},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 201
+
+        result = await db_session.execute(
+            select(ImageStatusHistory).where(
+                ImageStatusHistory.image_id == image.image_id  # type: ignore[arg-type]
+            )
+        )
+        assert result.scalars().all() == []
+
     async def test_create_review_with_existing_open_review_fails(
         self, client: AsyncClient, db_session: AsyncSession
     ):


### PR DESCRIPTION
## Summary
- The `escalate_report` and `create_review` admin endpoints were updating `image.status = ImageStatus.REVIEW` without writing a corresponding `ImageStatusHistory` row.
- The public status-history endpoint therefore never showed the "X → REVIEW" transition — only the later "REVIEW → ACTIVE/INAPPROPRIATE" row written on close, leaving an unexplained gap in the audit trail.
- Both paths now log the transition to `ImageStatusHistory` (with `user_id=current_user.user_id`), matching the existing `change_image_status` pattern at `app/api/v1/admin.py:785`.

## Test plan
- [x] New `test_escalate_report_writes_status_history` in `tests/api/v1/test_reports.py` (failed before fix, passes now)
- [x] New `test_create_review_writes_status_history` in `tests/api/v1/test_reviews.py` (failed before fix, passes now)
- [x] Full review/report/history suites pass (135 tests, 5 unrelated skips)
- [x] `mypy app/api/v1/admin.py` clean

## Notes
- Pre-existing review transitions (e.g. image 1115945) will not be backfilled — only new escalations are captured. A one-row backfill is possible if needed.
- Visibility of the moderator on the response is governed by the existing `VISIBLE_USER_STATUSES` filter in `app/api/v1/images.py:1195` — for an `ACTIVE → REVIEW` transition the moderator's `UserSummary` will be exposed because `old_status=ACTIVE` is in the visible set. If retaliation concerns surface, that filter can be tightened separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)