### PR TITLE
feat(auth): structured outcome logging for login and forgot-password

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -276,6 +276,11 @@ async def login(
     user = result.scalar_one_or_none()
 
     if not user:
+        logger.info(
+            "login_attempt",
+            outcome="user_not_found",
+            username=credentials.username,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
@@ -286,6 +291,13 @@ async def login(
         now = datetime.now(UTC)
         if user.lockout_until > now:
             remaining_minutes = int((user.lockout_until - now).total_seconds() / 60)
+            logger.info(
+                "login_attempt",
+                outcome="account_locked",
+                username=user.username,
+                user_id=user.user_id,
+                lockout_until=user.lockout_until.isoformat(),
+            )
             raise HTTPException(
                 status_code=status.HTTP_423_LOCKED,
                 detail=f"Account locked due to too many failed login attempts. Try again in {remaining_minutes} minutes.",
@@ -317,6 +329,14 @@ async def login(
         if user.failed_login_attempts >= 5:
             user.lockout_until = datetime.now(UTC) + timedelta(minutes=15)
             await db.commit()
+            logger.warning(
+                "login_attempt",
+                outcome="lockout_triggered",
+                username=user.username,
+                user_id=user.user_id,
+                failed_attempts=user.failed_login_attempts,
+                password_type=user.password_type,
+            )
             raise HTTPException(
                 status_code=status.HTTP_423_LOCKED,
                 detail="Account locked due to too many failed login attempts. Try again in 15 minutes.",
@@ -324,10 +344,25 @@ async def login(
 
         await db.commit()
         if user.password_type == "md5":
+            logger.info(
+                "login_attempt",
+                outcome="md5_unsupported",
+                username=user.username,
+                user_id=user.user_id,
+                failed_attempts=user.failed_login_attempts,
+            )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Your account uses a legacy password format that is no longer supported. Please reset your password.",
             )
+        logger.info(
+            "login_attempt",
+            outcome="wrong_password",
+            username=user.username,
+            user_id=user.user_id,
+            failed_attempts=user.failed_login_attempts,
+            password_type=user.password_type,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
@@ -357,6 +392,15 @@ async def login(
     user.last_login = now
     user.last_active = now
     await db.commit()
+
+    logger.info(
+        "login_attempt",
+        outcome="success",
+        username=user.username,
+        user_id=user.user_id,
+        password_type=user.password_type,
+        migrated_to_bcrypt=migrate_to_bcrypt,
+    )
 
     return TokenResponse(
         access_token=access_token,
@@ -750,7 +794,20 @@ async def forgot_password(
     user = result.scalar_one_or_none()
 
     # Silently do nothing if user not found or inactive
-    if not user or not user.active:
+    if not user:
+        logger.info(
+            "forgot_password_attempt",
+            outcome="user_not_found",
+            email=request_data.email,
+        )
+        return MessageResponse(message=generic_message)
+    if not user.active:
+        logger.info(
+            "forgot_password_attempt",
+            outcome="user_inactive",
+            email=request_data.email,
+            user_id=user.user_id,
+        )
         return MessageResponse(message=generic_message)
 
     # Rate limit: 1 reset per 5 minutes
@@ -759,6 +816,13 @@ async def forgot_password(
     if user.password_reset_sent_at:
         time_since_last = datetime.now(UTC) - user.password_reset_sent_at
         if time_since_last < timedelta(minutes=5):
+            logger.info(
+                "forgot_password_attempt",
+                outcome="rate_limited",
+                email=request_data.email,
+                user_id=user.user_id,
+                seconds_since_last=int(time_since_last.total_seconds()),
+            )
             return MessageResponse(message=generic_message)
 
     # Generate token
@@ -777,6 +841,13 @@ async def forgot_password(
         "send_password_reset_email_job",
         user_id=user.user_id,
         token=RedactedStr(raw_token),
+    )
+
+    logger.info(
+        "forgot_password_attempt",
+        outcome="enqueued",
+        email=request_data.email,
+        user_id=user.user_id,
     )
 
     return MessageResponse(message=generic_message)

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -310,6 +310,9 @@ async def login(
     # Verify password
     password_valid = False
     migrate_to_bcrypt = False
+    # Capture pre-migration type so the success log records what the user
+    # actually authenticated with (user.password_type gets overwritten below).
+    original_password_type = user.password_type
 
     if user.password_type == "bcrypt":
         password_valid = verify_password(credentials.password, user.password)
@@ -398,7 +401,7 @@ async def login(
         outcome="success",
         username=user.username,
         user_id=user.user_id,
-        password_type=user.password_type,
+        password_type=original_password_type,
         migrated_to_bcrypt=migrate_to_bcrypt,
     )
 
@@ -805,7 +808,6 @@ async def forgot_password(
         logger.info(
             "forgot_password_attempt",
             outcome="user_inactive",
-            email=request_data.email,
             user_id=user.user_id,
         )
         return MessageResponse(message=generic_message)
@@ -819,7 +821,6 @@ async def forgot_password(
             logger.info(
                 "forgot_password_attempt",
                 outcome="rate_limited",
-                email=request_data.email,
                 user_id=user.user_id,
                 seconds_since_last=int(time_since_last.total_seconds()),
             )
@@ -846,7 +847,6 @@ async def forgot_password(
     logger.info(
         "forgot_password_attempt",
         outcome="enqueued",
-        email=request_data.email,
         user_id=user.user_id,
     )
 


### PR DESCRIPTION
## Summary
- Adds one structlog event per outcome on `/api/v1/auth/login` and `/api/v1/auth/forgot-password` so login-trouble investigations can attribute attempts to specific users/emails instead of guessing from timestamps and IPs.
- `login_attempt` outcomes: `success`, `user_not_found`, `account_locked`, `wrong_password`, `lockout_triggered` (warning), `md5_unsupported`.
- `forgot_password_attempt` outcomes: `enqueued`, `user_not_found`, `user_inactive`, `rate_limited`.
- No behavioral change — only logging. Events ride the existing structlog request context so `request_id` and authenticated `user_id` come along automatically.

## Motivation
While investigating a "can't log in" report for user `centersolace`, we saw 27 failed auth attempts in Loki but could not tell which were for that user. The login endpoint had the username in scope and never logged it; the forgot-password endpoint returned generic 200 to prevent enumeration but also stayed silent server-side. These additions close those gaps without changing client-facing behavior.

## Test plan
- [ ] After deploy: trigger a forgot-password for a known active user and confirm `forgot_password_attempt outcome=enqueued` lands in Loki with the right `user_id`.
- [ ] Trigger one failed login and confirm `login_attempt outcome=wrong_password` lands with the right `username` and `failed_attempts` count.
- [ ] Trigger a login for a non-existent username and confirm `login_attempt outcome=user_not_found`.
- [ ] Confirm a successful login still emits `outcome=success` with `migrated_to_bcrypt` as expected.