### PR TITLE
fix(deps): pin pymysql<1.2 to unbreak prod after rebuild

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # Database (MySQL)
     "sqlalchemy[asyncio]>=2.0.0",
     "aiomysql>=0.2.0",
-    "pymysql>=1.1.0", # For Alembic sync operations
+    "pymysql>=1.1.0,<1.2", # <1.2: pymysql 1.2.0 changed Connection.ping() signature in a way sqlalchemy's aiomysql adapter doesn't handle, causing intermittent ASGI errors when the pool revalidates a stale connection.
     "alembic>=1.13.0",
     # Cache
     "redis>=5.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pyjwt", specifier = ">=2.8.0,<3.0.0" },
-    { name = "pymysql", specifier = ">=1.1.0" },
+    { name = "pymysql", specifier = ">=1.1.0,<1.2" },
     { name = "python-json-logger", specifier = ">=2.0.7" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary
- PyMySQL 1.2.0 made `reconnect` a required positional arg on `Connection.ping()`. The current SQLAlchemy aiomysql adapter (2.0.49) calls `ping()` with no args, so every connection-pool revalidation raises `TypeError: AsyncAdapt_aiomysql_connection.ping() missing 1 required positional argument: 'reconnect'` and returns a 500.
- Pin pymysql to `>=1.1.0,<1.2` so the next rebuild stays on a compatible version (currently 1.1.3).

## How prod broke
Today's rebuild for #217 (nginx resolver) and #218 (date drift) dragged pymysql from 1.1.x to 1.2.0. The `Dockerfile` does `uv pip install --system -r pyproject.toml` *without* using `uv.lock`, so every rebuild re-resolves to whatever's latest under the existing constraints. Once the bad pymysql was in the image and pods recycled, requests started intermittently 500ing — fresh pool connections worked, revalidated ones crashed — which surfaced on-site as random "logged out" and random "no image results."

## Already deployed
Built and recreated `api`/`arq-worker` from this working tree before opening the PR. Verified:
- `pymysql` now reports `1.1.3` in the running image.
- 10/10 rapid GETs against `/api/v1/images/...` return 200.
- No `TypeError: ... ping() missing` in `docker logs shuushuu-api-prod --since 1m`.

## Follow-up (separate PR)
The root cause is the Dockerfile not using the lock file. Worth changing `RUN uv pip install --system -r pyproject.toml` to `RUN uv sync --frozen --no-install-project` (or equivalent) so all transitive versions are pinned by `uv.lock` and a stray rebuild can't drag in incompatible deps again. Not in this PR — kept this one minimal to keep the prod paper trail clean.

## Test plan
- [x] Smoke: rapid GETs to `/api/v1/images/...` return 200 consistently.
- [x] No `ping()` TypeError in api logs.
- [ ] Confirm logged-in sessions persist across reloads (no random logouts).
- [ ] Confirm image lists render consistently.