### PR TITLE
chore(docker): copy scripts/ into prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN uv pip install --system -r pyproject.toml
 # Copy only what's needed for runtime (explicit allowlist)
 COPY app/ ./app/
 COPY alembic/ ./alembic/
+COPY scripts/ ./scripts/
 
 # Expose port
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- Add `COPY scripts/ ./scripts/` to the prod Dockerfile alongside `app/` and `alembic/`.

Without this, one-off operations (e.g. `scripts/reindex_search.py` after a deploy that introduces a new search index, or `scripts/populate_iqdb.py`) require bind-mounting `scripts/` into a `docker compose run` container, which is easy to miss and yields confusing "No such file or directory" errors. `.dockerignore` already excludes caches/venv/git, so the COPY just adds the source tree.

## Test plan
- [x] Rebuild image: `docker compose build api`
- [x] Verify scripts present: `docker compose run --rm api ls scripts/`
- [x] Run a one-off as a smoke test: `docker compose run --rm api uv run --no-project python scripts/reindex_search.py --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)