### PR TITLE
fix(banners): preserve in_r2 across redis cache round-trip

### DIFF
--- a/app/schemas/banner.py
+++ b/app/schemas/banner.py
@@ -25,10 +25,13 @@ class BannerResponse(BaseModel):
     middle_image: str | None
     right_image: str | None
 
-    # Internal storage-routing detail consumed by _image_url to pick CDN vs
-    # local FS; exclude=True keeps it out of the API response while still
-    # letting the URL helper read it.
-    in_r2: bool = Field(default=False, exclude=True)
+    # Storage-routing flag consumed by _image_url to pick CDN vs local FS.
+    # NOT excluded from serialization: BannerResponse instances are cached
+    # to redis via model_dump_json(), and a field-level exclude=True drops
+    # the value from the cached payload — every subsequent cache hit then
+    # deserializes with in_r2=default=False and silently falls back to the
+    # local FS path even when the row in the DB has in_r2=True.
+    in_r2: bool = Field(default=False)
 
     model_config = {"from_attributes": True}
 

--- a/tests/unit/test_banner_schema.py
+++ b/tests/unit/test_banner_schema.py
@@ -206,13 +206,15 @@ def test_banner_content_type_raises_on_missing_extension():
         banner_content_type("noextension")
 
 
-def test_banner_response_excludes_in_r2_from_serialization() -> None:
-    """``in_r2`` is an internal routing detail; clients only see *_url fields.
+def test_banner_response_round_trip_preserves_in_r2() -> None:
+    """``in_r2`` MUST survive a model_dump_json -> model_validate_json cycle.
 
-    Asserts both model_dump() and model_dump_json() drop the key, while it
-    remains readable on the instance (so the computed URL fields can use it).
+    Banner responses are cached in redis via ``model_dump_json()`` and read back
+    via ``model_validate_json()``. If ``in_r2`` were excluded from serialization
+    (as it once was), every cache hit would deserialize with the default
+    ``False`` and silently fall back to the local-FS URL even when the DB row
+    has ``in_r2=True``.
     """
-    import json
 
     from app.schemas.banner import BannerResponse
 
@@ -230,13 +232,8 @@ def test_banner_response_excludes_in_r2_from_serialization() -> None:
         in_r2=True,
     )
 
-    dumped = resp.model_dump()
-    assert "in_r2" not in dumped, f"in_r2 leaked into model_dump(): {sorted(dumped)}"
+    round_tripped = BannerResponse.model_validate_json(resp.model_dump_json())
 
-    dumped_json = json.loads(resp.model_dump_json())
-    assert "in_r2" not in dumped_json, (
-        f"in_r2 leaked into model_dump_json(): {sorted(dumped_json)}"
+    assert round_tripped.in_r2 is True, (
+        "in_r2 was lost across the cache serialization round trip"
     )
-
-    # Still readable on the instance for the URL helper.
-    assert resp.in_r2 is True


### PR DESCRIPTION
## Summary

`BannerResponse.in_r2` had `Field(default=False, exclude=True)` to hide the internal storage-routing flag from API responses. But banners are cached in redis via `BannerResponse.model_dump_json()` and read back via `BannerResponse.model_validate_json()` — and field-level `exclude=True` drops the value from the cached JSON. Every cache hit then deserializes with `in_r2 = default = False`, and `_image_url` silently falls back to the local-FS path even when the row in the DB has `in_r2 = True`.

In production this means the first request after cache eviction correctly returns the CDN URL, and every request for the rest of the TTL window serves from local FS. With all 16 banners migrated to R2 (`SUM(in_r2) = 16` in the DB) the bug was 100% reproducible.

## Reproduction

```bash
docker compose exec redis redis-cli FLUSHDB
curl -s "http://localhost:8000/api/v1/banners/current?theme=dark&size=small" | jq .full_image_url
# → "https://cdn.e-shuushuu.net/banners/whitekitten-neon-small.png"  (correct, fresh from DB)

# Hit again (now cache-served):
curl -s "http://localhost:8000/api/v1/banners/current?theme=dark&size=small" | jq .full_image_url
# → "https://e-shuushuu.net/images/banners/whitekitten-neon-small.png"  (wrong; in_r2 lost in cache)
```

## Fix

Drop `exclude=True`. `in_r2` now appears in API responses — one bool per banner, informational, not sensitive. Other ways to fix this exist (cache the raw row, cache resolved URLs, separate internal/public models) but `exclude=True` was the smallest change that broke caching, and dropping it is the smallest change that restores it.

The previous `test_banner_response_excludes_in_r2_from_serialization` test was guarding the very behavior that broke caching. Replaced with `test_banner_response_round_trip_preserves_in_r2`, which asserts the contract that actually matters: a `model_dump_json -> model_validate_json` round trip preserves `in_r2`.

## Test plan

- [x] `uv run pytest tests/unit/test_banner_schema.py tests/unit/test_banner_model.py tests/unit/test_banner_config.py tests/unit/test_banner_preferences_schema.py tests/integration/test_banner_service.py -q` → 38 passed, 2 skipped (pre-existing Redis-unavailable)
- [x] `uv run mypy app/schemas/banner.py` → clean
- [ ] Post-deploy: `redis-cli FLUSHDB`, hit `/api/v1/banners/current` twice, both return CDN URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)