### PR TITLE
fix(images): stop date-prefix drift at local-midnight uploads

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -2164,9 +2164,10 @@ async def upload_image(
         # Calculate total pixels (in megapixels)
         total_pixels = Decimal((width * height) / 1_000_000)
 
-        # Generate filename for storage (date-id format)
-        date_prefix = datetime.now().strftime("%Y-%m-%d")
-        filename = f"{date_prefix}-{image_id}"  # Store without extension
+        # Derive from the actually-saved fullsize path so DB.filename matches
+        # the on-disk name even when upload straddles a local-midnight boundary
+        # (datetime.now() recomputed here can land on the next day).
+        filename = file_path.stem  # e.g. "2026-05-18-1116164"
 
         # Check IQDB for near-duplicate images unless user confirmed
         if not confirm_similar:
@@ -2276,7 +2277,7 @@ async def upload_image(
 
         # Add to IQDB index AFTER thumbnail is created
         # Use defer to ensure thumbnail completes first (simple approach)
-        thumb_path = FilePath(settings.STORAGE_PATH) / "thumbs" / f"{date_prefix}-{image_id}.webp"
+        thumb_path = FilePath(settings.STORAGE_PATH) / "thumbs" / f"{filename}.webp"
         await enqueue_job(
             "add_to_iqdb_job",
             image_id=image_id,

--- a/app/services/image_processing.py
+++ b/app/services/image_processing.py
@@ -20,6 +20,18 @@ logger = get_logger(__name__)
 _srgb_profile = ImageCms.createProfile("sRGB")
 
 
+def _date_prefix_from_source(source_path: FilePath) -> str:
+    """Extract the YYYY-MM-DD prefix from a source filename in the form
+    `{date}-{image_id}.{ext}`. Raises if the stem can't be split — a
+    malformed source name would otherwise produce a silently-orphaned
+    variant whose path no consumer can derive.
+    """
+    parts = source_path.stem.rsplit("-", 1)
+    if len(parts) != 2:
+        raise ValueError(f"Unexpected source filename format: {source_path.name!r}")
+    return parts[0]
+
+
 async def _update_image_variant_field(image_id: int, field: str, value: int) -> None:
     """Update medium or large field in database.
 
@@ -81,7 +93,7 @@ def _create_variant(
     # Mirror the source filename's date prefix so disk names stay consistent
     # with the fullsize/thumb/DB at a local-midnight boundary (otherwise
     # datetime.now() in this job can land on the next day relative to upload).
-    date_prefix = source_path.stem.rsplit("-", 1)[0]
+    date_prefix = _date_prefix_from_source(source_path)
     variant_filename = f"{date_prefix}-{image_id}.{ext}"
     variant_path = variant_dir / variant_filename
 
@@ -258,8 +270,7 @@ def create_thumbnail(source_path: FilePath, image_id: int, ext: str, storage_pat
         thumbs_dir.mkdir(parents=True, exist_ok=True)
 
         # Generate thumbnail filename (WebP format for better compression)
-        # Extract date prefix from source filename (assumes format: {date_prefix}-{image_id}.{ext})
-        date_prefix = source_path.stem.rsplit("-", 1)[0]
+        date_prefix = _date_prefix_from_source(source_path)
         thumb_filename = f"{date_prefix}-{image_id}.webp"
         thumb_path = thumbs_dir / thumb_filename
 

--- a/app/services/image_processing.py
+++ b/app/services/image_processing.py
@@ -3,7 +3,6 @@ Image processing utilities for validation, dimension extraction, and thumbnail g
 """
 
 import hashlib
-from datetime import datetime
 from pathlib import Path as FilePath
 
 from fastapi import HTTPException, UploadFile, status
@@ -79,8 +78,10 @@ def _create_variant(
     variant_dir = FilePath(storage_path) / variant_type
     variant_dir.mkdir(parents=True, exist_ok=True)
 
-    # Generate variant filename
-    date_prefix = datetime.now().strftime("%Y-%m-%d")
+    # Mirror the source filename's date prefix so disk names stay consistent
+    # with the fullsize/thumb/DB at a local-midnight boundary (otherwise
+    # datetime.now() in this job can land on the next day relative to upload).
+    date_prefix = source_path.stem.rsplit("-", 1)[0]
     variant_filename = f"{date_prefix}-{image_id}.{ext}"
     variant_path = variant_dir / variant_filename
 

--- a/tests/unit/test_image_processing.py
+++ b/tests/unit/test_image_processing.py
@@ -14,37 +14,39 @@ from app.config import settings
 from app.services.image_processing import create_large_variant, create_medium_variant, validate_image_file
 
 
+# Fixtures use production-format names (`YYYY-MM-DD-<id>.<ext>`) so the
+# date-prefix extraction logic under test is exercised against realistic
+# input. A bare `tempfile.NamedTemporaryFile` stem has no hyphens, in which
+# case both the test and the impl trivially agree on a non-date value and
+# a regression (e.g. reverting to `datetime.now()`) wouldn't be caught.
 @pytest.fixture
 def test_image_large():
     """Create a temporary large test image (3000x2000 pixels)."""
-    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "2026-05-18-99001.jpg"
         img = Image.new("RGB", (3000, 2000), color="red")
-        img.save(f.name, quality=95)
-        yield Path(f.name)
-        # Cleanup
-        Path(f.name).unlink(missing_ok=True)
+        img.save(path, quality=95)
+        yield path
 
 
 @pytest.fixture
 def test_image_medium():
     """Create a temporary medium test image (1500x1000 pixels)."""
-    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "2026-05-18-99002.jpg"
         img = Image.new("RGB", (1500, 1000), color="blue")
-        img.save(f.name, quality=95)
-        yield Path(f.name)
-        # Cleanup
-        Path(f.name).unlink(missing_ok=True)
+        img.save(path, quality=95)
+        yield path
 
 
 @pytest.fixture
 def test_image_small():
     """Create a temporary small test image (800x600 pixels)."""
-    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "2026-05-18-99003.jpg"
         img = Image.new("RGB", (800, 600), color="green")
-        img.save(f.name, quality=95)
-        yield Path(f.name)
-        # Cleanup
-        Path(f.name).unlink(missing_ok=True)
+        img.save(path, quality=95)
+        yield path
 
 
 @pytest.fixture
@@ -57,14 +59,13 @@ def temp_storage():
 @pytest.fixture
 def test_image_highly_compressed():
     """Create a temporary highly compressed small image for size validation tests."""
-    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "2026-05-18-99004.jpg"
         # Create a small 100x100 solid color image with very low quality
         # This will be tiny and resizing won't make it smaller
         img = Image.new("RGB", (100, 100), color="red")
-        img.save(f.name, quality=1)  # Extremely low quality
-        yield Path(f.name)
-        # Cleanup
-        Path(f.name).unlink(missing_ok=True)
+        img.save(path, quality=1)  # Extremely low quality
+        yield path
 
 
 class TestCreateMediumVariant:
@@ -208,7 +209,7 @@ class TestFileSizeValidation:
         """Test that medium variant is deleted if it's larger than the original."""
         # Create an already-optimized tiny image that will produce a LARGER resized version
         # Use a very small JPEG with maximum compression
-        original_path = Path(temp_storage) / "original.jpg"
+        original_path = Path(temp_storage) / "2026-05-18-99999.jpg"
         # Tiny image with extreme compression
         img = Image.new("RGB", (1500, 1000), color=(255, 0, 0))
         img.save(original_path, format="JPEG", quality=1, optimize=True)
@@ -252,7 +253,7 @@ class TestFileSizeValidation:
     def test_large_variant_deleted_when_larger_than_original(self, temp_storage):
         """Test that large variant is deleted if it's larger than the original."""
         # Create an already-optimized tiny image that will produce a LARGER resized version
-        original_path = Path(temp_storage) / "original.jpg"
+        original_path = Path(temp_storage) / "2026-05-18-99999.jpg"
         # Tiny image with extreme compression
         img = Image.new("RGB", (3000, 2000), color=(0, 255, 0))
         img.save(original_path, format="JPEG", quality=1, optimize=True)

--- a/tests/unit/test_image_processing.py
+++ b/tests/unit/test_image_processing.py
@@ -4,7 +4,6 @@ Tests for image processing utilities.
 
 import tempfile
 from pathlib import Path
-from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -97,9 +96,7 @@ class TestCreateMediumVariant:
         assert medium_dir.exists()
 
         # Check that variant file exists with correct naming
-
-
-        date_prefix = datetime.now().strftime("%Y-%m-%d")
+        date_prefix = test_image_large.stem.rsplit("-", 1)[0]
         expected_filename = f"{date_prefix}-{image_id}.{ext}"
         variant_path = medium_dir / expected_filename
         assert variant_path.exists()
@@ -166,7 +163,7 @@ class TestCreateLargeVariant:
         assert large_dir.exists()
 
         # Check that variant file exists with correct naming
-        date_prefix = datetime.now().strftime("%Y-%m-%d")
+        date_prefix = test_image_large.stem.rsplit("-", 1)[0]
         expected_filename = f"{date_prefix}-{image_id}.{ext}"
         variant_path = large_dir / expected_filename
         assert variant_path.exists()
@@ -234,7 +231,7 @@ class TestFileSizeValidation:
 
         # Get variant path
         medium_dir = Path(temp_storage) / "medium"
-        date_prefix = datetime.now().strftime("%Y-%m-%d")
+        date_prefix = original_path.stem.rsplit("-", 1)[0]
         expected_filename = f"{date_prefix}-{image_id}.{ext}"
         variant_path = medium_dir / expected_filename
 
@@ -278,7 +275,7 @@ class TestFileSizeValidation:
 
         # Get variant path
         large_dir = Path(temp_storage) / "large"
-        date_prefix = datetime.now().strftime("%Y-%m-%d")
+        date_prefix = original_path.stem.rsplit("-", 1)[0]
         expected_filename = f"{date_prefix}-{image_id}.{ext}"
         variant_path = large_dir / expected_filename
 


### PR DESCRIPTION
## Summary
- An upload that lands within ~1 second of local midnight saves the fullsize file with one date prefix (e.g. \`2026-05-18-\`) while the DB \`filename\` column, the thumb path passed to \`add_to_iqdb_job\`, and the medium/large variants all use the *next* day's prefix (e.g. \`2026-05-19-\`). Downstream jobs (\`r2_finalize_upload_job\`, \`add_to_iqdb_job\`) then derive expected paths from the mismatched name and never find the files.
- Three sites called \`datetime.now().strftime("%Y-%m-%d")\` independently, plus a fourth site re-used that drifted variable. This PR consolidates on a single source of truth (the fullsize path saved by \`save_uploaded_image\`) and derives the rest from it.

## Concrete incident
Image 1116164 uploaded at 2026-05-19 03:59:59 UTC (23:59:59 EDT on 05-18). Disk state after upload:
\`\`\`
fullsize/2026-05-18-1116164.png    ← saved at 23:59 EDT (correct, local 05-18)
thumbs/2026-05-18-1116164.webp     ← mirrors fullsize (correct)
medium/2026-05-19-1116164.png      ← variant job at 00:00 EDT, drifted
large/2026-05-19-1116164.png       ← same, drifted
\`\`\`
DB row had \`filename='2026-05-19-1116164'\`, \`r2_location=0\`. \`r2_finalize_upload_job\` exhausted retries looking for the fullsize at the 05-19 path; iqdb failed with \`iqdb_job_thumbnail_missing\`.

## Changes
- \`app/api/v1/images.py:2169\` — \`filename = file_path.stem\` (was \`datetime.now().strftime(...) + "-" + image_id\`).
- \`app/api/v1/images.py:2280\` — thumb_path uses \`{filename}.webp\` (was the now-removed \`date_prefix\` variable).
- \`app/services/image_processing.py:84\` — \`date_prefix = source_path.stem.rsplit("-", 1)[0]\` (was \`datetime.now().strftime(...)\`). Mirrors how \`create_thumbnail\` already does it.
- \`tests/unit/test_image_processing.py\` — four assertions used the same buggy pattern to compute the expected variant filename; updated to derive from \`source_path.stem\` instead.

The fullsize-naming site at \`app/services/upload.py:112\` is left as-is — it's the single source of truth that everything else now derives from.

## Bug-scan
Grepped for other instances of the pattern (\`datetime.now().strftime\`, \`date_prefix\`, \`{image_id}.{ext}\` filename construction). The only remaining call is the source-of-truth in \`upload.py\`. All downstream sites (\`app/schemas/image.py\`, \`app/api/v1/iqdb_feed.py\`, \`app/api/v1/media.py\`, \`scripts/populate_iqdb.py\`) already use \`image.filename\` from the DB.

Spotted a separate, pre-existing cosmetic bug at \`app/tasks/image_jobs.py:57\` (logs \`thumb_path\` with \`.jpeg\` even though the actual file is \`.webp\`). Out of scope for this PR — flagging for a follow-up.

## Operational state (already addressed before this PR)
Image 1116164 was manually unstuck:
1. Renamed \`fullsize/2026-05-18-1116164.png\` → \`fullsize/2026-05-19-1116164.png\` and same for the thumb.
2. Re-enqueued \`r2_finalize_upload_job\` and \`add_to_iqdb_job\` — both succeeded (\`r2_finalize_succeeded\`, \`iqdb_job_completed success=true\`).
3. DB now has \`r2_location=1\`.

This PR prevents the drift from recurring on future midnight-boundary uploads.

## Test plan
- [x] \`tests/unit/test_image_processing.py\` — 11/11 pass.
- [x] \`tests/api/v1/test_upload.py\` — 5/5 pass (would have failed without the line-2280 fix).
- [x] \`tests/api/v1/test_image_upload_r2.py\` — 2/2 pass.
- [x] Broader scan: 119/119 pass across image_processing/upload/r2/media/jobs/media-serving/url-generation/check-similar suites.