### PR TITLE
feat(history): include linked tag on user-history tag_metadata rows

### DIFF
--- a/app/api/v1/history.py
+++ b/app/api/v1/history.py
@@ -95,10 +95,45 @@ async def get_user_history(
     # Using (timestamp, type_priority, source_id) for stable sorting.
     items_with_sort_keys: list[tuple[datetime, int, int, UserHistoryItem]] = []
 
+    # Batch-load the "other" tags referenced by tag_metadata rows so the
+    # frontend can render things like "Aliased to <X>" without a follow-up
+    # request. Mirrors the per-tag /tags/{id}/history endpoint.
+    linked_tag_ids: set[int] = set()
+    for audit_log, _ in tag_audit_rows:
+        for fk in (
+            audit_log.old_alias_of,
+            audit_log.new_alias_of,
+            audit_log.old_parent_id,
+            audit_log.new_parent_id,
+            audit_log.character_tag_id,
+            audit_log.source_tag_id,
+        ):
+            if fk:
+                linked_tag_ids.add(fk)
+
+    linked_tags_map: dict[int, LinkedTag] = {}
+    if linked_tag_ids:
+        linked_tags_result = await db.execute(
+            select(Tags.tag_id, Tags.title, Tags.type).where(  # type: ignore[call-overload]
+                Tags.tag_id.in_(linked_tag_ids)  # type: ignore[union-attr]
+            )
+        )
+        linked_tags_map = {
+            row[0]: LinkedTag(tag_id=row[0], title=row[1], type=row[2])
+            for row in linked_tags_result.all()
+        }
+
     # Transform tag audit log entries (type_priority=1)
     for audit_log, tag in tag_audit_rows:
         timestamp = audit_log.created_at or datetime.min
         tag_info = LinkedTag(tag_id=tag.tag_id, title=tag.title, type=tag.type) if tag else None
+
+        # Resolve the "other" tag(s) per action_type. Matches the per-tag
+        # endpoint: alias uses new_alias_of OR old_alias_of (whichever is set
+        # for this row's set/removed variant), parent likewise, and source-
+        # linked rows carry both character and source side-by-side.
+        alias_target_id = audit_log.new_alias_of or audit_log.old_alias_of
+        parent_target_id = audit_log.new_parent_id or audit_log.old_parent_id
         item = UserHistoryItem(
             type="tag_metadata",
             action_type=audit_log.action_type,
@@ -106,6 +141,18 @@ async def get_user_history(
             old_title=audit_log.old_title,
             new_title=audit_log.new_title,
             created_at=timestamp,
+            alias_tag=linked_tags_map.get(alias_target_id) if alias_target_id else None,
+            parent_tag=linked_tags_map.get(parent_target_id) if parent_target_id else None,
+            character_tag=(
+                linked_tags_map.get(audit_log.character_tag_id)
+                if audit_log.character_tag_id and audit_log.source_tag_id
+                else None
+            ),
+            source_tag=(
+                linked_tags_map.get(audit_log.source_tag_id)
+                if audit_log.character_tag_id and audit_log.source_tag_id
+                else None
+            ),
         )
         items_with_sort_keys.append((timestamp, 1, audit_log.id or 0, item))
 

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -238,6 +238,16 @@ class UserHistoryItem(BaseModel):
     old_title: str | None = None
     new_title: str | None = None
 
+    # For tag_metadata: the *other* tag involved in the action. Populated per
+    # action_type — alias_set/alias_removed → alias_tag, parent_set/parent_removed
+    # → parent_tag, source_linked/source_unlinked → source_tag + character_tag.
+    # Naming mirrors TagAuditLogResponse so the frontend can reuse its
+    # getLinkedTag() helper.
+    alias_tag: LinkedTag | None = None
+    parent_tag: LinkedTag | None = None
+    source_tag: LinkedTag | None = None
+    character_tag: LinkedTag | None = None
+
 
 class UserHistoryListResponse(BaseModel):
     """Paginated list of user history items."""

--- a/tests/api/v1/test_user_history_endpoint.py
+++ b/tests/api/v1/test_user_history_endpoint.py
@@ -641,7 +641,7 @@ class TestUserHistoryLinkedTags:
 
     Field naming mirrors TagAuditLogResponse 1:1 so the frontend can reuse
     its existing getLinkedTag() helper. See
-    /home/dtaylor/shuu/shuushuu-frontend/docs/plans/2026-05-23-history-linked-tags-api-requirements.md
+    https://github.com/anonymousobject/shuushuu-frontend/blob/main/docs/plans/2026-05-23-history-linked-tags-api-requirements.md
     """
 
     async def _make_user(self, db_session: AsyncSession, username: str) -> Users:
@@ -859,32 +859,42 @@ class TestUserHistoryLinkedTags:
         assert item["alias_tag"] is None
         assert item["parent_tag"] is None
 
-    async def test_rename_has_null_linked_tag_fields(
+    async def test_self_contained_actions_have_null_linked_tag_fields(
         self, client: AsyncClient, db_session: AsyncSession
     ) -> None:
-        """Self-contained actions (rename, type_change) should leave all four fields null."""
+        """Actions with no linked tag (rename, type_change) should leave all four fields null."""
         user = await self._make_user(db_session, "linkedrename")
         tag = Tags(title="Cirno", type=TagType.CHARACTER)
         db_session.add(tag)
         await db_session.commit()
         await db_session.refresh(tag)
 
-        db_session.add(
-            TagAuditLog(
-                tag_id=tag.tag_id,
-                user_id=user.user_id,
-                action_type=TagAuditActionType.RENAME,
-                old_title="Cirno (9)",
-                new_title="Cirno",
-            )
+        db_session.add_all(
+            [
+                TagAuditLog(
+                    tag_id=tag.tag_id,
+                    user_id=user.user_id,
+                    action_type=TagAuditActionType.RENAME,
+                    old_title="Cirno (9)",
+                    new_title="Cirno",
+                ),
+                TagAuditLog(
+                    tag_id=tag.tag_id,
+                    user_id=user.user_id,
+                    action_type=TagAuditActionType.TYPE_CHANGE,
+                    old_type=TagType.THEME,
+                    new_type=TagType.CHARACTER,
+                ),
+            ]
         )
         await db_session.commit()
 
-        item = await self._find_metadata_item(client, user.user_id, "rename")
-        assert item["alias_tag"] is None
-        assert item["parent_tag"] is None
-        assert item["source_tag"] is None
-        assert item["character_tag"] is None
+        for action_type in ("rename", "type_change"):
+            item = await self._find_metadata_item(client, user.user_id, action_type)
+            assert item["alias_tag"] is None, action_type
+            assert item["parent_tag"] is None, action_type
+            assert item["source_tag"] is None, action_type
+            assert item["character_tag"] is None, action_type
 
     async def test_non_metadata_rows_have_null_linked_tag_fields(
         self, client: AsyncClient, db_session: AsyncSession

--- a/tests/api/v1/test_user_history_endpoint.py
+++ b/tests/api/v1/test_user_history_endpoint.py
@@ -629,3 +629,303 @@ class TestGetUserHistory:
 
         item = tag_usage_items[0]
         assert item["action"] == "removed"
+
+
+@pytest.mark.api
+class TestUserHistoryLinkedTags:
+    """
+    The user-history endpoint must surface the *second* tag involved in each
+    tag_metadata action (alias_set/removed, parent_set/removed,
+    source_linked/unlinked). Without it the frontend renders things like
+    "Removed tag alias [yua]" with no way to say what it was removed from.
+
+    Field naming mirrors TagAuditLogResponse 1:1 so the frontend can reuse
+    its existing getLinkedTag() helper. See
+    /home/dtaylor/shuu/shuushuu-frontend/docs/plans/2026-05-23-history-linked-tags-api-requirements.md
+    """
+
+    async def _make_user(self, db_session: AsyncSession, username: str) -> Users:
+        user = Users(
+            username=username,
+            password="hashed",
+            password_type="bcrypt",
+            salt="",
+            email=f"{username}@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        return user
+
+    async def _find_metadata_item(
+        self, client: AsyncClient, user_id: int, action_type: str
+    ) -> dict:
+        response = await client.get(f"/api/v1/users/{user_id}/history")
+        assert response.status_code == 200
+        items = [
+            item
+            for item in response.json()["items"]
+            if item["type"] == "tag_metadata" and item["action_type"] == action_type
+        ]
+        assert len(items) == 1, f"expected one {action_type} row, got {len(items)}"
+        return items[0]
+
+    async def test_alias_set_includes_alias_tag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        user = await self._make_user(db_session, "linkedalias_set")
+        source_tag = Tags(title="Pixiv 481037", type=TagType.THEME)
+        target_tag = Tags(title="yua", type=TagType.CHARACTER)
+        db_session.add_all([source_tag, target_tag])
+        await db_session.commit()
+        await db_session.refresh(source_tag)
+        await db_session.refresh(target_tag)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=source_tag.tag_id,
+                user_id=user.user_id,
+                action_type=TagAuditActionType.ALIAS_SET,
+                new_alias_of=target_tag.tag_id,
+            )
+        )
+        await db_session.commit()
+
+        item = await self._find_metadata_item(client, user.user_id, "alias_set")
+        assert item["alias_tag"] is not None
+        assert item["alias_tag"]["tag_id"] == target_tag.tag_id
+        assert item["alias_tag"]["title"] == "yua"
+        assert item["alias_tag"]["type"] == TagType.CHARACTER
+        assert item["parent_tag"] is None
+        assert item["source_tag"] is None
+        assert item["character_tag"] is None
+
+    async def test_alias_removed_includes_alias_tag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        user = await self._make_user(db_session, "linkedalias_rm")
+        source_tag = Tags(title="Pixiv 740604", type=TagType.THEME)
+        prev_target = Tags(title="yua", type=TagType.CHARACTER)
+        db_session.add_all([source_tag, prev_target])
+        await db_session.commit()
+        await db_session.refresh(source_tag)
+        await db_session.refresh(prev_target)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=source_tag.tag_id,
+                user_id=user.user_id,
+                action_type=TagAuditActionType.ALIAS_REMOVED,
+                old_alias_of=prev_target.tag_id,
+            )
+        )
+        await db_session.commit()
+
+        item = await self._find_metadata_item(client, user.user_id, "alias_removed")
+        assert item["alias_tag"] is not None
+        assert item["alias_tag"]["tag_id"] == prev_target.tag_id
+        assert item["alias_tag"]["title"] == "yua"
+        assert item["alias_tag"]["type"] == TagType.CHARACTER
+        assert item["parent_tag"] is None
+        assert item["source_tag"] is None
+        assert item["character_tag"] is None
+
+    async def test_parent_set_includes_parent_tag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        user = await self._make_user(db_session, "linkedparent_set")
+        child = Tags(title="school uniform", type=TagType.THEME)
+        parent = Tags(title="clothing", type=TagType.THEME)
+        db_session.add_all([child, parent])
+        await db_session.commit()
+        await db_session.refresh(child)
+        await db_session.refresh(parent)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=child.tag_id,
+                user_id=user.user_id,
+                action_type=TagAuditActionType.PARENT_SET,
+                new_parent_id=parent.tag_id,
+            )
+        )
+        await db_session.commit()
+
+        item = await self._find_metadata_item(client, user.user_id, "parent_set")
+        assert item["parent_tag"] is not None
+        assert item["parent_tag"]["tag_id"] == parent.tag_id
+        assert item["parent_tag"]["title"] == "clothing"
+        assert item["parent_tag"]["type"] == TagType.THEME
+        assert item["alias_tag"] is None
+        assert item["source_tag"] is None
+        assert item["character_tag"] is None
+
+    async def test_parent_removed_includes_parent_tag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        user = await self._make_user(db_session, "linkedparent_rm")
+        child = Tags(title="school uniform", type=TagType.THEME)
+        prev_parent = Tags(title="clothing", type=TagType.THEME)
+        db_session.add_all([child, prev_parent])
+        await db_session.commit()
+        await db_session.refresh(child)
+        await db_session.refresh(prev_parent)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=child.tag_id,
+                user_id=user.user_id,
+                action_type=TagAuditActionType.PARENT_REMOVED,
+                old_parent_id=prev_parent.tag_id,
+            )
+        )
+        await db_session.commit()
+
+        item = await self._find_metadata_item(client, user.user_id, "parent_removed")
+        assert item["parent_tag"] is not None
+        assert item["parent_tag"]["tag_id"] == prev_parent.tag_id
+        assert item["parent_tag"]["title"] == "clothing"
+        assert item["parent_tag"]["type"] == TagType.THEME
+        assert item["alias_tag"] is None
+        assert item["source_tag"] is None
+        assert item["character_tag"] is None
+
+    async def test_source_linked_includes_character_and_source_tags(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        user = await self._make_user(db_session, "linkedsrc_set")
+        character = Tags(title="Sakura Kinomoto", type=TagType.CHARACTER)
+        source = Tags(title="Cardcaptor Sakura", type=TagType.SOURCE)
+        db_session.add_all([character, source])
+        await db_session.commit()
+        await db_session.refresh(character)
+        await db_session.refresh(source)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=character.tag_id,
+                user_id=user.user_id,
+                action_type=TagAuditActionType.SOURCE_LINKED,
+                character_tag_id=character.tag_id,
+                source_tag_id=source.tag_id,
+            )
+        )
+        await db_session.commit()
+
+        item = await self._find_metadata_item(client, user.user_id, "source_linked")
+        assert item["character_tag"] is not None
+        assert item["character_tag"]["tag_id"] == character.tag_id
+        assert item["character_tag"]["title"] == "Sakura Kinomoto"
+        assert item["character_tag"]["type"] == TagType.CHARACTER
+        assert item["source_tag"] is not None
+        assert item["source_tag"]["tag_id"] == source.tag_id
+        assert item["source_tag"]["title"] == "Cardcaptor Sakura"
+        assert item["source_tag"]["type"] == TagType.SOURCE
+        assert item["alias_tag"] is None
+        assert item["parent_tag"] is None
+
+    async def test_source_unlinked_includes_character_and_source_tags(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        user = await self._make_user(db_session, "linkedsrc_rm")
+        character = Tags(title="Tomoyo Daidouji", type=TagType.CHARACTER)
+        source = Tags(title="Cardcaptor Sakura", type=TagType.SOURCE)
+        db_session.add_all([character, source])
+        await db_session.commit()
+        await db_session.refresh(character)
+        await db_session.refresh(source)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=character.tag_id,
+                user_id=user.user_id,
+                action_type=TagAuditActionType.SOURCE_UNLINKED,
+                character_tag_id=character.tag_id,
+                source_tag_id=source.tag_id,
+            )
+        )
+        await db_session.commit()
+
+        item = await self._find_metadata_item(client, user.user_id, "source_unlinked")
+        assert item["character_tag"] is not None
+        assert item["character_tag"]["tag_id"] == character.tag_id
+        assert item["character_tag"]["title"] == "Tomoyo Daidouji"
+        assert item["character_tag"]["type"] == TagType.CHARACTER
+        assert item["source_tag"] is not None
+        assert item["source_tag"]["tag_id"] == source.tag_id
+        assert item["source_tag"]["title"] == "Cardcaptor Sakura"
+        assert item["source_tag"]["type"] == TagType.SOURCE
+        assert item["alias_tag"] is None
+        assert item["parent_tag"] is None
+
+    async def test_rename_has_null_linked_tag_fields(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """Self-contained actions (rename, type_change) should leave all four fields null."""
+        user = await self._make_user(db_session, "linkedrename")
+        tag = Tags(title="Cirno", type=TagType.CHARACTER)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=tag.tag_id,
+                user_id=user.user_id,
+                action_type=TagAuditActionType.RENAME,
+                old_title="Cirno (9)",
+                new_title="Cirno",
+            )
+        )
+        await db_session.commit()
+
+        item = await self._find_metadata_item(client, user.user_id, "rename")
+        assert item["alias_tag"] is None
+        assert item["parent_tag"] is None
+        assert item["source_tag"] is None
+        assert item["character_tag"] is None
+
+    async def test_non_metadata_rows_have_null_linked_tag_fields(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """tag_usage and status_change rows should never populate the new fields."""
+        user = await self._make_user(db_session, "linkedusage")
+        tag = Tags(title="aviator glasses", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        image = Images(
+            filename="linkedusage1",
+            ext="jpg",
+            md5_hash="linkedusagemd5111111111111111",
+            user_id=user.user_id,
+            width=100,
+            height=100,
+            filesize=1000,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        db_session.add(
+            TagHistory(
+                image_id=image.image_id,
+                tag_id=tag.tag_id,
+                user_id=user.user_id,
+                action="a",
+                date=datetime.now(UTC),
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/users/{user.user_id}/history")
+        assert response.status_code == 200
+        usage_items = [i for i in response.json()["items"] if i["type"] == "tag_usage"]
+        assert len(usage_items) == 1
+        item = usage_items[0]
+        assert item["alias_tag"] is None
+        assert item["parent_tag"] is None
+        assert item["source_tag"] is None
+        assert item["character_tag"] is None


### PR DESCRIPTION
## Summary

- Adds four optional `LinkedTag` fields (`alias_tag`, `parent_tag`, `source_tag`, `character_tag`) to `UserHistoryItem` so the user-history endpoint surfaces the *other* tag in alias/parent/source-link actions — the frontend currently has nothing to render for those rows and produces lines like `Removed tag alias [yua]` with no way to say what it was removed *from*.
- Names match `TagAuditLogResponse` 1:1 (per the brief) so the frontend can reuse its existing `getLinkedTag()` helper rather than writing a parallel one.
- Single batched `Tags.in_()` lookup for the linked tags — same approach the per-tag `/tags/{id}/history` endpoint already uses; no schema change, no backfill, the FK columns are already on `tag_audit_log`.

Spec: [shuushuu-frontend/docs/plans/2026-05-23-history-linked-tags-api-requirements.md](https://github.com/anonymousobject/shuushuu-frontend/blob/main/docs/plans/2026-05-23-history-linked-tags-api-requirements.md)

## Acceptance criteria (from the brief)

- [x] `GET /api/v1/users/{id}/history` returns the four fields on every `tag_metadata` item, populated per `action_type`
- [x] The new fields are `null` on rows where they don't apply (including non-`tag_metadata` rows)
- [x] OpenAPI schema reflects the additions (verified via `app.openapi()`)
- [x] Per-tag `/tags/{id}/history` is unchanged (existing 28 tests still pass)

## Test plan

- [x] Added `TestUserHistoryLinkedTags` (8 tests): one per affected `action_type` (alias_set/removed, parent_set/removed, source_linked/unlinked) plus a `rename` control and a `tag_usage` control to confirm the new fields are `null` where they shouldn't apply.
- [x] `tests/api/v1/test_user_history_endpoint.py tests/api/v1/test_tag_audit_log.py` — 36 passed
- [x] `mypy app/api/v1/history.py app/schemas/audit.py` — 0 issues
- [x] `ruff check` + `ruff format --check` clean