### PR TITLE
feat: extend R2 storage to avatars and banners

### DIFF
--- a/alembic/versions/7b2101b37080_add_in_r2_to_banners.py
+++ b/alembic/versions/7b2101b37080_add_in_r2_to_banners.py
@@ -32,5 +32,12 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Remove in_r2 column."""
-    op.drop_column("banners", "in_r2")
+    """Remove in_r2 column.
+
+    Mirror the upgrade's metadata-only ALTER (ALGORITHM=INSTANT, LOCK=NONE)
+    so the rollback path is non-locking too.
+    """
+    op.execute(
+        "ALTER TABLE banners DROP COLUMN in_r2, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )

--- a/alembic/versions/7b2101b37080_add_in_r2_to_banners.py
+++ b/alembic/versions/7b2101b37080_add_in_r2_to_banners.py
@@ -1,0 +1,36 @@
+"""add in_r2 to banners
+
+Revision ID: 7b2101b37080
+Revises: 832e3165122d
+Create Date: 2026-05-08 13:41:28.364492
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7b2101b37080'
+down_revision: str | Sequence[str] | None = '832e3165122d'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add in_r2 to banners.
+
+    Tracks whether all of full_image / left_image / middle_image / right_image
+    referenced by this row exist in R2. Default 0 — backfill is a separate
+    one-shot run via `scripts/r2_sync.py banners-backfill`.
+    """
+    op.execute(
+        "ALTER TABLE banners ADD COLUMN in_r2 BOOLEAN NOT NULL DEFAULT 0, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )
+
+
+def downgrade() -> None:
+    """Remove in_r2 column."""
+    op.drop_column("banners", "in_r2")

--- a/alembic/versions/832e3165122d_add_avatar_in_r2_to_users.py
+++ b/alembic/versions/832e3165122d_add_avatar_in_r2_to_users.py
@@ -35,5 +35,12 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Remove avatar_in_r2 column."""
-    op.drop_column("users", "avatar_in_r2")
+    """Remove avatar_in_r2 column.
+
+    Mirror the upgrade's metadata-only ALTER (ALGORITHM=INSTANT, LOCK=NONE)
+    so the rollback path is non-locking too.
+    """
+    op.execute(
+        "ALTER TABLE users DROP COLUMN avatar_in_r2, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )

--- a/alembic/versions/832e3165122d_add_avatar_in_r2_to_users.py
+++ b/alembic/versions/832e3165122d_add_avatar_in_r2_to_users.py
@@ -1,0 +1,39 @@
+"""add avatar_in_r2 to users
+
+Revision ID: 832e3165122d
+Revises: 6f286ed3c418
+Create Date: 2026-05-08 13:40:56.544377
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '832e3165122d'
+down_revision: str | Sequence[str] | None = '6f286ed3c418'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add avatar_in_r2 to users.
+
+    Tracks whether the avatar file referenced by users.avatar exists in R2.
+    Default 0 — backfill is a separate one-shot run via
+    `scripts/r2_sync.py avatars-backfill`.
+
+    Uses ALGORITHM=INSTANT, LOCK=NONE so the migration is metadata-only on
+    InnoDB (MariaDB 12) — no table rewrite, no row locks.
+    """
+    op.execute(
+        "ALTER TABLE users ADD COLUMN avatar_in_r2 BOOLEAN NOT NULL DEFAULT 0, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )
+
+
+def downgrade() -> None:
+    """Remove avatar_in_r2 column."""
+    op.drop_column("users", "avatar_in_r2")

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -128,6 +128,7 @@ async def _build_user_summaries(db: AsyncSession, user_ids: set[int]) -> dict[in
             user_id=user.id,
             username=user.username,
             avatar=user.avatar,
+            avatar_in_r2=user.avatar_in_r2,
             user_title=user.user_title,
             groups=user.groups,
         )

--- a/app/api/v1/comments.py
+++ b/app/api/v1/comments.py
@@ -666,6 +666,7 @@ async def report_comment(
             user_id=reporter.id,
             username=reporter.username,
             avatar=reporter.avatar,
+            avatar_in_r2=reporter.avatar_in_r2,
             user_title=reporter.user_title,
             groups=reporter.groups,
         ),

--- a/app/api/v1/favorites.py
+++ b/app/api/v1/favorites.py
@@ -51,6 +51,7 @@ async def get_favorite_images(
                 Users.user_id,  # type: ignore[arg-type]
                 Users.username,  # type: ignore[arg-type]
                 Users.avatar,  # type: ignore[arg-type]
+                Users.avatar_in_r2,  # type: ignore[arg-type]
                 Users.user_title,  # type: ignore[arg-type]
             )
         )

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -145,6 +145,7 @@ async def _hydrate_similar_images(
                 Users.user_id,  # type: ignore[arg-type]
                 Users.username,  # type: ignore[arg-type]
                 Users.avatar,  # type: ignore[arg-type]
+                Users.avatar_in_r2,  # type: ignore[arg-type]
                 Users.user_title,  # type: ignore[arg-type]
             )
         )
@@ -1326,6 +1327,7 @@ async def search_by_hash(
                 Users.user_id,  # type: ignore[arg-type]
                 Users.username,  # type: ignore[arg-type]
                 Users.avatar,  # type: ignore[arg-type]
+                Users.avatar_in_r2,  # type: ignore[arg-type]
                 Users.user_title,  # type: ignore[arg-type]
             )
         )
@@ -1557,6 +1559,7 @@ async def get_bookmark_image(
                 Users.user_id,  # type: ignore[arg-type]
                 Users.username,  # type: ignore[arg-type]
                 Users.avatar,  # type: ignore[arg-type]
+                Users.avatar_in_r2,  # type: ignore[arg-type]
                 Users.user_title,  # type: ignore[arg-type]
             )
         )

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1120,6 +1120,7 @@ async def get_image_tag_history(
                 user_id=user.user_id,
                 username=user.username,
                 avatar=user.avatar,
+                avatar_in_r2=user.avatar_in_r2,
                 user_title=user.user_title,
                 groups=user.groups if user else [],
             )
@@ -1205,6 +1206,7 @@ async def get_image_status_history(
                 user_id=user.user_id,
                 username=user.username,
                 avatar=user.avatar,
+                avatar_in_r2=user.avatar_in_r2,
                 user_title=user.user_title,
                 groups=user.groups if user else [],
             )
@@ -2505,6 +2507,7 @@ async def report_image(
         user_id=reporter.id,
         username=reporter.username,
         avatar=reporter.avatar,
+        avatar_in_r2=reporter.avatar_in_r2,
         user_title=reporter.user_title,
         groups=reporter.groups,
     )

--- a/app/api/v1/privmsgs.py
+++ b/app/api/v1/privmsgs.py
@@ -12,7 +12,6 @@ from sqlalchemy import and_, case, delete, desc, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import PaginationParams
-from app.config import settings
 from app.core.auth import VerifiedUser, get_current_user
 from app.core.database import get_db
 from app.core.permissions import Permission, has_permission
@@ -26,6 +25,7 @@ from app.schemas.privmsg import (
     ThreadList,
     ThreadSummary,
 )
+from app.services.avatar import avatar_url
 from app.tasks.queue import enqueue_job
 
 router = APIRouter(prefix="/privmsgs", tags=["privmsgs"])
@@ -229,11 +229,13 @@ async def get_threads(
 
     # Fetch other user details (username, avatar)
     user_result = await db.execute(
-        select(Users.user_id, Users.username, Users.avatar).where(Users.user_id.in_(other_user_ids))  # type: ignore[call-overload,union-attr]
+        select(Users.user_id, Users.username, Users.avatar, Users.avatar_in_r2).where(  # type: ignore[call-overload]
+            Users.user_id.in_(other_user_ids)  # type: ignore[union-attr]
+        )
     )
     user_rows = user_result.all()
-    user_map: dict[int, tuple[str | None, str | None]] = {
-        row[0]: (row[1], row[2]) for row in user_rows
+    user_map: dict[int, tuple[str | None, str | None, bool]] = {
+        row[0]: (row[1], row[2], row[3]) for row in user_rows
     }
 
     # Fetch groups for other users
@@ -267,10 +269,8 @@ async def get_threads(
     # Build thread summaries
     threads: list[ThreadSummary] = []
     for row in thread_rows:
-        username, avatar = user_map.get(row.other_user_id, (None, None))
-        avatar_url: str | None = None
-        if avatar:
-            avatar_url = f"{settings.IMAGE_BASE_URL}/images/avatars/{avatar}"
+        username, avatar, avatar_in_r2 = user_map.get(row.other_user_id, (None, None, False))
+        other_avatar_url = avatar_url(avatar, avatar_in_r2)
 
         subject = _strip_re_prefix(row.subject or "")
         preview_text = latest_text_map.get(row.thread_id, "")
@@ -283,7 +283,7 @@ async def get_threads(
                 subject=subject,
                 other_user_id=row.other_user_id,
                 other_username=username,
-                other_avatar_url=avatar_url,
+                other_avatar_url=other_avatar_url,
                 other_groups=groups_map.get(row.other_user_id, []),
                 latest_message_preview=preview_text,
                 latest_message_date=row.latest_date.isoformat() if row.latest_date else "",
@@ -378,8 +378,10 @@ async def get_thread_messages(
             Privmsgs,
             SenderUser.c.username.label("sender_username"),
             SenderUser.c.avatar.label("sender_avatar"),
+            SenderUser.c.avatar_in_r2.label("sender_avatar_in_r2"),
             RecipientUser.c.username.label("recipient_username"),
             RecipientUser.c.avatar.label("recipient_avatar"),
+            RecipientUser.c.avatar_in_r2.label("recipient_avatar_in_r2"),
         )
         .join(SenderUser, Privmsgs.from_user_id == SenderUser.c.user_id, isouter=True)
         .join(RecipientUser, Privmsgs.to_user_id == RecipientUser.c.user_id, isouter=True)
@@ -406,15 +408,13 @@ async def get_thread_messages(
         msg = row[0]
         sender_username = row[1]
         sender_avatar = row[2]
-        recipient_username = row[3]
-        recipient_avatar = row[4]
+        sender_avatar_in_r2 = bool(row[3])
+        recipient_username = row[4]
+        recipient_avatar = row[5]
+        recipient_avatar_in_r2 = bool(row[6])
 
-        from_avatar_url: str | None = None
-        to_avatar_url: str | None = None
-        if sender_avatar:
-            from_avatar_url = f"{settings.IMAGE_BASE_URL}/images/avatars/{sender_avatar}"
-        if recipient_avatar:
-            to_avatar_url = f"{settings.IMAGE_BASE_URL}/images/avatars/{recipient_avatar}"
+        from_avatar_url = avatar_url(sender_avatar, sender_avatar_in_r2)
+        to_avatar_url = avatar_url(recipient_avatar, recipient_avatar_in_r2)
 
         data = {
             "privmsg_id": msg.privmsg_id,
@@ -551,7 +551,7 @@ async def get_received_privmsgs(
 
     # Query messages with sender username and avatar joined (outer join to be safe)
     query = (
-        select(Privmsgs, Users.username, Users.avatar)  # type: ignore[call-overload]
+        select(Privmsgs, Users.username, Users.avatar, Users.avatar_in_r2)  # type: ignore[call-overload]
         .join(Users, Privmsgs.from_user_id == Users.user_id, isouter=True)
         .where(Privmsgs.to_user_id == target_user_id)
         .order_by(desc(Privmsgs.date))  # type: ignore[arg-type]
@@ -572,9 +572,8 @@ async def get_received_privmsgs(
         msg: Privmsgs = row[0]
         sender_username: str | None = row[1] if len(row) > 1 else None
         sender_avatar: str | None = row[2] if len(row) > 2 else None
-        from_avatar_url: str | None = None
-        if sender_avatar:
-            from_avatar_url = f"{settings.IMAGE_BASE_URL}/images/avatars/{sender_avatar}"
+        sender_avatar_in_r2: bool = bool(row[3]) if len(row) > 3 else False
+        from_avatar_url = avatar_url(sender_avatar, sender_avatar_in_r2)
 
         data = {
             "privmsg_id": msg.privmsg_id,
@@ -641,7 +640,7 @@ async def get_sent_privmsgs(
 
     # Query messages with recipient username and avatar joined (outer join to be safe)
     query = (
-        select(Privmsgs, Users.username, Users.avatar)  # type: ignore[call-overload]
+        select(Privmsgs, Users.username, Users.avatar, Users.avatar_in_r2)  # type: ignore[call-overload]
         .join(Users, Privmsgs.to_user_id == Users.user_id, isouter=True)
         .where(Privmsgs.from_user_id == target_user_id)
         .order_by(desc(Privmsgs.date))  # type: ignore[arg-type]
@@ -662,9 +661,8 @@ async def get_sent_privmsgs(
         msg: Privmsgs = row[0]
         recipient_username: str | None = row[1] if len(row) > 1 else None
         recipient_avatar: str | None = row[2] if len(row) > 2 else None
-        to_avatar_url: str | None = None
-        if recipient_avatar:
-            to_avatar_url = f"{settings.IMAGE_BASE_URL}/images/avatars/{recipient_avatar}"
+        recipient_avatar_in_r2: bool = bool(row[3]) if len(row) > 3 else False
+        to_avatar_url = avatar_url(recipient_avatar, recipient_avatar_in_r2)
 
         data = {
             "privmsg_id": msg.privmsg_id,
@@ -722,25 +720,29 @@ async def get_privmsg(
 
     # Try to fetch usernames and avatars for sender/recipient
     sender_res = await db.execute(
-        select(Users.username, Users.avatar).where(Users.user_id == msg.from_user_id)  # type: ignore[call-overload]
+        select(Users.username, Users.avatar, Users.avatar_in_r2).where(  # type: ignore[call-overload]
+            Users.user_id == msg.from_user_id
+        )
     )
     sender_row = sender_res.first()
     recipient_res = await db.execute(
-        select(Users.username, Users.avatar).where(Users.user_id == msg.to_user_id)  # type: ignore[call-overload]
+        select(Users.username, Users.avatar, Users.avatar_in_r2).where(  # type: ignore[call-overload]
+            Users.user_id == msg.to_user_id
+        )
     )
     recipient_row = recipient_res.first()
 
     sender_username = sender_row[0] if sender_row else None
     sender_avatar = sender_row[1] if sender_row and len(sender_row) > 1 else None
+    sender_avatar_in_r2 = bool(sender_row[2]) if sender_row and len(sender_row) > 2 else False
     recipient_username = recipient_row[0] if recipient_row else None
     recipient_avatar = recipient_row[1] if recipient_row and len(recipient_row) > 1 else None
+    recipient_avatar_in_r2 = (
+        bool(recipient_row[2]) if recipient_row and len(recipient_row) > 2 else False
+    )
 
-    from_avatar_url: str | None = None
-    to_avatar_url: str | None = None
-    if sender_avatar:
-        from_avatar_url = f"{settings.IMAGE_BASE_URL}/images/avatars/{sender_avatar}"
-    if recipient_avatar:
-        to_avatar_url = f"{settings.IMAGE_BASE_URL}/images/avatars/{recipient_avatar}"
+    from_avatar_url = avatar_url(sender_avatar, sender_avatar_in_r2)
+    to_avatar_url = avatar_url(recipient_avatar, recipient_avatar_in_r2)
 
     # Fetch groups for both sender and recipient
     user_ids = [uid for uid in [msg.from_user_id, msg.to_user_id] if uid]

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -763,6 +763,7 @@ async def get_images_by_tag(
                 Users.user_id,  # type: ignore[arg-type]
                 Users.username,  # type: ignore[arg-type]
                 Users.avatar,  # type: ignore[arg-type]
+                Users.avatar_in_r2,  # type: ignore[arg-type]
                 Users.user_title,  # type: ignore[arg-type]
             )
         )
@@ -933,6 +934,7 @@ async def get_tag(
             user_id=user.user_id or 0,
             username=user.username,
             avatar=user.avatar or None,
+            avatar_in_r2=user.avatar_in_r2,
             user_title=user.user_title,
             groups=user.groups,  # Uses the eager-loaded groups property
         )
@@ -1100,6 +1102,7 @@ async def get_tag_history(
                 user_id=user.user_id,
                 username=user.username,
                 avatar=user.avatar,
+                avatar_in_r2=user.avatar_in_r2,
                 user_title=user.user_title,
                 groups=user.groups if user else [],
             )
@@ -1216,6 +1219,7 @@ async def get_tag_usage_history(
                 user_id=user.user_id,
                 username=user.username,
                 avatar=user.avatar,
+                avatar_in_r2=user.avatar_in_r2,
                 user_title=user.user_title,
                 groups=user.groups if user else [],
             )

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -670,6 +670,7 @@ async def get_user_images(
                 Users.user_id,  # type: ignore[arg-type]
                 Users.username,  # type: ignore[arg-type]
                 Users.avatar,  # type: ignore[arg-type]
+                Users.avatar_in_r2,  # type: ignore[arg-type]
                 Users.user_title,  # type: ignore[arg-type]
             ),
             selectinload(Images.tag_links).selectinload(TagLinks.tag),  # type: ignore[arg-type]
@@ -784,6 +785,7 @@ async def get_user_favorites(
                 Users.user_id,  # type: ignore[arg-type]
                 Users.username,  # type: ignore[arg-type]
                 Users.avatar,  # type: ignore[arg-type]
+                Users.avatar_in_r2,  # type: ignore[arg-type]
                 Users.user_title,  # type: ignore[arg-type]
             ),
             selectinload(Images.tag_links).selectinload(TagLinks.tag),  # type: ignore[arg-type]

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -324,7 +324,7 @@ async def _upload_avatar(
 
         # Clean up old avatar if orphaned (after commit to ensure new one is saved)
         if old_avatar and old_avatar != new_filename:
-            await delete_avatar_if_orphaned(old_avatar, db)
+            await delete_avatar_if_orphaned(old_avatar, user.avatar_in_r2, db)
 
     finally:
         # Clean up temp file
@@ -465,15 +465,17 @@ async def _delete_avatar(
 
     # Save old avatar filename for cleanup
     old_avatar = user.avatar
+    old_in_r2 = user.avatar_in_r2
 
     # Clear avatar
     user.avatar = ""
+    user.avatar_in_r2 = False
     await db.commit()
     await db.refresh(user)
 
     # Clean up old avatar file if orphaned
     if old_avatar:
-        await delete_avatar_if_orphaned(old_avatar, db)
+        await delete_avatar_if_orphaned(old_avatar, old_in_r2, db)
 
     return UserResponse.model_validate(user)
 

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -27,7 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.api.dependencies import ImageSortParams, PaginationParams, UserSortParams
-from app.config import SuspensionAction
+from app.config import SuspensionAction, settings
 from app.core.auth import (
     get_client_ip,
     get_current_user,
@@ -35,8 +35,10 @@ from app.core.auth import (
     get_optional_current_user,
 )
 from app.core.database import get_db
+from app.core.logging import get_logger
 from app.core.permission_cache import get_cached_user_permissions
 from app.core.permissions import Permission, has_permission
+from app.core.r2_client import get_r2_storage
 from app.core.redis import get_redis
 from app.core.security import RedactedStr, get_password_hash, validate_password_strength
 from app.models import Favorites, Images, Privmsgs, TagLinks, Users
@@ -55,6 +57,7 @@ from app.schemas.user import (
     UserWarningsResponse,
 )
 from app.services.avatar import (
+    _avatar_content_type,
     delete_avatar_if_orphaned,
     resize_avatar,
     save_avatar,
@@ -65,6 +68,8 @@ from app.services.rate_limit import check_registration_rate_limit
 from app.services.turnstile import verify_turnstile_token
 from app.services.upload import get_uploads_today
 from app.tasks.queue import enqueue_job
+
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -298,8 +303,12 @@ async def _upload_avatar(
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
 
-    # Save old avatar filename for potential cleanup
+    # Capture old avatar state BEFORE any mutation. The orphan helper needs
+    # the old `avatar_in_r2` bit to know whether to issue an R2 delete; if we
+    # captured it after the commit below, the new value would have already
+    # overwritten the old one.
     old_avatar = user.avatar
+    old_in_r2 = user.avatar_in_r2
 
     # Save uploaded file to temp location for validation
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
@@ -317,14 +326,47 @@ async def _upload_avatar(
         # Save to permanent storage
         new_filename = save_avatar(processed_content, ext)
 
+        # Best-effort dual-write to R2. Failure is non-fatal: the local file
+        # is the source of truth during the dual-write phase. A failed upload
+        # leaves avatar_in_r2=False and the URL falls back to local.
+        new_in_r2 = False
+        if settings.R2_ENABLED:
+            try:
+                r2 = get_r2_storage()
+                await r2.upload_bytes(
+                    bucket=settings.R2_PUBLIC_BUCKET,
+                    key=f"avatars/{new_filename}",
+                    body=processed_content,
+                    content_type=_avatar_content_type(ext),
+                )
+                new_in_r2 = True
+                logger.info(
+                    "avatar_r2_uploaded",
+                    user_id=user_id,
+                    key=f"avatars/{new_filename}",
+                )
+            except Exception as e:
+                logger.warning(
+                    "avatar_r2_upload_failed",
+                    user_id=user_id,
+                    key=f"avatars/{new_filename}",
+                    error=type(e).__name__,
+                    error_msg=str(e),
+                )
+
         # Update user record
         user.avatar = new_filename
+        user.avatar_in_r2 = new_in_r2
         await db.commit()
         await db.refresh(user)
 
-        # Clean up old avatar if orphaned (after commit to ensure new one is saved)
+        # Clean up old avatar if orphaned (after commit to ensure new one is
+        # saved). The orphan check counts users referencing old_avatar AFTER
+        # the commit — so a same-MD5 re-upload (new_filename == old_avatar)
+        # finds the user themselves still references it (count >= 1) and
+        # safely skips deletion.
         if old_avatar and old_avatar != new_filename:
-            await delete_avatar_if_orphaned(old_avatar, user.avatar_in_r2, db)
+            await delete_avatar_if_orphaned(old_avatar, old_in_r2, db)
 
     finally:
         # Clean up temp file

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -57,7 +57,7 @@ from app.schemas.user import (
     UserWarningsResponse,
 )
 from app.services.avatar import (
-    _avatar_content_type,
+    avatar_content_type,
     delete_avatar_if_orphaned,
     resize_avatar,
     save_avatar,
@@ -337,7 +337,7 @@ async def _upload_avatar(
                     bucket=settings.R2_PUBLIC_BUCKET,
                     key=f"avatars/{new_filename}",
                     body=processed_content,
-                    content_type=_avatar_content_type(ext),
+                    content_type=avatar_content_type(ext),
                 )
                 new_in_r2 = True
                 logger.info(

--- a/app/config.py
+++ b/app/config.py
@@ -111,6 +111,7 @@ class Settings(BaseSettings):
 
     # Avatar Settings
     AVATAR_STORAGE_PATH: str = ""  # Derived from STORAGE_PATH if not set
+    BANNER_STORAGE_PATH: str = ""  # Derived from STORAGE_PATH if not set
     MAX_AVATAR_SIZE: int = 1 * 1024 * 1024  # 1MB max upload size
     MAX_AVATAR_DIMENSION: int = 200  # Max width/height after resize
 
@@ -245,6 +246,12 @@ class Settings(BaseSettings):
     def set_default_avatar_storage_path(self) -> Settings:
         if not self.AVATAR_STORAGE_PATH:
             self.AVATAR_STORAGE_PATH = f"{self.STORAGE_PATH}/avatars"
+        return self
+
+    @model_validator(mode="after")
+    def set_default_banner_storage_path(self) -> Settings:
+        if not self.BANNER_STORAGE_PATH:
+            self.BANNER_STORAGE_PATH = f"{self.STORAGE_PATH}/banners"
         return self
 
 

--- a/app/models/misc.py
+++ b/app/models/misc.py
@@ -52,6 +52,7 @@ class BannerBase(SQLModel):
 
     # State
     active: bool = Field(default=True)
+    in_r2: bool = Field(default=False)
 
 
 class Banners(BannerBase, table=True):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -44,7 +44,11 @@ class UserBase(SQLModel):
 
     # Avatar
     avatar: str = Field(default="", max_length=255)
-    avatar_in_r2: bool = Field(default=False)
+    # Internal storage-routing detail used by the avatar_url helper to pick
+    # CDN vs local FS. Excluded from serialization (exclude=True) — clients
+    # only ever see avatar_url, never this routing bit. Still readable on
+    # the model instance, so the computed_field can consume it.
+    avatar_in_r2: bool = Field(default=False, exclude=True)
     gender: str = Field(default="", max_length=50)
 
     # Public stats

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -44,6 +44,7 @@ class UserBase(SQLModel):
 
     # Avatar
     avatar: str = Field(default="", max_length=255)
+    avatar_in_r2: bool = Field(default=False)
     gender: str = Field(default="", max_length=50)
 
     # Public stats

--- a/app/schemas/banner.py
+++ b/app/schemas/banner.py
@@ -25,11 +25,15 @@ class BannerResponse(BaseModel):
     middle_image: str | None
     right_image: str | None
 
+    in_r2: bool = False
+
     model_config = {"from_attributes": True}
 
     def _image_url(self, path: str | None) -> str | None:
         if not path:
             return None
+        if settings.R2_ENABLED and self.in_r2:
+            return f"{settings.R2_PUBLIC_CDN_URL}/banners/{path.lstrip('/')}"
         return f"{settings.BANNER_BASE_URL.rstrip('/')}/{path.lstrip('/')}"
 
     @computed_field  # type: ignore[prop-decorator]

--- a/app/schemas/banner.py
+++ b/app/schemas/banner.py
@@ -3,7 +3,7 @@
 Defines request/response models for banner endpoints.
 """
 
-from pydantic import BaseModel, computed_field, model_validator
+from pydantic import BaseModel, Field, computed_field, model_validator
 
 from app.config import settings
 from app.models.misc import BannerSize, BannerTheme
@@ -25,7 +25,10 @@ class BannerResponse(BaseModel):
     middle_image: str | None
     right_image: str | None
 
-    in_r2: bool = False
+    # Internal storage-routing detail consumed by _image_url to pick CDN vs
+    # local FS; exclude=True keeps it out of the API response while still
+    # letting the URL helper read it.
+    in_r2: bool = Field(default=False, exclude=True)
 
     model_config = {"from_attributes": True}
 

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -4,8 +4,6 @@ Shared/common Pydantic schemas used across multiple endpoints
 
 from pydantic import BaseModel, computed_field
 
-from app.config import settings
-
 
 class UserSummary(BaseModel):
     """
@@ -18,6 +16,7 @@ class UserSummary(BaseModel):
     user_id: int
     username: str
     avatar: str | None = None  # Avatar filename from database
+    avatar_in_r2: bool = False
     user_title: str | None = None
     groups: list[str] = []  # Group names for username coloring (e.g., ["mods", "admins"])
 
@@ -28,6 +27,6 @@ class UserSummary(BaseModel):
     @property
     def avatar_url(self) -> str | None:
         """Generate avatar URL from avatar field"""
-        if self.avatar:
-            return f"{settings.IMAGE_BASE_URL}/images/avatars/{self.avatar}"
-        return None
+        from app.services.avatar import avatar_url as _build_avatar_url
+
+        return _build_avatar_url(self.avatar, self.avatar_in_r2)

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -2,7 +2,7 @@
 Shared/common Pydantic schemas used across multiple endpoints
 """
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, Field, computed_field
 
 
 class UserSummary(BaseModel):
@@ -16,7 +16,10 @@ class UserSummary(BaseModel):
     user_id: int
     username: str
     avatar: str | None = None  # Avatar filename from database
-    avatar_in_r2: bool = False
+    # Internal storage-routing detail consumed by the avatar_url
+    # computed_field; exclude=True keeps it out of the API response while
+    # still letting the property read it.
+    avatar_in_r2: bool = Field(default=False, exclude=True)
     user_title: str | None = None
     groups: list[str] = []  # Group names for username coloring (e.g., ["mods", "admins"])
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -4,7 +4,6 @@ Pydantic schemas for User endpoints
 
 from pydantic import BaseModel, EmailStr, computed_field, field_validator
 
-from app.config import settings
 from app.models.user import UserBase
 from app.schemas.base import UTCDatetime, UTCDatetimeOptional
 
@@ -156,9 +155,9 @@ class UserResponse(UserBase):
     @property
     def avatar_url(self) -> str | None:
         """Generate avatar URL from avatar field"""
-        if self.avatar:
-            return f"{settings.IMAGE_BASE_URL}/images/avatars/{self.avatar}"
-        return None
+        from app.services.avatar import avatar_url as _build_avatar_url
+
+        return _build_avatar_url(self.avatar, self.avatar_in_r2)
 
     @field_validator("active", "admin", mode="before")
     @classmethod

--- a/app/services/avatar.py
+++ b/app/services/avatar.py
@@ -202,15 +202,19 @@ def save_avatar(content: bytes, ext: str) -> str:
     return filename
 
 
-async def delete_avatar_if_orphaned(filename: str, db: AsyncSession) -> bool:
-    """Delete avatar file from disk if no users reference it.
+async def delete_avatar_if_orphaned(filename: str, old_in_r2: bool, db: AsyncSession) -> bool:
+    """Delete avatar file from disk (and R2 if old_in_r2) if no users reference it.
 
     Args:
         filename: Avatar filename to check
+        old_in_r2: Whether this filename's R2 object existed at the start of the
+            request — used to decide whether to issue an R2 delete. Avoids a
+            needless API call for legacy local-only rows.
         db: Database session
 
     Returns:
-        True if file was deleted, False otherwise
+        True if the local file was deleted, False otherwise. R2 delete is
+        best-effort and not reflected in the return value.
     """
     if not filename:
         return False
@@ -221,12 +225,23 @@ async def delete_avatar_if_orphaned(filename: str, db: AsyncSession) -> bool:
     )
     count = result.scalar() or 0
 
-    if count == 0:
-        # No users reference this avatar, safe to delete
-        file_path = Path(settings.AVATAR_STORAGE_PATH) / filename
-        if file_path.exists():
-            file_path.unlink()
-            logger.info("orphaned_avatar_deleted", filename=filename)
-            return True
+    if count != 0:
+        return False
 
-    return False
+    deleted_local = False
+    file_path = Path(settings.AVATAR_STORAGE_PATH) / filename
+    if file_path.exists():
+        file_path.unlink()
+        deleted_local = True
+        logger.info("orphaned_avatar_deleted", filename=filename)
+
+    if old_in_r2 and settings.R2_ENABLED:
+        # Local import avoids a circular import (r2_client → r2_storage → logging,
+        # avatar.py is imported by r2_client's caller graph).
+        from app.core.r2_client import get_r2_storage
+
+        r2 = get_r2_storage()
+        await r2.delete_object(bucket=settings.R2_PUBLIC_BUCKET, key=f"avatars/{filename}")
+        logger.info("avatar_r2_orphan_deleted", key=f"avatars/{filename}")
+
+    return deleted_local

--- a/app/services/avatar.py
+++ b/app/services/avatar.py
@@ -22,6 +22,32 @@ logger = get_logger(__name__)
 
 ALLOWED_AVATAR_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif"}
 
+_AVATAR_CONTENT_TYPES: dict[str, str] = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "gif": "image/gif",
+}
+
+
+def _avatar_content_type(ext: str) -> str:
+    """Map an avatar extension (no dot) to its image/* MIME type."""
+    return _AVATAR_CONTENT_TYPES[ext.lower()]
+
+
+def avatar_url(filename: str | None, in_r2: bool) -> str | None:
+    """Return the public URL for an avatar, choosing CDN vs local FS.
+
+    When R2_ENABLED is false, the per-row bit is ignored and the local URL
+    is returned — preserving today's dev-only behavior even if a dev pulls
+    a prod DB dump where rows have the bit set.
+    """
+    if not filename:
+        return None
+    if settings.R2_ENABLED and in_r2:
+        return f"{settings.R2_PUBLIC_CDN_URL}/avatars/{filename}"
+    return f"{settings.IMAGE_BASE_URL}/images/avatars/{filename}"
+
 
 def validate_avatar_upload(file: UploadFile, temp_path: Path) -> None:
     """Validate uploaded avatar file.

--- a/app/services/avatar.py
+++ b/app/services/avatar.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.core.logging import get_logger
+from app.core.r2_client import get_r2_storage
 from app.models import Users
 from app.services.image_processing import validate_image_file
 
@@ -236,10 +237,6 @@ async def delete_avatar_if_orphaned(filename: str, old_in_r2: bool, db: AsyncSes
         logger.info("orphaned_avatar_deleted", filename=filename)
 
     if old_in_r2 and settings.R2_ENABLED:
-        # Local import avoids a circular import (r2_client → r2_storage → logging,
-        # avatar.py is imported by r2_client's caller graph).
-        from app.core.r2_client import get_r2_storage
-
         r2 = get_r2_storage()
         await r2.delete_object(bucket=settings.R2_PUBLIC_BUCKET, key=f"avatars/{filename}")
         logger.info("avatar_r2_orphan_deleted", key=f"avatars/{filename}")

--- a/app/services/avatar.py
+++ b/app/services/avatar.py
@@ -31,9 +31,16 @@ _AVATAR_CONTENT_TYPES: dict[str, str] = {
 }
 
 
-def _avatar_content_type(ext: str) -> str:
-    """Map an avatar extension (no dot) to its image/* MIME type."""
-    return _AVATAR_CONTENT_TYPES[ext.lower()]
+def avatar_content_type(ext: str) -> str:
+    """Map an avatar extension (no dot) to its image/* MIME type.
+
+    Raises:
+        ValueError: When the extension is not in the allowed avatar set.
+    """
+    ct = _AVATAR_CONTENT_TYPES.get(ext.lower())
+    if ct is None:
+        raise ValueError(f"No Content-Type mapping for avatar extension {ext!r}")
+    return ct
 
 
 def avatar_url(filename: str | None, in_r2: bool) -> str | None:

--- a/app/services/banner.py
+++ b/app/services/banner.py
@@ -18,6 +18,36 @@ from app.schemas.banner import BannerPinResponse, BannerPreferencesResponse, Ban
 
 BANNER_CACHE_KEY_PREFIX = "banner:current:"
 
+# Strict extension -> Content-Type mapping for banner uploads.
+# We refuse to fall back to application/octet-stream because nosniff/CSP
+# break inline rendering of any object served with that type — the whole
+# point of making R2Storage.upload_bytes' content_type mandatory was to
+# force the call site to pick a real image/* MIME type.
+_BANNER_CONTENT_TYPES: dict[str, str] = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "gif": "image/gif",
+    "webp": "image/webp",
+}
+
+
+def banner_content_type(path: str) -> str:
+    """Return the image/* MIME type for a banner image path.
+
+    Args:
+        path: Banner image path (e.g. ``"eva/full.jpg"``); only the
+            extension is used.
+
+    Raises:
+        ValueError: When the extension isn't in the supported banner set.
+    """
+    ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+    ct = _BANNER_CONTENT_TYPES.get(ext)
+    if ct is None:
+        raise ValueError(f"No Content-Type mapping for banner path {path!r}")
+    return ct
+
 
 def _make_cache_key(theme: str, size: str) -> str:
     return f"{BANNER_CACHE_KEY_PREFIX}{theme}:{size}"

--- a/app/services/r2_storage.py
+++ b/app/services/r2_storage.py
@@ -81,6 +81,16 @@ class R2Storage:
         async with self._acquire_client() as s3:
             await s3.upload_file(str(path), bucket, key)
 
+    async def upload_bytes(self, bucket: str, key: str, body: bytes, content_type: str) -> None:
+        """Upload an in-memory bytes payload with an explicit Content-Type.
+
+        Content-Type is mandatory because R2 stores `application/octet-stream`
+        when none is set, which can break inline image rendering under strict
+        CSP / X-Content-Type-Options: nosniff.
+        """
+        async with self._acquire_client() as s3:
+            await s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType=content_type)
+
     async def copy_object(self, src_bucket: str, dst_bucket: str, key: str) -> None:
         """Copy an object between buckets, preserving the key."""
         async with self._acquire_client() as s3:
@@ -136,6 +146,9 @@ class DummyR2Storage:
         yield  # pragma: no cover  (unreachable; satisfies generator typing)
 
     async def upload_file(self, bucket: str, key: str, path: Path) -> None:
+        raise RuntimeError(self._ERR)
+
+    async def upload_bytes(self, bucket: str, key: str, body: bytes, content_type: str) -> None:
         raise RuntimeError(self._ERR)
 
     async def copy_object(self, src_bucket: str, dst_bucket: str, key: str) -> None:

--- a/docs/plans/2026-05-08-r2-avatars-banners-design.md
+++ b/docs/plans/2026-05-08-r2-avatars-banners-design.md
@@ -80,14 +80,9 @@ The banner equivalent lives on `BannerResponse._image_url` and applies the same 
 
 ```python
 def upgrade() -> None:
-    op.add_column(
-        "users",
-        sa.Column(
-            "avatar_in_r2",
-            sa.Boolean(),
-            nullable=False,
-            server_default=sa.text("0"),
-        ),
+    op.execute(
+        "ALTER TABLE users ADD COLUMN avatar_in_r2 BOOLEAN NOT NULL DEFAULT 0, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
     )
 
 def downgrade() -> None:
@@ -98,14 +93,9 @@ def downgrade() -> None:
 
 ```python
 def upgrade() -> None:
-    op.add_column(
-        "banners",
-        sa.Column(
-            "in_r2",
-            sa.Boolean(),
-            nullable=False,
-            server_default=sa.text("0"),
-        ),
+    op.execute(
+        "ALTER TABLE banners ADD COLUMN in_r2 BOOLEAN NOT NULL DEFAULT 0, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
     )
 
 def downgrade() -> None:
@@ -113,6 +103,8 @@ def downgrade() -> None:
 ```
 
 Both columns default false on existing rows; no data migration required. No indexes — these columns are read alongside the row, never queried in isolation.
+
+**Locking:** the project runs MariaDB 12 (`docker-compose.yml`). Adding a `NOT NULL DEFAULT 0` column at the end of an InnoDB table with `ALGORITHM=INSTANT, LOCK=NONE` is metadata-only — no table rewrite, no row locks. A raw `op.execute` is used instead of `op.add_column` to make the algorithm/lock hints explicit and visible in code review; alembic's `add_column` does not surface them by default. The migration is expected to complete in tens of milliseconds even on the production `users` table.
 
 ### Model updates
 
@@ -135,6 +127,8 @@ def set_default_banner_storage_path(self) -> Settings:
 
 This is the on-disk path the `banners-backfill` subcommand reads from. Today there is no setting — the URL is derived from `IMAGE_BASE_URL`, but the disk path is implicit. Backfill needs an explicit knob.
 
+The `set_default_banner_storage_path` validator is a **separate** `@model_validator(mode="after")` on `Settings`, sitting alongside (not merged into) the existing `set_default_avatar_storage_path` validator at `app/config.py:244–248`. Pydantic chains all `model_validator(mode="after")` instances and runs them in declaration order; keeping them as siblings preserves the existing pattern.
+
 No new R2 settings — `R2_PUBLIC_BUCKET`, `R2_PUBLIC_CDN_URL`, and the existing R2 credentials are reused.
 
 ## Storage adapter changes
@@ -142,41 +136,72 @@ No new R2 settings — `R2_PUBLIC_BUCKET`, `R2_PUBLIC_CDN_URL`, and the existing
 `app/services/r2_storage.py` gains an `upload_bytes` method on both `R2Storage` and `DummyR2Storage`:
 
 ```python
+# R2Storage
 async def upload_bytes(
-    self, bucket: str, key: str, body: bytes, content_type: str | None = None
+    self, bucket: str, key: str, body: bytes, content_type: str
 ) -> None:
-    """Upload an in-memory bytes payload."""
+    """Upload an in-memory bytes payload with an explicit Content-Type."""
     async with self._acquire_client() as s3:
-        kwargs: dict[str, Any] = {"Bucket": bucket, "Key": key, "Body": body}
-        if content_type:
-            kwargs["ContentType"] = content_type
-        await s3.put_object(**kwargs)
+        await s3.put_object(
+            Bucket=bucket, Key=key, Body=body, ContentType=content_type
+        )
+
+# DummyR2Storage
+async def upload_bytes(
+    self, bucket: str, key: str, body: bytes, content_type: str
+) -> None:
+    raise RuntimeError(self._ERR)
 ```
 
-`DummyR2Storage.upload_bytes` raises the same `RuntimeError` its peers do, so a code path reaching it under `R2_ENABLED=false` surfaces loudly.
+`content_type` is **mandatory**, not optional. R2 stores whatever Content-Type is set on PUT; without one, R2 returns `application/octet-stream`, which Cloudflare's CDN passes through. `application/octet-stream` triggers download instead of inline render in some browser/CSP combinations and breaks `<img src>` under strict `X-Content-Type-Options: nosniff`. The avatar caller derives Content-Type from the extension via a small helper (`app/services/avatar.py::_avatar_content_type(ext: str) -> str` mapping `jpg/png/gif` → `image/jpeg|image/png|image/gif`). The backfill subcommands use `upload_file(path)` instead of `upload_bytes`; aioboto3's `upload_file` derives Content-Type from the filename via mimetypes, which is correct for our extensions.
 
-The avatar write path uses `upload_bytes` directly because `resize_avatar` returns the processed bytes; round-tripping through a temp file just to call `upload_file` would be wasteful. Backfill subcommands use the existing `upload_file(path)`.
+The avatar write path uses `upload_bytes` directly because `resize_avatar` returns the processed bytes; round-tripping through a temp file just to call `upload_file` would be wasteful. Backfill subcommands read existing on-disk files and use `upload_file(path)`.
+
+### Failure surface for `upload_bytes`
+
+The avatar handler catches `Exception` from the `upload_bytes` call and treats it as an R2-upload failure (log + continue with `avatar_in_r2=False`). The broad catch is intentional and matches the log-and-continue contract:
+
+- `botocore.exceptions.ClientError` — R2 5xx, auth failures, invalid bucket
+- `botocore.exceptions.EndpointConnectionError` / `ConnectionError` — network or DNS
+- `asyncio.TimeoutError` — `read_timeout` or `connect_timeout` from the existing `_R2_CLIENT_CONFIG`
+- `aiobotocore.session`-internal `BotoCoreError` subclasses
+
+Errors are logged with `error=type(e).__name__` and `error_msg=str(e)` to keep the log structure useful without committing to a static taxonomy of failure types.
 
 ## Avatar write path
 
 In `app/api/v1/users.py`, the upload-avatar handler currently calls `save_avatar(processed_content, ext)` then commits `user.avatar = new_filename`. The flow becomes:
 
-1. Validate, resize, write to local FS via `save_avatar` → returns `new_filename`.
-2. If `settings.R2_ENABLED`:
-   - Attempt `r2.upload_bytes(R2_PUBLIC_BUCKET, f"avatars/{new_filename}", processed_content, content_type=...)`.
+1. Capture `old_avatar = user.avatar` and `old_in_r2 = user.avatar_in_r2` **before** any mutation.
+2. Validate, resize, write to local FS via `save_avatar` → returns `new_filename`.
+3. If `settings.R2_ENABLED`:
+   - Attempt `r2.upload_bytes(R2_PUBLIC_BUCKET, f"avatars/{new_filename}", processed_content, content_type=_avatar_content_type(ext))`.
    - On success: `new_in_r2 = True`, log `avatar_r2_uploaded`.
-   - On exception: `new_in_r2 = False`, log `avatar_r2_upload_failed` with the error. Do **not** raise — request continues.
+   - On `Exception`: `new_in_r2 = False`, log `avatar_r2_upload_failed` with `error=type(e).__name__` and `error_msg=str(e)`. Do **not** raise — request continues.
    - Else (`R2_ENABLED=false`): `new_in_r2 = False`.
-3. Set `user.avatar = new_filename`, `user.avatar_in_r2 = new_in_r2`, commit.
-4. Old-avatar cleanup: existing `delete_avatar_if_orphaned(old_avatar, db)` runs as today, returning whether it deleted the local file. Extension: if it deleted locally **and** the old `avatar_in_r2` was true at the start of the request **and** `R2_ENABLED`, also call `r2.delete_object(R2_PUBLIC_BUCKET, f"avatars/{old_avatar}")`. Idempotent; missing keys are success.
+4. Set `user.avatar = new_filename`, `user.avatar_in_r2 = new_in_r2`, commit.
+5. Old-avatar cleanup: call `delete_avatar_if_orphaned(old_avatar, old_in_r2, db)`. The function (a) re-counts users referencing `old_avatar` (after commit, so the current user has already moved off), (b) if zero, unlinks the local file as today, (c) **if zero AND `old_in_r2 AND R2_ENABLED`**, also calls `r2.delete_object(R2_PUBLIC_BUCKET, f"avatars/{old_avatar}")`. Idempotent; missing keys are success.
 
-`delete_avatar_if_orphaned` evolves to take responsibility for the R2 delete since the orphan check (count of users referencing the file) is the only place we know it's safe. Its signature gains an `old_in_r2: bool` argument.
+`delete_avatar_if_orphaned` gains the `old_in_r2: bool` argument so the R2 delete fires only when the file was known to exist in R2 — avoiding a needless API call for legacy local-only rows.
 
-The `_delete_avatar` helper (`/me/avatar` and `/{user_id}/avatar` DELETE endpoints) follows the same orphan-cleanup path with `old_in_r2 = user.avatar_in_r2`.
+The `_delete_avatar` helper (`/me/avatar` and `/{user_id}/avatar` DELETE endpoints) follows the same orphan-cleanup path: capture `old_in_r2 = user.avatar_in_r2` before clearing, then call `delete_avatar_if_orphaned(old_avatar, old_in_r2, db)` after commit.
 
 ### Failure semantics
 
-The choice to log-and-continue on R2 upload failure is deliberate (see Goals). It mirrors the image phase-1 dual-write contract: local FS is the source of truth; R2 is best-effort during the dual-write phase. A row with `avatar_in_r2=false` after a failure is not "broken" — its URL falls back to `IMAGE_BASE_URL` and serves correctly. The `avatars-backfill` subcommand catches up such rows on a later run.
+The choice to log-and-continue on R2 upload failure is deliberate (see Goals). It mirrors the image phase-1 dual-write contract: local FS is the source of truth; R2 is best-effort during the dual-write phase. A row with `avatar_in_r2=false` after a failure is not "broken" — its URL falls back to `IMAGE_BASE_URL` and serves correctly.
+
+**No async retry queue.** This design deliberately diverges from the image pipeline, which uses `r2_finalize_upload_job` (arq) to retry uploads on failure. Avatars are different in three ways that justify the divergence:
+- Avatar uploads are infrequent and small (≤200px after resize, MAX_AVATAR_SIZE=1MB pre-resize); the cost of a missed-and-not-retried upload is one user serving from local until the next backfill run.
+- There is no equivalent of variant-generation latency — `resize_avatar` produces final bytes synchronously inside the request, so the `r2_finalize_upload_job`-style "wait until variants are ready" complexity does not apply.
+- The orphan-delete path is the only deletion path; no public/private status transitions to track. A queued retry would also need a queued-retry equivalent for the orphan delete to preserve consistency, doubling the surface area for negligible benefit.
+
+The trade-off: a transient R2 outage during the rollout window leaves some rows with `avatar_in_r2=false` even though their files are eventually uploadable. **The `avatars-backfill` subcommand catches up such rows.** Operationally this means: re-run `avatars-backfill` periodically (or on demand after a known R2 outage) to reach steady-state.
+
+### Concurrency notes
+
+- **Orphan-delete race.** Two concurrent requests can each see "0 users reference `old_avatar`" and both attempt to delete. Local `unlink` is idempotent (`exists()` check before unlink); R2 `delete_object` is idempotent (S3 treats missing keys as success). Net effect: redundant work, no incorrect state. No row lock added — the existing race is benign and the extension preserves that.
+- **Same-MD5 concurrent uploads.** Two users uploading identical bytes concurrently produce the same key (`avatars/{md5}.{ext}`). Both `put_object` calls succeed (last-write-wins on identical bytes); both `avatar_in_r2` flags settle to `true`. If one upload fails transiently and the other succeeds, the failed user's flag stays `false` and their URL falls back to local — even though the R2 object exists. Acceptable: backfill catches up.
+- **Re-upload of identical content.** A user uploading the same bytes they already have (`new_filename == old_avatar`) is a degenerate case. Step 5's orphan check counts users referencing `old_avatar` *after* `user.avatar = new_filename` is committed — the user themselves still references it, so count ≥ 1, and no delete fires. Verified by an explicit test (see Testing § "same-MD5 re-upload").
 
 ## Banner write path
 
@@ -194,15 +219,15 @@ Centralize on a single helper `app/services/avatar.py::avatar_url(filename, in_r
 
 Update sites:
 
-- `app/schemas/user.py:157` — `avatar_url` computed_field reads `self.avatar` and `self.avatar_in_r2`, calls helper.
-- `app/schemas/common.py:29` — same shape; if it's a separate base, update both.
-- `app/api/v1/privmsgs.py` — six string-concatenation sites at lines 271–273, 412–417, 565–577, 660–667, 738–743, 757–760. Each currently builds the URL inline from `IMAGE_BASE_URL` and a fetched `avatar` filename. Each query that fetches `avatar` must additionally fetch `avatar_in_r2` from the same `users` row, then pass both into the helper.
+- `app/schemas/user.py` — `avatar_url` computed_field (around line 155–161) reads `self.avatar` and `self.avatar_in_r2`, calls helper.
+- `app/schemas/common.py` — same shape (around line 27–33); if it's a separate base, update both.
+- `app/api/v1/privmsgs.py` — **seven** inline `f"{settings.IMAGE_BASE_URL}/images/avatars/{...}"` sites at lines **273, 415, 417, 577, 667, 741, 743**. Each currently builds the URL inline from `IMAGE_BASE_URL` and a fetched `avatar` filename. Each query that fetches `avatar` must additionally fetch `avatar_in_r2` from the same `users` row (the queries already select from `users`; one extra column), then pass both into the helper. Implementation will do a final pre-merge sweep over `app/api/v1/privmsgs.py` to confirm no site is missed; this is the largest concentration of inline URL building in the codebase.
 
 ### Banners
 
 Single update to `BannerResponse._image_url` in `app/schemas/banner.py:30`. `BannerResponse` adds `in_r2: bool` so it deserializes from the row via `model_config["from_attributes"]`. All four `*_image_url` computed fields use the updated helper.
 
-Cache implications: `app/services/banner.py:89` deserializes cached banners via `BannerResponse.model_validate_json(cached_str)`. The cache key (`banner:current:{theme}:{size}`) does not include `R2_ENABLED` or `in_r2`, so the cached payload contains URLs computed at cache-write time. After the bit flips on a banner row, cached entries serve stale URLs until TTL expiry (`BANNER_CACHE_TTL` = 600s + jitter). Acceptable: stale URLs still resolve through the local-FS fallback, and TTL expiry resolves the drift within minutes. No deliberate cache invalidation needed.
+Cache implications: `app/services/banner.py:89` deserializes cached banners via `BannerResponse.model_validate_json(cached_str)`. The cache key (`banner:current:{theme}:{size}`) does not include `R2_ENABLED` or `in_r2`, so the cached payload contains URLs computed at cache-write time. After the bit flips on a banner row, cached entries serve stale URLs until TTL expiry. With current settings — `BANNER_CACHE_TTL=600s`, `BANNER_CACHE_TTL_JITTER=300s` (`app/config.py:183–184`) — staleness is bounded at 600–900s (10–15 min). Acceptable: stale URLs still resolve through the local-FS fallback, and TTL expiry resolves the drift naturally. No deliberate cache invalidation needed.
 
 ## Backfill / ops tooling
 
@@ -270,10 +295,15 @@ TDD per project rules (`AGENTS.md`). New tests:
 ### `tests/services/test_avatar.py` (new or extend)
 
 - Upload with `R2_ENABLED=false` writes local only, sets `avatar_in_r2 = false`. (Already today's behavior modulo the new field.)
-- Upload with `R2_ENABLED=true` and moto bucket: writes local AND R2, sets `avatar_in_r2 = true`.
-- Upload with `R2_ENABLED=true` but R2 unavailable (closed moto port or patched `upload_bytes` raising): local write succeeds, `avatar_in_r2 = false`, request returns success, `avatar_r2_upload_failed` log captured.
+- Upload with `R2_ENABLED=true` and moto bucket: writes local AND R2, sets `avatar_in_r2 = true`. R2 object has the expected Content-Type (`image/png`/`jpeg`/`gif`).
+- Upload with `R2_ENABLED=true` but R2 unavailable (patched `upload_bytes` raising): local write succeeds, `avatar_in_r2 = false`, request returns success, `avatar_r2_upload_failed` log captured.
 - Orphan deletion with old `avatar_in_r2 = true`: local file unlinked AND R2 object deleted. With old `avatar_in_r2 = false`: R2 not touched.
 - Orphan deletion when another user still references the avatar: neither local nor R2 touched.
+- **Same-MD5 re-upload** (`new_filename == old_avatar`): the new-bytes-equal-old-bytes case. Verify the orphan check sees the user themselves still referencing the file post-commit, and neither the local nor R2 file is deleted.
+
+### Test scope notes
+
+The orphan-delete concurrency race (two requests racing to delete the last reference) is not covered by an automated test. The race is benign — both `unlink` and `delete_object` are idempotent — and reproducing it deterministically would require artificial sleeps or shared-state hacks that don't pay for themselves. Documented here so reviewers understand the gap is intentional.
 
 ### `tests/api/v1/test_users_avatar.py` (extend)
 
@@ -304,19 +334,31 @@ All R2-touching tests reuse the `ThreadedMotoServer` fixture pattern from `tests
 
 ## Rollout
 
-1. Land the feature behind the existing `R2_ENABLED` flag — schema migrations, model bits, write-path dual-write, URL helpers, backfill subcommands, tests. With `R2_ENABLED=false` everywhere (current dev/staging default), behavior is unchanged: bits default false, fall-back URLs continue to work.
-2. In production (`R2_ENABLED=true` already): run `avatars-backfill` and `banners-backfill` with `R2_ALLOW_BULK_BACKFILL=true`. Verify a random sample resolves through the CDN with `curl -I`.
-3. New uploads from this point dual-write automatically; new banners require an `r2_sync.py banners-backfill` run to flip their bit.
-4. (Future, out of scope) Once stable and IQDB/avatar/banner code paths can fully read from R2, demote local FS for these classes to read-only fallback or remove entirely.
+The feature ships as a single deploy. Schema migrations, model bits, write-path dual-write, URL helpers, and backfill subcommands all land together. The order of operations *after* deploy matters more than splitting the deploy itself.
+
+1. **Deploy.** Schema migrations apply (instant ADD COLUMN, see Database schema). All existing rows get `avatar_in_r2=false` / `in_r2=false` defaults. URL generation respects `R2_ENABLED AND row_bit` — every existing row continues to serve from local FS exactly as before. New avatar uploads start dual-writing immediately; rows uploaded after deploy will have `avatar_in_r2=true` (or `false` on R2 failure). New banners do not exist yet (no admin endpoint).
+2. **Backfill avatars.** Run `uv run python scripts/r2_sync.py avatars-backfill --concurrency 8` in production (requires `R2_ENABLED=true` and `R2_ALLOW_BULK_BACKFILL=true`, both already true in prod). Walks all `users.avatar_in_r2=false` rows and uploads. Idempotent against in-flight new uploads — content-addressed keys plus `head_object` short-circuit make racing the live write path safe.
+3. **Backfill banners.** Run `uv run python scripts/r2_sync.py banners-backfill`. Tens of rows, completes in seconds.
+4. **Verify.** Spot-check via `curl -I` that randomly-selected avatar and banner CDN URLs return 200 with the expected `Content-Type`. Confirm a few user-facing pages render avatars and banners correctly under the new URLs.
+5. **Steady state.** New uploads dual-write automatically. New banners require running `banners-backfill` after seeding files; this is documented in the script's `--help`. After a known R2 outage, re-run `avatars-backfill` to mop up rows that fell back to `avatar_in_r2=false`.
+
+**Why one-deploy is safe:** the bit defaults `false`, the URL helper is `R2_ENABLED AND bit`, and the dual-write code path correctly handles both pre-backfill (no R2 object exists) and post-backfill (R2 object exists) starting states. There is no consistency window where a URL points at a missing R2 object.
+
+**Window of partial-state operation** (between step 1 and step 2): some rows have `avatar_in_r2=true` (newly uploaded post-deploy), others `false` (pre-deploy rows not yet backfilled). Both serve correctly through their respective URL paths. Backfill should follow deploy promptly to minimize the period where the CDN is under-utilized, but there is no correctness deadline.
+
+6. **(Future, out of scope)** Once stable and IQDB/avatar/banner code paths can fully read from R2, demote local FS for these classes to read-only fallback or remove entirely.
 
 ## Risks and mitigations
 
-- **R2 upload failure on the avatar hot path** — mitigated by log-and-continue semantics. Worst case: a small number of rows have `avatar_in_r2=false` and serve from local; backfill catches up.
-- **Banner cache staleness after bit flip** — accepted; max ~15 minutes (TTL + jitter), and the fall-back URL remains valid through the staleness window.
+- **R2 upload failure on the avatar hot path** — mitigated by log-and-continue semantics. Worst case: a small number of rows have `avatar_in_r2=false` and serve from local; backfill catches up. **Important:** failed uploads are *not* retried automatically (no async finalize-job equivalent — see Avatar write path § "No async retry queue"). Operationally this means re-running `avatars-backfill` after a known R2 outage.
+- **Banner cache staleness after bit flip** — accepted; bounded at 600–900s (`BANNER_CACHE_TTL=600` + `BANNER_CACHE_TTL_JITTER=300`), and the fall-back URL remains valid through the staleness window.
 - **Partial backfill leaves rows pointing at local** — by design. The bit guarantees URL correctness regardless of backfill state. Re-running the backfill is safe.
-- **Forgotten privmsg call site** — six string-built URLs in `app/api/v1/privmsgs.py` is the largest concentration of inline URL building. Mitigated by the centralized helper plus tests for representative endpoints; a follow-up pass over the full file before merge confirms all sites are migrated.
+- **Forgotten privmsg call site** — seven string-built URLs in `app/api/v1/privmsgs.py` (lines 273, 415, 417, 577, 667, 741, 743) are the largest concentration of inline URL building. Mitigated by the centralized helper plus tests for representative endpoints; a final `grep` over `app/api/v1/privmsgs.py` for `IMAGE_BASE_URL.*avatars` before merge confirms all sites are migrated.
 - **Local-FS path for banners not configured today** — adding `BANNER_STORAGE_PATH` with a derived default keeps existing deployments working without a config change.
+- **Concurrent orphan-delete or same-MD5 upload races** — analyzed in Avatar write path § "Concurrency notes". Both local and R2 deletes are idempotent; same-MD5 PUT is last-write-wins on identical bytes. No row locks added.
 
 ## Open questions
 
-None at design time. Implementation will surface a few mechanical questions (exact log field names, helper module location for the avatar URL function) that fall through to the implementation plan.
+- **Helper module placement.** `avatar_url(filename, in_r2)` could live in `app/services/avatar.py` (alongside save/delete) or in `app/schemas/_helpers.py` (alongside the schemas that use it). Defaulting to `app/services/avatar.py` keeps avatar concerns co-located, but if circular-import issues arise (schemas → services), the helper moves to a leaf-level module with no other imports. Implementation will resolve.
+- **Log field naming.** The R2 jobs use `image_id`, `bucket`, `key` as standard fields. Avatar/banner equivalents (`user_id` for avatar, `banner_id` for banner) are intuitive, but the exact `event=` names (`avatar_r2_uploaded` vs `r2_avatar_uploaded`, etc.) should be confirmed against `app/tasks/r2_jobs.py` conventions. Listed in Observability — minor stylistic alignment.
+- **Should backfill subcommands also live in `r2_sync.py` or in a sibling script?** Defaulting to `r2_sync.py` for operational discoverability (one CLI for all R2 ops) and to reuse `require_bulk_backfill()`. The script is currently 877 lines; if these additions push it past a comfortable size, splitting into `scripts/r2/{images,avatars,banners}.py` becomes worth considering. Out of scope for this design.

--- a/docs/plans/2026-05-08-r2-avatars-banners-design.md
+++ b/docs/plans/2026-05-08-r2-avatars-banners-design.md
@@ -153,9 +153,13 @@ async def upload_bytes(
     raise RuntimeError(self._ERR)
 ```
 
-`content_type` is **mandatory**, not optional. R2 stores whatever Content-Type is set on PUT; without one, R2 returns `application/octet-stream`, which Cloudflare's CDN passes through. `application/octet-stream` triggers download instead of inline render in some browser/CSP combinations and breaks `<img src>` under strict `X-Content-Type-Options: nosniff`. The avatar caller derives Content-Type from the extension via a small helper (`app/services/avatar.py::_avatar_content_type(ext: str) -> str` mapping `jpg/png/gif` → `image/jpeg|image/png|image/gif`). The backfill subcommands use `upload_file(path)` instead of `upload_bytes`; aioboto3's `upload_file` derives Content-Type from the filename via mimetypes, which is correct for our extensions.
+`content_type` is **mandatory**, not optional. R2 stores whatever Content-Type is set on PUT; without one, R2 returns `application/octet-stream`, which Cloudflare's CDN passes through. `application/octet-stream` triggers download instead of inline render in some browser/CSP combinations and breaks `<img src>` under strict `X-Content-Type-Options: nosniff`. The avatar caller derives Content-Type from the extension via a small helper (`app/services/avatar.py::_avatar_content_type(ext: str) -> str` mapping `jpg/png/gif` → `image/jpeg|image/png|image/gif`).
 
-The avatar write path uses `upload_bytes` directly because `resize_avatar` returns the processed bytes; round-tripping through a temp file just to call `upload_file` would be wasteful. Backfill subcommands read existing on-disk files and use `upload_file(path)`.
+The avatar write path uses `upload_bytes` directly because `resize_avatar` returns the processed bytes; round-tripping through a temp file just to call `upload_file` would be wasteful.
+
+**Backfill also uses `upload_bytes`, not `upload_file`.** Boto3/aioboto3's `upload_file` does **not** auto-derive Content-Type — the underlying s3transfer library uploads with whatever `ExtraArgs={"ContentType": ...}` is passed, defaulting to no Content-Type (R2 stores `application/octet-stream`). Since `upload_file`'s only advantage over `upload_bytes` is multipart-streaming for large files, and avatars (≤1MB) and banner parts (typically <1MB each) are well below the multipart threshold, backfill reads each file into memory with `path.read_bytes()` and calls `upload_bytes(bucket, key, body, content_type)` with a Content-Type derived from the extension via `mimetypes.guess_type(path)[0]` (with a fallback for unknown extensions). Using `upload_bytes` for both the live write path and backfill keeps a single Content-Type-correct code path.
+
+Note for future image backfill consistency: the existing `R2Storage.upload_file` is still used by `r2_sync.py split-existing` for image variants. Those uploads currently land without an explicit Content-Type — out of scope here, but flagged in case a follow-up wants to fix image Content-Type alongside.
 
 ### Failure surface for `upload_bytes`
 
@@ -241,9 +245,9 @@ uv run python scripts/r2_sync.py avatars-backfill [--dry-run] [--concurrency N]
 
 - Walks `users` where `avatar != ''` AND `avatar_in_r2 = false`.
 - For each user (concurrent up to N):
-  - Read local file from `{AVATAR_STORAGE_PATH}/{filename}`. If missing, log `avatar_local_missing` and skip (bit stays false).
+  - Read local file bytes from `{AVATAR_STORAGE_PATH}/{filename}`. If missing, log `avatar_local_missing` and skip (bit stays false).
   - `head_object` for `avatars/{filename}` in `R2_PUBLIC_BUCKET`. If exists, skip upload (idempotent — content-addressed key).
-  - Else `upload_file(local_path)`.
+  - Else `upload_bytes(bucket, key, body, content_type=mimetypes.guess_type(filename)[0] or "application/octet-stream")`. (See Storage adapter changes for why bytes-based upload over `upload_file`.)
   - On success, `UPDATE users SET avatar_in_r2 = true WHERE user_id = ?`.
 - Wraps the loop in `r2.bulk_session()` to share one client across the burst.
 - `--dry-run` reports counts without writing.
@@ -258,8 +262,8 @@ uv run python scripts/r2_sync.py banners-backfill [--dry-run]
 - Walks `banners` where `in_r2 = false`.
 - For each banner:
   - Collect non-null paths from `full_image`, `left_image`, `middle_image`, `right_image` (1 path for full-image banners, 3 for three-part).
-  - For each path: read `{BANNER_STORAGE_PATH}/{path}`. If any is missing, log `banner_local_missing` with the row's `banner_id` and skip the row entirely (bit stays false).
-  - For each path: `head_object` then upload-if-missing as in avatars-backfill.
+  - For each path: read bytes from `{BANNER_STORAGE_PATH}/{path}`. If any is missing, log `banner_local_missing` with the row's `banner_id` and skip the row entirely (bit stays false).
+  - For each path: `head_object` then `upload_bytes(bucket, key, body, content_type=mimetypes.guess_type(path)[0] or "application/octet-stream")` if missing.
   - If **all** parts uploaded (or already existed), `UPDATE banners SET in_r2 = true WHERE banner_id = ?`. Otherwise the bit stays false; re-running picks up where it left off.
 - Sequential row processing is fine — banners are tens of rows, not millions.
 
@@ -308,7 +312,7 @@ The orphan-delete concurrency race (two requests racing to delete the last refer
 ### `tests/api/v1/test_users_avatar.py` (extend)
 
 - Avatar URL on `UserResponse` switches to CDN URL when `R2_ENABLED=true` and `avatar_in_r2=true`; stays local otherwise.
-- Privmsg responses include avatar URLs that respect the same rule (smoke-test a few of the six call sites).
+- Privmsg responses include avatar URLs that respect the same rule (smoke-test a few of the seven call sites).
 
 ### `tests/api/v1/test_banners.py` (extend)
 

--- a/docs/plans/2026-05-08-r2-avatars-banners-design.md
+++ b/docs/plans/2026-05-08-r2-avatars-banners-design.md
@@ -1,0 +1,322 @@
+# R2 storage for avatars and banners — design
+
+**Date:** 2026-05-08
+**Status:** design
+**Related:** `docs/plans/2026-04-16-r2-image-serving-design.md`
+
+## Problem
+
+Image fullsizes, variants, and thumbnails are stored in Cloudflare R2 (public bucket for ACTIVE/SPOILER/REPOST, private bucket for protected statuses) in production, alongside parallel local-FS copies. Avatars and banners still live on local filesystem only. The production server's local-disk capacity ceiling and a planned move to a smaller-disk host both apply equally to avatars and banners — they need to live in R2 too.
+
+This design extends R2 storage to avatars and banners using the lightest pattern that fits each: dual-write on the avatar upload hot path, one-shot backfill plus passive URL switching for banners. Both are inherently public assets (no permission gate, no status transitions), so the design is materially simpler than the image pipeline.
+
+## Goals
+
+- Avatars and banners stored in `R2_PUBLIC_BUCKET` and served from `R2_PUBLIC_CDN_URL` when `R2_ENABLED=true` and a per-row tracking bit is set.
+- New avatar uploads dual-write to local FS + R2; failure to upload to R2 is non-fatal (request succeeds, bit stays false, URL falls back to local).
+- One-shot backfill subcommands (`avatars-backfill`, `banners-backfill`) in `scripts/r2_sync.py` for existing rows.
+- Banner URL generation flips to CDN once the row's bit is set; no admin upload endpoint added.
+- `R2_ENABLED=false` (dev / disabled-prod) preserves today's behavior exactly: writes go local, URLs stay on `IMAGE_BASE_URL`/`BANNER_BASE_URL`, no R2 calls issued.
+- Test suite gains coverage for the new dual-write, URL switching, orphan-deletion, and backfill paths.
+
+## Non-goals
+
+- No admin upload endpoint for banners. Banners continue to be seeded out-of-band; the `banners-backfill` subcommand registers them after files land on disk.
+- No private-bucket support. Avatars and banners are public.
+- No CDN purge orchestration on routine writes. Avatars are content-addressed (MD5 filenames) so updates produce a new key; banner replacements are rare and admin-purged manually if needed.
+- No removal of local-FS storage for avatars/banners. Local remains a working fallback (mirrors image phase 1).
+- No reconcile/verify subcommands for avatars/banners (no public/private transitions to police; orphan delete is the only deletion path and is idempotent).
+- No changes to IQDB, iqdb_feed, or other unrelated subsystems.
+
+## Architecture
+
+### Bucket and key layout
+
+Single bucket: `R2_PUBLIC_BUCKET`. Keys mirror the local-FS layout so backfill is a straight upload with no key rewriting:
+
+```
+avatars/{md5}.{ext}                    # e.g. avatars/abc123…def.png
+banners/{path-as-stored-in-DB}         # e.g. banners/eva/full.jpg, banners/halloween/left.png
+```
+
+CDN URLs:
+
+```
+{R2_PUBLIC_CDN_URL}/avatars/{filename}
+{R2_PUBLIC_CDN_URL}/banners/{path}
+```
+
+Avatar keys are content-addressed (`users.avatar` is `{md5}.{ext}`), so re-uploading the same content overwrites with identical bytes. Two users sharing an avatar resolve to the same key, mirroring the local-FS dedup semantic.
+
+### Per-row tracking bits
+
+Two new boolean columns:
+
+- `users.avatar_in_r2: bool default false` — "the file referenced by `users.avatar` exists in R2 right now."
+- `banners.in_r2: bool default false` — "all of `full_image`/`left_image`/`middle_image`/`right_image` referenced by this row exist in R2."
+
+The bits exist so URL generation is safe under partial backfill: a row with the bit `false` falls back to local-FS URLs and works correctly whether or not R2 is enabled, whether or not backfill has run.
+
+For banners, a single bit covers the row because banner layouts are committed atomically (the validator forbids mixed full/three-part). All three parts of a three-part banner must upload before the bit flips.
+
+### URL generation rule
+
+Always check `settings.R2_ENABLED` first, then the per-row bit. In dev with `R2_ENABLED=false`, the bit is never consulted, so a dev pulling a prod DB dump still resolves URLs locally.
+
+```python
+def avatar_url(filename: str | None, in_r2: bool) -> str | None:
+    if not filename:
+        return None
+    if settings.R2_ENABLED and in_r2:
+        return f"{settings.R2_PUBLIC_CDN_URL}/avatars/{filename}"
+    return f"{settings.IMAGE_BASE_URL}/images/avatars/{filename}"
+```
+
+The banner equivalent lives on `BannerResponse._image_url` and applies the same rule with `BANNER_BASE_URL` as the fallback.
+
+## Database schema
+
+### Migration: `users.avatar_in_r2`
+
+```python
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "avatar_in_r2",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+def downgrade() -> None:
+    op.drop_column("users", "avatar_in_r2")
+```
+
+### Migration: `banners.in_r2`
+
+```python
+def upgrade() -> None:
+    op.add_column(
+        "banners",
+        sa.Column(
+            "in_r2",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+def downgrade() -> None:
+    op.drop_column("banners", "in_r2")
+```
+
+Both columns default false on existing rows; no data migration required. No indexes — these columns are read alongside the row, never queried in isolation.
+
+### Model updates
+
+- `app/models/user.py` (`UserBase` or `Users` — wherever `avatar` is declared): add `avatar_in_r2: bool = Field(default=False)`.
+- `app/models/misc.py` (`BannerBase`): add `in_r2: bool = Field(default=False)`.
+
+## Configuration
+
+One new setting in `app/config.py`, mirroring `AVATAR_STORAGE_PATH`:
+
+```python
+BANNER_STORAGE_PATH: str = ""  # Derived from STORAGE_PATH if not set
+
+@model_validator(mode="after")
+def set_default_banner_storage_path(self) -> Settings:
+    if not self.BANNER_STORAGE_PATH:
+        self.BANNER_STORAGE_PATH = f"{self.STORAGE_PATH}/banners"
+    return self
+```
+
+This is the on-disk path the `banners-backfill` subcommand reads from. Today there is no setting — the URL is derived from `IMAGE_BASE_URL`, but the disk path is implicit. Backfill needs an explicit knob.
+
+No new R2 settings — `R2_PUBLIC_BUCKET`, `R2_PUBLIC_CDN_URL`, and the existing R2 credentials are reused.
+
+## Storage adapter changes
+
+`app/services/r2_storage.py` gains an `upload_bytes` method on both `R2Storage` and `DummyR2Storage`:
+
+```python
+async def upload_bytes(
+    self, bucket: str, key: str, body: bytes, content_type: str | None = None
+) -> None:
+    """Upload an in-memory bytes payload."""
+    async with self._acquire_client() as s3:
+        kwargs: dict[str, Any] = {"Bucket": bucket, "Key": key, "Body": body}
+        if content_type:
+            kwargs["ContentType"] = content_type
+        await s3.put_object(**kwargs)
+```
+
+`DummyR2Storage.upload_bytes` raises the same `RuntimeError` its peers do, so a code path reaching it under `R2_ENABLED=false` surfaces loudly.
+
+The avatar write path uses `upload_bytes` directly because `resize_avatar` returns the processed bytes; round-tripping through a temp file just to call `upload_file` would be wasteful. Backfill subcommands use the existing `upload_file(path)`.
+
+## Avatar write path
+
+In `app/api/v1/users.py`, the upload-avatar handler currently calls `save_avatar(processed_content, ext)` then commits `user.avatar = new_filename`. The flow becomes:
+
+1. Validate, resize, write to local FS via `save_avatar` → returns `new_filename`.
+2. If `settings.R2_ENABLED`:
+   - Attempt `r2.upload_bytes(R2_PUBLIC_BUCKET, f"avatars/{new_filename}", processed_content, content_type=...)`.
+   - On success: `new_in_r2 = True`, log `avatar_r2_uploaded`.
+   - On exception: `new_in_r2 = False`, log `avatar_r2_upload_failed` with the error. Do **not** raise — request continues.
+   - Else (`R2_ENABLED=false`): `new_in_r2 = False`.
+3. Set `user.avatar = new_filename`, `user.avatar_in_r2 = new_in_r2`, commit.
+4. Old-avatar cleanup: existing `delete_avatar_if_orphaned(old_avatar, db)` runs as today, returning whether it deleted the local file. Extension: if it deleted locally **and** the old `avatar_in_r2` was true at the start of the request **and** `R2_ENABLED`, also call `r2.delete_object(R2_PUBLIC_BUCKET, f"avatars/{old_avatar}")`. Idempotent; missing keys are success.
+
+`delete_avatar_if_orphaned` evolves to take responsibility for the R2 delete since the orphan check (count of users referencing the file) is the only place we know it's safe. Its signature gains an `old_in_r2: bool` argument.
+
+The `_delete_avatar` helper (`/me/avatar` and `/{user_id}/avatar` DELETE endpoints) follows the same orphan-cleanup path with `old_in_r2 = user.avatar_in_r2`.
+
+### Failure semantics
+
+The choice to log-and-continue on R2 upload failure is deliberate (see Goals). It mirrors the image phase-1 dual-write contract: local FS is the source of truth; R2 is best-effort during the dual-write phase. A row with `avatar_in_r2=false` after a failure is not "broken" — its URL falls back to `IMAGE_BASE_URL` and serves correctly. The `avatars-backfill` subcommand catches up such rows on a later run.
+
+## Banner write path
+
+Banners have no application-level write endpoint. Files are seeded out-of-band; rows are inserted via `scripts/seed_banners.sql` or similar. The write-path change for banners is therefore confined to:
+
+- `BannerResponse` reads `in_r2` from the row and feeds it to `_image_url`.
+- The `banners-backfill` subcommand uploads files and flips bits on existing rows.
+- Future-added banners follow the same pattern: place files on disk, run `banners-backfill`.
+
+## URL generation — call sites
+
+### Avatars
+
+Centralize on a single helper `app/services/avatar.py::avatar_url(filename, in_r2)`.
+
+Update sites:
+
+- `app/schemas/user.py:157` — `avatar_url` computed_field reads `self.avatar` and `self.avatar_in_r2`, calls helper.
+- `app/schemas/common.py:29` — same shape; if it's a separate base, update both.
+- `app/api/v1/privmsgs.py` — six string-concatenation sites at lines 271–273, 412–417, 565–577, 660–667, 738–743, 757–760. Each currently builds the URL inline from `IMAGE_BASE_URL` and a fetched `avatar` filename. Each query that fetches `avatar` must additionally fetch `avatar_in_r2` from the same `users` row, then pass both into the helper.
+
+### Banners
+
+Single update to `BannerResponse._image_url` in `app/schemas/banner.py:30`. `BannerResponse` adds `in_r2: bool` so it deserializes from the row via `model_config["from_attributes"]`. All four `*_image_url` computed fields use the updated helper.
+
+Cache implications: `app/services/banner.py:89` deserializes cached banners via `BannerResponse.model_validate_json(cached_str)`. The cache key (`banner:current:{theme}:{size}`) does not include `R2_ENABLED` or `in_r2`, so the cached payload contains URLs computed at cache-write time. After the bit flips on a banner row, cached entries serve stale URLs until TTL expiry (`BANNER_CACHE_TTL` = 600s + jitter). Acceptable: stale URLs still resolve through the local-FS fallback, and TTL expiry resolves the drift within minutes. No deliberate cache invalidation needed.
+
+## Backfill / ops tooling
+
+Two new subcommands in `scripts/r2_sync.py`, both gated by the existing `require_bulk_backfill()` (R2_ENABLED + R2_ALLOW_BULK_BACKFILL).
+
+### `avatars-backfill`
+
+```
+uv run python scripts/r2_sync.py avatars-backfill [--dry-run] [--concurrency N]
+```
+
+- Walks `users` where `avatar != ''` AND `avatar_in_r2 = false`.
+- For each user (concurrent up to N):
+  - Read local file from `{AVATAR_STORAGE_PATH}/{filename}`. If missing, log `avatar_local_missing` and skip (bit stays false).
+  - `head_object` for `avatars/{filename}` in `R2_PUBLIC_BUCKET`. If exists, skip upload (idempotent — content-addressed key).
+  - Else `upload_file(local_path)`.
+  - On success, `UPDATE users SET avatar_in_r2 = true WHERE user_id = ?`.
+- Wraps the loop in `r2.bulk_session()` to share one client across the burst.
+- `--dry-run` reports counts without writing.
+- Default `--concurrency 8` (matches `split-existing`).
+
+### `banners-backfill`
+
+```
+uv run python scripts/r2_sync.py banners-backfill [--dry-run]
+```
+
+- Walks `banners` where `in_r2 = false`.
+- For each banner:
+  - Collect non-null paths from `full_image`, `left_image`, `middle_image`, `right_image` (1 path for full-image banners, 3 for three-part).
+  - For each path: read `{BANNER_STORAGE_PATH}/{path}`. If any is missing, log `banner_local_missing` with the row's `banner_id` and skip the row entirely (bit stays false).
+  - For each path: `head_object` then upload-if-missing as in avatars-backfill.
+  - If **all** parts uploaded (or already existed), `UPDATE banners SET in_r2 = true WHERE banner_id = ?`. Otherwise the bit stays false; re-running picks up where it left off.
+- Sequential row processing is fine — banners are tens of rows, not millions.
+
+### Re-run safety
+
+Both subcommands are idempotent against partial state: head-then-upload skips work already done, and the bit only flips when all uploads in a logical unit succeed. A failed run (network blip, `KeyboardInterrupt`) leaves the DB consistent — every row with `in_r2=true` has all its files in R2.
+
+## Observability
+
+New structured-log events, mirroring the `r2_*` event-name convention from `app/tasks/r2_jobs.py`:
+
+- `avatar_r2_uploaded` (request path) — `user_id`, `key`
+- `avatar_r2_upload_failed` (request path) — `user_id`, `key`, `error`
+- `avatar_r2_orphan_deleted` (request path) — `key`
+- `avatar_r2_backfilled` (script) — `user_id`, `key`, `skipped_existing`
+- `avatar_local_missing` (script) — `user_id`, `filename`
+- `banner_r2_backfilled` (script) — `banner_id`, `parts_uploaded`, `parts_skipped`
+- `banner_r2_partial` (script) — `banner_id`, `missing` paths
+- `banner_local_missing` (script) — `banner_id`, `path`
+
+## Testing
+
+TDD per project rules (`AGENTS.md`). New tests:
+
+### `tests/unit/test_r2_storage.py` (extend)
+
+- `upload_bytes` round-trip via the existing `moto_server`/`storage` fixtures. Verify object content matches input and `ContentType` is set when supplied.
+
+### `tests/unit/test_r2_client.py` (extend)
+
+- `DummyR2Storage.upload_bytes` raises `RuntimeError` like its peers.
+
+### `tests/services/test_avatar.py` (new or extend)
+
+- Upload with `R2_ENABLED=false` writes local only, sets `avatar_in_r2 = false`. (Already today's behavior modulo the new field.)
+- Upload with `R2_ENABLED=true` and moto bucket: writes local AND R2, sets `avatar_in_r2 = true`.
+- Upload with `R2_ENABLED=true` but R2 unavailable (closed moto port or patched `upload_bytes` raising): local write succeeds, `avatar_in_r2 = false`, request returns success, `avatar_r2_upload_failed` log captured.
+- Orphan deletion with old `avatar_in_r2 = true`: local file unlinked AND R2 object deleted. With old `avatar_in_r2 = false`: R2 not touched.
+- Orphan deletion when another user still references the avatar: neither local nor R2 touched.
+
+### `tests/api/v1/test_users_avatar.py` (extend)
+
+- Avatar URL on `UserResponse` switches to CDN URL when `R2_ENABLED=true` and `avatar_in_r2=true`; stays local otherwise.
+- Privmsg responses include avatar URLs that respect the same rule (smoke-test a few of the six call sites).
+
+### `tests/api/v1/test_banners.py` (extend)
+
+- `BannerResponse._image_url` returns CDN URL when `R2_ENABLED=true` and `in_r2=true`; falls back to `BANNER_BASE_URL` otherwise.
+- Cover both full-image and three-part banner shapes.
+
+### `tests/scripts/test_r2_sync_avatars.py` (new)
+
+- Backfill happy path: rows with `avatar_in_r2=false` and local files present are uploaded and flipped to true.
+- Idempotent re-run: rows already in R2 are detected via `head_object`, no re-upload, bit flipped to true.
+- Missing local file: log captured, bit stays false, no R2 call.
+- `--dry-run` does not write to R2 or DB.
+- Refuses to run with `R2_ALLOW_BULK_BACKFILL=false`.
+
+### `tests/scripts/test_r2_sync_banners.py` (new)
+
+- Backfill happy path for full-image banner: single key uploaded, bit flipped.
+- Backfill happy path for three-part banner: three keys uploaded, bit flipped.
+- Partial-success three-part: one part missing on disk, no upload happens for that row, bit stays false, log captured.
+- Idempotent re-run with `head_object` short-circuit.
+
+All R2-touching tests reuse the `ThreadedMotoServer` fixture pattern from `tests/unit/test_r2_storage.py`; flag toggling uses `monkeypatch.setattr(settings, "R2_ENABLED", True)` per existing convention in `tests/unit/test_r2_finalize_job.py`.
+
+## Rollout
+
+1. Land the feature behind the existing `R2_ENABLED` flag — schema migrations, model bits, write-path dual-write, URL helpers, backfill subcommands, tests. With `R2_ENABLED=false` everywhere (current dev/staging default), behavior is unchanged: bits default false, fall-back URLs continue to work.
+2. In production (`R2_ENABLED=true` already): run `avatars-backfill` and `banners-backfill` with `R2_ALLOW_BULK_BACKFILL=true`. Verify a random sample resolves through the CDN with `curl -I`.
+3. New uploads from this point dual-write automatically; new banners require an `r2_sync.py banners-backfill` run to flip their bit.
+4. (Future, out of scope) Once stable and IQDB/avatar/banner code paths can fully read from R2, demote local FS for these classes to read-only fallback or remove entirely.
+
+## Risks and mitigations
+
+- **R2 upload failure on the avatar hot path** — mitigated by log-and-continue semantics. Worst case: a small number of rows have `avatar_in_r2=false` and serve from local; backfill catches up.
+- **Banner cache staleness after bit flip** — accepted; max ~15 minutes (TTL + jitter), and the fall-back URL remains valid through the staleness window.
+- **Partial backfill leaves rows pointing at local** — by design. The bit guarantees URL correctness regardless of backfill state. Re-running the backfill is safe.
+- **Forgotten privmsg call site** — six string-built URLs in `app/api/v1/privmsgs.py` is the largest concentration of inline URL building. Mitigated by the centralized helper plus tests for representative endpoints; a follow-up pass over the full file before merge confirms all sites are migrated.
+- **Local-FS path for banners not configured today** — adding `BANNER_STORAGE_PATH` with a derived default keeps existing deployments working without a config change.
+
+## Open questions
+
+None at design time. Implementation will surface a few mechanical questions (exact log field names, helper module location for the avatar URL function) that fall through to the implementation plan.

--- a/docs/plans/2026-05-08-r2-avatars-banners-impl.md
+++ b/docs/plans/2026-05-08-r2-avatars-banners-impl.md
@@ -1,0 +1,1534 @@
+# R2 storage for avatars and banners — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend Cloudflare R2 storage to user avatars and site banners using a lightweight dual-write pattern gated by per-row tracking bits. Local FS remains a working fallback; existing dev (`R2_ENABLED=false`) behavior is preserved.
+
+**Architecture:** Two new boolean columns (`users.avatar_in_r2`, `banners.in_r2`) gate URL generation and orphan-cleanup. Avatar uploads dual-write inline (best-effort R2, falls back to local-only on failure). One-shot `r2_sync.py` subcommands (`avatars-backfill`, `banners-backfill`) cover existing files. No async retry queue, no admin upload endpoint, no private-bucket support.
+
+**Tech Stack:** Python 3.14, FastAPI, SQLModel, Alembic, MariaDB 12, aioboto3, moto (test), pytest. Spec: `docs/plans/2026-05-08-r2-avatars-banners-design.md`.
+
+---
+
+## Pre-flight
+
+The design doc currently lives on branch `docs/r2-avatars-banners-design`. Implementation should branch off `main` once the spec is merged (or rebase as appropriate). Convention from prior work suggests `feat/r2-avatars-banners`.
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only
+git checkout -b feat/r2-avatars-banners
+```
+
+Confirm the test suite is green before starting:
+
+```bash
+uv run pytest tests/unit -x -q
+```
+
+Confirm alembic head is `6f286ed3c418` (the iqdb-hash migration) — both new migrations descend from it:
+
+```bash
+uv run alembic heads
+```
+
+If the head is different, the migration `down_revision` values in this plan must be updated to match the actual current head before generating new revisions.
+
+## File structure
+
+**New files**
+
+- `alembic/versions/<rev1>_add_avatar_in_r2_to_users.py` — schema migration
+- `alembic/versions/<rev2>_add_in_r2_to_banners.py` — schema migration
+- `tests/unit/test_avatar_url_helper.py` — pure-function tests for the new URL helper
+- `tests/unit/test_avatar_r2_dual_write.py` — moto-backed dual-write integration tests for `_upload_avatar`
+- `tests/unit/test_r2_sync_avatars_backfill.py` — backfill CLI tests
+- `tests/unit/test_r2_sync_banners_backfill.py` — backfill CLI tests
+
+**Modified files**
+
+- `app/config.py` — add `BANNER_STORAGE_PATH` setting + `set_default_banner_storage_path` validator
+- `app/models/user.py` — add `avatar_in_r2` to `UserBase`
+- `app/models/misc.py` — add `in_r2` to `BannerBase`
+- `app/services/r2_storage.py` — add `upload_bytes` to `R2Storage` and `DummyR2Storage`
+- `app/services/avatar.py` — add `_avatar_content_type`, `avatar_url`; extend `delete_avatar_if_orphaned` signature
+- `app/schemas/banner.py` — `BannerResponse.in_r2` field, update `_image_url`
+- `app/schemas/user.py` — update `UserResponse.avatar_url` to use helper
+- `app/schemas/common.py` — update `UserSummary.avatar_url` to use helper, add `avatar_in_r2` field
+- `app/api/v1/users.py` — `_upload_avatar` and `_delete_avatar` capture old_in_r2, dual-write, pass to orphan helper
+- `app/api/v1/privmsgs.py` — replace 7 inline avatar URL builds with helper; queries fetch `avatar_in_r2`
+- `scripts/r2_sync.py` — add `avatars-backfill` and `banners-backfill` subcommands
+- `tests/unit/test_r2_storage.py` — extend with `upload_bytes` test
+- `tests/unit/test_r2_client.py` — extend with `DummyR2Storage.upload_bytes` test
+- `tests/unit/test_avatar.py` — existing avatar-service tests; extend with new orphan-helper signature
+- `tests/unit/test_banner_schema.py` — extend with `in_r2` switch tests
+
+---
+
+## Chunk 1: Schema, models, config
+
+Goal of this chunk: alembic migrations land, model fields exist, config knob exists. After this chunk, the application still behaves identically (bits default false everywhere, no code consumes them yet).
+
+### Task 1.1: Alembic migration — `users.avatar_in_r2`
+
+**Files:**
+- Create: `alembic/versions/<auto>_add_avatar_in_r2_to_users.py`
+
+- [ ] **Step 1: Generate the migration scaffolding**
+
+```bash
+uv run alembic revision -m "add avatar_in_r2 to users"
+```
+
+Note the generated filename (it'll be `alembic/versions/<hash>_add_avatar_in_r2_to_users.py`).
+
+- [ ] **Step 2: Replace the generated `upgrade`/`downgrade` bodies**
+
+Edit the new file. Set `down_revision = "6f286ed3c418"` (the current head). Replace upgrade/downgrade with:
+
+```python
+def upgrade() -> None:
+    """Add avatar_in_r2 to users.
+
+    Tracks whether the avatar file referenced by users.avatar exists in R2.
+    Default 0 — backfill is a separate one-shot run via
+    `scripts/r2_sync.py avatars-backfill`.
+
+    Uses ALGORITHM=INSTANT, LOCK=NONE so the migration is metadata-only on
+    InnoDB (MariaDB 12) — no table rewrite, no row locks.
+    """
+    op.execute(
+        "ALTER TABLE users ADD COLUMN avatar_in_r2 BOOLEAN NOT NULL DEFAULT 0, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )
+
+
+def downgrade() -> None:
+    """Remove avatar_in_r2 column."""
+    op.drop_column("users", "avatar_in_r2")
+```
+
+- [ ] **Step 3: Apply, verify, downgrade-roundtrip**
+
+```bash
+uv run alembic upgrade head
+uv run alembic downgrade -1
+uv run alembic upgrade head
+```
+
+Expected: each command exits 0. After the final upgrade, `uv run alembic heads` reports the new revision as head.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add alembic/versions/*_add_avatar_in_r2_to_users.py
+git commit -m "feat(alembic): add avatar_in_r2 column to users"
+```
+
+### Task 1.2: Alembic migration — `banners.in_r2`
+
+**Files:**
+- Create: `alembic/versions/<auto>_add_in_r2_to_banners.py`
+
+- [ ] **Step 1: Generate the migration**
+
+```bash
+uv run alembic revision -m "add in_r2 to banners"
+```
+
+- [ ] **Step 2: Replace bodies**
+
+`down_revision` must be the migration hash from Task 1.1. Bodies:
+
+```python
+def upgrade() -> None:
+    """Add in_r2 to banners.
+
+    Tracks whether all of full_image / left_image / middle_image / right_image
+    referenced by this row exist in R2. Default 0 — backfill is a separate
+    one-shot run via `scripts/r2_sync.py banners-backfill`.
+    """
+    op.execute(
+        "ALTER TABLE banners ADD COLUMN in_r2 BOOLEAN NOT NULL DEFAULT 0, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )
+
+
+def downgrade() -> None:
+    """Remove in_r2 column."""
+    op.drop_column("banners", "in_r2")
+```
+
+- [ ] **Step 3: Apply, verify, downgrade-roundtrip**
+
+Same commands as Task 1.1. Confirm both columns are present after `upgrade head`:
+
+```bash
+uv run python -c "
+import asyncio
+from sqlalchemy import inspect
+from app.core.database import engine
+async def main():
+    async with engine.connect() as c:
+        cols = await c.run_sync(lambda s: {col['name'] for col in inspect(s).get_columns('users')} | {col['name'] for col in inspect(s).get_columns('banners')})
+        assert 'avatar_in_r2' in cols and 'in_r2' in cols, cols
+        print('OK')
+asyncio.run(main())
+"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add alembic/versions/*_add_in_r2_to_banners.py
+git commit -m "feat(alembic): add in_r2 column to banners"
+```
+
+### Task 1.3: Add `avatar_in_r2` to `UserBase`
+
+**Files:**
+- Modify: `app/models/user.py:46`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_user_loader.py` (or create `tests/unit/test_user_avatar_in_r2_field.py` if simpler — a single tiny test):
+
+```python
+def test_userbase_has_avatar_in_r2_field():
+    from app.models.user import UserBase
+    field = UserBase.model_fields["avatar_in_r2"]
+    assert field.annotation is bool
+    assert field.default is False
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+uv run pytest tests/unit/test_user_avatar_in_r2_field.py -v
+```
+
+Expected: FAIL with `KeyError: 'avatar_in_r2'`.
+
+- [ ] **Step 3: Add the field**
+
+In `app/models/user.py`, immediately after `avatar: str = Field(...)` (line 46):
+
+```python
+    avatar_in_r2: bool = Field(default=False)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+uv run pytest tests/unit/test_user_avatar_in_r2_field.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full unit suite to catch fallout**
+
+```bash
+uv run pytest tests/unit -x -q
+```
+
+Expected: all green. If any test fails because a `Users(...)` constructor has a positional-arg expectation, those need fixing in the same commit — but `bool` defaults shouldn't break call sites.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/models/user.py tests/unit/test_user_avatar_in_r2_field.py
+git commit -m "feat(models): add avatar_in_r2 field to UserBase"
+```
+
+### Task 1.4: Add `in_r2` to `BannerBase`
+
+**Files:**
+- Modify: `app/models/misc.py` (in `BannerBase` class around line 31–54)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_banner_model.py`:
+
+```python
+def test_bannerbase_has_in_r2_field():
+    from app.models.misc import BannerBase
+    field = BannerBase.model_fields["in_r2"]
+    assert field.annotation is bool
+    assert field.default is False
+```
+
+- [ ] **Step 2: Verify it fails**
+
+```bash
+uv run pytest tests/unit/test_banner_model.py::test_bannerbase_has_in_r2_field -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Add the field**
+
+In `BannerBase`, after `active: bool = Field(default=True)`:
+
+```python
+    in_r2: bool = Field(default=False)
+```
+
+- [ ] **Step 4: Verify pass + suite**
+
+```bash
+uv run pytest tests/unit/test_banner_model.py -v
+uv run pytest tests/unit -x -q
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/misc.py tests/unit/test_banner_model.py
+git commit -m "feat(models): add in_r2 field to BannerBase"
+```
+
+### Task 1.5: Add `BANNER_STORAGE_PATH` setting
+
+**Files:**
+- Modify: `app/config.py` (add setting field near line 181, add validator near line 244–248)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_config.py` (or wherever banner config tests live — confirm with `grep`; otherwise create `tests/unit/test_config_banner_storage.py`):
+
+```python
+def test_banner_storage_path_default_derives_from_storage_path(monkeypatch):
+    from app.config import Settings
+    s = Settings(STORAGE_PATH="/tmp/test", BANNER_STORAGE_PATH="")
+    assert s.BANNER_STORAGE_PATH == "/tmp/test/banners"
+
+
+def test_banner_storage_path_explicit_value_preserved():
+    from app.config import Settings
+    s = Settings(STORAGE_PATH="/tmp/test", BANNER_STORAGE_PATH="/elsewhere")
+    assert s.BANNER_STORAGE_PATH == "/elsewhere"
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+uv run pytest tests/unit/test_config_banner_storage.py -v
+```
+
+Expected: FAIL — attribute does not exist.
+
+- [ ] **Step 3: Add setting and validator**
+
+In `app/config.py`, alongside `AVATAR_STORAGE_PATH` declaration around line 113:
+
+```python
+    BANNER_STORAGE_PATH: str = ""  # Derived from STORAGE_PATH if not set
+```
+
+Add a sibling `@model_validator(mode="after")` after `set_default_avatar_storage_path` (around line 244):
+
+```python
+    @model_validator(mode="after")
+    def set_default_banner_storage_path(self) -> Settings:
+        if not self.BANNER_STORAGE_PATH:
+            self.BANNER_STORAGE_PATH = f"{self.STORAGE_PATH}/banners"
+        return self
+```
+
+- [ ] **Step 4: Verify pass + suite**
+
+```bash
+uv run pytest tests/unit/test_config_banner_storage.py -v
+uv run pytest tests/unit -x -q
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/config.py tests/unit/test_config_banner_storage.py
+git commit -m "feat(config): add BANNER_STORAGE_PATH setting"
+```
+
+---
+
+## Chunk 2: R2 adapter + URL helpers
+
+Goal: `R2Storage.upload_bytes` exists and is tested; `avatar_url` and the banner URL switch read the new bits but **don't** dual-write yet. Behavior change: rows with `avatar_in_r2=true` (none yet, since defaults are false) would now serve from CDN. With all bits false post-Chunk-1, runtime behavior is unchanged.
+
+### Task 2.1: Add `R2Storage.upload_bytes`
+
+**Files:**
+- Modify: `app/services/r2_storage.py` (add method around line 79, alongside `upload_file`)
+- Modify: `tests/unit/test_r2_storage.py` (extend `TestR2Storage`)
+- Modify: `tests/unit/test_r2_client.py` (extend `DummyR2Storage` test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_r2_storage.py` inside `class TestR2Storage`:
+
+```python
+    async def test_upload_bytes_round_trip(self, setup_buckets, moto_session, moto_server):
+        storage = setup_buckets
+        await storage.upload_bytes(
+            bucket="public",
+            key="avatars/abc.png",
+            body=b"PNG-bytes",
+            content_type="image/png",
+        )
+        assert await storage.object_exists(bucket="public", key="avatars/abc.png")
+        # Verify Content-Type was set
+        async with moto_session.client("s3", endpoint_url=moto_server) as s3:
+            head = await s3.head_object(Bucket="public", Key="avatars/abc.png")
+            assert head["ContentType"] == "image/png"
+```
+
+Append to `tests/unit/test_r2_client.py`:
+
+```python
+async def test_dummy_upload_bytes_raises():
+    from app.services.r2_storage import DummyR2Storage
+    storage = DummyR2Storage()
+    import pytest
+    with pytest.raises(RuntimeError):
+        await storage.upload_bytes(
+            bucket="x", key="y", body=b"z", content_type="image/png"
+        )
+```
+
+- [ ] **Step 2: Verify failures**
+
+```bash
+uv run pytest tests/unit/test_r2_storage.py::TestR2Storage::test_upload_bytes_round_trip tests/unit/test_r2_client.py -v
+```
+
+Expected: both tests fail (`AttributeError: 'R2Storage' object has no attribute 'upload_bytes'` etc.).
+
+- [ ] **Step 3: Implement on `R2Storage`**
+
+In `app/services/r2_storage.py`, add a method to the `R2Storage` class (insert after `upload_file`):
+
+```python
+    async def upload_bytes(
+        self, bucket: str, key: str, body: bytes, content_type: str
+    ) -> None:
+        """Upload an in-memory bytes payload with an explicit Content-Type.
+
+        Content-Type is mandatory because R2 stores `application/octet-stream`
+        when none is set, which can break inline image rendering under strict
+        CSP / X-Content-Type-Options: nosniff.
+        """
+        async with self._acquire_client() as s3:
+            await s3.put_object(
+                Bucket=bucket, Key=key, Body=body, ContentType=content_type
+            )
+```
+
+- [ ] **Step 4: Implement on `DummyR2Storage`**
+
+In the same file, add to `DummyR2Storage`:
+
+```python
+    async def upload_bytes(
+        self, bucket: str, key: str, body: bytes, content_type: str
+    ) -> None:
+        raise RuntimeError(self._ERR)
+```
+
+- [ ] **Step 5: Verify pass**
+
+```bash
+uv run pytest tests/unit/test_r2_storage.py tests/unit/test_r2_client.py -v
+```
+
+Expected: all green including the new tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/r2_storage.py tests/unit/test_r2_storage.py tests/unit/test_r2_client.py
+git commit -m "feat(r2): add upload_bytes to R2Storage"
+```
+
+### Task 2.2: Add avatar URL helper and `_avatar_content_type`
+
+**Files:**
+- Modify: `app/services/avatar.py`
+- Create: `tests/unit/test_avatar_url_helper.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_avatar_url_helper.py`:
+
+```python
+"""Tests for avatar URL helper and content-type derivation."""
+
+import pytest
+
+from app.config import settings
+from app.services.avatar import _avatar_content_type, avatar_url
+
+
+def test_avatar_url_returns_none_for_empty():
+    assert avatar_url("", in_r2=True) is None
+    assert avatar_url(None, in_r2=True) is None
+
+
+def test_avatar_url_local_when_r2_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "R2_ENABLED", False)
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    assert avatar_url("abc.png", in_r2=True) == "http://local.test/images/avatars/abc.png"
+
+
+def test_avatar_url_local_when_bit_false(monkeypatch):
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    assert avatar_url("abc.png", in_r2=False) == "http://local.test/images/avatars/abc.png"
+
+
+def test_avatar_url_cdn_when_both_true(monkeypatch):
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    assert avatar_url("abc.png", in_r2=True) == "https://cdn.test/avatars/abc.png"
+
+
+@pytest.mark.parametrize("ext,expected", [
+    ("png", "image/png"),
+    ("jpg", "image/jpeg"),
+    ("jpeg", "image/jpeg"),
+    ("gif", "image/gif"),
+])
+def test_avatar_content_type(ext, expected):
+    assert _avatar_content_type(ext) == expected
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+uv run pytest tests/unit/test_avatar_url_helper.py -v
+```
+
+Expected: ImportError on `avatar_url` and `_avatar_content_type`.
+
+- [ ] **Step 3: Add helpers to `app/services/avatar.py`**
+
+After the `ALLOWED_AVATAR_EXTENSIONS` constant:
+
+```python
+_AVATAR_CONTENT_TYPES: dict[str, str] = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "gif": "image/gif",
+}
+
+
+def _avatar_content_type(ext: str) -> str:
+    """Map an avatar extension (no dot) to its image/* MIME type."""
+    return _AVATAR_CONTENT_TYPES[ext.lower()]
+
+
+def avatar_url(filename: str | None, in_r2: bool) -> str | None:
+    """Return the public URL for an avatar, choosing CDN vs local FS.
+
+    When R2_ENABLED is false, the per-row bit is ignored and the local URL
+    is returned — preserving today's dev-only behavior even if a dev pulls
+    a prod DB dump where rows have the bit set.
+    """
+    if not filename:
+        return None
+    if settings.R2_ENABLED and in_r2:
+        return f"{settings.R2_PUBLIC_CDN_URL}/avatars/{filename}"
+    return f"{settings.IMAGE_BASE_URL}/images/avatars/{filename}"
+```
+
+- [ ] **Step 4: Verify pass**
+
+```bash
+uv run pytest tests/unit/test_avatar_url_helper.py -v
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/avatar.py tests/unit/test_avatar_url_helper.py
+git commit -m "feat(avatar): add avatar_url helper and content-type mapping"
+```
+
+### Task 2.3: Switch `UserResponse.avatar_url` and `UserSummary.avatar_url` to the helper
+
+**Files:**
+- Modify: `app/schemas/user.py:157` (UserResponse.avatar_url computed_field)
+- Modify: `app/schemas/common.py:29` (UserSummary.avatar_url computed_field)
+- Modify: `app/schemas/common.py:20` (UserSummary class — add `avatar_in_r2` field)
+
+- [ ] **Step 1: Write the failing test**
+
+Create or extend `tests/unit/test_avatar_url_helper.py` with a schema-level test:
+
+```python
+def test_user_response_avatar_url_uses_helper(monkeypatch):
+    from app.schemas.user import UserResponse
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+    # Build via from_attributes pathway with a minimal stand-in
+    data = {
+        "user_id": 1, "username": "alice", "avatar": "abc.png",
+        "avatar_in_r2": True,
+        # plus any other required UserResponse fields — fill from model_fields
+    }
+    # Use model_construct to bypass deep validation for fields we don't care about
+    resp = UserResponse.model_construct(**data)
+    assert resp.avatar_url == "https://cdn.test/avatars/abc.png"
+
+
+def test_user_summary_avatar_url_uses_helper(monkeypatch):
+    from app.schemas.common import UserSummary
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+    summary = UserSummary(user_id=1, username="alice", avatar="abc.png", avatar_in_r2=True)
+    assert summary.avatar_url == "https://cdn.test/avatars/abc.png"
+```
+
+The exact `UserResponse` field set may need adjusting — confirm by reading `app/schemas/user.py` lines 140–177.
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+uv run pytest tests/unit/test_avatar_url_helper.py -v
+```
+
+Expected: failure — `UserSummary` doesn't have `avatar_in_r2` and the URL is built from the inline f-string, not the helper.
+
+- [ ] **Step 3: Add `avatar_in_r2` to `UserSummary`**
+
+In `app/schemas/common.py` after the `avatar` field (line 20):
+
+```python
+    avatar_in_r2: bool = False
+```
+
+- [ ] **Step 4: Replace both computed_fields with helper calls**
+
+In `app/schemas/common.py:29`:
+
+```python
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def avatar_url(self) -> str | None:
+        """Generate avatar URL from avatar field"""
+        from app.services.avatar import avatar_url as _build_avatar_url
+        return _build_avatar_url(self.avatar, self.avatar_in_r2)
+```
+
+In `app/schemas/user.py:157`:
+
+```python
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def avatar_url(self) -> str | None:
+        """Generate avatar URL from avatar field"""
+        from app.services.avatar import avatar_url as _build_avatar_url
+        return _build_avatar_url(self.avatar, self.avatar_in_r2)
+```
+
+(The local-import shape avoids any lingering circular-import concerns between schemas and services. If the existing module already imports from `app.services.avatar` at top level, hoist it to module-level.)
+
+- [ ] **Step 5: Verify pass + full unit suite**
+
+```bash
+uv run pytest tests/unit/test_avatar_url_helper.py -v
+uv run pytest tests/unit -x -q
+```
+
+Expected: all green. If `UserResponse`-driven tests break because callers don't pass `avatar_in_r2`, the field reads from `UserBase` (Task 1.3) so model_validate from a row works; manual constructor calls in tests need the new field passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/schemas/user.py app/schemas/common.py tests/unit/test_avatar_url_helper.py
+git commit -m "feat(schemas): route avatar URL generation through helper"
+```
+
+### Task 2.4: Add `in_r2` to `BannerResponse` and switch `_image_url`
+
+**Files:**
+- Modify: `app/schemas/banner.py:12-80` (BannerResponse class)
+- Modify: `tests/unit/test_banner_schema.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_banner_schema.py`:
+
+```python
+def test_banner_response_uses_cdn_when_in_r2_and_enabled(monkeypatch):
+    from app.config import settings
+    from app.models.misc import BannerSize
+    from app.schemas.banner import BannerResponse
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    monkeypatch.setattr(settings, "BANNER_BASE_URL", "http://local.test/banners")
+
+    resp = BannerResponse(
+        banner_id=1, name="t", author=None, size=BannerSize.small,
+        supports_dark=True, supports_light=True,
+        full_image="eva/full.jpg", left_image=None, middle_image=None, right_image=None,
+        in_r2=True,
+    )
+    assert resp.full_image_url == "https://cdn.test/banners/eva/full.jpg"
+
+
+def test_banner_response_falls_back_when_bit_false(monkeypatch):
+    from app.config import settings
+    from app.models.misc import BannerSize
+    from app.schemas.banner import BannerResponse
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    monkeypatch.setattr(settings, "BANNER_BASE_URL", "http://local.test/banners")
+
+    resp = BannerResponse(
+        banner_id=1, name="t", author=None, size=BannerSize.small,
+        supports_dark=True, supports_light=True,
+        full_image="eva/full.jpg", left_image=None, middle_image=None, right_image=None,
+        in_r2=False,
+    )
+    assert resp.full_image_url == "http://local.test/banners/eva/full.jpg"
+
+
+def test_banner_response_three_part_uses_cdn(monkeypatch):
+    from app.config import settings
+    from app.models.misc import BannerSize
+    from app.schemas.banner import BannerResponse
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    monkeypatch.setattr(settings, "BANNER_BASE_URL", "http://local.test/banners")
+
+    resp = BannerResponse(
+        banner_id=1, name="t", author=None, size=BannerSize.large,
+        supports_dark=True, supports_light=True,
+        full_image=None,
+        left_image="hw/l.png", middle_image="hw/m.png", right_image="hw/r.png",
+        in_r2=True,
+    )
+    assert resp.left_image_url == "https://cdn.test/banners/hw/l.png"
+    assert resp.middle_image_url == "https://cdn.test/banners/hw/m.png"
+    assert resp.right_image_url == "https://cdn.test/banners/hw/r.png"
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+uv run pytest tests/unit/test_banner_schema.py -v
+```
+
+Expected: failure — `in_r2` field missing on `BannerResponse`.
+
+- [ ] **Step 3: Add field and switch helper**
+
+In `app/schemas/banner.py`, add to `BannerResponse` (after `right_image: str | None`, before `model_config`):
+
+```python
+    in_r2: bool = False
+```
+
+Replace `_image_url`:
+
+```python
+    def _image_url(self, path: str | None) -> str | None:
+        if not path:
+            return None
+        if settings.R2_ENABLED and self.in_r2:
+            return f"{settings.R2_PUBLIC_CDN_URL}/banners/{path.lstrip('/')}"
+        return f"{settings.BANNER_BASE_URL.rstrip('/')}/{path.lstrip('/')}"
+```
+
+- [ ] **Step 4: Verify pass + full unit suite**
+
+```bash
+uv run pytest tests/unit/test_banner_schema.py -v
+uv run pytest tests/unit -x -q
+```
+
+If tests under `tests/unit/test_banner_*` fail because existing fixtures don't pass `in_r2`, the default of `False` should keep them green (Pydantic uses the default). Confirm with the run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/schemas/banner.py tests/unit/test_banner_schema.py
+git commit -m "feat(banners): route image URLs through CDN when in_r2 set"
+```
+
+---
+
+## Chunk 3: Avatar write path (dual-write + orphan delete)
+
+Goal: avatar uploads dual-write to R2 when `R2_ENABLED`; failures log and continue with `avatar_in_r2=false`. Orphan-delete cleans up R2 when the old bit was true.
+
+### Task 3.1: Extend `delete_avatar_if_orphaned` signature
+
+**Files:**
+- Modify: `app/services/avatar.py:179`
+- Modify: `tests/unit/test_avatar.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_avatar.py`:
+
+```python
+class TestDeleteAvatarIfOrphanedR2:
+    """Orphan deletion now considers the old_in_r2 bit."""
+
+    @pytest.mark.asyncio
+    async def test_signature_accepts_old_in_r2(self, tmp_path, monkeypatch):
+        from app.services.avatar import delete_avatar_if_orphaned
+        # Just confirm the new signature exists
+        import inspect
+        sig = inspect.signature(delete_avatar_if_orphaned)
+        assert "old_in_r2" in sig.parameters
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+uv run pytest tests/unit/test_avatar.py::TestDeleteAvatarIfOrphanedR2 -v
+```
+
+Expected: FAIL — signature lacks `old_in_r2`.
+
+- [ ] **Step 3: Update the function**
+
+In `app/services/avatar.py`, change `delete_avatar_if_orphaned`:
+
+```python
+async def delete_avatar_if_orphaned(
+    filename: str, old_in_r2: bool, db: AsyncSession
+) -> bool:
+    """Delete avatar file from disk (and R2 if old_in_r2) if no users reference it.
+
+    Args:
+        filename: Avatar filename to check
+        old_in_r2: Whether this filename's R2 object existed at the start of the
+            request — used to decide whether to issue an R2 delete.
+        db: Database session
+
+    Returns:
+        True if the local file was deleted, False otherwise. R2 delete is
+        best-effort and not reflected in the return value.
+    """
+    if not filename:
+        return False
+
+    result = await db.execute(
+        select(func.count()).select_from(Users).where(Users.avatar == filename)  # type: ignore[arg-type]
+    )
+    count = result.scalar() or 0
+
+    if count != 0:
+        return False
+
+    deleted_local = False
+    file_path = Path(settings.AVATAR_STORAGE_PATH) / filename
+    if file_path.exists():
+        file_path.unlink()
+        deleted_local = True
+        logger.info("orphaned_avatar_deleted", filename=filename)
+
+    if old_in_r2 and settings.R2_ENABLED:
+        from app.core.r2_client import get_r2_storage
+        r2 = get_r2_storage()
+        await r2.delete_object(
+            bucket=settings.R2_PUBLIC_BUCKET, key=f"avatars/{filename}"
+        )
+        logger.info("avatar_r2_orphan_deleted", key=f"avatars/{filename}")
+
+    return deleted_local
+```
+
+- [ ] **Step 4: Update existing call sites**
+
+`app/api/v1/users.py` has two callers:
+- Line ~327: `await delete_avatar_if_orphaned(old_avatar, db)` → must capture `old_in_r2 = user.avatar_in_r2` before mutation, pass it.
+- Line ~476 in `_delete_avatar`: same.
+
+These edits are part of Task 3.2 below. For this task, only update the function signature and the existing tests so they still compile.
+
+Update existing tests in `tests/unit/test_avatar.py` that call `delete_avatar_if_orphaned`: pass `old_in_r2=False` (preserves today's behavior — no R2 call).
+
+- [ ] **Step 5: Verify pass + suite**
+
+```bash
+uv run pytest tests/unit/test_avatar.py -v
+```
+
+If `app/api/v1/users.py` still calls the old signature, expect the call sites to fail at runtime — since this is a dependency-injection wired path, it shows up under integration tests, not unit. Move quickly into Task 3.2; or if any unit test imports the route, fix the call site here.
+
+```bash
+uv run pytest tests/unit -x -q
+```
+
+Expected: green; if the integration suite is in scope, it'll be green after Task 3.2.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/avatar.py tests/unit/test_avatar.py
+git commit -m "feat(avatar): orphan-delete also clears R2 object when old_in_r2"
+```
+
+### Task 3.2: Dual-write in `_upload_avatar`, capture `old_in_r2` in `_delete_avatar`
+
+**Files:**
+- Modify: `app/api/v1/users.py:272–333` (`_upload_avatar`)
+- Modify: `app/api/v1/users.py:439–478` (`_delete_avatar`)
+- Create: `tests/unit/test_avatar_r2_dual_write.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_avatar_r2_dual_write.py`. This is moto-backed; reuse the `moto_server` / `moto_session` fixtures by importing them from `tests/unit/test_r2_storage.py` (or reproduce them) — for cleanliness, **lift those fixtures into `tests/unit/conftest.py`** as part of Task 2.1, and reuse here. (If skipped at Task 2.1, do it now.)
+
+Sketch:
+
+```python
+"""Dual-write integration tests for avatar upload."""
+import io
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+from PIL import Image
+
+from app.config import settings
+from app.core.r2_client import get_r2_storage, reset_r2_storage
+from app.services.avatar import _avatar_content_type
+
+
+@pytest.fixture
+def png_bytes():
+    img = Image.new("RGB", (50, 50), color="red")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+# ... fixtures wiring R2_ENABLED=true, R2_PUBLIC_BUCKET, etc. to moto
+
+
+@pytest.mark.asyncio
+async def test_dual_write_success_sets_bit(...):
+    """Upload writes local file AND R2 object, sets avatar_in_r2=true."""
+    # Hit POST /users/me/avatar via the test client; assert
+    # 1. local file at AVATAR_STORAGE_PATH/<md5>.png exists
+    # 2. R2 head_object("avatars/<md5>.png") returns 200 with image/png
+    # 3. user.avatar_in_r2 is True after refresh
+
+
+@pytest.mark.asyncio
+async def test_dual_write_r2_failure_falls_back(...):
+    """If R2 upload raises, request still succeeds with avatar_in_r2=false."""
+    # Patch R2Storage.upload_bytes to raise ClientError or similar
+    # Assert local file exists, user.avatar_in_r2 is False
+    # Assert avatar_r2_upload_failed log was emitted
+
+
+@pytest.mark.asyncio
+async def test_orphan_delete_clears_r2_when_old_in_r2(...):
+    """Replacing an avatar with old_in_r2=true and no other refs deletes R2 object."""
+
+
+@pytest.mark.asyncio
+async def test_orphan_delete_skips_r2_when_old_in_r2_false(...):
+    """Replacing an avatar with old_in_r2=false leaves R2 alone (and there is no R2 object anyway)."""
+
+
+@pytest.mark.asyncio
+async def test_same_md5_reupload_preserves_file(...):
+    """User uploads identical bytes — orphan check sees the user still references the file post-commit, no delete fires."""
+```
+
+The exact test client / DB fixture pattern is determined by `tests/conftest.py`. Read it before fleshing these out.
+
+- [ ] **Step 2: Verify the new tests fail**
+
+```bash
+uv run pytest tests/unit/test_avatar_r2_dual_write.py -v
+```
+
+Expected: failures (no dual-write yet).
+
+- [ ] **Step 3: Modify `_upload_avatar` for dual-write**
+
+Reading `app/api/v1/users.py:272–333`. Restructure to capture `old_in_r2` before mutation, dual-write to R2 after `save_avatar`, set the bit.
+
+```python
+async def _upload_avatar(
+    user_id: int,
+    avatar: UploadFile,
+    db: AsyncSession,
+) -> UserResponse:
+    # ... unchanged: load user, raise 404, etc.
+
+    old_avatar = user.avatar
+    old_in_r2 = user.avatar_in_r2
+
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_path = FilePath(temp_file.name)
+        content = await avatar.read()
+        temp_file.write(content)
+
+    try:
+        validate_avatar_upload(avatar, temp_path)
+        processed_content, ext = resize_avatar(temp_path)
+        new_filename = save_avatar(processed_content, ext)
+
+        new_in_r2 = False
+        if settings.R2_ENABLED:
+            try:
+                r2 = get_r2_storage()
+                await r2.upload_bytes(
+                    bucket=settings.R2_PUBLIC_BUCKET,
+                    key=f"avatars/{new_filename}",
+                    body=processed_content,
+                    content_type=_avatar_content_type(ext),
+                )
+                new_in_r2 = True
+                logger.info(
+                    "avatar_r2_uploaded",
+                    user_id=user_id,
+                    key=f"avatars/{new_filename}",
+                )
+            except Exception as e:
+                logger.warning(
+                    "avatar_r2_upload_failed",
+                    user_id=user_id,
+                    key=f"avatars/{new_filename}",
+                    error=type(e).__name__,
+                    error_msg=str(e),
+                )
+
+        user.avatar = new_filename
+        user.avatar_in_r2 = new_in_r2
+        await db.commit()
+        await db.refresh(user)
+
+        if old_avatar and old_avatar != new_filename:
+            await delete_avatar_if_orphaned(old_avatar, old_in_r2, db)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+    return UserResponse.model_validate(user)
+```
+
+Add the two new imports near the top of `app/api/v1/users.py`:
+
+```python
+from app.core.r2_client import get_r2_storage
+from app.services.avatar import _avatar_content_type
+```
+
+(Confirm the existing imports — `validate_avatar_upload`, `resize_avatar`, `save_avatar`, `delete_avatar_if_orphaned` — are already imported around line 58–60.)
+
+- [ ] **Step 4: Modify `_delete_avatar` to capture and pass `old_in_r2`**
+
+In `_delete_avatar`:
+
+```python
+    old_avatar = user.avatar
+    old_in_r2 = user.avatar_in_r2
+
+    user.avatar = ""
+    user.avatar_in_r2 = False
+    await db.commit()
+    await db.refresh(user)
+
+    if old_avatar:
+        await delete_avatar_if_orphaned(old_avatar, old_in_r2, db)
+```
+
+- [ ] **Step 5: Verify pass**
+
+```bash
+uv run pytest tests/unit/test_avatar_r2_dual_write.py tests/unit/test_avatar.py -v
+```
+
+If integration tests live under `tests/integration` for the routes, run those too:
+
+```bash
+uv run pytest tests/integration -x -q
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/v1/users.py tests/unit/test_avatar_r2_dual_write.py
+git commit -m "feat(avatar): dual-write avatar uploads to R2 with fallback"
+```
+
+---
+
+## Chunk 4: privmsgs.py — replace 7 inline URL builds
+
+Goal: every avatar URL in `app/api/v1/privmsgs.py` flows through the helper. Each query that fetches `users.avatar` also fetches `users.avatar_in_r2`.
+
+### Task 4.1: Replace each call site
+
+**Files:**
+- Modify: `app/api/v1/privmsgs.py` at lines 273, 415, 417, 577, 667, 741, 743 (and the surrounding queries that fetch `avatar`)
+
+- [ ] **Step 1: Add helper import at top of `app/api/v1/privmsgs.py`**
+
+```python
+from app.services.avatar import avatar_url
+```
+
+- [ ] **Step 2: Walk each site and replace**
+
+For each line with `f"{settings.IMAGE_BASE_URL}/images/avatars/{...}"`:
+
+1. Read the surrounding query (a few lines up) — it selects `Users.avatar` (or aliases). Extend the SELECT to include `Users.avatar_in_r2`.
+2. Where the result row is unpacked, capture both columns.
+3. Replace the f-string with `avatar_url(<filename_var>, <in_r2_var>)`. Note the helper returns `str | None`; existing code already conditions on truthy `avatar`, so adapt.
+
+Concrete example for line 273 area:
+
+Before:
+```python
+sender_avatar = ...  # from query
+avatar_url_str: str | None = None
+if sender_avatar:
+    avatar_url_str = f"{settings.IMAGE_BASE_URL}/images/avatars/{sender_avatar}"
+```
+
+After:
+```python
+sender_avatar, sender_avatar_in_r2 = ...  # extended query
+avatar_url_str = avatar_url(sender_avatar, sender_avatar_in_r2)
+```
+
+Apply to all 7 sites (273, 415, 417, 577, 667, 741, 743) plus the corresponding queries.
+
+- [ ] **Step 3: Run privmsg-related tests**
+
+```bash
+uv run pytest tests/unit/test_privmsg_schemas.py -v
+uv run pytest tests/integration -k privmsg -v 2>&1 | tail -40   # if integration suite covers privmsg endpoints
+```
+
+Expected: green. Failures here usually mean a missed call site or a dropped column from the query.
+
+- [ ] **Step 4: Final grep sweep**
+
+```bash
+grep -n "IMAGE_BASE_URL.*avatars" app/api/v1/privmsgs.py app/schemas/ app/api/
+```
+
+Expected: zero matches outside of test files.
+
+- [ ] **Step 5: Run full unit suite**
+
+```bash
+uv run pytest tests/unit -x -q
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/v1/privmsgs.py
+git commit -m "refactor(privmsgs): route avatar URLs through helper"
+```
+
+---
+
+## Chunk 5: backfill subcommands
+
+Goal: `r2_sync.py avatars-backfill` and `r2_sync.py banners-backfill` exist, are gated by `R2_ALLOW_BULK_BACKFILL`, idempotent, dry-runnable.
+
+### Task 5.1: `avatars-backfill`
+
+**Files:**
+- Modify: `scripts/r2_sync.py` (extend `_build_parser`, add `cmd_avatars_backfill`)
+- Create: `tests/unit/test_r2_sync_avatars_backfill.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_r2_sync_avatars_backfill.py`. Use the existing moto fixtures (lifted to `conftest.py` in Chunk 2). Tests:
+
+```python
+@pytest.mark.asyncio
+async def test_backfill_uploads_and_flips_bit(...):
+    # Seed 2 users with avatars on disk, both avatar_in_r2=False
+    # Run cmd_avatars_backfill
+    # Assert both users have avatar_in_r2=True
+    # Assert both R2 keys exist with image/png content type
+
+
+@pytest.mark.asyncio
+async def test_backfill_idempotent_skips_existing(...):
+    # Seed 1 user, pre-upload the R2 object
+    # Run cmd_avatars_backfill
+    # Assert head_object short-circuits (no upload), bit flips to True
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_when_local_missing(...):
+    # Seed 1 user with an avatar filename, NO local file on disk
+    # Run cmd_avatars_backfill
+    # Assert avatar_local_missing log captured, bit stays False, no R2 object
+
+
+@pytest.mark.asyncio
+async def test_backfill_dry_run_writes_nothing(...):
+    # Seed 1 user, run with --dry-run
+    # Assert no R2 object, bit stays False
+
+
+def test_backfill_refuses_without_bulk_flag(monkeypatch):
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", False)
+    with pytest.raises(BulkBackfillDisallowedError):
+        require_bulk_backfill()
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+uv run pytest tests/unit/test_r2_sync_avatars_backfill.py -v
+```
+
+Expected: ImportError or AttributeError on `cmd_avatars_backfill`.
+
+- [ ] **Step 3: Implement `cmd_avatars_backfill` in `scripts/r2_sync.py`**
+
+Sketch (adapt to the existing CLI patterns in `scripts/r2_sync.py` — read `_build_parser`, the existing `cmd_*` functions, and `require_bulk_backfill` first):
+
+```python
+import asyncio
+import mimetypes
+from pathlib import Path as FilePath
+
+from app.models.user import Users
+
+
+async def cmd_avatars_backfill(args: argparse.Namespace) -> int:
+    require_bulk_backfill()
+    r2 = get_r2_storage()
+    avatar_dir = FilePath(settings.AVATAR_STORAGE_PATH)
+    sem = asyncio.Semaphore(args.concurrency)
+
+    async with r2.bulk_session(), get_async_session() as db:
+        result = await db.execute(
+            select(Users.user_id, Users.avatar).where(
+                Users.avatar != "", Users.avatar_in_r2 == False  # noqa: E712
+            )
+        )
+        rows = result.all()
+
+        async def process(user_id: int, filename: str) -> None:
+            async with sem:
+                local = avatar_dir / filename
+                if not local.exists():
+                    logger.warning(
+                        "avatar_local_missing",
+                        user_id=user_id,
+                        filename=filename,
+                    )
+                    return
+                key = f"avatars/{filename}"
+                if not await r2.object_exists(
+                    bucket=settings.R2_PUBLIC_BUCKET, key=key
+                ):
+                    if args.dry_run:
+                        logger.info("avatar_r2_backfill_dry_run", key=key)
+                        return
+                    body = local.read_bytes()
+                    ct = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+                    await r2.upload_bytes(
+                        bucket=settings.R2_PUBLIC_BUCKET, key=key,
+                        body=body, content_type=ct,
+                    )
+                    logger.info(
+                        "avatar_r2_backfilled",
+                        user_id=user_id, key=key, skipped_existing=False,
+                    )
+                else:
+                    logger.info(
+                        "avatar_r2_backfilled",
+                        user_id=user_id, key=key, skipped_existing=True,
+                    )
+                if not args.dry_run:
+                    await db.execute(
+                        update(Users)
+                        .where(Users.user_id == user_id)
+                        .values(avatar_in_r2=True)
+                    )
+                    await db.commit()
+
+        await asyncio.gather(*[process(uid, fn) for uid, fn in rows])
+
+    return 0
+```
+
+Add to `_build_parser`:
+
+```python
+ab = sub.add_parser("avatars-backfill")
+ab.add_argument("--dry-run", action="store_true")
+ab.add_argument(
+    "--concurrency", type=_positive_int, default=8,
+    help="Max users processed in parallel (default: 8).",
+)
+```
+
+Wire up in the main dispatch (find the existing dispatch table or `if/elif` chain in `main()`).
+
+- [ ] **Step 4: Verify pass**
+
+```bash
+uv run pytest tests/unit/test_r2_sync_avatars_backfill.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/r2_sync.py tests/unit/test_r2_sync_avatars_backfill.py
+git commit -m "feat(r2_sync): add avatars-backfill subcommand"
+```
+
+### Task 5.2: `banners-backfill`
+
+**Files:**
+- Modify: `scripts/r2_sync.py`
+- Create: `tests/unit/test_r2_sync_banners_backfill.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Mirror `test_r2_sync_avatars_backfill.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_backfill_full_image_banner(...):
+    # Seed 1 banner with full_image="eva/full.jpg" and the file on disk
+    # Run cmd_banners_backfill
+    # Assert bit flips to True, R2 object exists
+
+
+@pytest.mark.asyncio
+async def test_backfill_three_part_banner(...):
+    # Seed 1 banner with left/middle/right_image and all 3 files on disk
+    # Run cmd_banners_backfill
+    # Assert bit flips, all 3 R2 objects exist
+
+
+@pytest.mark.asyncio
+async def test_backfill_three_part_partial_missing_skips_row(...):
+    # Seed 1 banner with three parts, but only left/middle on disk
+    # Run cmd_banners_backfill
+    # Assert bit stays False, banner_local_missing logged for right_image
+    # Critically: do NOT upload left/middle either — it's all-or-nothing per row
+
+
+@pytest.mark.asyncio
+async def test_backfill_idempotent_skips_existing(...):
+    # Pre-upload the banner R2 object, run again
+    # Assert no double-upload, bit flips to True
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+uv run pytest tests/unit/test_r2_sync_banners_backfill.py -v
+```
+
+- [ ] **Step 3: Implement `cmd_banners_backfill`**
+
+```python
+async def cmd_banners_backfill(args: argparse.Namespace) -> int:
+    require_bulk_backfill()
+    r2 = get_r2_storage()
+    banner_dir = FilePath(settings.BANNER_STORAGE_PATH)
+
+    async with r2.bulk_session(), get_async_session() as db:
+        result = await db.execute(
+            select(Banners).where(Banners.in_r2 == False)  # noqa: E712
+        )
+        banners = result.scalars().all()
+
+        for banner in banners:
+            paths = [
+                p for p in (
+                    banner.full_image, banner.left_image,
+                    banner.middle_image, banner.right_image,
+                ) if p
+            ]
+            # Pre-flight: confirm all files exist
+            missing = [p for p in paths if not (banner_dir / p).exists()]
+            if missing:
+                for p in missing:
+                    logger.warning(
+                        "banner_local_missing",
+                        banner_id=banner.banner_id, path=p,
+                    )
+                continue
+
+            uploaded: list[str] = []
+            skipped: list[str] = []
+            for p in paths:
+                key = f"banners/{p}"
+                if await r2.object_exists(
+                    bucket=settings.R2_PUBLIC_BUCKET, key=key
+                ):
+                    skipped.append(p)
+                    continue
+                if args.dry_run:
+                    continue
+                body = (banner_dir / p).read_bytes()
+                ct = mimetypes.guess_type(p)[0] or "application/octet-stream"
+                await r2.upload_bytes(
+                    bucket=settings.R2_PUBLIC_BUCKET, key=key,
+                    body=body, content_type=ct,
+                )
+                uploaded.append(p)
+
+            if args.dry_run:
+                continue
+
+            await db.execute(
+                update(Banners)
+                .where(Banners.banner_id == banner.banner_id)
+                .values(in_r2=True)
+            )
+            await db.commit()
+            logger.info(
+                "banner_r2_backfilled",
+                banner_id=banner.banner_id,
+                parts_uploaded=uploaded,
+                parts_skipped=skipped,
+            )
+
+    return 0
+```
+
+Wire `banners-backfill` into `_build_parser` (no `--concurrency`; rows are tens):
+
+```python
+bb = sub.add_parser("banners-backfill")
+bb.add_argument("--dry-run", action="store_true")
+```
+
+Wire up in the main dispatch.
+
+- [ ] **Step 4: Verify pass**
+
+```bash
+uv run pytest tests/unit/test_r2_sync_banners_backfill.py -v
+uv run pytest tests/unit -x -q
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/r2_sync.py tests/unit/test_r2_sync_banners_backfill.py
+git commit -m "feat(r2_sync): add banners-backfill subcommand"
+```
+
+---
+
+## Chunk 6: final wiring + verification
+
+Goal: confirm no avatar URL is built outside the helper; full test suite green; PR-ready.
+
+### Task 6.1: Sweep for forgotten URL builds
+
+- [ ] **Step 1: Avatar grep**
+
+```bash
+grep -rn "IMAGE_BASE_URL.*avatars" app/ scripts/ | grep -v test_ | grep -v __pycache__
+```
+
+Expected: zero matches outside `app/services/avatar.py` (the helper itself).
+
+If matches appear, route them through `avatar_url(...)` and run the relevant tests.
+
+- [ ] **Step 2: Banner grep**
+
+```bash
+grep -rn "BANNER_BASE_URL" app/ scripts/ | grep -v test_ | grep -v __pycache__
+```
+
+Expected: only the helper site in `app/schemas/banner.py` and the config in `app/config.py`.
+
+- [ ] **Step 3: Full test suite**
+
+```bash
+uv run pytest tests/ -x -q
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Type-check**
+
+```bash
+uv run mypy app/
+```
+
+Expected: clean (or no new errors introduced — compare to a pre-branch baseline if mypy already has known noise).
+
+- [ ] **Step 5: Lint**
+
+```bash
+uv run ruff check app/ scripts/ tests/
+uv run ruff format --check app/ scripts/ tests/
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit any final fixups**
+
+```bash
+git status
+# resolve any straggling diffs, then:
+git add -A
+git commit -m "chore: tidy up after R2 avatars/banners landing" || true
+```
+
+### Task 6.2: PR
+
+- [ ] **Step 1: Push branch and open PR**
+
+```bash
+git push -u origin feat/r2-avatars-banners
+```
+
+PR body should:
+- Link to the design doc.
+- Spell out the rollout sequence from the design doc § Rollout (deploy migration; run `avatars-backfill`; run `banners-backfill`; verify with `curl -I`).
+- Note the dev-side no-op (`R2_ENABLED=false` keeps current behavior).
+- Note no admin upload endpoint added.
+
+- [ ] **Step 2: Verify CI**
+
+Watch CI; fix any environment-specific test failures. Common gotchas:
+- moto fixture port collision — fixed by `port=0` (random port, already used in existing tests).
+- alembic migration ordering on a non-fresh CI DB — confirm CI runs migrations from scratch.
+
+---
+
+## Out-of-band notes (not implementation steps)
+
+- **Production rollout** (post-merge, performed by an operator):
+  ```bash
+  uv run python scripts/r2_sync.py avatars-backfill --concurrency 8
+  uv run python scripts/r2_sync.py banners-backfill
+  ```
+  Both require `R2_ENABLED=true` and `R2_ALLOW_BULK_BACKFILL=true` in the environment. Re-runs are safe.
+- **After known R2 outage:** re-run `avatars-backfill` to mop up rows where the live write path fell back to `avatar_in_r2=false`.
+- **Image Content-Type follow-up** (out of scope; design doc § Storage adapter changes notes this): existing image variants uploaded via `r2_sync.py split-existing` and `r2_finalize_upload_job` go through `R2Storage.upload_file`, which doesn't set Content-Type. A follow-up PR could fix this for image variants alongside.

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -4,22 +4,26 @@ Subcommands:
     split-existing       — one-time move protected images from public bucket to private
     backfill-locations   — one-shot flip r2_location for existing rows (gated)
     reconcile            — heal: upload missing R2 objects from local FS (gated)
+    avatars-backfill     — one-shot upload local avatars to R2 + flip avatar_in_r2 (gated)
     image                — inspect/re-sync a single image
     verify               — audit R2 vs DB state (read-only; --fix flips drifted rows to NONE)
     purge-cache          — manually purge CDN for one image
     health               — report unsynced counts and storage usage (read-only)
 
-Guarded by R2_ENABLED=true (all commands). backfill-locations, reconcile, and
-verify --fix additionally require R2_ALLOW_BULK_BACKFILL=true to prevent
-staging from mass-touching prod-imported images against its small staging bucket.
+Guarded by R2_ENABLED=true (all commands). backfill-locations, reconcile,
+avatars-backfill, and verify --fix additionally require R2_ALLOW_BULK_BACKFILL=true
+to prevent staging from mass-touching prod-imported data against its small
+staging bucket.
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import mimetypes
 import sys
 import time
+from pathlib import Path as FilePath
 from typing import Any
 
 from sqlalchemy import select, update
@@ -34,6 +38,7 @@ from app.core.r2_constants import (
     R2Location,
 )
 from app.models.image import Images, VariantStatus
+from app.models.user import Users
 from app.services.cloudflare import purge_cache_by_urls
 
 logger = get_logger(__name__)
@@ -106,6 +111,14 @@ def _build_parser() -> argparse.ArgumentParser:
     sub.add_parser("backfill-locations")
     rec = sub.add_parser("reconcile")
     rec.add_argument("--stale-after", type=_positive_int, default=600)
+    ab = sub.add_parser("avatars-backfill")
+    ab.add_argument("--dry-run", action="store_true")
+    ab.add_argument(
+        "--concurrency",
+        type=_positive_int,
+        default=8,
+        help="Max users processed in parallel (default: 8).",
+    )
     img = sub.add_parser("image")
     img.add_argument("image_id", type=int)
     img.add_argument(
@@ -436,6 +449,142 @@ async def reconcile(*, stale_after: int) -> None:
                     healed += len(public_healed_ids) + len(private_healed_ids)
 
     print(f"reconciled {healed}/{processed} rows")
+
+
+async def cmd_avatars_backfill(
+    *, dry_run: bool = False, concurrency: int = 8
+) -> dict[str, int]:
+    """Upload local avatars to R2 and flip avatar_in_r2=True per row.
+
+    Walks `users` rows where ``avatar != ''`` AND ``avatar_in_r2 = false``,
+    HEADs each ``avatars/{filename}`` against ``R2_PUBLIC_BUCKET``, and uploads
+    from ``AVATAR_STORAGE_PATH/{filename}`` if missing. Idempotent — already-
+    present R2 objects flip the bit without re-uploading. Missing local files
+    are logged and skipped (the bit stays false so the row will be retried on
+    the next run).
+
+    Concurrency is bounded by ``--concurrency`` (default 8); all R2 ops share
+    one aioboto3 client via ``bulk_session()`` so we don't pay TLS setup per
+    call. ``--dry-run`` logs intent without writing to R2 or the DB.
+    """
+    require_bulk_backfill()
+    r2 = get_r2_storage()
+    avatar_dir = FilePath(settings.AVATAR_STORAGE_PATH)
+    sem = asyncio.Semaphore(concurrency)
+
+    processed = 0
+    uploaded = 0
+    skipped_existing = 0
+    missing_local = 0
+
+    logger.info(
+        "avatars_backfill_started", dry_run=dry_run, concurrency=concurrency
+    )
+
+    async with r2.bulk_session():
+        async with get_async_session() as db:
+            result = await db.execute(
+                select(Users.user_id, Users.avatar).where(
+                    Users.avatar != "",  # type: ignore[arg-type]
+                    Users.avatar_in_r2 == False,  # type: ignore[arg-type]  # noqa: E712
+                )
+            )
+            rows = result.all()
+
+            async def process(user_id: int, filename: str) -> tuple[int, int, int]:
+                """Process one user. Returns (uploaded, skipped_existing, missing_local)."""
+                async with sem:
+                    local = avatar_dir / filename
+                    if not local.exists():
+                        logger.warning(
+                            "avatar_local_missing",
+                            user_id=user_id,
+                            filename=filename,
+                        )
+                        return (0, 0, 1)
+
+                    key = f"avatars/{filename}"
+                    already_present = await r2.object_exists(
+                        bucket=settings.R2_PUBLIC_BUCKET, key=key
+                    )
+                    if already_present:
+                        logger.info(
+                            "avatar_r2_backfilled",
+                            user_id=user_id,
+                            key=key,
+                            skipped_existing=True,
+                            dry_run=dry_run,
+                        )
+                        local_uploaded = 0
+                        local_skipped = 1
+                    else:
+                        if dry_run:
+                            logger.info(
+                                "avatar_r2_backfilled",
+                                user_id=user_id,
+                                key=key,
+                                skipped_existing=False,
+                                dry_run=True,
+                            )
+                            return (0, 0, 0)
+                        body = local.read_bytes()
+                        ct = (
+                            mimetypes.guess_type(filename)[0]
+                            or "application/octet-stream"
+                        )
+                        await r2.upload_bytes(
+                            bucket=settings.R2_PUBLIC_BUCKET,
+                            key=key,
+                            body=body,
+                            content_type=ct,
+                        )
+                        logger.info(
+                            "avatar_r2_backfilled",
+                            user_id=user_id,
+                            key=key,
+                            skipped_existing=False,
+                            dry_run=False,
+                        )
+                        local_uploaded = 1
+                        local_skipped = 0
+
+                    if not dry_run:
+                        await db.execute(
+                            update(Users)
+                            .where(Users.user_id == user_id)  # type: ignore[arg-type]
+                            .values(avatar_in_r2=True)
+                        )
+                        await db.commit()
+                    return (local_uploaded, local_skipped, 0)
+
+            results = await asyncio.gather(
+                *(process(uid, fn) for uid, fn in rows)
+            )
+            for u, s, m in results:
+                processed += 1
+                uploaded += u
+                skipped_existing += s
+                missing_local += m
+
+    logger.info(
+        "avatars_backfill_completed",
+        processed=processed,
+        uploaded=uploaded,
+        skipped_existing=skipped_existing,
+        missing_local=missing_local,
+        dry_run=dry_run,
+    )
+    print(
+        f"{'[dry-run] ' if dry_run else ''}avatars: processed {processed} "
+        f"(uploaded {uploaded}, skipped_existing {skipped_existing}, "
+        f"missing_local {missing_local})"
+    )
+    return {
+        "processed": processed,
+        "uploaded": uploaded,
+        "skipped_existing": skipped_existing,
+        "missing_local": missing_local,
+    }
 
 
 async def resync_image(image_id: int) -> None:
@@ -840,6 +989,10 @@ async def _run(args: argparse.Namespace) -> int:
         await backfill_locations()
     elif args.command == "reconcile":
         await reconcile(stale_after=args.stale_after)
+    elif args.command == "avatars-backfill":
+        await cmd_avatars_backfill(
+            dry_run=args.dry_run, concurrency=args.concurrency
+        )
     elif args.command == "image":
         if args.force_reupload:
             await force_reupload_image(image_id=args.image_id, dry_run=args.dry_run)

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -465,25 +465,102 @@ async def cmd_avatars_backfill(
     from ``AVATAR_STORAGE_PATH/{filename}`` if missing. Idempotent — already-
     present R2 objects flip the bit without re-uploading. Missing local files
     are logged and skipped (the bit stays false so the row will be retried on
-    the next run).
+    the next run). Per-row upload failures are logged and counted (``failed``);
+    the rest of the run continues.
 
     Concurrency is bounded by ``--concurrency`` (default 8); all R2 ops share
     one aioboto3 client via ``bulk_session()`` so we don't pay TLS setup per
-    call. ``--dry-run`` logs intent without writing to R2 or the DB.
+    call. Per-task DB writes would be unsafe (``AsyncSession`` is not
+    concurrency-safe); instead each task returns its outcome and a single
+    batched UPDATE flips ``avatar_in_r2`` for all successful user_ids after
+    ``gather`` completes. ``--dry-run`` logs intent without writing to R2 or
+    the DB and reports ``would_upload`` for rows that would have uploaded.
     """
     require_bulk_backfill()
     r2 = get_r2_storage()
     avatar_dir = FilePath(settings.AVATAR_STORAGE_PATH)
     sem = asyncio.Semaphore(concurrency)
 
-    processed = 0
-    uploaded = 0
-    skipped_existing = 0
-    missing_local = 0
-
     logger.info(
         "avatars_backfill_started", dry_run=dry_run, concurrency=concurrency
     )
+
+    async def process(user_id: int, filename: str) -> tuple[int, str]:
+        """Process one user (R2 ops only; no DB writes).
+
+        Returns ``(user_id, outcome)`` where outcome is one of
+        ``'uploaded'`` (real-run upload succeeded), ``'skipped_existing'``
+        (R2 object already present), ``'missing_local'`` (no file on disk),
+        ``'would_upload'`` (dry-run, would have uploaded), or ``'failed'``
+        (upload raised). Only ``'uploaded'`` and ``'skipped_existing'``
+        outcomes feed the post-gather batched UPDATE.
+        """
+        async with sem:
+            local = avatar_dir / filename
+            if not local.exists():
+                logger.warning(
+                    "avatar_local_missing",
+                    user_id=user_id,
+                    filename=filename,
+                )
+                return (user_id, "missing_local")
+
+            key = f"avatars/{filename}"
+            already_present = await r2.object_exists(
+                bucket=settings.R2_PUBLIC_BUCKET, key=key
+            )
+            if already_present:
+                logger.info(
+                    "avatar_r2_backfilled",
+                    user_id=user_id,
+                    key=key,
+                    skipped_existing=True,
+                    dry_run=dry_run,
+                )
+                return (user_id, "skipped_existing")
+
+            if dry_run:
+                logger.info(
+                    "avatar_r2_backfilled",
+                    user_id=user_id,
+                    key=key,
+                    skipped_existing=False,
+                    dry_run=True,
+                )
+                return (user_id, "would_upload")
+
+            body = local.read_bytes()
+            ct = (
+                mimetypes.guess_type(filename)[0]
+                or "application/octet-stream"
+            )
+            try:
+                await r2.upload_bytes(
+                    bucket=settings.R2_PUBLIC_BUCKET,
+                    key=key,
+                    body=body,
+                    content_type=ct,
+                )
+            except Exception as exc:
+                # Don't let one transient failure abort the whole run; log
+                # and move on. The bit stays false so the row will be
+                # retried on the next backfill run.
+                logger.warning(
+                    "avatar_r2_backfill_failed",
+                    user_id=user_id,
+                    key=key,
+                    error=type(exc).__name__,
+                    error_msg=str(exc),
+                )
+                return (user_id, "failed")
+            logger.info(
+                "avatar_r2_backfilled",
+                user_id=user_id,
+                key=key,
+                skipped_existing=False,
+                dry_run=False,
+            )
+            return (user_id, "uploaded")
 
     async with r2.bulk_session():
         async with get_async_session() as db:
@@ -495,80 +572,42 @@ async def cmd_avatars_backfill(
             )
             rows = result.all()
 
-            async def process(user_id: int, filename: str) -> tuple[int, int, int]:
-                """Process one user. Returns (uploaded, skipped_existing, missing_local)."""
-                async with sem:
-                    local = avatar_dir / filename
-                    if not local.exists():
-                        logger.warning(
-                            "avatar_local_missing",
-                            user_id=user_id,
-                            filename=filename,
-                        )
-                        return (0, 0, 1)
+        # Run all R2 ops outside any DB session — AsyncSession is not safe
+        # for concurrent use across gather'd tasks (SQLAlchemy 2.0).
+        results = await asyncio.gather(*(process(uid, fn) for uid, fn in rows))
 
-                    key = f"avatars/{filename}"
-                    already_present = await r2.object_exists(
-                        bucket=settings.R2_PUBLIC_BUCKET, key=key
-                    )
-                    if already_present:
-                        logger.info(
-                            "avatar_r2_backfilled",
-                            user_id=user_id,
-                            key=key,
-                            skipped_existing=True,
-                            dry_run=dry_run,
-                        )
-                        local_uploaded = 0
-                        local_skipped = 1
-                    else:
-                        if dry_run:
-                            logger.info(
-                                "avatar_r2_backfilled",
-                                user_id=user_id,
-                                key=key,
-                                skipped_existing=False,
-                                dry_run=True,
-                            )
-                            return (0, 0, 0)
-                        body = local.read_bytes()
-                        ct = (
-                            mimetypes.guess_type(filename)[0]
-                            or "application/octet-stream"
-                        )
-                        await r2.upload_bytes(
-                            bucket=settings.R2_PUBLIC_BUCKET,
-                            key=key,
-                            body=body,
-                            content_type=ct,
-                        )
-                        logger.info(
-                            "avatar_r2_backfilled",
-                            user_id=user_id,
-                            key=key,
-                            skipped_existing=False,
-                            dry_run=False,
-                        )
-                        local_uploaded = 1
-                        local_skipped = 0
+        processed = len(results)
+        uploaded = 0
+        skipped_existing = 0
+        missing_local = 0
+        would_upload = 0
+        failed = 0
+        flip_user_ids: list[int] = []
+        for user_id, outcome in results:
+            if outcome == "uploaded":
+                uploaded += 1
+                flip_user_ids.append(user_id)
+            elif outcome == "skipped_existing":
+                skipped_existing += 1
+                flip_user_ids.append(user_id)
+            elif outcome == "missing_local":
+                missing_local += 1
+            elif outcome == "would_upload":
+                would_upload += 1
+            elif outcome == "failed":
+                failed += 1
 
-                    if not dry_run:
-                        await db.execute(
-                            update(Users)
-                            .where(Users.user_id == user_id)  # type: ignore[arg-type]
-                            .values(avatar_in_r2=True)
-                        )
-                        await db.commit()
-                    return (local_uploaded, local_skipped, 0)
-
-            results = await asyncio.gather(
-                *(process(uid, fn) for uid, fn in rows)
-            )
-            for u, s, m in results:
-                processed += 1
-                uploaded += u
-                skipped_existing += s
-                missing_local += m
+        # Single batched UPDATE post-gather (mirrors cmd_verify's pattern).
+        # Skip on dry-run — would_upload outcomes don't feed the flip list
+        # anyway, but skipped_existing rows shouldn't be flipped in dry-run.
+        if not dry_run and flip_user_ids:
+            async with get_async_session() as db:
+                await db.execute(
+                    update(Users)
+                    .where(Users.user_id.in_(flip_user_ids))  # type: ignore[union-attr]
+                    .values(avatar_in_r2=True)
+                )
+                await db.commit()
 
     logger.info(
         "avatars_backfill_completed",
@@ -576,18 +615,23 @@ async def cmd_avatars_backfill(
         uploaded=uploaded,
         skipped_existing=skipped_existing,
         missing_local=missing_local,
+        would_upload=would_upload,
+        failed=failed,
         dry_run=dry_run,
     )
     print(
         f"{'[dry-run] ' if dry_run else ''}avatars: processed {processed} "
         f"(uploaded {uploaded}, skipped_existing {skipped_existing}, "
-        f"missing_local {missing_local})"
+        f"missing_local {missing_local}, would_upload {would_upload}, "
+        f"failed {failed})"
     )
     return {
         "processed": processed,
         "uploaded": uploaded,
         "skipped_existing": skipped_existing,
         "missing_local": missing_local,
+        "would_upload": would_upload,
+        "failed": failed,
     }
 
 

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import mimetypes
 import sys
 import time
 from pathlib import Path as FilePath
@@ -41,6 +40,8 @@ from app.core.r2_constants import (
 from app.models.image import Images, VariantStatus
 from app.models.misc import Banners
 from app.models.user import Users
+from app.services.avatar import avatar_content_type
+from app.services.banner import banner_content_type
 from app.services.cloudflare import purge_cache_by_urls
 
 logger = get_logger(__name__)
@@ -514,8 +515,14 @@ async def cmd_avatars_backfill(*, dry_run: bool = False, concurrency: int = 8) -
                 return (user_id, "would_upload")
 
             body = local.read_bytes()
-            ct = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+            # Avatars are constrained to ALLOWED_AVATAR_EXTENSIONS at upload
+            # time, so the strict mapping in avatar_content_type is correct;
+            # an unknown extension here means a corrupted DB row and should
+            # surface as a per-row failure (not silently uploaded as
+            # application/octet-stream, which nosniff/CSP would reject).
+            ext = filename.rsplit(".", 1)[-1] if "." in filename else ""
             try:
+                ct = avatar_content_type(ext)
                 await r2.upload_bytes(
                     bucket=settings.R2_PUBLIC_BUCKET,
                     key=key,
@@ -698,8 +705,12 @@ async def cmd_banners_backfill(*, dry_run: bool = False) -> dict[str, int]:
                     would_upload_parts += 1
                     continue
                 body = (banner_dir / path).read_bytes()
-                ct = mimetypes.guess_type(path)[0] or "application/octet-stream"
+                # Strict extension -> Content-Type mapping; refuse to fall
+                # back to application/octet-stream because nosniff/CSP would
+                # block inline rendering. An unknown banner extension is an
+                # operator-actionable failure, not something to paper over.
                 try:
+                    ct = banner_content_type(path)
                     await r2.upload_bytes(
                         bucket=settings.R2_PUBLIC_BUCKET,
                         key=key,

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -647,8 +647,16 @@ async def cmd_banners_backfill(*, dry_run: bool = False) -> dict[str, int]:
     half a banner because the URL helper expects all parts to be in R2 once
     ``in_r2`` flips.
 
+    Per-part upload failures are wrapped in try/except: the offending row is
+    marked failed (bit stays false, mid-upload R2 state is left as-is for
+    next-run idempotency to clean up), counted in ``failed_rows``, and the
+    loop continues. Only fully-successful rows feed the post-loop batched
+    UPDATE.
+
     Idempotent — already-present R2 objects don't re-upload. ``--dry-run``
-    logs intent without writing.
+    logs intent without writing and reports ``would_upload_parts`` (parts
+    that would have uploaded) and ``would_flip_rows`` (rows that would have
+    flipped).
 
     No ``--concurrency`` knob: banner counts are tens, not millions.
     """
@@ -657,8 +665,11 @@ async def cmd_banners_backfill(*, dry_run: bool = False) -> dict[str, int]:
     banner_dir = FilePath(settings.BANNER_STORAGE_PATH)
 
     processed = 0
-    flipped = 0
     skipped_missing_local = 0
+    failed_rows = 0
+    would_upload_parts = 0
+    would_flip_rows = 0
+    flipped_banner_ids: list[int] = []
 
     logger.info("banners_backfill_started", dry_run=dry_run)
 
@@ -669,87 +680,123 @@ async def cmd_banners_backfill(*, dry_run: bool = False) -> dict[str, int]:
             )
             banners = list(result.scalars())
 
-            for banner in banners:
-                processed += 1
-                paths = [
-                    p
-                    for p in (
-                        banner.full_image,
-                        banner.left_image,
-                        banner.middle_image,
-                        banner.right_image,
-                    )
-                    if p
-                ]
+        for banner in banners:
+            processed += 1
+            paths = [
+                p
+                for p in (
+                    banner.full_image,
+                    banner.left_image,
+                    banner.middle_image,
+                    banner.right_image,
+                )
+                if p
+            ]
 
-                # Pre-flight: every part must exist locally. All-or-nothing.
-                missing = [p for p in paths if not (banner_dir / p).exists()]
-                if missing:
-                    for path in missing:
-                        logger.warning(
-                            "banner_local_missing",
-                            banner_id=banner.banner_id,
-                            path=path,
-                        )
-                    skipped_missing_local += 1
+            # Pre-flight: every part must exist locally. All-or-nothing.
+            missing = [p for p in paths if not (banner_dir / p).exists()]
+            if missing:
+                for path in missing:
+                    logger.warning(
+                        "banner_local_missing",
+                        banner_id=banner.banner_id,
+                        path=path,
+                    )
+                skipped_missing_local += 1
+                continue
+
+            parts_uploaded: list[str] = []
+            parts_skipped: list[str] = []
+            row_failed = False
+            for path in paths:
+                key = f"banners/{path}"
+                if await r2.object_exists(
+                    bucket=settings.R2_PUBLIC_BUCKET, key=key
+                ):
+                    parts_skipped.append(path)
                     continue
-
-                parts_uploaded: list[str] = []
-                parts_skipped: list[str] = []
-                for path in paths:
-                    key = f"banners/{path}"
-                    if await r2.object_exists(
-                        bucket=settings.R2_PUBLIC_BUCKET, key=key
-                    ):
-                        parts_skipped.append(path)
-                        continue
-                    if dry_run:
-                        parts_uploaded.append(path)
-                        continue
-                    body = (banner_dir / path).read_bytes()
-                    ct = (
-                        mimetypes.guess_type(path)[0]
-                        or "application/octet-stream"
-                    )
+                if dry_run:
+                    parts_uploaded.append(path)
+                    would_upload_parts += 1
+                    continue
+                body = (banner_dir / path).read_bytes()
+                ct = (
+                    mimetypes.guess_type(path)[0]
+                    or "application/octet-stream"
+                )
+                try:
                     await r2.upload_bytes(
                         bucket=settings.R2_PUBLIC_BUCKET,
                         key=key,
                         body=body,
                         content_type=ct,
                     )
-                    parts_uploaded.append(path)
-
-                if not dry_run:
-                    await db.execute(
-                        update(Banners)
-                        .where(Banners.banner_id == banner.banner_id)  # type: ignore[arg-type]
-                        .values(in_r2=True)
+                except Exception as exc:
+                    # All-or-nothing: bail on this row's remaining parts;
+                    # bit stays false so next run retries. Already-uploaded
+                    # parts from this row stay in R2 (object_exists will
+                    # short-circuit them on retry).
+                    logger.warning(
+                        "banner_r2_backfill_failed",
+                        banner_id=banner.banner_id,
+                        key=key,
+                        error=type(exc).__name__,
+                        error_msg=str(exc),
                     )
-                    await db.commit()
-                    flipped += 1
-                logger.info(
-                    "banner_r2_backfilled",
-                    banner_id=banner.banner_id,
-                    parts_uploaded=parts_uploaded,
-                    parts_skipped=parts_skipped,
-                    dry_run=dry_run,
-                )
+                    row_failed = True
+                    break
+                parts_uploaded.append(path)
 
+            if row_failed:
+                failed_rows += 1
+                continue
+
+            if dry_run:
+                would_flip_rows += 1
+            else:
+                flipped_banner_ids.append(banner.banner_id)  # type: ignore[arg-type]
+            logger.info(
+                "banner_r2_backfilled",
+                banner_id=banner.banner_id,
+                parts_uploaded=parts_uploaded,
+                parts_skipped=parts_skipped,
+                dry_run=dry_run,
+            )
+
+        # Single batched UPDATE post-loop (mirrors cmd_verify's pattern).
+        if not dry_run and flipped_banner_ids:
+            async with get_async_session() as db:
+                await db.execute(
+                    update(Banners)
+                    .where(Banners.banner_id.in_(flipped_banner_ids))  # type: ignore[union-attr]
+                    .values(in_r2=True)
+                )
+                await db.commit()
+
+    flipped = len(flipped_banner_ids)
     logger.info(
         "banners_backfill_completed",
         processed=processed,
         flipped=flipped,
         skipped_missing_local=skipped_missing_local,
+        failed_rows=failed_rows,
+        would_upload_parts=would_upload_parts,
+        would_flip_rows=would_flip_rows,
         dry_run=dry_run,
     )
     print(
         f"{'[dry-run] ' if dry_run else ''}banners: processed {processed} "
-        f"(flipped {flipped}, skipped_missing_local {skipped_missing_local})"
+        f"(flipped {flipped}, skipped_missing_local {skipped_missing_local}, "
+        f"failed_rows {failed_rows}, would_upload_parts {would_upload_parts}, "
+        f"would_flip_rows {would_flip_rows})"
     )
     return {
         "processed": processed,
         "flipped": flipped,
         "skipped_missing_local": skipped_missing_local,
+        "failed_rows": failed_rows,
+        "would_upload_parts": would_upload_parts,
+        "would_flip_rows": would_flip_rows,
     }
 
 

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -211,9 +211,7 @@ async def split_existing(*, dry_run: bool, concurrency: int = 8) -> None:
     last_tick_at = started_at
     last_tick_moved = 0
 
-    logger.info(
-        "split_existing_started", dry_run=dry_run, concurrency=concurrency
-    )
+    logger.info("split_existing_started", dry_run=dry_run, concurrency=concurrency)
 
     async def process_image(image: Images) -> tuple[int, int]:
         """Process one image. Returns (moved_count, error_count)."""
@@ -225,9 +223,7 @@ async def split_existing(*, dry_run: bool, concurrency: int = 8) -> None:
                 ext = "webp" if variant == "thumbs" else image.ext
                 key = f"{variant}/{image.filename}.{ext}"
                 try:
-                    if not await r2.object_exists(
-                        bucket=settings.R2_PUBLIC_BUCKET, key=key
-                    ):
+                    if not await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key):
                         continue
                     if dry_run:
                         print(
@@ -241,9 +237,7 @@ async def split_existing(*, dry_run: bool, concurrency: int = 8) -> None:
                         dst_bucket=settings.R2_PRIVATE_BUCKET,
                         key=key,
                     )
-                    await r2.delete_object(
-                        bucket=settings.R2_PUBLIC_BUCKET, key=key
-                    )
+                    await r2.delete_object(bucket=settings.R2_PUBLIC_BUCKET, key=key)
                     local_moved += 1
                 except Exception as exc:
                     # Isolate per-variant failures — one bad object shouldn't
@@ -261,9 +255,7 @@ async def split_existing(*, dry_run: bool, concurrency: int = 8) -> None:
         """Drain completed tasks until in_flight is below `until`."""
         nonlocal moved, errors
         while len(in_flight) > until:
-            done, _ = await asyncio.wait(
-                in_flight, return_when=asyncio.FIRST_COMPLETED
-            )
+            done, _ = await asyncio.wait(in_flight, return_when=asyncio.FIRST_COMPLETED)
             for task in done:
                 in_flight.discard(task)
                 m, e = task.result()
@@ -287,12 +279,8 @@ async def split_existing(*, dry_run: bool, concurrency: int = 8) -> None:
                 if images_seen % 100 == 0:
                     now = time.monotonic()
                     window = now - last_tick_at
-                    recent_rate = (
-                        (moved - last_tick_moved) / window if window > 0 else 0.0
-                    )
-                    overall_rate = (
-                        moved / (now - started_at) if now > started_at else 0.0
-                    )
+                    recent_rate = (moved - last_tick_moved) / window if window > 0 else 0.0
+                    overall_rate = moved / (now - started_at) if now > started_at else 0.0
                     logger.info(
                         "split_existing_progress",
                         images_seen=images_seen,
@@ -421,7 +409,9 @@ async def reconcile(*, stale_after: int) -> None:
                     key = f"{variant}/{image.filename}.{ext}"
                     local = FilePath(settings.STORAGE_PATH) / variant / f"{image.filename}.{ext}"
                     if not local.exists():
-                        logger.warning("reconcile_local_missing", image_id=image.image_id, variant=variant)
+                        logger.warning(
+                            "reconcile_local_missing", image_id=image.image_id, variant=variant
+                        )
                         all_uploaded = False
                         break
                     if not await r2.object_exists(bucket=bucket, key=key):
@@ -455,9 +445,7 @@ async def reconcile(*, stale_after: int) -> None:
     print(f"reconciled {healed}/{processed} rows")
 
 
-async def cmd_avatars_backfill(
-    *, dry_run: bool = False, concurrency: int = 8
-) -> dict[str, int]:
+async def cmd_avatars_backfill(*, dry_run: bool = False, concurrency: int = 8) -> dict[str, int]:
     """Upload local avatars to R2 and flip avatar_in_r2=True per row.
 
     Walks `users` rows where ``avatar != ''`` AND ``avatar_in_r2 = false``,
@@ -481,9 +469,7 @@ async def cmd_avatars_backfill(
     avatar_dir = FilePath(settings.AVATAR_STORAGE_PATH)
     sem = asyncio.Semaphore(concurrency)
 
-    logger.info(
-        "avatars_backfill_started", dry_run=dry_run, concurrency=concurrency
-    )
+    logger.info("avatars_backfill_started", dry_run=dry_run, concurrency=concurrency)
 
     async def process(user_id: int, filename: str) -> tuple[int, str]:
         """Process one user (R2 ops only; no DB writes).
@@ -506,9 +492,7 @@ async def cmd_avatars_backfill(
                 return (user_id, "missing_local")
 
             key = f"avatars/{filename}"
-            already_present = await r2.object_exists(
-                bucket=settings.R2_PUBLIC_BUCKET, key=key
-            )
+            already_present = await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key)
             if already_present:
                 logger.info(
                     "avatar_r2_backfilled",
@@ -530,10 +514,7 @@ async def cmd_avatars_backfill(
                 return (user_id, "would_upload")
 
             body = local.read_bytes()
-            ct = (
-                mimetypes.guess_type(filename)[0]
-                or "application/octet-stream"
-            )
+            ct = mimetypes.guess_type(filename)[0] or "application/octet-stream"
             try:
                 await r2.upload_bytes(
                     bucket=settings.R2_PUBLIC_BUCKET,
@@ -598,8 +579,7 @@ async def cmd_avatars_backfill(
                 failed += 1
 
         # Single batched UPDATE post-gather (mirrors cmd_verify's pattern).
-        # Skip on dry-run — would_upload outcomes don't feed the flip list
-        # anyway, but skipped_existing rows shouldn't be flipped in dry-run.
+        # Suppressed in dry-run regardless of which outcomes landed in flip_user_ids.
         if not dry_run and flip_user_ids:
             async with get_async_session() as db:
                 await db.execute(
@@ -710,9 +690,7 @@ async def cmd_banners_backfill(*, dry_run: bool = False) -> dict[str, int]:
             row_failed = False
             for path in paths:
                 key = f"banners/{path}"
-                if await r2.object_exists(
-                    bucket=settings.R2_PUBLIC_BUCKET, key=key
-                ):
+                if await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key):
                     parts_skipped.append(path)
                     continue
                 if dry_run:
@@ -720,10 +698,7 @@ async def cmd_banners_backfill(*, dry_run: bool = False) -> dict[str, int]:
                     would_upload_parts += 1
                     continue
                 body = (banner_dir / path).read_bytes()
-                ct = (
-                    mimetypes.guess_type(path)[0]
-                    or "application/octet-stream"
-                )
+                ct = mimetypes.guess_type(path)[0] or "application/octet-stream"
                 try:
                     await r2.upload_bytes(
                         bucket=settings.R2_PUBLIC_BUCKET,
@@ -970,12 +945,8 @@ async def verify(
                 ext = "webp" if variant == "thumbs" else image.ext
                 key = f"{variant}/{image.filename}.{ext}"
                 try:
-                    in_public = await r2.object_exists(
-                        bucket=settings.R2_PUBLIC_BUCKET, key=key
-                    )
-                    in_private = await r2.object_exists(
-                        bucket=settings.R2_PRIVATE_BUCKET, key=key
-                    )
+                    in_public = await r2.object_exists(bucket=settings.R2_PUBLIC_BUCKET, key=key)
+                    in_private = await r2.object_exists(bucket=settings.R2_PRIVATE_BUCKET, key=key)
                 except Exception as exc:
                     # Don't report bogus discrepancies on transient HEAD failures.
                     logger.error(
@@ -1112,10 +1083,7 @@ async def verify(
         "errors": errors,
     }
     suffix = f", flipped {flipped} to NONE" if fix else ""
-    print(
-        f"checked {checked} rows, {len(discrepancies)} discrepancies"
-        f" ({errors} errors){suffix}"
-    )
+    print(f"checked {checked} rows, {len(discrepancies)} discrepancies ({errors} errors){suffix}")
     for d in discrepancies[:20]:
         location = f"{d['bucket']}/{d['key']}" if d.get("bucket") else d["key"]
         print(f"  {d['kind']}: {location} (image_id={d['image_id']})")
@@ -1203,9 +1171,7 @@ async def _run(args: argparse.Namespace) -> int:
     elif args.command == "reconcile":
         await reconcile(stale_after=args.stale_after)
     elif args.command == "avatars-backfill":
-        await cmd_avatars_backfill(
-            dry_run=args.dry_run, concurrency=args.concurrency
-        )
+        await cmd_avatars_backfill(dry_run=args.dry_run, concurrency=args.concurrency)
     elif args.command == "banners-backfill":
         await cmd_banners_backfill(dry_run=args.dry_run)
     elif args.command == "image":

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -5,15 +5,16 @@ Subcommands:
     backfill-locations   — one-shot flip r2_location for existing rows (gated)
     reconcile            — heal: upload missing R2 objects from local FS (gated)
     avatars-backfill     — one-shot upload local avatars to R2 + flip avatar_in_r2 (gated)
+    banners-backfill     — one-shot upload local banner images to R2 + flip in_r2 (gated)
     image                — inspect/re-sync a single image
     verify               — audit R2 vs DB state (read-only; --fix flips drifted rows to NONE)
     purge-cache          — manually purge CDN for one image
     health               — report unsynced counts and storage usage (read-only)
 
 Guarded by R2_ENABLED=true (all commands). backfill-locations, reconcile,
-avatars-backfill, and verify --fix additionally require R2_ALLOW_BULK_BACKFILL=true
-to prevent staging from mass-touching prod-imported data against its small
-staging bucket.
+avatars-backfill, banners-backfill, and verify --fix additionally require
+R2_ALLOW_BULK_BACKFILL=true to prevent staging from mass-touching prod-imported
+data against its small staging bucket.
 """
 
 from __future__ import annotations
@@ -38,6 +39,7 @@ from app.core.r2_constants import (
     R2Location,
 )
 from app.models.image import Images, VariantStatus
+from app.models.misc import Banners
 from app.models.user import Users
 from app.services.cloudflare import purge_cache_by_urls
 
@@ -119,6 +121,8 @@ def _build_parser() -> argparse.ArgumentParser:
         default=8,
         help="Max users processed in parallel (default: 8).",
     )
+    bb = sub.add_parser("banners-backfill")
+    bb.add_argument("--dry-run", action="store_true")
     img = sub.add_parser("image")
     img.add_argument("image_id", type=int)
     img.add_argument(
@@ -587,6 +591,124 @@ async def cmd_avatars_backfill(
     }
 
 
+async def cmd_banners_backfill(*, dry_run: bool = False) -> dict[str, int]:
+    """Upload local banner images to R2 and flip in_r2=True per row.
+
+    Walks `banners` rows where ``in_r2 = false``. For each row, collects the
+    non-null path columns (``full_image`` for one-piece banners; or any of
+    ``left_image``/``middle_image``/``right_image`` for three-piece banners),
+    pre-flights local existence for ALL of them, then uploads each missing R2
+    object. Per-row atomicity: if any local file is missing, the row is
+    skipped entirely and the bit stays false — there's no point uploading
+    half a banner because the URL helper expects all parts to be in R2 once
+    ``in_r2`` flips.
+
+    Idempotent — already-present R2 objects don't re-upload. ``--dry-run``
+    logs intent without writing.
+
+    No ``--concurrency`` knob: banner counts are tens, not millions.
+    """
+    require_bulk_backfill()
+    r2 = get_r2_storage()
+    banner_dir = FilePath(settings.BANNER_STORAGE_PATH)
+
+    processed = 0
+    flipped = 0
+    skipped_missing_local = 0
+
+    logger.info("banners_backfill_started", dry_run=dry_run)
+
+    async with r2.bulk_session():
+        async with get_async_session() as db:
+            result = await db.execute(
+                select(Banners).where(Banners.in_r2 == False)  # type: ignore[arg-type]  # noqa: E712
+            )
+            banners = list(result.scalars())
+
+            for banner in banners:
+                processed += 1
+                paths = [
+                    p
+                    for p in (
+                        banner.full_image,
+                        banner.left_image,
+                        banner.middle_image,
+                        banner.right_image,
+                    )
+                    if p
+                ]
+
+                # Pre-flight: every part must exist locally. All-or-nothing.
+                missing = [p for p in paths if not (banner_dir / p).exists()]
+                if missing:
+                    for path in missing:
+                        logger.warning(
+                            "banner_local_missing",
+                            banner_id=banner.banner_id,
+                            path=path,
+                        )
+                    skipped_missing_local += 1
+                    continue
+
+                parts_uploaded: list[str] = []
+                parts_skipped: list[str] = []
+                for path in paths:
+                    key = f"banners/{path}"
+                    if await r2.object_exists(
+                        bucket=settings.R2_PUBLIC_BUCKET, key=key
+                    ):
+                        parts_skipped.append(path)
+                        continue
+                    if dry_run:
+                        parts_uploaded.append(path)
+                        continue
+                    body = (banner_dir / path).read_bytes()
+                    ct = (
+                        mimetypes.guess_type(path)[0]
+                        or "application/octet-stream"
+                    )
+                    await r2.upload_bytes(
+                        bucket=settings.R2_PUBLIC_BUCKET,
+                        key=key,
+                        body=body,
+                        content_type=ct,
+                    )
+                    parts_uploaded.append(path)
+
+                if not dry_run:
+                    await db.execute(
+                        update(Banners)
+                        .where(Banners.banner_id == banner.banner_id)  # type: ignore[arg-type]
+                        .values(in_r2=True)
+                    )
+                    await db.commit()
+                    flipped += 1
+                logger.info(
+                    "banner_r2_backfilled",
+                    banner_id=banner.banner_id,
+                    parts_uploaded=parts_uploaded,
+                    parts_skipped=parts_skipped,
+                    dry_run=dry_run,
+                )
+
+    logger.info(
+        "banners_backfill_completed",
+        processed=processed,
+        flipped=flipped,
+        skipped_missing_local=skipped_missing_local,
+        dry_run=dry_run,
+    )
+    print(
+        f"{'[dry-run] ' if dry_run else ''}banners: processed {processed} "
+        f"(flipped {flipped}, skipped_missing_local {skipped_missing_local})"
+    )
+    return {
+        "processed": processed,
+        "flipped": flipped,
+        "skipped_missing_local": skipped_missing_local,
+    }
+
+
 async def resync_image(image_id: int) -> None:
     """Debug tool: print current R2 state for one image (read-only)."""
     r2 = get_r2_storage()
@@ -993,6 +1115,8 @@ async def _run(args: argparse.Namespace) -> int:
         await cmd_avatars_backfill(
             dry_run=args.dry_run, concurrency=args.concurrency
         )
+    elif args.command == "banners-backfill":
+        await cmd_banners_backfill(dry_run=args.dry_run)
     elif args.command == "image":
         if args.force_reupload:
             await force_reupload_image(image_id=args.image_id, dry_run=args.dry_run)

--- a/tests/api/v1/test_image_tag_history_endpoint.py
+++ b/tests/api/v1/test_image_tag_history_endpoint.py
@@ -465,7 +465,9 @@ class TestGetImageTagHistory:
         assert item_user is not None
         assert item_user["user_id"] == user.user_id
         assert item_user["avatar"] == "abc.png"
-        assert item_user["avatar_in_r2"] is True
+        # avatar_in_r2 is internal routing state and is excluded from
+        # serialization; clients only see avatar_url.
+        assert "avatar_in_r2" not in item_user
         assert item_user["avatar_url"] == "https://cdn.test/avatars/abc.png"
 
     async def test_handles_null_user(

--- a/tests/api/v1/test_image_tag_history_endpoint.py
+++ b/tests/api/v1/test_image_tag_history_endpoint.py
@@ -9,7 +9,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import TagType
+from app.config import TagType, settings
 from app.models.image import Images
 from app.models.tag import Tags
 from app.models.tag_history import TagHistory
@@ -392,6 +392,81 @@ class TestGetImageTagHistory:
         assert data["items"][0]["tag_history_id"] == history3.tag_history_id
         assert data["items"][1]["tag_history_id"] == history2.tag_history_id
         assert data["items"][2]["tag_history_id"] == history1.tag_history_id
+
+    async def test_user_avatar_url_uses_cdn_when_avatar_in_r2(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When R2 is enabled and the user has avatar_in_r2=True, the embedded
+        UserSummary's avatar_url must point at the CDN, not local FS.
+
+        Regression: previously the route built UserSummary without passing
+        avatar_in_r2 through, so the schema default (False) leaked and forced
+        local URLs even after backfill flipped the bit.
+        """
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+        monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+
+        # Create a user with avatar in R2
+        user = Users(
+            username="r2avataruser",
+            password="hashed",
+            password_type="bcrypt",
+            salt="",
+            email="r2avatar@example.com",
+            active=1,
+            avatar="abc.png",
+            avatar_in_r2=True,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        # Create an image
+        image = Images(
+            filename="r2avatar1",
+            ext="jpg",
+            md5_hash="r2avatarmd511111111111111111111",
+            user_id=user.user_id,
+            width=100,
+            height=100,
+            filesize=1000,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        # Create a tag and history entry attributed to that user
+        tag = Tags(title="r2 avatar tag", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        history = TagHistory(
+            image_id=image.image_id,
+            tag_id=tag.tag_id,
+            action="a",
+            user_id=user.user_id,
+        )
+        db_session.add(history)
+        await db_session.commit()
+
+        # GET image tag history
+        response = await client.get(f"/api/v1/images/{image.image_id}/tag-history")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data["items"]) == 1
+
+        item_user = data["items"][0]["user"]
+        assert item_user is not None
+        assert item_user["user_id"] == user.user_id
+        assert item_user["avatar"] == "abc.png"
+        assert item_user["avatar_in_r2"] is True
+        assert item_user["avatar_url"] == "https://cdn.test/avatars/abc.png"
 
     async def test_handles_null_user(
         self, client: AsyncClient, db_session: AsyncSession

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,7 +1,13 @@
 """Fixtures for unit tests."""
 
+import time
+
+import aioboto3
 import pytest
 import redis.asyncio as redis
+from moto.server import ThreadedMotoServer
+
+from app.services.r2_storage import R2Storage
 
 
 @pytest.fixture
@@ -26,3 +32,61 @@ async def redis_client():
     # Cleanup - flush test database
     await client.flushdb()
     await client.aclose()
+
+
+# =============================================================================
+# moto / R2 storage fixtures
+# =============================================================================
+# Lifted from tests/unit/test_r2_storage.py so multiple test modules can reuse
+# them. mock_aws() patches the sync botocore HTTP layer but aiobotocore 2.x
+# awaits async HTTP responses — incompatible on this stack. ThreadedMotoServer
+# starts a real Flask-based HTTP server so aiobotocore can make genuine async
+# HTTP calls against a local mock endpoint.
+
+_R2_TEST_CREDS = {
+    "aws_access_key_id": "test",
+    "aws_secret_access_key": "test",
+    "region_name": "us-east-1",
+}
+
+
+@pytest.fixture(scope="module")
+def moto_server():
+    """Start a ThreadedMotoServer for the duration of the test module."""
+    server = ThreadedMotoServer(port=0)
+    server.start()
+    time.sleep(0.2)  # let the server come up
+    host, port = server.get_host_and_port()
+    yield f"http://{host}:{port}"
+    server.stop()
+
+
+@pytest.fixture
+def moto_session(moto_server):
+    """aioboto3 session pointed at the moto server."""
+    return aioboto3.Session(**_R2_TEST_CREDS)
+
+
+@pytest.fixture
+async def storage(moto_session, moto_server):
+    """R2Storage instance wired to the moto server endpoint."""
+    return R2Storage(session=moto_session, endpoint_url=moto_server)
+
+
+@pytest.fixture
+async def setup_buckets(storage, moto_session, moto_server):
+    """Create public and private buckets and clean them up after the test."""
+    async with moto_session.client("s3", endpoint_url=moto_server) as s3:
+        await s3.create_bucket(Bucket="public")
+        await s3.create_bucket(Bucket="private")
+    yield storage
+    # Cleanup: empty and delete buckets so tests are isolated
+    async with moto_session.client("s3", endpoint_url=moto_server) as s3:
+        for bucket in ("public", "private"):
+            try:
+                resp = await s3.list_objects_v2(Bucket=bucket)
+                for obj in resp.get("Contents", []):
+                    await s3.delete_object(Bucket=bucket, Key=obj["Key"])
+                await s3.delete_bucket(Bucket=bucket)
+            except Exception:
+                pass

--- a/tests/unit/test_avatar.py
+++ b/tests/unit/test_avatar.py
@@ -5,9 +5,11 @@ Tests cover:
 - Avatar validation (file type, size, content)
 - Avatar resizing (static images, animated GIFs)
 - Avatar storage (MD5 hashing, file saving)
+- Orphan-deletion signature (R2-aware via old_in_r2 flag)
 """
 
 import hashlib
+import inspect
 from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -18,6 +20,7 @@ from PIL import Image
 
 from app.services.avatar import (
     ALLOWED_AVATAR_EXTENSIONS,
+    delete_avatar_if_orphaned,
     resize_avatar,
     save_avatar,
     validate_avatar_upload,
@@ -353,3 +356,15 @@ class TestAllowedExtensions:
         assert ".png" in ALLOWED_AVATAR_EXTENSIONS
         assert ".gif" in ALLOWED_AVATAR_EXTENSIONS
         assert len(ALLOWED_AVATAR_EXTENSIONS) == 4
+
+
+class TestDeleteAvatarIfOrphanedR2:
+    """Orphan deletion now considers the old_in_r2 bit."""
+
+    def test_signature_accepts_old_in_r2(self):
+        """Confirm the new signature exposes old_in_r2 as a parameter."""
+        sig = inspect.signature(delete_avatar_if_orphaned)
+        assert "old_in_r2" in sig.parameters
+        # Order matters: callers pass it positionally between filename and db.
+        params = list(sig.parameters)
+        assert params == ["filename", "old_in_r2", "db"]

--- a/tests/unit/test_avatar_r2_dual_write.py
+++ b/tests/unit/test_avatar_r2_dual_write.py
@@ -1,0 +1,284 @@
+"""Dual-write integration tests for avatar upload.
+
+Exercises ``_upload_avatar`` end-to-end against a real moto S3 server (via the
+shared ``setup_buckets``/``moto_session``/``moto_server`` fixtures in
+``tests/unit/conftest.py``) plus the real ``db_session`` fixture from the
+parent conftest. R2 behaviour is tested against a live mock — only the
+fallback semantics use ``patch`` to force ``upload_bytes`` to raise.
+"""
+
+import io
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import UploadFile
+from PIL import Image
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.datastructures import Headers
+
+from app.api.v1.users import _upload_avatar
+from app.config import settings
+from app.core import r2_client
+from app.models.user import Users
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _png_bytes(color: str = "red") -> bytes:
+    """Return a small PNG payload."""
+    img = Image.new("RGB", (50, 50), color=color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_upload(name: str, data: bytes, content_type: str = "image/png") -> UploadFile:
+    """Build a Starlette/FastAPI UploadFile from in-memory bytes."""
+    return UploadFile(
+        file=io.BytesIO(data),
+        filename=name,
+        size=len(data),
+        headers=Headers({"content-type": content_type}),
+    )
+
+
+@pytest.fixture
+async def avatar_user(db_session: AsyncSession) -> Users:
+    """Insert a fresh user with no avatar set."""
+    user = Users(
+        username="dualwrite_user",
+        password="hashed",
+        password_type="bcrypt",
+        salt="saltsalt12345678",
+        email="dualwrite@example.com",
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def avatar_settings(monkeypatch, tmp_path: Path):
+    """Wire the avatar-relevant settings to tmp_path / R2 enabled / a moto bucket name.
+
+    Tests opt in to R2_ENABLED individually (some test the R2_ENABLED=false
+    branch); this fixture sets the local-storage path and the bucket name
+    only.
+    """
+    monkeypatch.setattr(settings, "AVATAR_STORAGE_PATH", str(tmp_path))
+    monkeypatch.setattr(settings, "MAX_AVATAR_SIZE", 1 * 1024 * 1024)
+    monkeypatch.setattr(settings, "MAX_AVATAR_DIMENSION", 200)
+    monkeypatch.setattr(settings, "R2_PUBLIC_BUCKET", "public")
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+    return tmp_path
+
+
+@pytest.fixture
+def install_r2(monkeypatch, setup_buckets):
+    """Install the moto-backed R2Storage as the process singleton.
+
+    ``setup_buckets`` is the moto-wired R2Storage with ``public`` and
+    ``private`` buckets pre-created. We swap it into the ``r2_client._instance``
+    cache so any ``get_r2_storage()`` call returns it instead of opening a
+    real aioboto3 session.
+    """
+    monkeypatch.setattr(r2_client, "_instance", setup_buckets)
+    return setup_buckets
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_dual_write_success_sets_bit(
+    avatar_user, avatar_settings, install_r2, db_session, monkeypatch, moto_session, moto_server
+):
+    """R2 enabled + moto bucket exists → local file + R2 object + bit=True."""
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+    payload = _png_bytes("red")
+    upload = _make_upload("test.png", payload)
+
+    response = await _upload_avatar(avatar_user.user_id, upload, db_session)
+
+    # Local file present
+    assert response.avatar
+    assert response.avatar.endswith(".png")
+    local = avatar_settings / response.avatar
+    assert local.exists(), "expected local avatar file to be saved"
+
+    # User row reflects R2 success
+    await db_session.refresh(avatar_user)
+    assert avatar_user.avatar == response.avatar
+    assert avatar_user.avatar_in_r2 is True
+
+    # R2 object present and content-type is image/png
+    key = f"avatars/{response.avatar}"
+    assert await install_r2.object_exists(bucket="public", key=key)
+    async with moto_session.client("s3", endpoint_url=moto_server) as s3:
+        head = await s3.head_object(Bucket="public", Key=key)
+        assert head["ContentType"] == "image/png"
+
+
+@pytest.mark.unit
+async def test_dual_write_r2_failure_falls_back(
+    avatar_user, avatar_settings, install_r2, db_session, monkeypatch, caplog
+):
+    """When upload_bytes raises, the request still succeeds with bit=False."""
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+    # Force upload_bytes to raise. We patch the bound method on the live
+    # R2Storage instance the singleton points at — this is testing the
+    # fallback semantics, not R2 behaviour, so a forced raise is appropriate
+    # under AGENTS.md.
+    async def _boom(self, bucket: str, key: str, body: bytes, content_type: str) -> None:
+        raise RuntimeError("simulated R2 outage")
+
+    with patch.object(install_r2.__class__, "upload_bytes", _boom):
+        with caplog.at_level(logging.WARNING):
+            payload = _png_bytes("blue")
+            upload = _make_upload("test.png", payload)
+            response = await _upload_avatar(avatar_user.user_id, upload, db_session)
+
+    # Local file still saved
+    assert response.avatar
+    local = avatar_settings / response.avatar
+    assert local.exists()
+
+    # Bit stays False
+    await db_session.refresh(avatar_user)
+    assert avatar_user.avatar == response.avatar
+    assert avatar_user.avatar_in_r2 is False
+
+    # R2 object should NOT exist (the put_object never landed)
+    assert not await install_r2.object_exists(bucket="public", key=f"avatars/{response.avatar}")
+
+    # Failure log emitted
+    log_messages = " ".join(record.getMessage() for record in caplog.records)
+    assert "avatar_r2_upload_failed" in log_messages
+
+
+@pytest.mark.unit
+async def test_orphan_delete_clears_r2_when_old_in_r2(
+    avatar_user, avatar_settings, install_r2, db_session, monkeypatch
+):
+    """Replacing an avatar where old_in_r2=True deletes the old R2 object."""
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+    # Pre-seed: user has an old avatar present in R2
+    old_payload = _png_bytes("green")
+    old_filename = "deadbeef000000000000000000000000.png"
+    (avatar_settings / old_filename).write_bytes(old_payload)
+    await install_r2.upload_bytes(
+        bucket="public",
+        key=f"avatars/{old_filename}",
+        body=old_payload,
+        content_type="image/png",
+    )
+    avatar_user.avatar = old_filename
+    avatar_user.avatar_in_r2 = True
+    await db_session.commit()
+    await db_session.refresh(avatar_user)
+
+    assert await install_r2.object_exists(bucket="public", key=f"avatars/{old_filename}")
+
+    # New upload — different bytes, so different MD5 / new key
+    new_payload = _png_bytes("blue")
+    upload = _make_upload("new.png", new_payload)
+    response = await _upload_avatar(avatar_user.user_id, upload, db_session)
+
+    assert response.avatar != old_filename
+
+    # Old R2 object cleaned up
+    assert not await install_r2.object_exists(bucket="public", key=f"avatars/{old_filename}")
+    # Old local file cleaned up
+    assert not (avatar_settings / old_filename).exists()
+    # New R2 object exists
+    assert await install_r2.object_exists(bucket="public", key=f"avatars/{response.avatar}")
+
+
+@pytest.mark.unit
+async def test_orphan_delete_skips_r2_when_old_in_r2_false(
+    avatar_user, avatar_settings, install_r2, db_session, monkeypatch
+):
+    """When old_in_r2=False, no R2 delete fires for the old key."""
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+    # Pre-seed: user has an old avatar locally only — no R2 object
+    old_payload = _png_bytes("green")
+    old_filename = "cafebabe000000000000000000000000.png"
+    (avatar_settings / old_filename).write_bytes(old_payload)
+    avatar_user.avatar = old_filename
+    avatar_user.avatar_in_r2 = False
+    await db_session.commit()
+    await db_session.refresh(avatar_user)
+
+    # Spy on delete_object so we can assert it was NOT called for the old key
+    delete_calls: list[tuple[str, str]] = []
+    real_delete = install_r2.delete_object
+
+    async def _spy_delete(bucket: str, key: str) -> None:
+        delete_calls.append((bucket, key))
+        await real_delete(bucket=bucket, key=key)
+
+    with patch.object(install_r2, "delete_object", _spy_delete):
+        new_payload = _png_bytes("blue")
+        upload = _make_upload("new.png", new_payload)
+        response = await _upload_avatar(avatar_user.user_id, upload, db_session)
+
+    assert response.avatar != old_filename
+
+    # No R2 delete attempted for the old key
+    old_key = f"avatars/{old_filename}"
+    assert not any(bucket == "public" and key == old_key for bucket, key in delete_calls), (
+        f"unexpected R2 delete on old key: {delete_calls!r}"
+    )
+
+    # Local old file still deleted by the orphan helper
+    assert not (avatar_settings / old_filename).exists()
+
+
+@pytest.mark.unit
+async def test_same_md5_reupload_preserves_file(
+    avatar_user, avatar_settings, install_r2, db_session, monkeypatch
+):
+    """Re-uploading identical bytes leaves the existing file/R2 object intact."""
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+
+    # First upload — establishes the avatar in both local and R2
+    payload = _png_bytes("red")
+    upload = _make_upload("first.png", payload)
+    first = await _upload_avatar(avatar_user.user_id, upload, db_session)
+
+    await db_session.refresh(avatar_user)
+    assert avatar_user.avatar_in_r2 is True
+    first_filename = first.avatar
+    assert (avatar_settings / first_filename).exists()
+    assert await install_r2.object_exists(bucket="public", key=f"avatars/{first_filename}")
+
+    # Second upload — identical bytes, same MD5, same key
+    upload2 = _make_upload("first.png", payload)
+    second = await _upload_avatar(avatar_user.user_id, upload2, db_session)
+
+    assert second.avatar == first_filename, "MD5-addressed filename must match"
+
+    # Critical: orphan check after the commit must see the user themselves
+    # still referencing first_filename (count >= 1) and skip deletion.
+    assert (avatar_settings / first_filename).exists(), (
+        "local file deleted despite the user still referencing it"
+    )
+    assert await install_r2.object_exists(bucket="public", key=f"avatars/{first_filename}"), (
+        "R2 object deleted despite the user still referencing it"
+    )
+
+    await db_session.refresh(avatar_user)
+    assert avatar_user.avatar == first_filename
+    assert avatar_user.avatar_in_r2 is True

--- a/tests/unit/test_avatar_url_helper.py
+++ b/tests/unit/test_avatar_url_helper.py
@@ -1,0 +1,45 @@
+"""Tests for avatar URL helper and content-type derivation."""
+
+import pytest
+
+from app.config import settings
+from app.services.avatar import _avatar_content_type, avatar_url
+
+
+def test_avatar_url_returns_none_for_empty():
+    assert avatar_url("", in_r2=True) is None
+    assert avatar_url(None, in_r2=True) is None
+
+
+def test_avatar_url_local_when_r2_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "R2_ENABLED", False)
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    assert avatar_url("abc.png", in_r2=True) == "http://local.test/images/avatars/abc.png"
+
+
+def test_avatar_url_local_when_bit_false(monkeypatch):
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    assert avatar_url("abc.png", in_r2=False) == "http://local.test/images/avatars/abc.png"
+
+
+def test_avatar_url_cdn_when_both_true(monkeypatch):
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    assert avatar_url("abc.png", in_r2=True) == "https://cdn.test/avatars/abc.png"
+
+
+@pytest.mark.parametrize(
+    "ext,expected",
+    [
+        ("png", "image/png"),
+        ("jpg", "image/jpeg"),
+        ("jpeg", "image/jpeg"),
+        ("gif", "image/gif"),
+    ],
+)
+def test_avatar_content_type(ext, expected):
+    assert _avatar_content_type(ext) == expected

--- a/tests/unit/test_avatar_url_helper.py
+++ b/tests/unit/test_avatar_url_helper.py
@@ -43,3 +43,30 @@ def test_avatar_url_cdn_when_both_true(monkeypatch):
 )
 def test_avatar_content_type(ext, expected):
     assert _avatar_content_type(ext) == expected
+
+
+def test_user_response_avatar_url_uses_helper(monkeypatch):
+    from app.schemas.user import UserResponse
+
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+    # Use model_construct to bypass deep validation for fields we don't care about
+    data = {
+        "user_id": 1,
+        "username": "alice",
+        "avatar": "abc.png",
+        "avatar_in_r2": True,
+    }
+    resp = UserResponse.model_construct(**data)
+    assert resp.avatar_url == "https://cdn.test/avatars/abc.png"
+
+
+def test_user_summary_avatar_url_uses_helper(monkeypatch):
+    from app.schemas.common import UserSummary
+
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+    summary = UserSummary(user_id=1, username="alice", avatar="abc.png", avatar_in_r2=True)
+    assert summary.avatar_url == "https://cdn.test/avatars/abc.png"

--- a/tests/unit/test_avatar_url_helper.py
+++ b/tests/unit/test_avatar_url_helper.py
@@ -3,7 +3,7 @@
 import pytest
 
 from app.config import settings
-from app.services.avatar import _avatar_content_type, avatar_url
+from app.services.avatar import avatar_content_type, avatar_url
 
 
 def test_avatar_url_returns_none_for_empty():
@@ -42,7 +42,12 @@ def test_avatar_url_cdn_when_both_true(monkeypatch):
     ],
 )
 def test_avatar_content_type(ext, expected):
-    assert _avatar_content_type(ext) == expected
+    assert avatar_content_type(ext) == expected
+
+
+def test_avatar_content_type_raises_on_unknown_extension():
+    with pytest.raises(ValueError, match="No Content-Type mapping for avatar extension"):
+        avatar_content_type("webp")
 
 
 def test_user_response_avatar_url_uses_helper(monkeypatch):

--- a/tests/unit/test_avatar_url_helper.py
+++ b/tests/unit/test_avatar_url_helper.py
@@ -75,3 +75,57 @@ def test_user_summary_avatar_url_uses_helper(monkeypatch):
     monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
     summary = UserSummary(user_id=1, username="alice", avatar="abc.png", avatar_in_r2=True)
     assert summary.avatar_url == "https://cdn.test/avatars/abc.png"
+
+
+def test_user_summary_excludes_avatar_in_r2_from_serialization() -> None:
+    """``avatar_in_r2`` is an internal routing detail; clients only see avatar_url."""
+    import json
+
+    from app.schemas.common import UserSummary
+
+    summary = UserSummary(user_id=1, username="alice", avatar="abc.png", avatar_in_r2=True)
+
+    dumped = summary.model_dump()
+    assert "avatar_in_r2" not in dumped, (
+        f"avatar_in_r2 leaked into model_dump(): {sorted(dumped)}"
+    )
+
+    dumped_json = json.loads(summary.model_dump_json())
+    assert "avatar_in_r2" not in dumped_json, (
+        f"avatar_in_r2 leaked into model_dump_json(): {sorted(dumped_json)}"
+    )
+
+    # Still readable on the instance for the URL helper.
+    assert summary.avatar_in_r2 is True
+
+
+def test_user_response_excludes_avatar_in_r2_from_serialization() -> None:
+    """UserResponse inherits avatar_in_r2 from UserBase; exclude=True must propagate."""
+    from app.schemas.user import UserResponse
+
+    data = {
+        "user_id": 1,
+        "username": "alice",
+        "avatar": "abc.png",
+        "avatar_in_r2": True,
+    }
+    resp = UserResponse.model_construct(**data)
+    dumped = resp.model_dump()
+    assert "avatar_in_r2" not in dumped, (
+        f"avatar_in_r2 leaked into UserResponse.model_dump(): {sorted(dumped)}"
+    )
+    # Still readable on the instance.
+    assert resp.avatar_in_r2 is True
+
+
+def test_user_create_response_excludes_avatar_in_r2_from_serialization() -> None:
+    """UserCreateResponse inherits from UserBase; exclude=True must propagate."""
+    from app.schemas.user import UserCreateResponse
+
+    resp = UserCreateResponse.model_construct(
+        user_id=1, username="alice", email="a@x.test", avatar_in_r2=True
+    )
+    dumped = resp.model_dump()
+    assert "avatar_in_r2" not in dumped, (
+        f"avatar_in_r2 leaked into UserCreateResponse.model_dump(): {sorted(dumped)}"
+    )

--- a/tests/unit/test_banner_model.py
+++ b/tests/unit/test_banner_model.py
@@ -86,3 +86,11 @@ class TestUserBannerPinsModel:
 
     def test_table_name(self):
         assert UserBannerPins.__tablename__ == "user_banner_pins"
+
+
+def test_bannerbase_has_in_r2_field():
+    from app.models.misc import BannerBase
+
+    field = BannerBase.model_fields["in_r2"]
+    assert field.annotation is bool
+    assert field.default is False

--- a/tests/unit/test_banner_schema.py
+++ b/tests/unit/test_banner_schema.py
@@ -204,3 +204,39 @@ def test_banner_content_type_raises_on_missing_extension():
 
     with pytest.raises(ValueError, match="No Content-Type mapping for banner path"):
         banner_content_type("noextension")
+
+
+def test_banner_response_excludes_in_r2_from_serialization() -> None:
+    """``in_r2`` is an internal routing detail; clients only see *_url fields.
+
+    Asserts both model_dump() and model_dump_json() drop the key, while it
+    remains readable on the instance (so the computed URL fields can use it).
+    """
+    import json
+
+    from app.schemas.banner import BannerResponse
+
+    resp = BannerResponse(
+        banner_id=1,
+        name="t",
+        author=None,
+        size=BannerSize.small,
+        supports_dark=True,
+        supports_light=True,
+        full_image="eva/full.png",
+        left_image=None,
+        middle_image=None,
+        right_image=None,
+        in_r2=True,
+    )
+
+    dumped = resp.model_dump()
+    assert "in_r2" not in dumped, f"in_r2 leaked into model_dump(): {sorted(dumped)}"
+
+    dumped_json = json.loads(resp.model_dump_json())
+    assert "in_r2" not in dumped_json, (
+        f"in_r2 leaked into model_dump_json(): {sorted(dumped_json)}"
+    )
+
+    # Still readable on the instance for the URL helper.
+    assert resp.in_r2 is True

--- a/tests/unit/test_banner_schema.py
+++ b/tests/unit/test_banner_schema.py
@@ -174,3 +174,33 @@ def test_banner_response_three_part_uses_cdn(monkeypatch) -> None:
     assert resp.left_image_url == "https://cdn.test/banners/hw/l.png"
     assert resp.middle_image_url == "https://cdn.test/banners/hw/m.png"
     assert resp.right_image_url == "https://cdn.test/banners/hw/r.png"
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("eva/full.jpg", "image/jpeg"),
+        ("foo.JPEG", "image/jpeg"),
+        ("hw/l.png", "image/png"),
+        ("anim.gif", "image/gif"),
+        ("modern.webp", "image/webp"),
+    ],
+)
+def test_banner_content_type_known_extensions(path, expected):
+    from app.services.banner import banner_content_type
+
+    assert banner_content_type(path) == expected
+
+
+def test_banner_content_type_raises_on_unknown_extension():
+    from app.services.banner import banner_content_type
+
+    with pytest.raises(ValueError, match="No Content-Type mapping for banner path"):
+        banner_content_type("foo.bmp")
+
+
+def test_banner_content_type_raises_on_missing_extension():
+    from app.services.banner import banner_content_type
+
+    with pytest.raises(ValueError, match="No Content-Type mapping for banner path"):
+        banner_content_type("noextension")

--- a/tests/unit/test_banner_schema.py
+++ b/tests/unit/test_banner_schema.py
@@ -103,3 +103,74 @@ def test_banner_response_requires_all_three_parts() -> None:
             supports_dark=True,
             supports_light=True,
         )
+
+
+def test_banner_response_uses_cdn_when_in_r2_and_enabled(monkeypatch) -> None:
+    from app.schemas.banner import BannerResponse
+
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    monkeypatch.setattr(settings, "BANNER_BASE_URL", "http://local.test/banners")
+
+    resp = BannerResponse(
+        banner_id=1,
+        name="t",
+        author=None,
+        size=BannerSize.small,
+        supports_dark=True,
+        supports_light=True,
+        full_image="eva/full.jpg",
+        left_image=None,
+        middle_image=None,
+        right_image=None,
+        in_r2=True,
+    )
+    assert resp.full_image_url == "https://cdn.test/banners/eva/full.jpg"
+
+
+def test_banner_response_falls_back_when_bit_false(monkeypatch) -> None:
+    from app.schemas.banner import BannerResponse
+
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    monkeypatch.setattr(settings, "BANNER_BASE_URL", "http://local.test/banners")
+
+    resp = BannerResponse(
+        banner_id=1,
+        name="t",
+        author=None,
+        size=BannerSize.small,
+        supports_dark=True,
+        supports_light=True,
+        full_image="eva/full.jpg",
+        left_image=None,
+        middle_image=None,
+        right_image=None,
+        in_r2=False,
+    )
+    assert resp.full_image_url == "http://local.test/banners/eva/full.jpg"
+
+
+def test_banner_response_three_part_uses_cdn(monkeypatch) -> None:
+    from app.schemas.banner import BannerResponse
+
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+    monkeypatch.setattr(settings, "BANNER_BASE_URL", "http://local.test/banners")
+
+    resp = BannerResponse(
+        banner_id=1,
+        name="t",
+        author=None,
+        size=BannerSize.large,
+        supports_dark=True,
+        supports_light=True,
+        full_image=None,
+        left_image="hw/l.png",
+        middle_image="hw/m.png",
+        right_image="hw/r.png",
+        in_r2=True,
+    )
+    assert resp.left_image_url == "https://cdn.test/banners/hw/l.png"
+    assert resp.middle_image_url == "https://cdn.test/banners/hw/m.png"
+    assert resp.right_image_url == "https://cdn.test/banners/hw/r.png"

--- a/tests/unit/test_config_banner_storage.py
+++ b/tests/unit/test_config_banner_storage.py
@@ -1,0 +1,15 @@
+"""Tests for BANNER_STORAGE_PATH setting derivation."""
+
+
+def test_banner_storage_path_default_derives_from_storage_path(monkeypatch):
+    from app.config import Settings
+
+    s = Settings(STORAGE_PATH="/tmp/test", BANNER_STORAGE_PATH="")
+    assert s.BANNER_STORAGE_PATH == "/tmp/test/banners"
+
+
+def test_banner_storage_path_explicit_value_preserved():
+    from app.config import Settings
+
+    s = Settings(STORAGE_PATH="/tmp/test", BANNER_STORAGE_PATH="/elsewhere")
+    assert s.BANNER_STORAGE_PATH == "/elsewhere"

--- a/tests/unit/test_r2_client.py
+++ b/tests/unit/test_r2_client.py
@@ -39,3 +39,10 @@ class TestGetR2Storage:
         storage = DummyR2Storage()
         with pytest.raises(RuntimeError, match="R2 is disabled"):
             await storage.object_exists(bucket="b", key="k")
+
+    async def test_dummy_upload_bytes_raises(self):
+        storage = DummyR2Storage()
+        with pytest.raises(RuntimeError, match="R2 is disabled"):
+            await storage.upload_bytes(
+                bucket="x", key="y", body=b"z", content_type="image/png"
+            )

--- a/tests/unit/test_r2_storage.py
+++ b/tests/unit/test_r2_storage.py
@@ -176,3 +176,17 @@ class TestR2Storage:
                 )
             # outer client still usable after inner exits
             await storage.delete_object(bucket="public", key="nested")
+
+    async def test_upload_bytes_round_trip(self, setup_buckets, moto_session, moto_server):
+        storage = setup_buckets
+        await storage.upload_bytes(
+            bucket="public",
+            key="avatars/abc.png",
+            body=b"PNG-bytes",
+            content_type="image/png",
+        )
+        assert await storage.object_exists(bucket="public", key="avatars/abc.png")
+        # Verify Content-Type was set
+        async with moto_session.client("s3", endpoint_url=moto_server) as s3:
+            head = await s3.head_object(Bucket="public", Key="avatars/abc.png")
+            assert head["ContentType"] == "image/png"

--- a/tests/unit/test_r2_storage.py
+++ b/tests/unit/test_r2_storage.py
@@ -1,66 +1,12 @@
 """Tests for R2Storage adapter (backed by moto ThreadedMotoServer).
 
-Note: mock_aws() patches the sync botocore HTTP layer but aiobotocore 2.x
-awaits async HTTP responses — incompatible on this stack. ThreadedMotoServer
-starts a real Flask-based HTTP server so aiobotocore can make genuine async
-HTTP calls against a local mock endpoint.
+Fixtures `moto_server`, `moto_session`, `storage`, and `setup_buckets` live in
+`tests/unit/conftest.py` so multiple test modules can share them.
 """
 
-import time
 from pathlib import Path
 
-import aioboto3
 import pytest
-from moto.server import ThreadedMotoServer
-
-from app.services.r2_storage import R2Storage
-
-_CREDS = {
-    "aws_access_key_id": "test",
-    "aws_secret_access_key": "test",
-    "region_name": "us-east-1",
-}
-
-
-@pytest.fixture(scope="module")
-def moto_server():
-    """Start a ThreadedMotoServer for the duration of this test module."""
-    server = ThreadedMotoServer(port=0)
-    server.start()
-    time.sleep(0.2)  # let the server come up
-    host, port = server.get_host_and_port()
-    yield f"http://{host}:{port}"
-    server.stop()
-
-
-@pytest.fixture
-def moto_session(moto_server):
-    """aioboto3 session pointed at the moto server."""
-    return aioboto3.Session(**_CREDS)
-
-
-@pytest.fixture
-async def storage(moto_session, moto_server):
-    """R2Storage instance wired to the moto server endpoint."""
-    return R2Storage(session=moto_session, endpoint_url=moto_server)
-
-
-@pytest.fixture
-async def setup_buckets(storage, moto_session, moto_server):
-    async with moto_session.client("s3", endpoint_url=moto_server) as s3:
-        await s3.create_bucket(Bucket="public")
-        await s3.create_bucket(Bucket="private")
-    yield storage
-    # Cleanup: empty and delete buckets so tests are isolated
-    async with moto_session.client("s3", endpoint_url=moto_server) as s3:
-        for bucket in ("public", "private"):
-            try:
-                resp = await s3.list_objects_v2(Bucket=bucket)
-                for obj in resp.get("Contents", []):
-                    await s3.delete_object(Bucket=bucket, Key=obj["Key"])
-                await s3.delete_bucket(Bucket=bucket)
-            except Exception:
-                pass
 
 
 @pytest.mark.unit
@@ -78,9 +24,7 @@ class TestR2Storage:
         src = tmp_path / "a.bin"
         src.write_bytes(b"data")
         await storage.upload_file(bucket="public", key="fullsize/a.bin", path=src)
-        await storage.copy_object(
-            src_bucket="public", dst_bucket="private", key="fullsize/a.bin"
-        )
+        await storage.copy_object(src_bucket="public", dst_bucket="private", key="fullsize/a.bin")
         assert await storage.object_exists(bucket="private", key="fullsize/a.bin") is True
 
     async def test_delete_object(self, setup_buckets, tmp_path: Path):
@@ -101,9 +45,7 @@ class TestR2Storage:
         src = tmp_path / "a.bin"
         src.write_bytes(b"data")
         await storage.upload_file(bucket="private", key="fullsize/a.bin", path=src)
-        url = await storage.generate_presigned_url(
-            bucket="private", key="fullsize/a.bin", ttl=60
-        )
+        url = await storage.generate_presigned_url(bucket="private", key="fullsize/a.bin", ttl=60)
         assert "a.bin" in url
         assert "Signature" in url or "X-Amz-Signature" in url
 
@@ -114,22 +56,13 @@ class TestR2Storage:
         src.write_bytes(b"data")
         async with storage.bulk_session():
             await storage.upload_file(bucket="public", key="fullsize/a.bin", path=src)
-            assert (
-                await storage.object_exists(bucket="public", key="fullsize/a.bin")
-                is True
-            )
+            assert await storage.object_exists(bucket="public", key="fullsize/a.bin") is True
             await storage.copy_object(
                 src_bucket="public", dst_bucket="private", key="fullsize/a.bin"
             )
             await storage.delete_object(bucket="public", key="fullsize/a.bin")
-            assert (
-                await storage.object_exists(bucket="public", key="fullsize/a.bin")
-                is False
-            )
-            assert (
-                await storage.object_exists(bucket="private", key="fullsize/a.bin")
-                is True
-            )
+            assert await storage.object_exists(bucket="public", key="fullsize/a.bin") is False
+            assert await storage.object_exists(bucket="private", key="fullsize/a.bin") is True
 
     async def test_bulk_session_reuses_single_client(
         self, setup_buckets, tmp_path: Path, monkeypatch
@@ -157,9 +90,7 @@ class TestR2Storage:
         async with storage.bulk_session():
             await storage.upload_file(bucket="public", key="two", path=src)
             await storage.object_exists(bucket="public", key="two")
-            await storage.copy_object(
-                src_bucket="public", dst_bucket="private", key="two"
-            )
+            await storage.copy_object(src_bucket="public", dst_bucket="private", key="two")
             await storage.delete_object(bucket="public", key="two")
         assert call_count == 1, "bulk_session opens one client for all ops inside"
 
@@ -171,9 +102,7 @@ class TestR2Storage:
         async with storage.bulk_session():
             await storage.upload_file(bucket="public", key="nested", path=src)
             async with storage.bulk_session():
-                assert (
-                    await storage.object_exists(bucket="public", key="nested") is True
-                )
+                assert await storage.object_exists(bucket="public", key="nested") is True
             # outer client still usable after inner exits
             await storage.delete_object(bucket="public", key="nested")
 

--- a/tests/unit/test_r2_sync_avatars_backfill.py
+++ b/tests/unit/test_r2_sync_avatars_backfill.py
@@ -1,0 +1,253 @@
+"""Tests for ``scripts/r2_sync.py avatars-backfill`` subcommand.
+
+Exercises ``cmd_avatars_backfill`` end-to-end against a real moto S3 server
+(via the shared ``setup_buckets``/``moto_session``/``moto_server`` fixtures in
+``tests/unit/conftest.py``) plus the real ``db_session`` fixture from the
+parent conftest. ``get_async_session`` is patched to yield the test session
+so the script's DB reads see the seeded users; ``r2_client._instance`` is
+swapped for the moto-wired R2Storage so ``get_r2_storage()`` returns it.
+"""
+
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.core import r2_client
+from app.models.user import Users
+from scripts.r2_sync import (
+    BulkBackfillDisallowedError,
+    cmd_avatars_backfill,
+    require_bulk_backfill,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _mock_session_cm(db_session: AsyncSession):
+    """Async-context-manager mock that yields the real test session.
+
+    Mirrors the helper in ``tests/unit/test_r2_sync_remaining.py`` — the
+    backfill code uses ``async with get_async_session() as db:``, so we need
+    to swap that callable for one whose result yields ``db_session`` from
+    ``__aenter__``.
+    """
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=db_session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+@pytest.fixture
+def avatar_settings(monkeypatch, tmp_path: Path) -> Path:
+    """Wire the avatar-relevant settings to tmp_path / public bucket / R2 enabled."""
+    monkeypatch.setattr(settings, "AVATAR_STORAGE_PATH", str(tmp_path))
+    monkeypatch.setattr(settings, "R2_PUBLIC_BUCKET", "public")
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", True)
+    return tmp_path
+
+
+@pytest.fixture
+def install_r2(monkeypatch, setup_buckets):
+    """Install the moto-backed R2Storage as the ``get_r2_storage()`` singleton."""
+    monkeypatch.setattr(r2_client, "_instance", setup_buckets)
+    return setup_buckets
+
+
+@pytest.fixture
+def patch_session(db_session: AsyncSession):
+    """Make ``scripts.r2_sync.get_async_session()`` yield the test session."""
+    with patch(
+        "scripts.r2_sync.get_async_session",
+        return_value=_mock_session_cm(db_session),
+    ):
+        yield
+
+
+def _make_user(
+    db_session: AsyncSession,
+    *,
+    username: str,
+    email: str,
+    avatar: str = "",
+    avatar_in_r2: bool = False,
+) -> Users:
+    user = Users(
+        username=username,
+        password="hashed",
+        password_type="bcrypt",
+        salt="saltsalt12345678",
+        email=email,
+        avatar=avatar,
+        avatar_in_r2=avatar_in_r2,
+    )
+    db_session.add(user)
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_backfill_uploads_and_flips_bit(
+    avatar_settings,
+    install_r2,
+    patch_session,
+    db_session,
+    moto_session,
+    moto_server,
+):
+    """Two users, both bit=False, both files on disk → both bit=True + uploaded."""
+    fname_a = "alpha000000000000000000000000aaaa.png"
+    fname_b = "beta0000000000000000000000000bbbb.png"
+    (avatar_settings / fname_a).write_bytes(b"\x89PNG-a")
+    (avatar_settings / fname_b).write_bytes(b"\x89PNG-b")
+
+    user_a = _make_user(
+        db_session, username="bf_a", email="bf_a@x.test", avatar=fname_a
+    )
+    user_b = _make_user(
+        db_session, username="bf_b", email="bf_b@x.test", avatar=fname_b
+    )
+    await db_session.commit()
+
+    report = await cmd_avatars_backfill(dry_run=False, concurrency=4)
+    assert report["uploaded"] == 2
+    assert report["skipped_existing"] == 0
+    assert report["missing_local"] == 0
+
+    await db_session.refresh(user_a)
+    await db_session.refresh(user_b)
+    assert user_a.avatar_in_r2 is True
+    assert user_b.avatar_in_r2 is True
+
+    # Both R2 objects exist with image/png content type
+    async with moto_session.client("s3", endpoint_url=moto_server) as s3:
+        for fname in (fname_a, fname_b):
+            head = await s3.head_object(Bucket="public", Key=f"avatars/{fname}")
+            assert head["ContentType"] == "image/png"
+
+
+@pytest.mark.unit
+async def test_backfill_idempotent_skips_existing(
+    avatar_settings,
+    install_r2,
+    patch_session,
+    db_session,
+):
+    """Pre-existing R2 object → no re-upload, but bit still flips to True."""
+    fname = "idem0000000000000000000000000000.png"
+    (avatar_settings / fname).write_bytes(b"local-bytes")
+
+    # Pre-seed R2 with different bytes so we can detect a re-upload by content.
+    await install_r2.upload_bytes(
+        bucket="public",
+        key=f"avatars/{fname}",
+        body=b"r2-pre-existing-bytes",
+        content_type="image/png",
+    )
+
+    user = _make_user(
+        db_session, username="bf_idem", email="bf_idem@x.test", avatar=fname
+    )
+    await db_session.commit()
+
+    # Spy on upload_bytes to assert the script did NOT call it.
+    with patch.object(
+        install_r2.__class__,
+        "upload_bytes",
+        AsyncMock(side_effect=AssertionError("upload_bytes must not be called")),
+    ):
+        report = await cmd_avatars_backfill(dry_run=False, concurrency=2)
+
+    assert report["uploaded"] == 0
+    assert report["skipped_existing"] == 1
+    assert report["missing_local"] == 0
+
+    await db_session.refresh(user)
+    assert user.avatar_in_r2 is True
+
+
+@pytest.mark.unit
+async def test_backfill_skips_when_local_missing(
+    avatar_settings,
+    install_r2,
+    patch_session,
+    db_session,
+    caplog,
+):
+    """Avatar filename in DB but no local file → log + bit stays False."""
+    fname = "missing0000000000000000000000000.png"
+    # Intentionally do NOT write the file to disk.
+
+    user = _make_user(
+        db_session, username="bf_miss", email="bf_miss@x.test", avatar=fname
+    )
+    await db_session.commit()
+
+    with caplog.at_level(logging.WARNING):
+        report = await cmd_avatars_backfill(dry_run=False, concurrency=2)
+
+    assert report["uploaded"] == 0
+    assert report["skipped_existing"] == 0
+    assert report["missing_local"] == 1
+
+    await db_session.refresh(user)
+    assert user.avatar_in_r2 is False
+
+    # No R2 object created
+    assert not await install_r2.object_exists(
+        bucket="public", key=f"avatars/{fname}"
+    )
+
+    # Warning log emitted
+    log_messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "avatar_local_missing" in log_messages
+
+
+@pytest.mark.unit
+async def test_backfill_dry_run_writes_nothing(
+    avatar_settings,
+    install_r2,
+    patch_session,
+    db_session,
+):
+    """--dry-run → no R2 object, bit stays False."""
+    fname = "dryrun00000000000000000000000000.png"
+    (avatar_settings / fname).write_bytes(b"\x89PNG-dry")
+
+    user = _make_user(
+        db_session, username="bf_dry", email="bf_dry@x.test", avatar=fname
+    )
+    await db_session.commit()
+
+    report = await cmd_avatars_backfill(dry_run=True, concurrency=2)
+
+    # No write attempted (would-be uploads aren't counted as actual uploads in
+    # dry-run; the report just reflects "nothing happened").
+    assert report["uploaded"] == 0
+    assert report["skipped_existing"] == 0
+    assert report["missing_local"] == 0
+
+    await db_session.refresh(user)
+    assert user.avatar_in_r2 is False
+    assert not await install_r2.object_exists(
+        bucket="public", key=f"avatars/{fname}"
+    )
+
+
+@pytest.mark.unit
+def test_backfill_refuses_without_bulk_flag(monkeypatch):
+    """R2_ALLOW_BULK_BACKFILL=false → require_bulk_backfill raises."""
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", False)
+    with pytest.raises(BulkBackfillDisallowedError):
+        require_bulk_backfill()

--- a/tests/unit/test_r2_sync_avatars_backfill.py
+++ b/tests/unit/test_r2_sync_avatars_backfill.py
@@ -231,17 +231,117 @@ async def test_backfill_dry_run_writes_nothing(
 
     report = await cmd_avatars_backfill(dry_run=True, concurrency=2)
 
-    # No write attempted (would-be uploads aren't counted as actual uploads in
-    # dry-run; the report just reflects "nothing happened").
+    # No actual upload; the would-be upload is reflected in `would_upload`.
     assert report["uploaded"] == 0
     assert report["skipped_existing"] == 0
     assert report["missing_local"] == 0
+    assert report["would_upload"] == 1
+    assert report["failed"] == 0
 
     await db_session.refresh(user)
     assert user.avatar_in_r2 is False
     assert not await install_r2.object_exists(
         bucket="public", key=f"avatars/{fname}"
     )
+
+
+@pytest.mark.unit
+async def test_backfill_dry_run_reports_would_upload(
+    avatar_settings,
+    install_r2,
+    patch_session,
+    db_session,
+):
+    """Two unbackfilled users in dry-run → would_upload == 2, no writes."""
+    fname_a = "wouldup0000000000000000000000aaa.png"
+    fname_b = "wouldup0000000000000000000000bbb.png"
+    (avatar_settings / fname_a).write_bytes(b"\x89PNG-a")
+    (avatar_settings / fname_b).write_bytes(b"\x89PNG-b")
+
+    user_a = _make_user(
+        db_session, username="bf_wa", email="bf_wa@x.test", avatar=fname_a
+    )
+    user_b = _make_user(
+        db_session, username="bf_wb", email="bf_wb@x.test", avatar=fname_b
+    )
+    await db_session.commit()
+
+    report = await cmd_avatars_backfill(dry_run=True, concurrency=4)
+
+    assert report["would_upload"] == 2
+    assert report["uploaded"] == 0
+    assert report["skipped_existing"] == 0
+    assert report["missing_local"] == 0
+    assert report["failed"] == 0
+
+    await db_session.refresh(user_a)
+    await db_session.refresh(user_b)
+    assert user_a.avatar_in_r2 is False
+    assert user_b.avatar_in_r2 is False
+    for fname in (fname_a, fname_b):
+        assert not await install_r2.object_exists(
+            bucket="public", key=f"avatars/{fname}"
+        )
+
+
+@pytest.mark.unit
+async def test_backfill_continues_on_upload_failure(
+    avatar_settings,
+    install_r2,
+    patch_session,
+    db_session,
+    caplog,
+):
+    """One upload raises → run continues; that user not flipped, others are."""
+    fname_a = "fail0000000000000000000000000aaa.png"
+    fname_b = "fail0000000000000000000000000bbb.png"
+    fname_c = "fail0000000000000000000000000ccc.png"
+    for fname in (fname_a, fname_b, fname_c):
+        (avatar_settings / fname).write_bytes(b"\x89PNG-" + fname[:1].encode())
+
+    user_a = _make_user(
+        db_session, username="bf_fa", email="bf_fa@x.test", avatar=fname_a
+    )
+    user_b = _make_user(
+        db_session, username="bf_fb", email="bf_fb@x.test", avatar=fname_b
+    )
+    user_c = _make_user(
+        db_session, username="bf_fc", email="bf_fc@x.test", avatar=fname_c
+    )
+    await db_session.commit()
+
+    real_upload = install_r2.__class__.upload_bytes
+    call_count = {"n": 0}
+
+    async def _flaky_upload(self, bucket: str, key: str, body: bytes, content_type: str) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise RuntimeError("simulated upload failure")
+        await real_upload(self, bucket=bucket, key=key, body=body, content_type=content_type)
+
+    with patch.object(install_r2.__class__, "upload_bytes", _flaky_upload):
+        with caplog.at_level(logging.WARNING):
+            # concurrency=1 makes ordering deterministic so we know exactly
+            # which call is the 2nd (and which user lands in `failed`).
+            report = await cmd_avatars_backfill(dry_run=False, concurrency=1)
+
+    assert report["uploaded"] == 2
+    assert report["failed"] == 1
+    assert report["skipped_existing"] == 0
+    assert report["missing_local"] == 0
+    assert report["would_upload"] == 0
+
+    # Refresh all three users; exactly two have the bit set.
+    await db_session.refresh(user_a)
+    await db_session.refresh(user_b)
+    await db_session.refresh(user_c)
+    flipped = [u.avatar_in_r2 for u in (user_a, user_b, user_c)]
+    assert sum(1 for f in flipped if f is True) == 2
+    assert sum(1 for f in flipped if f is False) == 1
+
+    # The failure log was captured.
+    log_messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "avatar_r2_backfill_failed" in log_messages
 
 
 @pytest.mark.unit

--- a/tests/unit/test_r2_sync_avatars_backfill.py
+++ b/tests/unit/test_r2_sync_avatars_backfill.py
@@ -345,6 +345,51 @@ async def test_backfill_continues_on_upload_failure(
 
 
 @pytest.mark.unit
+async def test_backfill_dry_run_existing_object_does_not_flip(
+    avatar_settings,
+    install_r2,
+    patch_session,
+    db_session,
+):
+    """Pre-existing R2 object + dry-run → skipped_existing >= 1, bit stays False.
+
+    Locks in the dry-run-suppresses-flip behavior: even though
+    ``skipped_existing`` outcomes do append to ``flip_user_ids`` internally,
+    the outer ``if not dry_run`` guard prevents the batched UPDATE from
+    running.
+    """
+    fname = "dryexist000000000000000000000000.png"
+    (avatar_settings / fname).write_bytes(b"local-bytes")
+
+    # Pre-seed R2 so the script's object_exists() check returns True.
+    await install_r2.upload_bytes(
+        bucket="public",
+        key=f"avatars/{fname}",
+        body=b"r2-pre-existing-bytes",
+        content_type="image/png",
+    )
+
+    user = _make_user(
+        db_session,
+        username="bf_dryexist",
+        email="bf_dryexist@x.test",
+        avatar=fname,
+    )
+    await db_session.commit()
+
+    report = await cmd_avatars_backfill(dry_run=True, concurrency=2)
+
+    assert report["skipped_existing"] >= 1
+    assert report["uploaded"] == 0
+    assert report["would_upload"] == 0
+    assert report["missing_local"] == 0
+    assert report["failed"] == 0
+
+    await db_session.refresh(user)
+    assert user.avatar_in_r2 is False
+
+
+@pytest.mark.unit
 def test_backfill_refuses_without_bulk_flag(monkeypatch):
     """R2_ALLOW_BULK_BACKFILL=false → require_bulk_backfill raises."""
     monkeypatch.setattr(settings, "R2_ENABLED", True)

--- a/tests/unit/test_r2_sync_banners_backfill.py
+++ b/tests/unit/test_r2_sync_banners_backfill.py
@@ -1,0 +1,287 @@
+"""Tests for ``scripts/r2_sync.py banners-backfill`` subcommand.
+
+Exercises ``cmd_banners_backfill`` end-to-end against a real moto S3 server
+(via the shared ``setup_buckets``/``moto_session``/``moto_server`` fixtures
+in ``tests/unit/conftest.py``) plus the real ``db_session`` fixture from the
+parent conftest. ``get_async_session`` is patched to yield the test session
+so the script's DB reads see the seeded banners; ``r2_client._instance`` is
+swapped for the moto-wired R2Storage so ``get_r2_storage()`` returns it.
+"""
+
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.core import r2_client
+from app.models.misc import BannerSize, Banners
+from scripts.r2_sync import cmd_banners_backfill
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _mock_session_cm(db_session: AsyncSession):
+    """Async-context-manager mock that yields the real test session."""
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=db_session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+@pytest.fixture
+def banner_settings(monkeypatch, tmp_path: Path) -> Path:
+    """Wire the banner-relevant settings to tmp_path / public bucket / R2 enabled."""
+    monkeypatch.setattr(settings, "BANNER_STORAGE_PATH", str(tmp_path))
+    monkeypatch.setattr(settings, "R2_PUBLIC_BUCKET", "public")
+    monkeypatch.setattr(settings, "R2_ENABLED", True)
+    monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", True)
+    return tmp_path
+
+
+@pytest.fixture
+def install_r2(monkeypatch, setup_buckets):
+    """Install the moto-backed R2Storage as the ``get_r2_storage()`` singleton."""
+    monkeypatch.setattr(r2_client, "_instance", setup_buckets)
+    return setup_buckets
+
+
+@pytest.fixture
+def patch_session(db_session: AsyncSession):
+    """Make ``scripts.r2_sync.get_async_session()`` yield the test session."""
+    with patch(
+        "scripts.r2_sync.get_async_session",
+        return_value=_mock_session_cm(db_session),
+    ):
+        yield
+
+
+def _seed_local(banner_dir: Path, *paths: str) -> None:
+    """Write small placeholder bytes for each banner subpath."""
+    for path in paths:
+        target = banner_dir / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"\x89PNG-banner-bytes")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_backfill_full_image_banner(
+    banner_settings,
+    install_r2,
+    patch_session,
+    db_session,
+):
+    """One-piece banner with full_image on disk → bit flips, R2 object exists."""
+    _seed_local(banner_settings, "eva/full.jpg")
+
+    banner = Banners(
+        name="eva",
+        size=BannerSize.small,
+        full_image="eva/full.jpg",
+    )
+    db_session.add(banner)
+    await db_session.commit()
+    await db_session.refresh(banner)
+
+    report = await cmd_banners_backfill(dry_run=False)
+    assert report["processed"] == 1
+    assert report["flipped"] == 1
+    assert report["skipped_missing_local"] == 0
+
+    await db_session.refresh(banner)
+    assert banner.in_r2 is True
+    assert await install_r2.object_exists(
+        bucket="public", key="banners/eva/full.jpg"
+    )
+
+
+@pytest.mark.unit
+async def test_backfill_three_part_banner(
+    banner_settings,
+    install_r2,
+    patch_session,
+    db_session,
+    moto_session,
+    moto_server,
+):
+    """Three-part banner with all files on disk → bit flips, all 3 R2 objects exist."""
+    _seed_local(
+        banner_settings,
+        "hw/l.png",
+        "hw/m.png",
+        "hw/r.png",
+    )
+
+    banner = Banners(
+        name="hw",
+        size=BannerSize.large,
+        left_image="hw/l.png",
+        middle_image="hw/m.png",
+        right_image="hw/r.png",
+    )
+    db_session.add(banner)
+    await db_session.commit()
+    await db_session.refresh(banner)
+
+    report = await cmd_banners_backfill(dry_run=False)
+    assert report["processed"] == 1
+    assert report["flipped"] == 1
+
+    await db_session.refresh(banner)
+    assert banner.in_r2 is True
+
+    # All three R2 objects exist with image/png content type
+    async with moto_session.client("s3", endpoint_url=moto_server) as s3:
+        for path in ("hw/l.png", "hw/m.png", "hw/r.png"):
+            head = await s3.head_object(
+                Bucket="public", Key=f"banners/{path}"
+            )
+            assert head["ContentType"] == "image/png"
+
+
+@pytest.mark.unit
+async def test_backfill_three_part_partial_missing_skips_row(
+    banner_settings,
+    install_r2,
+    patch_session,
+    db_session,
+    caplog,
+):
+    """Only 2 of 3 files on disk → no part uploaded, bit stays False."""
+    # Seed only left and middle; intentionally omit the right file.
+    _seed_local(banner_settings, "partial/l.png", "partial/m.png")
+
+    banner = Banners(
+        name="partial",
+        size=BannerSize.large,
+        left_image="partial/l.png",
+        middle_image="partial/m.png",
+        right_image="partial/r.png",  # not on disk
+    )
+    db_session.add(banner)
+    await db_session.commit()
+    await db_session.refresh(banner)
+
+    with caplog.at_level(logging.WARNING):
+        report = await cmd_banners_backfill(dry_run=False)
+
+    assert report["processed"] == 1
+    assert report["flipped"] == 0
+    assert report["skipped_missing_local"] == 1
+
+    await db_session.refresh(banner)
+    assert banner.in_r2 is False
+
+    # Critically: do NOT upload left/middle either — all-or-nothing per row.
+    for path in ("partial/l.png", "partial/m.png", "partial/r.png"):
+        assert not await install_r2.object_exists(
+            bucket="public", key=f"banners/{path}"
+        ), f"unexpected R2 object for {path} (should be all-or-nothing)"
+
+    # Warning logged for the missing path
+    log_messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "banner_local_missing" in log_messages
+
+
+@pytest.mark.unit
+async def test_backfill_idempotent_skips_existing(
+    banner_settings,
+    install_r2,
+    patch_session,
+    db_session,
+):
+    """Pre-existing R2 part → no double-upload of that part, bit still flips."""
+    _seed_local(
+        banner_settings,
+        "idem/l.png",
+        "idem/m.png",
+        "idem/r.png",
+    )
+
+    # Pre-upload one part with distinct bytes so we can detect a re-upload.
+    await install_r2.upload_bytes(
+        bucket="public",
+        key="banners/idem/m.png",
+        body=b"PRE-EXISTING-MIDDLE",
+        content_type="image/png",
+    )
+
+    banner = Banners(
+        name="idem",
+        size=BannerSize.large,
+        left_image="idem/l.png",
+        middle_image="idem/m.png",
+        right_image="idem/r.png",
+    )
+    db_session.add(banner)
+    await db_session.commit()
+    await db_session.refresh(banner)
+
+    # Spy on upload_bytes so we can count calls and ensure the pre-existing
+    # part isn't re-uploaded.
+    real_upload = install_r2.__class__.upload_bytes
+    upload_keys: list[str] = []
+
+    async def _spy_upload(self, bucket: str, key: str, body: bytes, content_type: str) -> None:
+        upload_keys.append(key)
+        await real_upload(self, bucket=bucket, key=key, body=body, content_type=content_type)
+
+    with patch.object(install_r2.__class__, "upload_bytes", _spy_upload):
+        report = await cmd_banners_backfill(dry_run=False)
+
+    assert report["processed"] == 1
+    assert report["flipped"] == 1
+
+    await db_session.refresh(banner)
+    assert banner.in_r2 is True
+
+    # Only the two missing parts were uploaded; pre-existing one was skipped.
+    assert sorted(upload_keys) == sorted(
+        ["banners/idem/l.png", "banners/idem/r.png"]
+    )
+
+    # Pre-existing object preserved (its bytes were not overwritten).
+    async with install_r2._acquire_client() as s3:
+        obj = await s3.get_object(Bucket="public", Key="banners/idem/m.png")
+        body = await obj["Body"].read()
+    assert body == b"PRE-EXISTING-MIDDLE"
+
+
+@pytest.mark.unit
+async def test_backfill_dry_run_writes_nothing(
+    banner_settings,
+    install_r2,
+    patch_session,
+    db_session,
+):
+    """--dry-run → no R2 objects created, bit stays False."""
+    _seed_local(banner_settings, "dry/full.jpg")
+
+    banner = Banners(
+        name="dry",
+        size=BannerSize.small,
+        full_image="dry/full.jpg",
+    )
+    db_session.add(banner)
+    await db_session.commit()
+    await db_session.refresh(banner)
+
+    report = await cmd_banners_backfill(dry_run=True)
+    assert report["processed"] == 1
+    assert report["flipped"] == 0
+    assert report["skipped_missing_local"] == 0
+
+    await db_session.refresh(banner)
+    assert banner.in_r2 is False
+    assert not await install_r2.object_exists(
+        bucket="public", key="banners/dry/full.jpg"
+    )

--- a/tests/unit/test_r2_sync_banners_backfill.py
+++ b/tests/unit/test_r2_sync_banners_backfill.py
@@ -347,6 +347,72 @@ async def test_backfill_dry_run_reports_would_upload_parts(
 
 
 @pytest.mark.unit
+async def test_backfill_dry_run_three_part_mixed(
+    banner_settings,
+    install_r2,
+    patch_session,
+    db_session,
+):
+    """Three-part banner: 1 part pre-existing in R2, 2 parts not.
+
+    Dry-run should report:
+      - ``would_upload_parts == 2`` (the two missing parts)
+      - ``would_flip_rows == 1`` (row would flip because all parts are
+        either already present or would-upload)
+      - ``in_r2`` stays False (dry-run suppresses the actual UPDATE)
+    """
+    _seed_local(
+        banner_settings,
+        "drymix/l.png",
+        "drymix/m.png",
+        "drymix/r.png",
+    )
+
+    # Pre-upload only the middle part; left and right would need uploading.
+    await install_r2.upload_bytes(
+        bucket="public",
+        key="banners/drymix/m.png",
+        body=b"PRE-EXISTING-MIDDLE",
+        content_type="image/png",
+    )
+
+    banner = Banners(
+        name="drymix",
+        size=BannerSize.large,
+        left_image="drymix/l.png",
+        middle_image="drymix/m.png",
+        right_image="drymix/r.png",
+    )
+    db_session.add(banner)
+    await db_session.commit()
+    await db_session.refresh(banner)
+
+    report = await cmd_banners_backfill(dry_run=True)
+
+    assert report["processed"] == 1
+    assert report["flipped"] == 0
+    assert report["skipped_missing_local"] == 0
+    assert report["failed_rows"] == 0
+    assert report["would_upload_parts"] == 2
+    assert report["would_flip_rows"] == 1
+
+    await db_session.refresh(banner)
+    assert banner.in_r2 is False
+
+    # The two missing parts were not actually uploaded.
+    for path in ("drymix/l.png", "drymix/r.png"):
+        assert not await install_r2.object_exists(
+            bucket="public", key=f"banners/{path}"
+        )
+
+    # Pre-existing middle object preserved (its bytes were not overwritten).
+    async with install_r2._acquire_client() as s3:
+        obj = await s3.get_object(Bucket="public", Key="banners/drymix/m.png")
+        body = await obj["Body"].read()
+    assert body == b"PRE-EXISTING-MIDDLE"
+
+
+@pytest.mark.unit
 async def test_backfill_continues_on_part_upload_failure(
     banner_settings,
     install_r2,

--- a/tests/unit/test_r2_sync_banners_backfill.py
+++ b/tests/unit/test_r2_sync_banners_backfill.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.core import r2_client
-from app.models.misc import BannerSize, Banners
+from app.models.misc import Banners, BannerSize
 from scripts.r2_sync import cmd_banners_backfill
 
 # ---------------------------------------------------------------------------
@@ -279,9 +279,124 @@ async def test_backfill_dry_run_writes_nothing(
     assert report["processed"] == 1
     assert report["flipped"] == 0
     assert report["skipped_missing_local"] == 0
+    assert report["failed_rows"] == 0
+    assert report["would_upload_parts"] == 1
+    assert report["would_flip_rows"] == 1
 
     await db_session.refresh(banner)
     assert banner.in_r2 is False
     assert not await install_r2.object_exists(
         bucket="public", key="banners/dry/full.jpg"
     )
+
+
+@pytest.mark.unit
+async def test_backfill_dry_run_reports_would_upload_parts(
+    banner_settings,
+    install_r2,
+    patch_session,
+    db_session,
+):
+    """Two unbackfilled banners (1 full + 1 three-part), dry-run → 4 would-parts, 2 would-rows."""
+    _seed_local(banner_settings, "wu_full/full.jpg")
+    _seed_local(
+        banner_settings,
+        "wu_3p/l.png",
+        "wu_3p/m.png",
+        "wu_3p/r.png",
+    )
+
+    banner_full = Banners(
+        name="wu_full",
+        size=BannerSize.small,
+        full_image="wu_full/full.jpg",
+    )
+    banner_3p = Banners(
+        name="wu_3p",
+        size=BannerSize.large,
+        left_image="wu_3p/l.png",
+        middle_image="wu_3p/m.png",
+        right_image="wu_3p/r.png",
+    )
+    db_session.add(banner_full)
+    db_session.add(banner_3p)
+    await db_session.commit()
+    await db_session.refresh(banner_full)
+    await db_session.refresh(banner_3p)
+
+    report = await cmd_banners_backfill(dry_run=True)
+
+    assert report["processed"] == 2
+    assert report["flipped"] == 0
+    assert report["skipped_missing_local"] == 0
+    assert report["failed_rows"] == 0
+    assert report["would_upload_parts"] == 4
+    assert report["would_flip_rows"] == 2
+
+    # No R2 writes
+    for path in ("wu_full/full.jpg", "wu_3p/l.png", "wu_3p/m.png", "wu_3p/r.png"):
+        assert not await install_r2.object_exists(
+            bucket="public", key=f"banners/{path}"
+        )
+
+    # No DB writes
+    await db_session.refresh(banner_full)
+    await db_session.refresh(banner_3p)
+    assert banner_full.in_r2 is False
+    assert banner_3p.in_r2 is False
+
+
+@pytest.mark.unit
+async def test_backfill_continues_on_part_upload_failure(
+    banner_settings,
+    install_r2,
+    patch_session,
+    db_session,
+    caplog,
+):
+    """Two banners; 2nd's upload raises → 1st flipped, 2nd stays false, failed_rows == 1."""
+    _seed_local(banner_settings, "ok/full.jpg")
+    _seed_local(banner_settings, "boom/full.jpg")
+
+    banner_ok = Banners(
+        name="ok",
+        size=BannerSize.small,
+        full_image="ok/full.jpg",
+    )
+    banner_boom = Banners(
+        name="boom",
+        size=BannerSize.small,
+        full_image="boom/full.jpg",
+    )
+    db_session.add(banner_ok)
+    db_session.add(banner_boom)
+    await db_session.commit()
+    await db_session.refresh(banner_ok)
+    await db_session.refresh(banner_boom)
+
+    real_upload = install_r2.__class__.upload_bytes
+
+    async def _flaky_upload(self, bucket: str, key: str, body: bytes, content_type: str) -> None:
+        if key == "banners/boom/full.jpg":
+            raise RuntimeError("simulated banner upload failure")
+        await real_upload(self, bucket=bucket, key=key, body=body, content_type=content_type)
+
+    with patch.object(install_r2.__class__, "upload_bytes", _flaky_upload):
+        with caplog.at_level(logging.WARNING):
+            report = await cmd_banners_backfill(dry_run=False)
+
+    assert report["processed"] == 2
+    assert report["flipped"] == 1
+    assert report["failed_rows"] == 1
+    assert report["skipped_missing_local"] == 0
+    assert report["would_upload_parts"] == 0
+    assert report["would_flip_rows"] == 0
+
+    await db_session.refresh(banner_ok)
+    await db_session.refresh(banner_boom)
+    assert banner_ok.in_r2 is True
+    assert banner_boom.in_r2 is False
+
+    # The failure log was captured.
+    log_messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "banner_r2_backfill_failed" in log_messages

--- a/tests/unit/test_user_avatar_in_r2_field.py
+++ b/tests/unit/test_user_avatar_in_r2_field.py
@@ -1,0 +1,9 @@
+"""Test for UserBase.avatar_in_r2 field."""
+
+
+def test_userbase_has_avatar_in_r2_field():
+    from app.models.user import UserBase
+
+    field = UserBase.model_fields["avatar_in_r2"]
+    assert field.annotation is bool
+    assert field.default is False


### PR DESCRIPTION
## Summary

Extends Cloudflare R2 storage to user avatars and site banners, mirroring the dual-write pattern already used for image variants. Closes parity gap left in the R2 image-serving rollout (PR #205-ish vintage).

## Design and implementation plan

- **Spec:** `docs/plans/2026-05-08-r2-avatars-banners-design.md` (passed two-pass spec review)
- **Plan:** `docs/plans/2026-05-08-r2-avatars-banners-impl.md` (six chunks, TDD throughout)

## What ships

- **Per-row tracking bits:** `users.avatar_in_r2`, `banners.in_r2`. Both default `false`; gates URL generation and orphan-delete behavior. Migrations use `ALGORITHM=INSTANT, LOCK=NONE` (instant, no table rewrite on MariaDB 12).
- **Avatar dual-write.** `_upload_avatar` writes local FS first, then attempts R2; failure logs `avatar_r2_upload_failed` and continues with `avatar_in_r2=false` (best-effort). Orphan delete drops the R2 object when the old bit was `true`. New `avatar_url(filename, in_r2)` helper in `app/services/avatar.py` centralizes URL generation; replaces 7 inline f-string sites in `privmsgs.py` plus `UserResponse` and `UserSummary` computed fields.
- **Banners.** `BannerResponse._image_url` switches to CDN when `R2_ENABLED AND in_r2`. New `BANNER_STORAGE_PATH` config knob.
- **Backfill subcommands.** `scripts/r2_sync.py avatars-backfill` (concurrent, batched UPDATE post-gather, mirrors `cmd_verify`'s session-safety pattern) and `banners-backfill` (sequential, all-or-nothing per row). Both gated by `R2_ALLOW_BULK_BACKFILL`, idempotent against pre-existing R2 objects, support `--dry-run` with explicit `would_upload` counters, resilient to per-upload failures (continue, log, increment `failed`).
- **Storage adapter.** New `R2Storage.upload_bytes(bucket, key, body, content_type)` with **mandatory** Content-Type. Without it, R2 returns `application/octet-stream` and Cloudflare passes it through, breaking inline render under strict CSP / `nosniff`.

## Behavior at `R2_ENABLED=false` (dev default)

Bit-for-bit identical to pre-feature. The URL helpers check `R2_ENABLED` **before** the per-row bit, so a dev pulling a prod DB dump where rows have the bit set still resolves to local FS.

## Rollout (post-merge, in prod where `R2_ENABLED=true`)

```bash
uv run python scripts/r2_sync.py avatars-backfill --concurrency 8
uv run python scripts/r2_sync.py banners-backfill
```

Both require `R2_ALLOW_BULK_BACKFILL=true` (already on in prod). Re-runs are safe. Re-run \`avatars-backfill\` after a known R2 outage to mop up rows where the live write path fell back to \`avatar_in_r2=false\`.

## Test plan

- [x] All 1599 tests pass (+42 over baseline; 60 new/extended)
- [x] \`mypy app/\`: clean
- [x] \`ruff check / format --check app/\`: clean
- [x] Migrations: forward + downgrade roundtrip verified
- [x] Avatar dual-write: success, R2 failure fallback, orphan delete with/without bit, same-MD5 re-upload — moto-backed against real S3 contract
- [x] Backfill: idempotent re-runs, missing-local skip, dry-run counters, per-upload failure resilience, all-or-nothing for banners
- [ ] **Manual verification post-merge:** \`curl -I\` randomly-selected avatar and banner CDN URLs after backfill
- [ ] **Manual verification post-merge:** spot-check a few user-facing pages render avatars and banners correctly

## Deferred follow-ups (not blockers)

- Image-variant Content-Type fix for \`R2Storage.upload_file\` callers (\`split-existing\`, \`r2_finalize_upload_job\`) — same potential nosniff/CSP issue as fixed here for avatars/banners
- Parametrized regression test sweeping all UserSummary-emitting endpoints to assert CDN URL emission with bit set (would have caught the chunk 6 + final-review slips earlier)
- Tighten \`UserSummary.avatar_in_r2\` to remove the default — forces construction-time errors on missing field, preventing silent local-URL regressions

## Review history

Six implementation chunks; each passed spec-compliance review then code-quality review before moving on. Two critical findings caught during review: shared \`AsyncSession\` across \`asyncio.gather\` in avatars-backfill (refactored to mirror \`cmd_verify\`); three \`UserSummary(...)\` constructor sites in \`images.py\` missing \`avatar_in_r2\` (silent local-URL regression — fixed with a regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)