### PR TITLE
fix(nginx): re-resolve upstream containers at request time

### DIFF
--- a/docker/nginx/frontend-production.conf.template
+++ b/docker/nginx/frontend-production.conf.template
@@ -32,7 +32,8 @@ server {
 
     # API proxy - the only endpoint SSR needs
     location /api/ {
-        proxy_pass http://api:8000;
+        set $api_upstream api:8000;
+        proxy_pass http://$api_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -84,7 +85,8 @@ server {
 
     # API proxy to FastAPI backend
     location /api/ {
-        proxy_pass http://api:8000;
+        set $api_upstream api:8000;
+        proxy_pass http://$api_upstream;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Forwarded-Port $server_port;
@@ -103,7 +105,8 @@ server {
 
     # Protected image routes - proxy to FastAPI for permission checks
     location ~ "^/images/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
-        proxy_pass http://api:8000;
+        set $api_upstream api:8000;
+        proxy_pass http://$api_upstream;
         proxy_set_header Host $http_host;
         proxy_set_header Cookie $http_cookie;
         proxy_set_header X-Real-IP $remote_addr;
@@ -112,7 +115,8 @@ server {
     }
 
     location ~ "^/thumbs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
-        proxy_pass http://api:8000;
+        set $api_upstream api:8000;
+        proxy_pass http://$api_upstream;
         proxy_set_header Host $http_host;
         proxy_set_header Cookie $http_cookie;
         proxy_set_header X-Real-IP $remote_addr;
@@ -121,7 +125,8 @@ server {
     }
 
     location ~ "^/medium/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
-        proxy_pass http://api:8000;
+        set $api_upstream api:8000;
+        proxy_pass http://$api_upstream;
         proxy_set_header Host $http_host;
         proxy_set_header Cookie $http_cookie;
         proxy_set_header X-Real-IP $remote_addr;
@@ -130,7 +135,8 @@ server {
     }
 
     location ~ "^/large/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]+\.(png|jpg|jpeg|gif|webp)$" {
-        proxy_pass http://api:8000;
+        set $api_upstream api:8000;
+        proxy_pass http://$api_upstream;
         proxy_set_header Host $http_host;
         proxy_set_header Cookie $http_cookie;
         proxy_set_header X-Real-IP $remote_addr;
@@ -188,7 +194,8 @@ server {
 
     # Frontend - proxy to SvelteKit SSR server (production build in Docker)
     location / {
-        proxy_pass http://frontend:3000;
+        set $frontend_upstream frontend:3000;
+        proxy_pass http://$frontend_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -36,6 +36,7 @@ http {
     # (which can change the container's IP) doesn't strand nginx on a
     # stale address. 127.0.0.11 is Docker's embedded DNS resolver.
     resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 5s;
 
     # Include server configs
     include /etc/nginx/conf.d/*.conf;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -32,6 +32,11 @@ http {
     # Allow uploads up to 32MB (matches app config MAX_IMAGE_SIZE)
     client_max_body_size 32M;
 
+    # Resolve upstream container names at request time so a recreate
+    # (which can change the container's IP) doesn't strand nginx on a
+    # stale address. 127.0.0.11 is Docker's embedded DNS resolver.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
     # Include server configs
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## Summary
- Adds `resolver 127.0.0.11 valid=10s ipv6=off;` (Docker embedded DNS) to the nginx http context.
- Rewrites each `proxy_pass http://<name>:<port>;` in the production template to a `set $upstream <name>:<port>; proxy_pass http://$upstream;` variable form so nginx re-resolves DNS at request time instead of caching the IP forever at startup.

## Motivation
Discovered during the deploy of #216: `make prod-deploy api` recreates the api container, which lands on a fresh docker network IP. Without a `resolver` directive and with a literal hostname in `proxy_pass`, nginx caches the original IP at config-load and never refreshes. All api traffic via nginx started returning 502 until I ran `docker exec shuushuu-nginx-prod nginx -s reload` manually.

With this change, any future api/frontend recreate is picked up within the 10s resolver cache TTL.

## Scope
- Applied to all upstreams in `frontend-production.conf.template` (6× api, 1× frontend).
- Dev/test templates (`frontend.conf.dev`, `frontend.conf.test`) share the same vulnerability but are out of scope here — happy to follow up if you want them included.

## Test plan
- [ ] `make prod-deploy api` should leave all api traffic working without a manual nginx reload. To verify after deploy: `docker exec shuushuu-nginx-prod nginx -s reload && curl -sI https://e-shuushuu.net/api/v1/meta/config` returns 200, then `docker compose up -d --force-recreate api` and curl the same endpoint immediately — should still return 200 (within 10s).
- [ ] Image protected routes (`/images/...`, `/thumbs/...`, etc.) still respond correctly.
- [ ] Frontend SSR (`/`) still responds correctly.
- [ ] `docker exec shuushuu-nginx-prod nginx -t` passes (graceful reload safe).