### PR TITLE
chore(iqdb): note that add_to_iqdb() appears unused

### DIFF
--- a/app/services/iqdb.py
+++ b/app/services/iqdb.py
@@ -80,7 +80,11 @@ async def check_iqdb_similarity(
 def add_to_iqdb(image_id: int, thumb_path: FilePath) -> None:
     """Add image to IQDB index for future similarity searches using REST API.
 
-    Called by add_to_iqdb_job in app/tasks/image_jobs.py (ARQ task).
+    UNUSED as of this writing -- `add_to_iqdb_job` in app/tasks/image_jobs.py
+    inlines the same HTTP call rather than calling this function. Kept for
+    now in case external scripts/tools depend on it; verify no callers
+    (`grep -r 'add_to_iqdb\\b'`) before deleting.
+
     Makes HTTP POST request to IQDB images endpoint to index the thumbnail.
 
     Args:


### PR DESCRIPTION
## Summary
A grep across \`app/\`, \`tests/\`, and \`scripts/\` finds no callers of \`app/services/iqdb.py::add_to_iqdb\` (excluding the unrelated \`add_to_iqdb_job\`, \`check_iqdb_similarity\`, \`remove_from_iqdb\`). \`add_to_iqdb_job\` in \`app/tasks/image_jobs.py\` inlines the same HTTP call rather than delegating to this helper, despite the docstring claiming otherwise.

Just leaving a note for the next person who looks at this file. Not deleting the function in case external scripts or tooling depend on it; the note tells them to verify with grep before removing.

## Test plan
- [ ] No code change — docstring only. CI green should be sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)