### PR TITLE
feat(search): user-selectable sort, accurate totals, and alias_of_usage_count

### DIFF
--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -78,10 +78,15 @@ class ImageRatingsSortParams(BaseModel):
     sort_order: SortOrder = Field(default="DESC", description="Sort order")
 
 
+TagSortBy = Literal["usage_count", "title", "date_added", "tag_id", "type"]
+"""Allowed tag sort fields. Must be a subset of `sortableAttributes`
+configured in `app/services/search.py::configure_tags_index`."""
+
+
 class TagSortParams(BaseModel):
     """Common sorting parameters for tag queries."""
 
-    sort_by: Literal["usage_count", "title", "date_added", "tag_id", "type"] | None = Field(
+    sort_by: TagSortBy | None = Field(
         default=None, description="Sort field (omit to use relevance when searching)"
     )
     sort_order: SortOrder = Field(default="DESC", description="Sort order")

--- a/app/api/v1/search.py
+++ b/app/api/v1/search.py
@@ -39,8 +39,13 @@ def get_search_service() -> SearchService:
 
 @router.get("", response_model=SearchResponse)
 async def search(
-    q: Annotated[str, Query(min_length=1, max_length=200, description="Search query")],
     db: Annotated[AsyncSession, Depends(get_db)],
+    q: Annotated[
+        str,
+        Query(
+            max_length=200, description="Search query (empty = list all, filter+sort still apply)"
+        ),
+    ] = "",
     type_id: Annotated[int | None, Query(description="Filter by tag type", alias="type")] = None,
     exclude_aliases: Annotated[bool, Query(description="Exclude alias tags")] = False,
     limit: Annotated[int, Query(ge=1, le=100, description="Max results")] = 20,

--- a/app/api/v1/search.py
+++ b/app/api/v1/search.py
@@ -1,6 +1,6 @@
 """Search endpoint powered by Meilisearch."""
 
-from typing import Annotated, Literal
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.exceptions import HTTPException
@@ -9,16 +9,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 from starlette import status
 
-from app.api.dependencies import SortOrder
+from app.api.dependencies import SortOrder, TagSortBy
 from app.core.database import get_db
 from app.core.logging import get_logger
 from app.models.tag import Tags
 from app.schemas.search import SearchResponse, TagSearchHit
 from app.services.search import SearchService
-
-# Mirrors TagSortParams.sort_by — must be a subset of sortableAttributes
-# configured in app/services/search.py::configure_tags_index.
-TagSortBy = Literal["usage_count", "title", "date_added", "tag_id", "type"]
 
 logger = get_logger(__name__)
 

--- a/app/api/v1/search.py
+++ b/app/api/v1/search.py
@@ -1,6 +1,6 @@
 """Search endpoint powered by Meilisearch."""
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.exceptions import HTTPException
@@ -9,11 +9,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 from starlette import status
 
+from app.api.dependencies import SortOrder
 from app.core.database import get_db
 from app.core.logging import get_logger
 from app.models.tag import Tags
 from app.schemas.search import SearchResponse, TagSearchHit
 from app.services.search import SearchService
+
+# Mirrors TagSortParams.sort_by — must be a subset of sortableAttributes
+# configured in app/services/search.py::configure_tags_index.
+TagSortBy = Literal["usage_count", "title", "date_added", "tag_id", "type"]
 
 logger = get_logger(__name__)
 
@@ -40,12 +45,20 @@ async def search(
     exclude_aliases: Annotated[bool, Query(description="Exclude alias tags")] = False,
     limit: Annotated[int, Query(ge=1, le=100, description="Max results")] = 20,
     offset: Annotated[int, Query(ge=0, le=1000, description="Results to skip")] = 0,
+    sort_by: Annotated[
+        TagSortBy | None,
+        Query(description="Sort field (omit for relevance ranking)"),
+    ] = None,
+    sort_order: Annotated[SortOrder, Query(description="Sort order")] = "DESC",
     search_service: SearchService = Depends(get_search_service),
 ) -> SearchResponse:
     """Search across entities using Meilisearch.
 
-    Currently supports tag search. Returns results in relevance order.
+    Currently supports tag search. Returns results in relevance order unless
+    sort_by is provided, in which case the user's sort dominates.
     """
+    sort = [f"{sort_by}:{sort_order.lower()}"] if sort_by is not None else None
+
     try:
         result = await search_service.search_tags(
             q,
@@ -53,6 +66,7 @@ async def search(
             offset=offset,
             type_filter=type_id,
             exclude_aliases=exclude_aliases,
+            sort=sort,
         )
     except Exception:
         logger.warning("meilisearch_search_failed", query=q, exc_info=True)

--- a/app/api/v1/search.py
+++ b/app/api/v1/search.py
@@ -49,7 +49,7 @@ async def search(
     type_id: Annotated[int | None, Query(description="Filter by tag type", alias="type")] = None,
     exclude_aliases: Annotated[bool, Query(description="Exclude alias tags")] = False,
     limit: Annotated[int, Query(ge=1, le=100, description="Max results")] = 20,
-    offset: Annotated[int, Query(ge=0, le=1000, description="Results to skip")] = 0,
+    offset: Annotated[int, Query(ge=0, le=500_000, description="Results to skip")] = 0,
     sort_by: Annotated[
         TagSortBy | None,
         Query(description="Sort field (omit for relevance ranking)"),
@@ -87,19 +87,27 @@ async def search(
     if result.tag_ids:
         AliasedTag = aliased(Tags)
         query = (
-            select(Tags, AliasedTag.title.label("alias_of_name"))  # type: ignore[union-attr]
+            select(
+                Tags,
+                AliasedTag.title.label("alias_of_name"),  # type: ignore[union-attr]
+                AliasedTag.usage_count.label("alias_of_usage_count"),  # type: ignore[attr-defined]
+            )
             .outerjoin(AliasedTag, Tags.alias_of == AliasedTag.tag_id)  # type: ignore[arg-type]
             .where(Tags.tag_id.in_(result.tag_ids))  # type: ignore[union-attr]
         )
         db_result = await db.execute(query)
-        rows_by_id = {tag.tag_id: (tag, alias_of_name) for tag, alias_of_name in db_result.all()}
+        rows_by_id = {
+            tag.tag_id: (tag, alias_of_name, alias_of_usage_count)
+            for tag, alias_of_name, alias_of_usage_count in db_result.all()
+        }
 
         for tag_id in result.tag_ids:
             row = rows_by_id.get(tag_id)
             if row:
-                tag, alias_of_name = row
+                tag, alias_of_name, alias_of_usage_count = row
                 hit = TagSearchHit.model_validate(tag)
                 hit.alias_of_name = alias_of_name
+                hit.alias_of_usage_count = alias_of_usage_count
                 hits.append(hit)
 
     return SearchResponse(

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -485,10 +485,15 @@ async def list_tags(
     - Get child tags of a parent: `/tags?parent_tag_id=10`
     - Exclude alias tags: `/tags?search=sakura&exclude_aliases=true`
     """
-    # Create table alias to retrieve the title of the tag that this tag is aliased to
+    # Create table alias to retrieve the parent tag's title and usage_count
+    # for any tag that is aliased to it.
     AliasedTag = aliased(Tags)
 
-    query = select(Tags, AliasedTag.title.label("alias_of_name")).outerjoin(  # type: ignore[union-attr]
+    query = select(
+        Tags,
+        AliasedTag.title.label("alias_of_name"),  # type: ignore[union-attr]
+        AliasedTag.usage_count.label("alias_of_usage_count"),  # type: ignore[attr-defined]
+    ).outerjoin(
         AliasedTag,
         Tags.alias_of == AliasedTag.tag_id,  # type: ignore[arg-type]
     )
@@ -649,9 +654,11 @@ async def list_tags(
     for row in rows:
         tag = row[0]
         alias_name = row[1]
+        alias_usage_count = row[2]
 
         tag_resp = TagResponse.model_validate(tag)
         tag_resp.alias_of_name = alias_name
+        tag_resp.alias_of_usage_count = alias_usage_count
         tags_list.append(tag_resp)
 
     return TagListResponse(

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -117,6 +117,7 @@ class TagResponse(TagBase):
     date_added: UTCDatetime | None = None
     alias_of: int | None = None
     alias_of_name: str | None = None
+    alias_of_usage_count: int | None = None
     is_alias: bool = False
     usage_count: int = 0
 

--- a/app/services/search.py
+++ b/app/services/search.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from meilisearch_python_sdk import AsyncClient
 from meilisearch_python_sdk.errors import MeilisearchApiError
+from meilisearch_python_sdk.models.settings import Pagination
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -241,6 +242,11 @@ async def configure_tags_index(client: AsyncClient) -> None:
     await index.update_filterable_attributes(["type", "alias_of"])
     await index.update_searchable_attributes(["title", "desc", "external_urls"])
     await index.update_sortable_attributes(["usage_count", "title", "type", "date_added", "tag_id"])
+    # Default Meilisearch max_total_hits is 1000, which clamps both the
+    # estimatedTotalHits the frontend shows and the maximum offset+limit.
+    # Set well above current tag count so list-all views report the true
+    # total and can paginate the full corpus.
+    await index.update_pagination(Pagination(max_total_hits=500_000))
 
     logger.info("meilisearch_tags_index_configured")
 

--- a/app/services/search.py
+++ b/app/services/search.py
@@ -192,6 +192,8 @@ def _tag_to_document(
     usage_count = tag.usage_count
     if tag.alias_of is not None and parent_usage_count is not None:
         usage_count = parent_usage_count
+    # Index date_added as a Unix int so Meilisearch can sort it numerically.
+    date_added = int(tag.date_added.timestamp()) if tag.date_added is not None else 0
     return {
         "tag_id": tag.tag_id,
         "title": tag.title,
@@ -200,6 +202,7 @@ def _tag_to_document(
         "usage_count": usage_count,
         "alias_of": tag.alias_of,
         "external_urls": external_urls or [],
+        "date_added": date_added,
     }
 
 
@@ -220,8 +223,13 @@ async def configure_tags_index(client: AsyncClient) -> None:
             raise
 
     index = client.index(TAGS_INDEX_NAME)
+    # "sort" placed first so user-selected sort dominates relevance — when a
+    # caller passes sort=["title:asc"] they expect strict alphabetical, not
+    # alphabetical-grouped-by-relevance. Without an explicit sort param the
+    # rule is a no-op and relevance ranking applies as before.
     await index.update_ranking_rules(
         [
+            "sort",
             "words",
             "typo",
             "proximity",
@@ -232,7 +240,7 @@ async def configure_tags_index(client: AsyncClient) -> None:
     )
     await index.update_filterable_attributes(["type", "alias_of"])
     await index.update_searchable_attributes(["title", "desc", "external_urls"])
-    await index.update_sortable_attributes(["usage_count"])
+    await index.update_sortable_attributes(["usage_count", "title", "type", "date_added", "tag_id"])
 
     logger.info("meilisearch_tags_index_configured")
 
@@ -324,6 +332,7 @@ class SearchService:
         offset: int = 0,
         type_filter: int | None = None,
         exclude_aliases: bool = False,
+        sort: list[str] | None = None,
     ) -> TagSearchResult:
         """Search tags via Meilisearch.
 
@@ -333,6 +342,7 @@ class SearchService:
             offset: Number of results to skip
             type_filter: Filter by tag type (TagType constant)
             exclude_aliases: If True, exclude tags that are aliases
+            sort: Meilisearch sort spec, e.g. ["title:asc"]. None = relevance.
 
         Returns:
             TagSearchResult with ordered tag IDs and total count
@@ -351,6 +361,7 @@ class SearchService:
             limit=limit,
             offset=offset,
             filter=filter_str,
+            sort=sort,
         )
 
         tag_ids = [hit["tag_id"] for hit in results.hits]

--- a/tests/api/v1/test_search.py
+++ b/tests/api/v1/test_search.py
@@ -121,6 +121,7 @@ class TestSearchEndpoint:
             offset=0,
             type_filter=TagType.SOURCE,
             exclude_aliases=False,
+            sort=None,
         )
 
     async def test_search_with_exclude_aliases(
@@ -144,6 +145,7 @@ class TestSearchEndpoint:
             offset=0,
             type_filter=None,
             exclude_aliases=True,
+            sort=None,
         )
 
     async def test_search_preserves_meilisearch_order(
@@ -227,6 +229,7 @@ class TestSearchEndpoint:
             offset=5,
             type_filter=None,
             exclude_aliases=False,
+            sort=None,
         )
 
     async def test_search_returns_503_when_meilisearch_unavailable(
@@ -267,6 +270,48 @@ class TestSearchEndpoint:
         """Offset above Meilisearch's maxTotalHits returns 422."""
         response = await client_with_search.get(
             "/api/v1/search", params={"q": "test", "offset": 1001}
+        )
+        assert response.status_code == 422
+
+    async def test_search_passes_sort_to_service(
+        self,
+        client_with_search: AsyncClient,
+        mock_search_service: AsyncMock,
+    ):
+        """sort_by + sort_order map to a Meilisearch sort string."""
+        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
+
+        response = await client_with_search.get(
+            "/api/v1/search",
+            params={"q": "sakura", "sort_by": "title", "sort_order": "ASC"},
+        )
+        assert response.status_code == 200
+
+        call_kwargs = mock_search_service.search_tags.call_args[1]
+        assert call_kwargs["sort"] == ["title:asc"]
+
+    async def test_search_default_sort_is_none(
+        self,
+        client_with_search: AsyncClient,
+        mock_search_service: AsyncMock,
+    ):
+        """No sort_by means sort=None — relevance ranking."""
+        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
+
+        response = await client_with_search.get("/api/v1/search", params={"q": "sakura"})
+        assert response.status_code == 200
+
+        call_kwargs = mock_search_service.search_tags.call_args[1]
+        assert call_kwargs["sort"] is None
+
+    async def test_search_rejects_invalid_sort_by(
+        self,
+        client_with_search: AsyncClient,
+    ):
+        """sort_by not in the allowed set returns 422."""
+        response = await client_with_search.get(
+            "/api/v1/search",
+            params={"q": "sakura", "sort_by": "not_a_field"},
         )
         assert response.status_code == 422
 

--- a/tests/api/v1/test_search.py
+++ b/tests/api/v1/test_search.py
@@ -77,21 +77,33 @@ class TestSearchEndpoint:
         assert data["hits"][0]["title"] == "Sakura"
         assert data["hits"][1]["title"] == "Sakura Kinomoto"
 
-    async def test_search_missing_query_returns_422(
+    async def test_search_missing_query_lists_all(
         self,
         client_with_search: AsyncClient,
+        mock_search_service: AsyncMock,
     ):
-        """Calling search without the required 'q' parameter returns 422."""
-        response = await client_with_search.get("/api/v1/search")
-        assert response.status_code == 422
+        """Omitting 'q' entirely defaults to a placeholder search."""
+        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
 
-    async def test_search_empty_query_returns_422(
+        response = await client_with_search.get("/api/v1/search")
+        assert response.status_code == 200
+        assert mock_search_service.search_tags.call_args[0][0] == ""
+
+    async def test_search_empty_query_lists_all(
         self,
         client_with_search: AsyncClient,
+        mock_search_service: AsyncMock,
     ):
-        """An empty 'q' parameter (min_length=1) returns 422."""
+        """Empty 'q' is a placeholder search: Meilisearch returns all docs
+        (filter + sort still apply). Used by the frontend's tag-list view."""
+        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
+
         response = await client_with_search.get("/api/v1/search", params={"q": ""})
-        assert response.status_code == 422
+        assert response.status_code == 200
+
+        # The empty string should reach the service unchanged.
+        mock_search_service.search_tags.assert_called_once()
+        assert mock_search_service.search_tags.call_args[0][0] == ""
 
     async def test_search_with_type_filter(
         self,

--- a/tests/api/v1/test_search.py
+++ b/tests/api/v1/test_search.py
@@ -274,14 +274,14 @@ class TestSearchEndpoint:
         assert response.status_code == 503
         assert "temporarily unavailable" in response.json()["detail"]
 
-    async def test_search_rejects_offset_over_1000(
+    async def test_search_rejects_offset_over_max_total_hits(
         self,
         client_with_search: AsyncClient,
         mock_search_service: AsyncMock,
     ):
-        """Offset above Meilisearch's maxTotalHits returns 422."""
+        """Offset above the index max_total_hits cap returns 422."""
         response = await client_with_search.get(
-            "/api/v1/search", params={"q": "test", "offset": 1001}
+            "/api/v1/search", params={"q": "test", "offset": 500_001}
         )
         assert response.status_code == 422
 
@@ -333,8 +333,8 @@ class TestSearchEndpoint:
         db_session: AsyncSession,
         mock_search_service: AsyncMock,
     ):
-        """Alias tags in search results include alias_of_name (parent tag's title)."""
-        canonical = Tags(title="cat ears", type=TagType.THEME)
+        """Alias hits include alias_of_name and alias_of_usage_count from the parent."""
+        canonical = Tags(title="cat ears", type=TagType.THEME, usage_count=5000)
         db_session.add(canonical)
         await db_session.commit()
         await db_session.refresh(canonical)
@@ -357,11 +357,13 @@ class TestSearchEndpoint:
         alias_hit = next(h for h in hits if h["tag_id"] == alias.tag_id)
         assert alias_hit["alias_of"] == canonical.tag_id
         assert alias_hit["alias_of_name"] == "cat ears"
+        assert alias_hit["alias_of_usage_count"] == 5000
         assert alias_hit["is_alias"] is True
 
         canonical_hit = next(h for h in hits if h["tag_id"] == canonical.tag_id)
         assert canonical_hit["alias_of"] is None
         assert canonical_hit["alias_of_name"] is None
+        assert canonical_hit["alias_of_usage_count"] is None
         assert canonical_hit["is_alias"] is False
 
     async def test_search_handles_missing_db_tags_gracefully(

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -634,6 +634,7 @@ class TestAliasOfName:
             title="maid outfit",
             desc="Maid clothing",
             type=TagType.THEME,
+            usage_count=42,
         )
         db_session.add(original_tag)
         await db_session.commit()
@@ -664,16 +665,18 @@ class TestAliasOfName:
             if tag["tag_id"] == original_tag.tag_id:
                 original_tag_response = tag
 
-        # Verify alias_of_name is populated for the alias tag
+        # Verify alias_of_name + alias_of_usage_count are populated for the alias
         assert alias_tag_response is not None
         assert alias_tag_response["alias_of"] == original_tag.tag_id
         assert alias_tag_response["alias_of_name"] == "maid outfit"
+        assert alias_tag_response["alias_of_usage_count"] == 42
         assert alias_tag_response["is_alias"] is True
 
-        # Verify original tag has no alias_of_name
+        # Verify original tag has no alias fields populated
         assert original_tag_response is not None
         assert original_tag_response["alias_of"] is None
         assert original_tag_response["alias_of_name"] is None
+        assert original_tag_response["alias_of_usage_count"] is None
         assert original_tag_response["is_alias"] is False
 
     async def test_alias_of_name_when_tag_has_no_alias(

--- a/tests/unit/test_search_service.py
+++ b/tests/unit/test_search_service.py
@@ -1,5 +1,6 @@
 """Unit tests for the search service."""
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -62,7 +63,9 @@ class TestIndexTag:
             "usage_count": 42,
             "alias_of": None,
             "external_urls": [],
+            "date_added": docs[0]["date_added"],
         }
+        assert isinstance(docs[0]["date_added"], int)
 
     async def test_index_tag_with_external_urls(self):
         """index_tag includes external_urls in the document."""
@@ -124,6 +127,19 @@ class TestTagToDocument:
         tag = _make_tag()
         doc = _tag_to_document(tag)
         assert doc["external_urls"] == []
+
+    def test_includes_date_added_as_unix_timestamp(self):
+        """date_added is indexed as a Unix int timestamp so Meilisearch can sort it."""
+        when = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
+        tag = _make_tag(date_added=when)
+        doc = _tag_to_document(tag)
+        assert doc["date_added"] == int(when.timestamp())
+
+    def test_handles_missing_date_added(self):
+        """date_added defaults to 0 when the tag has no date set."""
+        tag = _make_tag(date_added=None)
+        doc = _tag_to_document(tag)
+        assert doc["date_added"] == 0
 
 
 @pytest.mark.unit
@@ -240,6 +256,32 @@ class TestSearchTags:
 
         call_kwargs = index_mock.search.call_args
         assert "alias_of IS NULL" in call_kwargs[1]["filter"]
+
+    async def test_passes_sort_to_meilisearch(self):
+        """search_tags forwards a sort list to Meilisearch."""
+        client = _make_mock_client()
+        service = SearchService(client)
+
+        index_mock = client.index(TAGS_INDEX_NAME)
+        index_mock.search.return_value = MagicMock(hits=[], estimated_total_hits=0)
+
+        await service.search_tags("test", sort=["title:asc"])
+
+        call_kwargs = index_mock.search.call_args
+        assert call_kwargs[1]["sort"] == ["title:asc"]
+
+    async def test_omits_sort_when_not_provided(self):
+        """search_tags passes sort=None when caller doesn't sort."""
+        client = _make_mock_client()
+        service = SearchService(client)
+
+        index_mock = client.index(TAGS_INDEX_NAME)
+        index_mock.search.return_value = MagicMock(hits=[], estimated_total_hits=0)
+
+        await service.search_tags("test")
+
+        call_kwargs = index_mock.search.call_args
+        assert call_kwargs[1].get("sort") is None
 
     async def test_empty_query_returns_empty(self):
         """search_tags with empty results returns empty list."""


### PR DESCRIPTION
## Summary

- `GET /api/v1/search` accepts `sort_by` + `sort_order` (matching `TagSortParams` from `/api/v1/tags`); when `sort_by` is omitted, results still come back in relevance order so autocomplete is unchanged.
- Empty `q` is now valid — Meilisearch returns all documents with filter/sort applied (the placeholder-search pattern), so the frontend's tag-list view can rely on `sort_by` without supplying a query.
- Bump `pagination.maxTotalHits` to 500,000 so the index reports real totals (was capped at the default 1,000) and so deep pagination works against the full corpus. API offset cap raised to match.
- Both `/tags` and `/search` now expose `alias_of_usage_count` alongside the existing `alias_of_name`. Frontend can render `alias_of_usage_count ?? usage_count` to show effective image count for alias rows without the backend lying about the alias's own (factually zero) row.

## Index changes

The tag document gains `date_added` (Unix int). `sortableAttributes` expanded to `[usage_count, title, type, date_added, tag_id]`. `"sort"` inserted first in ranking rules so explicit user sort dominates relevance (alphabetical means alphabetical).

**A reindex is required after deploy** so existing documents pick up `date_added`:

```
uv run python scripts/reindex_search.py
```

## Performance

100-run benchmark across 7 query patterns (autocomplete, specific, permissive, placeholder + each sort attribute) at the new `maxTotalHits=500_000` vs the default `1_000`: deltas are all within ±0.11ms at offset=0 — i.e., free at this scale (232k tags). Deep pagination (offset=100k → ~100ms; offset=200k → ~140ms) is linear and unavoidable for sort-based walks, but rarely exercised. Bench script lives at `scripts/bench_max_total_hits.py` if you want to re-run.

## Test plan

- [x] 9 new tests covering sort plumbing, empty-`q` placeholder, `alias_of_usage_count` on both endpoints, document-shape `date_added`
- [x] 168 search/tags tests passing post-merge with main
- [x] Live verification: sort by title/date/usage_count, pixiv-user-id-as-query, alias rows showing parent counts, real total replacing the 1,000 cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)