### PR TITLE
fix(docker): use uv.lock for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # Dockerfile for Shuushuu API with uv
 FROM python:3.14-slim
 
-# Install uv from Astral's uv image (copy binaries into a directory on PATH)
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+# Install uv from Astral's uv image. Pinned because :latest defeats the
+# point of locking the Python deps below — a uv minor release can change
+# `sync` semantics or lockfile format. Bump deliberately, same as `uv lock`.
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /usr/local/bin/
 
 # Set working directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,19 +19,27 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy dependency files
-COPY pyproject.toml ./
+# Copy lock + manifest first so the dep layer caches independently of source
+# changes. Using uv.lock (via `--frozen`) is what keeps rebuilds reproducible:
+# a stray transitive bump (e.g. pymysql 1.1.x → 1.2.0) can't sneak in without
+# an explicit `uv lock` regenerate, which would also fail CI if it broke.
+COPY pyproject.toml uv.lock ./
 
-# Install Python dependencies using uv by installing the project (pyproject-based build)
-RUN uv pip install --system -r pyproject.toml
+# Install runtime deps only (no dev group). --no-install-project because
+# the app/ source isn't copied yet — installed in the layer below.
+RUN uv sync --frozen --no-install-project --no-dev
 
 # Copy only what's needed for runtime (explicit allowlist)
 COPY app/ ./app/
 COPY alembic/ ./alembic/
 COPY scripts/ ./scripts/
 
+# Install the project itself (cheap; deps are already in the venv).
+RUN uv sync --frozen --no-dev
+
 # Expose port
 EXPOSE 8000
 
-# Run the application
-CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# --no-sync: deps are already in sync from the build steps above; don't let
+# `uv run` re-check on every container start.
+CMD ["uv", "run", "--no-sync", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- The Dockerfile copied only \`pyproject.toml\` and ran \`uv pip install --system -r pyproject.toml\`, which re-resolves transitive deps on every build against the loose constraints in pyproject.toml. \`uv.lock\` existed in the repo but the image build never read it.
- Switch to \`uv sync --frozen --no-install-project --no-dev\` for the deps layer and \`uv sync --frozen --no-dev\` once source is in place. \`--frozen\` errors out if \`uv.lock\` doesn't match pyproject.toml, so a dep change requires an explicit \`uv lock\` regenerate that shows up in PR diffs.

## Why now
Today's rebuild for #217 and #218 silently dragged pymysql from 1.1.x to 1.2.0, whose ping() signature change broke sqlalchemy's aiomysql adapter. Site went intermittently 500 (random "logged out", random missing images). Patched immediately with #219 (pymysql<1.2 upper bound). This PR is the root-cause follow-up so the pyproject pin isn't load-bearing — even if someone removes the upper bound later, the image still installs whatever \`uv.lock\` says.

## Changes
- \`COPY pyproject.toml ./\` → \`COPY pyproject.toml uv.lock ./\`
- \`RUN uv pip install --system -r pyproject.toml\` → two \`uv sync --frozen --no-dev\` layers (deps, then project; cache-friendly).
- \`CMD ["uv", "run", "uvicorn", ...]\` → adds \`--no-sync\` so container start doesn't re-check the venv (everything is sync'd at build).

## Verified locally
- \`docker build\` succeeds with the new Dockerfile.
- Resulting image has \`pymysql=1.1.2\`, \`sqlalchemy=2.0.44\`, \`aiomysql=0.3.2\` — exactly what \`uv.lock\` specifies, not the latest-compatible.
- \`from app.main import app\` succeeds.
- \`from sqlalchemy.dialects.mysql.aiomysql import AsyncAdapt_aiomysql_connection\` succeeds (the class that crashed under pymysql 1.2.0).

## Sibling PRs
- #219: pyproject pin \`pymysql<1.2\` — short-circuit defense (works even if the Dockerfile change isn't merged).
- This PR: structural defense (works even if pyproject pin is removed later).

Either alone fixes the immediate bug. Both together make it really hard to regress.

## Test plan
- [x] Local build succeeds.
- [x] Image has the locked dep versions.
- [x] App + sqlalchemy adapter import.
- [ ] Test stack still works (the one-off \`docker compose run\` test command we use should still be able to \`uv sync --group dev --frozen\` into the image's existing \`/app/.venv\`).
- [ ] Prod rebuild + redeploy clean.