### PR TITLE
feat(models): tz-aware datetimes via UtcDateTime TypeDecorator

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -2421,7 +2421,6 @@ async def list_all_suspensions(
             reactivations_by_user[row.user_id].append(row.actioned_at)
 
     now = datetime.now(UTC)
-    now_naive = now.replace(tzinfo=None)
     active_count = 0
 
     items = []
@@ -2432,9 +2431,7 @@ async def list_all_suspensions(
             # Check if suspension is active:
             # 1. Not expired (suspended_until is None or in the future)
             # 2. No reactivation record after this suspension's actioned_at
-            not_expired = (
-                suspension.suspended_until is None or suspension.suspended_until > now_naive
-            )
+            not_expired = suspension.suspended_until is None or suspension.suspended_until > now
 
             # Check for reactivation after this suspension
             user_reactivations = reactivations_by_user.get(suspension.user_id, [])
@@ -2531,7 +2528,7 @@ async def suspend_user(
             # Only block if still suspended (no reactivation after, or suspension still active)
             if not reactivated_after and (
                 latest_suspended.suspended_until is None
-                or latest_suspended.suspended_until > datetime.now(UTC).replace(tzinfo=None)
+                or latest_suspended.suspended_until > datetime.now(UTC)
             ):
                 raise HTTPException(status_code=400, detail="User is already suspended")
 

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -88,9 +88,7 @@ async def _check_and_handle_suspension(
         suspension = next((s for s in suspensions if s.action == SuspensionAction.SUSPENDED), None)
         if suspension:
             # Check if suspension has expired
-            if suspension.suspended_until and suspension.suspended_until < datetime.now(
-                UTC
-            ).replace(tzinfo=None):
+            if suspension.suspended_until and suspension.suspended_until < datetime.now(UTC):
                 # Auto-reactivate expired suspension
                 user.active = 1
 
@@ -106,7 +104,7 @@ async def _check_and_handle_suspension(
                 # Still suspended - build detailed message
                 if suspension.suspended_until:
                     # Temporary suspension - show duration
-                    remaining = suspension.suspended_until - datetime.now(UTC).replace(tzinfo=None)
+                    remaining = suspension.suspended_until - datetime.now(UTC)
                     days = remaining.days
                     hours = remaining.seconds // 3600
                     minutes = (remaining.seconds % 3600) // 60
@@ -285,12 +283,9 @@ async def login(
 
     # Check if account is locked
     if user.lockout_until:
-        # MySQL DATETIME is timezone-naive, so lockout_until comes back without
-        # tzinfo. Drop tzinfo from `now` to match — comparing aware vs. naive
-        # raises TypeError, which previously locked users out indefinitely.
-        now_naive = datetime.now(UTC).replace(tzinfo=None)
-        if user.lockout_until > now_naive:
-            remaining_minutes = int((user.lockout_until - now_naive).total_seconds() / 60)
+        now = datetime.now(UTC)
+        if user.lockout_until > now:
+            remaining_minutes = int((user.lockout_until - now).total_seconds() / 60)
             raise HTTPException(
                 status_code=status.HTTP_423_LOCKED,
                 detail=f"Account locked due to too many failed login attempts. Try again in {remaining_minutes} minutes.",
@@ -405,8 +400,7 @@ async def refresh_token(
         )
 
     # Check if token is expired
-    # Note: MySQL DATETIME is timezone-naive, so we compare with naive datetime
-    if db_token.expires_at < datetime.now(UTC).replace(tzinfo=None):
+    if db_token.expires_at < datetime.now(UTC):
         # Clean up expired token
         await db.delete(db_token)
         await db.commit()
@@ -426,15 +420,7 @@ async def refresh_token(
 
         if db_token.revoked_at:
             # Check if revoked within last 10 seconds
-            # Handle both timezone-naive (from DB) and timezone-aware (from code) datetimes
-            revoked_at = db_token.revoked_at
-            if revoked_at.tzinfo is None:
-                # Naive datetime from DB - treat as UTC
-                revoked_at_utc = revoked_at.replace(tzinfo=UTC)
-            else:
-                # Already timezone-aware
-                revoked_at_utc = revoked_at
-            time_since_revoked = datetime.now(UTC) - revoked_at_utc
+            time_since_revoked = datetime.now(UTC) - db_token.revoked_at
 
             if time_since_revoked.total_seconds() < 10:
                 # Check if a child token exists (legitimate refresh happened)
@@ -686,7 +672,7 @@ async def verify_email(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid verification token"
         )
 
-    if user.email_verification_expires_at < datetime.now(UTC).replace(tzinfo=None):
+    if user.email_verification_expires_at < datetime.now(UTC):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Verification token expired. Please request a new one.",
@@ -716,9 +702,7 @@ async def resend_verification(
 
     # Rate limit: only 1 resend per 5 minutes
     if current_user.email_verification_sent_at:
-        time_since_last = (
-            datetime.now(UTC).replace(tzinfo=None) - current_user.email_verification_sent_at
-        )
+        time_since_last = datetime.now(UTC) - current_user.email_verification_sent_at
         if time_since_last < timedelta(minutes=5):
             remaining_seconds = int((timedelta(minutes=5) - time_since_last).total_seconds())
             raise HTTPException(
@@ -773,11 +757,7 @@ async def forgot_password(
     # Return generic 200 even when rate limited to prevent email enumeration
     # (a 429 only for existing users would leak whether the email exists)
     if user.password_reset_sent_at:
-        # Handle both timezone-aware (in-memory) and naive (from DB) datetimes
-        sent_at = user.password_reset_sent_at
-        if sent_at.tzinfo is not None:
-            sent_at = sent_at.replace(tzinfo=None)
-        time_since_last = datetime.now(UTC).replace(tzinfo=None) - sent_at
+        time_since_last = datetime.now(UTC) - user.password_reset_sent_at
         if time_since_last < timedelta(minutes=5):
             return MessageResponse(message=generic_message)
 
@@ -839,11 +819,7 @@ async def reset_password(
             detail="Invalid or expired reset token",
         )
 
-    # Handle timezone-aware vs naive datetime comparison (same pattern as forgot-password)
-    expires_at = user.password_reset_expires_at
-    if expires_at.tzinfo is not None:
-        expires_at = expires_at.replace(tzinfo=None)
-    if expires_at < datetime.now(UTC).replace(tzinfo=None):
+    if user.password_reset_expires_at < datetime.now(UTC):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Reset token has expired. Please request a new one.",

--- a/app/api/v1/feeds.py
+++ b/app/api/v1/feeds.py
@@ -1,6 +1,6 @@
 """Atom feed endpoints."""
 
-from datetime import UTC, datetime
+from datetime import datetime
 from email.utils import format_datetime, parsedate_to_datetime
 from typing import Annotated
 
@@ -35,13 +35,6 @@ def _self_url(request: Request) -> str:
     return str(request.url).split("?")[0]
 
 
-def _ensure_utc(dt: datetime) -> datetime:
-    """Treat naive datetimes as UTC — the DB stores naive timestamps for date_added."""
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=UTC)
-    return dt.astimezone(UTC)
-
-
 def _is_not_modified(request: Request, etag: str, last_mod: datetime | None) -> bool:
     """Conditional-request evaluation.
 
@@ -64,7 +57,7 @@ def _is_not_modified(request: Request, etag: str, last_mod: datetime | None) -> 
                 ims_dt = parsedate_to_datetime(ims)
             except (TypeError, ValueError):
                 ims_dt = None
-            if ims_dt is not None and ims_dt >= _ensure_utc(last_mod):
+            if ims_dt is not None and ims_dt >= last_mod:
                 return True
 
     return False
@@ -73,7 +66,7 @@ def _is_not_modified(request: Request, etag: str, last_mod: datetime | None) -> 
 def _cacheable_headers(etag: str, last_mod: datetime | None) -> dict[str, str]:
     headers = {"Cache-Control": CACHE_CONTROL, "ETag": etag}
     if last_mod is not None:
-        headers["Last-Modified"] = format_datetime(_ensure_utc(last_mod), usegmt=True)
+        headers["Last-Modified"] = format_datetime(last_mod, usegmt=True)
     return headers
 
 

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -390,7 +390,7 @@ async def acknowledge_warnings(
     )
     suspensions = result.scalars().all()
 
-    now = datetime.now(UTC).replace(tzinfo=None)
+    now = datetime.now(UTC)
     for suspension in suspensions:
         suspension.acknowledged_at = now
 

--- a/app/models/admin_action.py
+++ b/app/models/admin_action.py
@@ -16,6 +16,8 @@ from sqlalchemy import ForeignKeyConstraint, Index, text
 from sqlalchemy.dialects.mysql import JSON
 from sqlmodel import Column, Field, SQLModel
 
+from app.models.types import UtcDateTime
+
 
 class AdminActions(SQLModel, table=True):
     """
@@ -94,7 +96,8 @@ class AdminActions(SQLModel, table=True):
 
     # Timestamp (indexed for pruning queries)
     created_at: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/ban.py
+++ b/app/models/ban.py
@@ -14,8 +14,10 @@ This approach eliminates field duplication while maintaining security boundaries
 from datetime import datetime
 from enum import Enum
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 
 class BanAction(str, Enum):
@@ -100,8 +102,12 @@ class Bans(BanBase, table=True):
 
     # Override to add server default
     date: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
+
+    # Override to attach UtcDateTime column type
+    expires: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
 
     # Internal fields
     banned_by: int | None = Field(default=None, foreign_key="users.user_id")

--- a/app/models/character_source_link.py
+++ b/app/models/character_source_link.py
@@ -13,8 +13,10 @@ This approach eliminates field duplication while maintaining security boundaries
 
 from datetime import UTC, datetime
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 
 class CharacterSourceLinkBase(SQLModel):
@@ -93,7 +95,7 @@ class CharacterSourceLinks(CharacterSourceLinkBase, table=True):
     # Timestamp
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column_kwargs={"server_default": text("current_timestamp()")},
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/comment.py
+++ b/app/models/comment.py
@@ -17,8 +17,10 @@ but the model is named Comments and all references use 'comment' terminology.
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, Relationship, SQLModel
+
+from app.models.types import UtcDateTime
 
 if TYPE_CHECKING:
     from app.models.user import Users
@@ -115,7 +117,9 @@ class Comments(CommentBase, table=True):
     user_id: int = Field(foreign_key="users.user_id")
 
     # Public timestamp
-    date: datetime = Field(sa_column_kwargs={"server_default": text("current_timestamp()")})
+    date: datetime = Field(
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()"))
+    )
 
     # Public update tracking
     update_count: int = Field(default=0)
@@ -124,7 +128,9 @@ class Comments(CommentBase, table=True):
     ip: str = Field(default="", max_length=15)
 
     # Internal moderation fields
-    last_updated: datetime | None = Field(default=None)
+    last_updated: datetime | None = Field(
+        default=None, sa_column=Column(UtcDateTime, nullable=True)
+    )
     last_updated_user_id: int | None = Field(default=None, foreign_key="users.user_id")
 
     # Relationships

--- a/app/models/comment_report.py
+++ b/app/models/comment_report.py
@@ -10,6 +10,7 @@ from sqlalchemy import Column, ForeignKey, Index, Integer, text
 from sqlmodel import Field, SQLModel
 
 from app.config import ReportStatus
+from app.models.types import UtcDateTime
 
 
 class CommentReportBase(SQLModel):
@@ -74,7 +75,8 @@ class CommentReports(CommentReportBase, table=True):
     )
 
     created_at: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
 
     reviewed_by: int | None = Field(
@@ -85,4 +87,4 @@ class CommentReports(CommentReportBase, table=True):
             nullable=True,
         ),
     )
-    reviewed_at: datetime | None = Field(default=None)
+    reviewed_at: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))

--- a/app/models/favorite.py
+++ b/app/models/favorite.py
@@ -13,8 +13,10 @@ This approach eliminates field duplication while maintaining security boundaries
 
 from datetime import UTC, datetime
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 
 class FavoriteBase(SQLModel):
@@ -34,7 +36,7 @@ class FavoriteBase(SQLModel):
     # Public timestamp
     fav_date: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column_kwargs={"server_default": text("current_timestamp()")},
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/image.py
+++ b/app/models/image.py
@@ -17,11 +17,12 @@ from enum import Enum, IntEnum
 from typing import TYPE_CHECKING, Any
 
 from pydantic import ConfigDict, field_validator
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, Relationship, SQLModel
 
 from app.config import ImageStatus
 from app.core.r2_constants import R2Location
+from app.models.types import UtcDateTime
 
 if TYPE_CHECKING:
     from app.models.tag_link import TagLinks
@@ -225,7 +226,8 @@ class Images(ImageBase, table=True):
 
     # Public timestamp
     date_added: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
 
     # Internal tracking fields (privacy-sensitive)
@@ -237,8 +239,10 @@ class Images(ImageBase, table=True):
 
     # Internal moderation fields
     status_user_id: int | None = Field(default=None, foreign_key="users.user_id")
-    status_updated: datetime | None = Field(default=None)
-    last_post: datetime | None = Field(default=None)
+    status_updated: datetime | None = Field(
+        default=None, sa_column=Column(UtcDateTime, nullable=True)
+    )
+    last_post: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
 
     # Internal metadata
     total_pixels: Decimal | None = Field(default=None)

--- a/app/models/image_rating.py
+++ b/app/models/image_rating.py
@@ -15,8 +15,10 @@ Note: ImageRatings is a junction table with composite primary key (user_id, imag
 
 from datetime import datetime
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 
 class ImageRatingBase(SQLModel):
@@ -75,7 +77,8 @@ class ImageRatings(ImageRatingBase, table=True):
 
     # Public timestamp
     date: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/image_report.py
+++ b/app/models/image_report.py
@@ -17,6 +17,7 @@ from sqlalchemy import Column, ForeignKey, Index, Integer, text
 from sqlmodel import Field, SQLModel
 
 from app.config import ReportStatus
+from app.models.types import UtcDateTime
 
 
 class ImageReportBase(SQLModel):
@@ -92,7 +93,8 @@ class ImageReports(ImageReportBase, table=True):
 
     # Public timestamp
     created_at: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
 
     # Review tracking
@@ -104,7 +106,7 @@ class ImageReports(ImageReportBase, table=True):
             nullable=True,
         ),
     )
-    reviewed_at: datetime | None = Field(default=None)
+    reviewed_at: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
 
     # Note: Relationships are intentionally omitted.
     # Foreign keys are sufficient for queries, and omitting relationships avoids:

--- a/app/models/image_report_tag_suggestion.py
+++ b/app/models/image_report_tag_suggestion.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from sqlalchemy import Column, ForeignKey, Index, Integer, UniqueConstraint, text
 from sqlmodel import Field, SQLModel
 
+from app.models.types import UtcDateTime
+
 
 class ImageReportTagSuggestionBase(SQLModel):
     """
@@ -59,5 +61,6 @@ class ImageReportTagSuggestions(ImageReportTagSuggestionBase, table=True):
     )
 
     created_at: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )

--- a/app/models/image_review.py
+++ b/app/models/image_review.py
@@ -24,6 +24,7 @@ from sqlalchemy import Column, ForeignKey, Index, Integer, text
 from sqlmodel import Field, SQLModel
 
 from app.config import ReviewOutcome, ReviewStatus, ReviewType
+from app.models.types import UtcDateTime
 
 
 class ImageReviewBase(SQLModel):
@@ -128,13 +129,14 @@ class ImageReviews(ImageReviewBase, table=True):
     )
 
     # Voting deadline
-    deadline: datetime | None = Field(default=None)
+    deadline: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
 
     # Timestamps
     created_at: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
-    closed_at: datetime | None = Field(default=None)
+    closed_at: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
 
     # Note: Relationships are intentionally omitted.
     # Foreign keys are sufficient for queries, and omitting relationships avoids:

--- a/app/models/image_status_history.py
+++ b/app/models/image_status_history.py
@@ -11,8 +11,10 @@ Visibility rules:
 
 from datetime import datetime
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 
 class ImageStatusHistoryBase(SQLModel):
@@ -63,5 +65,5 @@ class ImageStatusHistory(ImageStatusHistoryBase, table=True):
     # Timestamp
     created_at: datetime | None = Field(
         default=None,
-        sa_column_kwargs={"server_default": text("current_timestamp()")},
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )

--- a/app/models/misc.py
+++ b/app/models/misc.py
@@ -13,8 +13,10 @@ These are generally simple utility tables with minimal relationships.
 from datetime import datetime
 from enum import Enum
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 # ===== Banners =====
 
@@ -66,7 +68,8 @@ class Banners(BannerBase, table=True):
 
     # Timestamp
     created_at: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
 
 
@@ -209,7 +212,9 @@ class DonationBase(SQLModel):
     Note: Original table has no primary key, but we need one for SQLModel.
     """
 
-    date: datetime = Field(sa_column_kwargs={"server_default": text("current_timestamp()")})
+    date: datetime = Field(
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()"))
+    )
     user_id: int | None = Field(default=None)
     nick: str | None = Field(default=None, max_length=30)
     amount: int | None = Field(default=None)

--- a/app/models/news.py
+++ b/app/models/news.py
@@ -13,8 +13,10 @@ This approach eliminates field duplication while maintaining security boundaries
 
 from datetime import datetime
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 
 class NewsBase(SQLModel):
@@ -75,8 +77,12 @@ class News(NewsBase, table=True):
 
     # Override to add server default
     date: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
+
+    # Override to attach UtcDateTime column type
+    edited: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
 
     # Note: Relationships are intentionally omitted.
     # Foreign keys are sufficient for queries, and omitting relationships avoids:

--- a/app/models/privmsg.py
+++ b/app/models/privmsg.py
@@ -15,8 +15,10 @@ Note: Privmsgs are private messages between users.
 
 from datetime import datetime
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 
 class PrivmsgBase(SQLModel):
@@ -97,7 +99,8 @@ class Privmsgs(PrivmsgBase, table=True):
 
     # Public timestamp
     date: datetime = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/refresh_token.py
+++ b/app/models/refresh_token.py
@@ -13,8 +13,10 @@ Security features:
 
 from datetime import datetime
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 
 class RefreshTokens(SQLModel, table=True):
@@ -59,12 +61,14 @@ class RefreshTokens(SQLModel, table=True):
     family_id: str = Field(max_length=255, index=True)
 
     # Expiration
-    created_at: datetime = Field(sa_column_kwargs={"server_default": text("current_timestamp()")})
-    expires_at: datetime
+    created_at: datetime = Field(
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()"))
+    )
+    expires_at: datetime = Field(sa_column=Column(UtcDateTime, nullable=False))
 
     # Revocation
     revoked: bool = Field(default=False)
-    revoked_at: datetime | None = Field(default=None)
+    revoked_at: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
 
     # Security tracking
     ip_address: str | None = Field(default=None, max_length=45)  # Supports IPv6

--- a/app/models/review_vote.py
+++ b/app/models/review_vote.py
@@ -18,6 +18,8 @@ from datetime import datetime
 from sqlalchemy import Column, ForeignKey, Index, Integer, text
 from sqlmodel import Field, SQLModel
 
+from app.models.types import UtcDateTime
+
 
 class ReviewVoteBase(SQLModel):
     """
@@ -99,7 +101,8 @@ class ReviewVotes(ReviewVoteBase, table=True):
 
     # Timestamp
     created_at: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/tag.py
+++ b/app/models/tag.py
@@ -14,10 +14,11 @@ This approach eliminates field duplication while maintaining security boundaries
 from datetime import UTC, datetime
 
 from pydantic import field_validator
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
 
 from app.config import TagType
+from app.models.types import UtcDateTime
 
 
 class TagBase(SQLModel):
@@ -114,7 +115,7 @@ class Tags(TagBase, table=True):
     # Public timestamp
     date_added: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column_kwargs={"server_default": text("current_timestamp()")},
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
     )
 
     # Usage count (number of images with this tag)

--- a/app/models/tag_audit_log.py
+++ b/app/models/tag_audit_log.py
@@ -13,8 +13,10 @@ Uses explicit columns per field type for type safety.
 
 from datetime import datetime
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 
 class TagAuditLogBase(SQLModel):
@@ -133,7 +135,7 @@ class TagAuditLog(TagAuditLogBase, table=True):
     # Timestamp
     created_at: datetime | None = Field(
         default=None,
-        sa_column_kwargs={"server_default": text("current_timestamp()")},
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/tag_external_link.py
+++ b/app/models/tag_external_link.py
@@ -13,8 +13,10 @@ This approach eliminates field duplication while maintaining security boundaries
 
 from datetime import UTC, datetime
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 
 class TagExternalLinkBase(SQLModel):
@@ -70,11 +72,11 @@ class TagExternalLinks(TagExternalLinkBase, table=True):
     # Timestamp
     date_added: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column_kwargs={"server_default": text("current_timestamp()")},
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
     )
 
     # Dead link tracking
-    dead_at: datetime | None = Field(default=None)
+    dead_at: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
     archive_url: str | None = Field(default=None, max_length=2000)
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/tag_history.py
+++ b/app/models/tag_history.py
@@ -15,8 +15,10 @@ Note: TagHistory tracks all tag additions/removals on images for auditing.
 
 from datetime import datetime
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 
 class TagHistoryBase(SQLModel):
@@ -95,7 +97,8 @@ class TagHistory(TagHistoryBase, table=True):
 
     # Override to add server default
     date: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
 
     # Internal field

--- a/app/models/tag_link.py
+++ b/app/models/tag_link.py
@@ -16,8 +16,10 @@ Note: TagLinks is a junction table connecting tags to images with metadata.
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, Relationship, SQLModel
+
+from app.models.types import UtcDateTime
 
 if TYPE_CHECKING:
     from app.models.tag import Tags
@@ -86,7 +88,8 @@ class TagLinks(TagLinkBase, table=True):
 
     # Public timestamp
     date_linked: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
 
     # Internal field

--- a/app/models/types.py
+++ b/app/models/types.py
@@ -1,0 +1,43 @@
+"""SQLAlchemy column types for the shuushuu-api models.
+
+UtcDateTime: a DateTime variant that round-trips tz-aware datetimes through
+MariaDB's tz-naive DATETIME. Stores values as UTC (tzinfo stripped); attaches
+tzinfo=UTC on read. Naive datetimes are rejected on bind to avoid ambiguous
+"is this UTC or local?" assumptions.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import DateTime
+from sqlalchemy.types import TypeDecorator
+
+
+class UtcDateTime(TypeDecorator[datetime]):
+    """DATETIME column that always exposes tz-aware UTC datetimes in Python.
+
+    MariaDB's DATETIME stores no tz info. Without this decorator, reads return
+    naive datetimes that cannot be compared with `datetime.now(UTC)` without
+    raising TypeError. This decorator centralizes the convention "DB stores
+    UTC, Python sees aware" so call sites never need to strip or attach
+    tzinfo manually.
+    """
+
+    impl = DateTime
+    cache_ok = True
+
+    def process_bind_param(self, value: datetime | None, dialect: Any) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            raise TypeError(
+                "naive datetime not allowed; pass datetime.now(UTC) or attach tzinfo=UTC"
+            )
+        return value.astimezone(UTC).replace(tzinfo=None)
+
+    def process_result_value(self, value: datetime | None, dialect: Any) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -14,8 +14,10 @@ This approach eliminates field duplication while maintaining security boundaries
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, Relationship, SQLModel
+
+from app.models.types import UtcDateTime
 
 if TYPE_CHECKING:
     from app.models.permissions import UserGroups
@@ -113,12 +115,13 @@ class Users(UserBase, table=True):
     # Public timestamps
     date_joined: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column_kwargs={"server_default": text("current_timestamp()")},
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
     )
     last_login: datetime | None = Field(
-        default=None, sa_column_kwargs={"server_default": text("current_timestamp()")}
+        default=None,
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
     )
-    last_active: datetime | None = Field(default=None)
+    last_active: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
 
     # Internal status fields
     active: int = Field(default=0)
@@ -133,19 +136,29 @@ class Users(UserBase, table=True):
 
     # Account lockout (security)
     failed_login_attempts: int = Field(default=0)
-    lockout_until: datetime | None = Field(default=None)
+    lockout_until: datetime | None = Field(
+        default=None, sa_column=Column(UtcDateTime, nullable=True)
+    )
 
     # Contact info (privacy-sensitive)
     email: str = Field(max_length=120)
     email_verified: bool = Field(default=False)
     email_verification_token: str | None = Field(default=None, max_length=64)
-    email_verification_sent_at: datetime | None = Field(default=None)
-    email_verification_expires_at: datetime | None = Field(default=None)
+    email_verification_sent_at: datetime | None = Field(
+        default=None, sa_column=Column(UtcDateTime, nullable=True)
+    )
+    email_verification_expires_at: datetime | None = Field(
+        default=None, sa_column=Column(UtcDateTime, nullable=True)
+    )
 
     # Password reset
     password_reset_token: str | None = Field(default=None, max_length=64)
-    password_reset_sent_at: datetime | None = Field(default=None)
-    password_reset_expires_at: datetime | None = Field(default=None)
+    password_reset_sent_at: datetime | None = Field(
+        default=None, sa_column=Column(UtcDateTime, nullable=True)
+    )
+    password_reset_expires_at: datetime | None = Field(
+        default=None, sa_column=Column(UtcDateTime, nullable=True)
+    )
 
     # User preferences (private)
     email_pm_pref: int = Field(default=1)

--- a/app/models/user_suspension.py
+++ b/app/models/user_suspension.py
@@ -8,8 +8,10 @@ logging and not exposed via API endpoints.
 
 from datetime import datetime
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
 
 
 class UserSuspensions(SQLModel, table=True):
@@ -73,14 +75,20 @@ class UserSuspensions(SQLModel, table=True):
     actioned_by: int | None = Field(default=None, foreign_key="users.user_id")
 
     # When the action occurred
-    actioned_at: datetime = Field(sa_column_kwargs={"server_default": text("current_timestamp()")})
+    actioned_at: datetime = Field(
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()"))
+    )
 
     # Suspension details (only for SuspensionAction.SUSPENDED action)
-    suspended_until: datetime | None = Field(default=None)
+    suspended_until: datetime | None = Field(
+        default=None, sa_column=Column(UtcDateTime, nullable=True)
+    )
     reason: str | None = Field(default=None, max_length=500)
 
     # Acknowledgement tracking (for warnings and post-suspension notices)
-    acknowledged_at: datetime | None = Field(default=None)
+    acknowledged_at: datetime | None = Field(
+        default=None, sa_column=Column(UtcDateTime, nullable=True)
+    )
 
     # Note: Relationships are intentionally omitted.
     # Foreign keys are sufficient for queries, and omitting relationships avoids:

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -10,10 +10,9 @@ These schemas handle:
 - User suspensions
 """
 
-from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import AwareDatetime, BaseModel, Field, field_validator, model_validator
 
 from app.schemas.base import UTCDatetime, UTCDatetimeOptional
 
@@ -197,7 +196,7 @@ class SuspendUserRequest(BaseModel):
         "suspended",
         description="Action type: 'suspended' to suspend the account, 'warning' for verbal warning only",
     )
-    suspended_until: datetime | None = Field(
+    suspended_until: AwareDatetime | None = Field(
         None,
         description="When the suspension expires (None = permanent). Ignored for warnings.",
     )

--- a/app/schemas/donations.py
+++ b/app/schemas/donations.py
@@ -1,8 +1,6 @@
 """Pydantic schemas for Donations endpoints."""
 
-from datetime import datetime
-
-from pydantic import BaseModel, Field, field_validator
+from pydantic import AwareDatetime, BaseModel, Field, field_validator
 
 from app.schemas.base import UTCDatetime
 
@@ -13,7 +11,7 @@ class DonationCreate(BaseModel):
     amount: int = Field(gt=0, description="Donation amount")
     nick: str | None = Field(default=None, max_length=30, description="Donor display name")
     user_id: int | None = Field(default=None, description="Donor user ID")
-    date: datetime | None = Field(default=None, description="Donation date (defaults to now)")
+    date: AwareDatetime | None = Field(default=None, description="Donation date (defaults to now)")
 
     @field_validator("nick", mode="before")
     @classmethod

--- a/app/services/review_jobs.py
+++ b/app/services/review_jobs.py
@@ -334,9 +334,7 @@ async def prune_admin_actions(
     Returns:
         Number of rows deleted
     """
-    # Use timezone-naive datetime for MySQL compatibility
-    # MySQL DATETIME columns don't store timezone info
-    cutoff_date = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=retention_years * 365)
+    cutoff_date = datetime.now(UTC) - timedelta(days=retention_years * 365)
 
     stmt = (
         delete(AdminActions)

--- a/app/services/upload.py
+++ b/app/services/upload.py
@@ -19,7 +19,7 @@ logger = get_logger(__name__)
 
 async def get_uploads_today(user_id: int, db: AsyncSession) -> int:
     """Count how many images a user has uploaded today."""
-    start_of_day = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
+    start_of_day = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
     result = await db.execute(
         select(func.count())
         .select_from(Images)

--- a/app/services/upload.py
+++ b/app/services/upload.py
@@ -59,7 +59,7 @@ async def check_upload_rate_limit(
     last_upload = result.scalar_one_or_none()
 
     if last_upload:
-        elapsed = (datetime.now(UTC).replace(tzinfo=None) - last_upload).total_seconds()
+        elapsed = (datetime.now(UTC) - last_upload).total_seconds()
         if elapsed < settings.UPLOAD_DELAY_SECONDS:
             wait_time = int(settings.UPLOAD_DELAY_SECONDS - elapsed)
             raise HTTPException(

--- a/app/services/user_cleanup.py
+++ b/app/services/user_cleanup.py
@@ -28,7 +28,7 @@ async def cleanup_unverified_accounts(db: AsyncSession) -> int:
     Returns:
         Count of deleted accounts
     """
-    cutoff_date = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=30)
+    cutoff_date = datetime.now(UTC) - timedelta(days=30)
 
     # Build query for stale unverified accounts
     query = select(Users).where(

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -361,7 +361,7 @@ async def reconcile(*, stale_after: int) -> None:
     from datetime import UTC, datetime, timedelta
     from pathlib import Path as FilePath
 
-    cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=stale_after)
+    cutoff = datetime.now(UTC) - timedelta(seconds=stale_after)
     r2 = get_r2_storage()
 
     batch_size = 500
@@ -795,9 +795,7 @@ async def health(*, output_json: bool = False) -> dict[str, Any]:
             select(func.min(Images.date_added)).where(Images.r2_location == R2Location.NONE)  # type: ignore[arg-type]
         )
         oldest = oldest_result.scalar_one_or_none()
-        oldest_age = (
-            int((datetime.now(UTC).replace(tzinfo=None) - oldest).total_seconds()) if oldest else 0
-        )
+        oldest_age = int((datetime.now(UTC) - oldest).total_seconds()) if oldest else 0
 
     try:
         du_output = await _asyncio.to_thread(

--- a/tests/api/v1/test_admin_suspensions.py
+++ b/tests/api/v1/test_admin_suspensions.py
@@ -213,8 +213,7 @@ class TestSuspendUser:
 
         # Manually suspend the user first
         target_user.active = 0
-        # Use naive datetime to match database storage
-        suspend_until = (datetime.now(UTC) + timedelta(days=1)).replace(tzinfo=None)
+        suspend_until = datetime.now(UTC) + timedelta(days=1)
         suspension = UserSuspensions(
             user_id=target_user.user_id,
             action=SuspensionAction.SUSPENDED,
@@ -407,8 +406,8 @@ class TestReactivateUser:
             db_session, username="reactivateme", active=0
         )
 
-        # Create suspension record (use naive datetime for DB storage)
-        suspend_until = (datetime.now(UTC) + timedelta(days=1)).replace(tzinfo=None)
+        # Create suspension record
+        suspend_until = datetime.now(UTC) + timedelta(days=1)
         suspension = UserSuspensions(
             user_id=target_user.user_id,
             action=SuspensionAction.SUSPENDED,
@@ -497,7 +496,7 @@ class TestReactivateUser:
         )
 
         # Create suspension and reactivation records (use naive datetimes)
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
         suspension = UserSuspensions(
             user_id=target_user.user_id,
             action=SuspensionAction.SUSPENDED,
@@ -558,7 +557,7 @@ class TestUserSuspensionHistory:
         target_user = await create_regular_user(db_session, username="historyuser")
 
         # Create multiple suspension records (use naive datetimes)
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
         suspension1 = UserSuspensions(
             user_id=target_user.user_id,
             action=SuspensionAction.SUSPENDED,
@@ -708,7 +707,7 @@ class TestUserWarningAcknowledgement:
         user = await create_regular_user(db_session, username="ackwarnuser")
         admin, _ = await create_admin_user(db_session)
 
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
 
         # Create an acknowledged warning
         acknowledged_warning = UserSuspensions(
@@ -776,7 +775,7 @@ class TestUserWarningAcknowledgement:
         user = await create_regular_user(db_session, username="suspendeduser")
         admin, _ = await create_admin_user(db_session)
 
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
 
         # Create an unacknowledged suspension
         suspension = UserSuspensions(
@@ -895,7 +894,7 @@ class TestAdminSuspensionList:
         user1 = await create_regular_user(db_session, username="suspended1")
         user2 = await create_regular_user(db_session, username="warned1")
 
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
 
         # Active suspension for user1
         suspension1 = UserSuspensions(
@@ -958,7 +957,7 @@ class TestAdminSuspensionList:
         user1 = await create_regular_user(db_session, username="filteruser1")
         user2 = await create_regular_user(db_session, username="filteruser2")
 
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
 
         # Create suspension
         suspension = UserSuspensions(
@@ -1005,7 +1004,7 @@ class TestAdminSuspensionList:
         user1 = await create_regular_user(db_session, username="warnfilter1")
         user2 = await create_regular_user(db_session, username="warnfilter2")
 
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
 
         # Create suspension
         suspension = UserSuspensions(
@@ -1051,7 +1050,7 @@ class TestAdminSuspensionList:
 
         user = await create_regular_user(db_session, username="daysbackuser")
 
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
 
         # Recent warning (1 day ago)
         recent = UserSuspensions(
@@ -1095,7 +1094,7 @@ class TestAdminSuspensionList:
 
         user = await create_regular_user(db_session, username="paginationuser")
 
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
 
         # Create 5 warnings
         for i in range(5):
@@ -1146,7 +1145,7 @@ class TestAdminSuspensionList:
         user2 = await create_regular_user(db_session, username="expireduser")
         user3 = await create_regular_user(db_session, username="reactivateduser")
 
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
 
         # Active suspension (not expired, not reactivated)
         active_suspension = UserSuspensions(
@@ -1238,7 +1237,7 @@ class TestAdminSuspensionList:
 
         user = await create_regular_user(db_session, username="excludereact")
 
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
 
         # Create suspension and reactivation
         suspension = UserSuspensions(

--- a/tests/api/v1/test_admin_suspensions.py
+++ b/tests/api/v1/test_admin_suspensions.py
@@ -322,6 +322,27 @@ class TestSuspendUser:
 
         assert response.status_code == 422
 
+    async def test_suspend_naive_datetime_returns_422(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A naive suspended_until must be rejected at the schema boundary as 422,
+        not propagated to UtcDateTime where it would surface as a 500."""
+        admin, admin_password = await create_admin_user(db_session)
+        await grant_permission(db_session, admin.user_id, "user_ban")
+        target_user = await create_regular_user(db_session, username="naivedt")
+
+        token = await login_user(client, admin.username, admin_password)
+
+        response = await client.post(
+            f"/api/v1/admin/users/{target_user.user_id}/suspend",
+            json={
+                "suspended_until": "2027-01-01T00:00:00",  # no offset = naive
+                "reason": "Testing tz validation",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 422
+
     async def test_warn_user(self, client: AsyncClient, db_session: AsyncSession):
         """Test issuing a warning to a user (no suspension)."""
         admin, admin_password = await create_admin_user(db_session)

--- a/tests/api/v1/test_admin_suspensions.py
+++ b/tests/api/v1/test_admin_suspensions.py
@@ -495,7 +495,7 @@ class TestReactivateUser:
             db_session, username="wasreactivated", active=0
         )
 
-        # Create suspension and reactivation records (use naive datetimes)
+        # Create suspension and reactivation records
         now = datetime.now(UTC)
         suspension = UserSuspensions(
             user_id=target_user.user_id,
@@ -556,7 +556,7 @@ class TestUserSuspensionHistory:
         await grant_permission(db_session, admin.user_id, "user_ban")
         target_user = await create_regular_user(db_session, username="historyuser")
 
-        # Create multiple suspension records (use naive datetimes)
+        # Create multiple suspension records
         now = datetime.now(UTC)
         suspension1 = UserSuspensions(
             user_id=target_user.user_id,

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -261,12 +261,7 @@ class TestLogin:
     async def test_login_with_expired_lockout_clears_and_succeeds(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Login must succeed when an existing lockout_until has already expired.
-
-        MySQL DATETIME is timezone-naive, so user.lockout_until comes back from the
-        DB without tzinfo. Comparing it against datetime.now(UTC) (tz-aware) raises
-        TypeError, which silently 500s the login and locks users out indefinitely.
-        """
+        """Login must succeed when an existing lockout_until has already expired."""
         user = Users(
             username="expiredlockuser",
             password=get_password_hash("TestPassword123!"),

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -702,8 +702,8 @@ class TestLoginSuspensionCheck:
         await db_session.commit()
         await db_session.refresh(user)
 
-        # Create active suspension record (use naive datetime for DB storage)
-        suspend_until = (datetime.now(UTC) + timedelta(days=7)).replace(tzinfo=None)
+        # Create active suspension record
+        suspend_until = datetime.now(UTC) + timedelta(days=7)
         suspension = UserSuspensions(
             user_id=user.user_id,
             action=SuspensionAction.SUSPENDED,
@@ -774,8 +774,8 @@ class TestLoginSuspensionCheck:
         await db_session.commit()
         await db_session.refresh(user)
 
-        # Create expired suspension record (use naive datetime)
-        suspend_until = (datetime.now(UTC) - timedelta(days=1)).replace(tzinfo=None)
+        # Create expired suspension record
+        suspend_until = datetime.now(UTC) - timedelta(days=1)
         suspension = UserSuspensions(
             user_id=user.user_id,
             action=SuspensionAction.SUSPENDED,
@@ -860,9 +860,9 @@ class TestRefreshSuspensionCheck:
         )
         assert login_response.status_code == 200
 
-        # Now suspend the user (use naive datetime)
+        # Now suspend the user
         user.active = 0
-        suspend_until = (datetime.now(UTC) + timedelta(days=7)).replace(tzinfo=None)
+        suspend_until = datetime.now(UTC) + timedelta(days=7)
         suspension = UserSuspensions(
             user_id=user.user_id,
             action=SuspensionAction.SUSPENDED,
@@ -902,9 +902,9 @@ class TestRefreshSuspensionCheck:
         )
         assert login_response.status_code == 200
 
-        # Suspend user with expired suspension (use naive datetime)
+        # Suspend user with expired suspension
         user.active = 0
-        suspend_until = (datetime.now(UTC) - timedelta(days=1)).replace(tzinfo=None)
+        suspend_until = datetime.now(UTC) - timedelta(days=1)
         suspension = UserSuspensions(
             user_id=user.user_id,
             action=SuspensionAction.SUSPENDED,

--- a/tests/api/v1/test_daily_upload_limit.py
+++ b/tests/api/v1/test_daily_upload_limit.py
@@ -41,7 +41,7 @@ def _make_image(user_id: int, suffix: str) -> Images:
         user_id=user_id,
         status=1,
         locked=0,
-        date_added=datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0, tzinfo=None),
+        date_added=datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0),
     )
 
 

--- a/tests/api/v1/test_donations.py
+++ b/tests/api/v1/test_donations.py
@@ -16,7 +16,7 @@ from app.models.user import Users
 @pytest.fixture
 async def sample_donations(db_session: AsyncSession) -> list[Donations]:
     """Create sample donation records."""
-    now = datetime.now()
+    now = datetime.now(UTC)
     donations = [
         Donations(date=now - timedelta(days=i), amount=(i + 1) * 10, nick=f"Donor {i}")
         for i in range(5)

--- a/tests/api/v1/test_donations.py
+++ b/tests/api/v1/test_donations.py
@@ -308,6 +308,19 @@ class TestCreateDonation:
         assert data["nick"] == "Generous"
         assert data["user_id"] == 123
 
+    async def test_create_naive_date_returns_422(
+        self, client: AsyncClient, user_with_donations_create: tuple[Users, str]
+    ):
+        """A naive date must be rejected at the schema boundary as 422,
+        not propagated to UtcDateTime where it would surface as a 500."""
+        _, token = user_with_donations_create
+        response = await client.post(
+            "/api/v1/donations",
+            json={"amount": 25, "date": "2027-01-01T00:00:00"},  # no offset = naive
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 422
+
     async def test_create_validates_amount_required(
         self, client: AsyncClient, user_with_donations_create: tuple[Users, str]
     ):

--- a/tests/api/v1/test_user_history_endpoint.py
+++ b/tests/api/v1/test_user_history_endpoint.py
@@ -445,7 +445,7 @@ class TestGetUserHistory:
         await db_session.refresh(tag)
 
         # Create audit log entries with different timestamps
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
         audit1 = TagAuditLog(
             tag_id=tag.tag_id,
             user_id=user.user_id,
@@ -522,7 +522,7 @@ class TestGetUserHistory:
         await db_session.commit()
         await db_session.refresh(tag)
 
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
 
         # Create entries with interleaved timestamps:
         # 1. tag_metadata (oldest)

--- a/tests/integration/test_datetime_round_trip.py
+++ b/tests/integration/test_datetime_round_trip.py
@@ -1,0 +1,115 @@
+"""Integration tests: UtcDateTime round-trips through real MariaDB.
+
+Verifies the TypeDecorator wires correctly into the SQLAlchemy machinery and
+behaves correctly against the actual aiomysql driver, not just in unit-level
+isolation. A throwaway table is created/dropped inside the test so we don't
+depend on any production model adopting UtcDateTime yet (that happens in
+later chunks).
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import Column, Integer, MetaData, Table, insert, select
+from sqlalchemy.exc import StatementError
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from app.models.types import UtcDateTime
+
+
+def _make_temp_table() -> Table:
+    """Build an isolated MetaData/Table for the round-trip test.
+
+    Using a fresh MetaData keeps this table out of the global SQLModel registry
+    so it doesn't pollute schema-sync tests or other autogenerate workflows.
+    """
+    metadata = MetaData()
+    return Table(
+        "utc_datetime_round_trip",
+        metadata,
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("ts", UtcDateTime, nullable=True),
+    )
+
+
+@pytest.fixture
+async def temp_dt_table(engine: AsyncEngine):
+    """Create the throwaway table on the test DB; drop it after the test."""
+    table = _make_temp_table()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(table.create)
+
+    try:
+        yield table
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(table.drop)
+
+
+@pytest.mark.integration
+class TestUtcDateTimeRoundTrip:
+    """End-to-end round-trip through the aiomysql driver."""
+
+    async def test_utc_aware_round_trips(
+        self, engine: AsyncEngine, temp_dt_table: Table
+    ):
+        """A UTC-aware datetime survives write+read with tz preserved."""
+        ts = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+
+        async with engine.begin() as conn:
+            result = await conn.execute(insert(temp_dt_table).values(ts=ts))
+            row_id = result.inserted_primary_key[0]
+
+        async with engine.connect() as conn:
+            row = (
+                await conn.execute(
+                    select(temp_dt_table.c.ts).where(temp_dt_table.c.id == row_id)
+                )
+            ).one()
+
+        loaded = row.ts
+        assert loaded == ts
+        assert loaded.tzinfo == UTC
+
+    async def test_non_utc_aware_stored_as_utc_equivalent(
+        self, engine: AsyncEngine, temp_dt_table: Table
+    ):
+        """A non-UTC aware datetime is converted to UTC on bind, returns as UTC-aware."""
+        est = timezone(timedelta(hours=-5))
+        # 12:00 EST == 17:00 UTC
+        ts_est = datetime(2026, 5, 1, 12, 0, 0, tzinfo=est)
+        expected_utc = datetime(2026, 5, 1, 17, 0, 0, tzinfo=UTC)
+
+        async with engine.begin() as conn:
+            result = await conn.execute(insert(temp_dt_table).values(ts=ts_est))
+            row_id = result.inserted_primary_key[0]
+
+        async with engine.connect() as conn:
+            row = (
+                await conn.execute(
+                    select(temp_dt_table.c.ts).where(temp_dt_table.c.id == row_id)
+                )
+            ).one()
+
+        loaded = row.ts
+        assert loaded == expected_utc
+        assert loaded == ts_est  # equal as instants
+        assert loaded.tzinfo == UTC
+
+    async def test_naive_datetime_bind_raises(
+        self, engine: AsyncEngine, temp_dt_table: Table
+    ):
+        """Binding a naive datetime raises TypeError before hitting the DB.
+
+        SQLAlchemy wraps bind-time exceptions in StatementError; assert the
+        underlying TypeError carries our diagnostic message.
+        """
+        naive = datetime(2026, 5, 1, 12, 0, 0)
+
+        with pytest.raises(StatementError) as exc_info:
+            async with engine.begin() as conn:
+                await conn.execute(insert(temp_dt_table).values(ts=naive))
+
+        assert isinstance(exc_info.value.orig, TypeError)
+        assert "naive datetime" in str(exc_info.value.orig)

--- a/tests/unit/test_daily_upload_limit.py
+++ b/tests/unit/test_daily_upload_limit.py
@@ -59,7 +59,7 @@ class TestGetUploadsToday:
                 user_id=user.user_id,
                 status=1,
                 locked=0,
-                date_added=datetime.now(UTC).replace(tzinfo=None),
+                date_added=datetime.now(UTC),
             )
             db_session.add(img)
         await db_session.commit()
@@ -104,7 +104,7 @@ class TestGetUploadsToday:
                     user_id=user1.user_id,
                     status=1,
                     locked=0,
-                    date_added=datetime.now(UTC).replace(tzinfo=None),
+                    date_added=datetime.now(UTC),
                 )
             )
         db_session.add(
@@ -119,7 +119,7 @@ class TestGetUploadsToday:
                 user_id=user2.user_id,
                 status=1,
                 locked=0,
-                date_added=datetime.now(UTC).replace(tzinfo=None),
+                date_added=datetime.now(UTC),
             )
         )
         await db_session.commit()
@@ -141,7 +141,7 @@ class TestGetUploadsToday:
         await db_session.commit()
         await db_session.refresh(user)
 
-        yesterday = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
+        yesterday = datetime.now(UTC) - timedelta(days=1)
         for i in range(2):
             db_session.add(
                 Images(
@@ -167,9 +167,7 @@ class TestGetUploadsToday:
 def _make_image(user_id: int, suffix: str) -> Images:
     """Create an Images instance with today's date but far enough back to avoid rate limit."""
     # Use start of today + 1 minute (UTC) so it's always "today" and always in the past
-    start_of_today = datetime.now(UTC).replace(
-        hour=0, minute=1, second=0, microsecond=0, tzinfo=None
-    )
+    start_of_today = datetime.now(UTC).replace(hour=0, minute=1, second=0, microsecond=0)
     return Images(
         filename=f"limit-{suffix}",
         ext="jpg",

--- a/tests/unit/test_models_types.py
+++ b/tests/unit/test_models_types.py
@@ -1,0 +1,56 @@
+"""Unit tests for app.models.types.UtcDateTime."""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from app.models.types import UtcDateTime
+
+
+class TestUtcDateTimeBind:
+    """process_bind_param converts Python -> DB value."""
+
+    def test_naive_datetime_raises(self):
+        """Naive datetimes must be rejected on bind to prevent ambiguous UTC assumptions."""
+        col = UtcDateTime()
+        with pytest.raises(TypeError, match="naive datetime"):
+            col.process_bind_param(datetime(2026, 5, 1, 12, 0, 0), dialect=None)
+
+    def test_utc_aware_datetime_strips_tzinfo(self):
+        col = UtcDateTime()
+        result = col.process_bind_param(datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC), dialect=None)
+        assert result == datetime(2026, 5, 1, 12, 0, 0)
+        assert result.tzinfo is None
+
+    def test_non_utc_aware_datetime_converts_to_utc(self):
+        est = timezone(timedelta(hours=-5))
+        col = UtcDateTime()
+        # 12:00 EST == 17:00 UTC
+        result = col.process_bind_param(datetime(2026, 5, 1, 12, 0, 0, tzinfo=est), dialect=None)
+        assert result == datetime(2026, 5, 1, 17, 0, 0)
+        assert result.tzinfo is None
+
+    def test_none_passthrough(self):
+        col = UtcDateTime()
+        assert col.process_bind_param(None, dialect=None) is None
+
+
+class TestUtcDateTimeResult:
+    """process_result_value converts DB value -> Python."""
+
+    def test_naive_datetime_becomes_utc_aware(self):
+        col = UtcDateTime()
+        result = col.process_result_value(datetime(2026, 5, 1, 12, 0, 0), dialect=None)
+        assert result == datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+        assert result.tzinfo == UTC
+
+    def test_already_aware_passthrough(self):
+        col = UtcDateTime()
+        aware = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+        result = col.process_result_value(aware, dialect=None)
+        assert result == aware
+        assert result.tzinfo == UTC
+
+    def test_none_passthrough(self):
+        col = UtcDateTime()
+        assert col.process_result_value(None, dialect=None) is None

--- a/tests/unit/test_review_deadline_job.py
+++ b/tests/unit/test_review_deadline_job.py
@@ -416,8 +416,7 @@ class TestPruneAdminActions:
 
     async def test_prune_old_actions(self, db_session: AsyncSession):
         """Old admin_actions are deleted."""
-        # Use timezone-naive datetimes for MySQL compatibility
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
 
         # Create old action (3 years ago)
         old_action = AdminActions(
@@ -449,7 +448,7 @@ class TestPruneAdminActions:
 
     async def test_prune_no_old_actions(self, db_session: AsyncSession):
         """No actions deleted when all are within retention period."""
-        now = datetime.now(UTC).replace(tzinfo=None)
+        now = datetime.now(UTC)
         action = AdminActions(
             user_id=1,
             action_type=AdminActionType.REPORT_DISMISS,


### PR DESCRIPTION
## Summary

Eliminates the structural mismatch between MariaDB's tz-naive `DATETIME` columns and the application's tz-aware `datetime.now(UTC)` usage. Introduces a SQLAlchemy `TypeDecorator` (`app/models/types.py::UtcDateTime`) that always exposes tz-aware UTC datetimes in Python, then deletes 18+ scattered `.replace(tzinfo=None)` workarounds across `app/api/` and `app/services/`.

PR #198 fixed one symptom of this design problem (login broke when `lockout_until` existed because someone forgot the workaround). This PR fixes the class.

## Why a TypeDecorator and not a column-type migration?

MariaDB has no `TIMESTAMP WITH TIME ZONE` type. SQLAlchemy's `DateTime(timezone=True)` is a no-op on MariaDB — it only takes effect on dialects like PostgreSQL. Migrating columns to MariaDB `TIMESTAMP` would buy implicit-UTC semantics but cost the 2038 ceiling (TIMESTAMP is a 32-bit Unix-epoch int) — bad fit for `expires_at`, `lockout_until`, `suspended_until`, etc.

The TypeDecorator pattern is the standard SQLAlchemy approach for cross-dialect tz handling on tz-naive databases. If a PostgreSQL migration ever happens, the decorator becomes a passthrough — no rework cost.

Full design rationale and decomposition in [`docs/plans/2026-05-01-utc-datetime-typedecorator-impl.md`](./docs/plans/2026-05-01-utc-datetime-typedecorator-impl.md).

## What's in the diff

- **Foundation** — `app/models/types.py::UtcDateTime` (`TypeDecorator(impl=DateTime)`):
  - `process_bind_param`: rejects naive datetimes (`TypeError`); converts non-UTC aware datetimes to UTC and strips tzinfo for storage
  - `process_result_value`: attaches `tzinfo=UTC` to naive DB values; passes through aware values
  - **Strict-on-bind** intentionally — surfaces ambiguous-UTC bugs at write time, not at the next comparison
- **Coverage** — every datetime column across 24 model files now uses `UtcDateTime`:
  - `app/models/user.py`, `refresh_token.py`, `user_suspension.py`, `image_review.py`, `ban.py`, `image.py`, `comment.py`, `comment_report.py`, `image_report.py`, `misc.py`, `privmsg.py`, `tag_external_link.py`, `tag_history.py`, `admin_action.py`, `character_source_link.py`, `favorite.py`, `image_rating.py`, `image_report_tag_suggestion.py`, `image_status_history.py`, `review_vote.py`, `tag.py`, `tag_audit_log.py`, `tag_link.py`, `news.py`
- **Workaround removal** — 18+ sites (with bonus fixes for buried `tzinfo=None` kwargs in `replace(...)` that the original grep missed):
  - `app/api/v1/auth.py` (8), `admin.py` (2), `users.py` (1), `feeds.py` (1, helper deleted)
  - `app/services/upload.py` (2), `review_jobs.py` (1), `user_cleanup.py` (1)
  - `scripts/r2_sync.py` (2)
- **Test fixture updates** in 7 files — naive `datetime(...)` literals → `datetime(..., tzinfo=UTC)`. No assertions loosened, no tests skipped.

## Out of scope (deferred follow-ups)

- Three `datetime.now()` calls in `upload.py:112`, `image_processing.py:83`, `images.py:2147` produce filename date prefixes via `.strftime`. They use server-local time. Trivial fix, separate PR.
- `app/schemas/base.py::UTCDatetime` Pydantic serializer currently appends `Z` without converting to UTC. Works correctly today because all values are now aware UTC, but could be hardened defensively.

## Test plan

- [x] 7 unit tests for `UtcDateTime` (bind/result symmetry, edge cases) — green
- [x] 3 integration tests round-tripping tz-aware datetimes through real MariaDB — green
- [x] Full test suite — 1493 passed, 0 failed, 9 (pre-existing) skips
- [x] mypy clean across 107 source files
- [x] No `.replace(tzinfo=...)` calls remain outside `UtcDateTime` itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)