### PR TITLE
feat(history): include old_type/new_type on user-history tag_metadata rows

### DIFF
--- a/app/api/v1/history.py
+++ b/app/api/v1/history.py
@@ -140,6 +140,8 @@ async def get_user_history(
             tag=tag_info,
             old_title=audit_log.old_title,
             new_title=audit_log.new_title,
+            old_type=audit_log.old_type,
+            new_type=audit_log.new_type,
             created_at=timestamp,
             alias_tag=linked_tags_map.get(alias_target_id) if alias_target_id else None,
             parent_tag=linked_tags_map.get(parent_target_id) if parent_target_id else None,

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -208,7 +208,9 @@ class UserHistoryItem(BaseModel):
     Combines different history types into a unified format.
     The exact fields present depend on the `type` field:
 
-    - tag_metadata: action_type, tag, old_title/new_title (for rename), created_at
+    - tag_metadata: action_type, tag, old_title/new_title (for rename),
+      old_type/new_type (for type_change), alias_tag/parent_tag/source_tag/
+      character_tag (for the corresponding link/unlink actions), created_at
     - tag_usage: action, tag, image_id, date
     - status_change: image_id, old_status, new_status, new_status_label, created_at
     """

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -238,6 +238,10 @@ class UserHistoryItem(BaseModel):
     old_title: str | None = None
     new_title: str | None = None
 
+    # For tag_metadata: type_change action
+    old_type: int | None = None
+    new_type: int | None = None
+
     # For tag_metadata: the *other* tag involved in the action. Populated per
     # action_type — alias_set/alias_removed → alias_tag, parent_set/parent_removed
     # → parent_tag, source_linked/source_unlinked → source_tag + character_tag.

--- a/tests/api/v1/test_user_history_endpoint.py
+++ b/tests/api/v1/test_user_history_endpoint.py
@@ -926,6 +926,16 @@ class TestUserHistoryLinkedTags:
             assert item["source_tag"] is None, action_type
             assert item["character_tag"] is None, action_type
 
+        # Symmetric pin: rename rows carry no type info; type_change rows
+        # carry no title info. Catches accidental cross-population if the
+        # serializer is ever refactored.
+        rename_item = await self._find_metadata_item(client, user.user_id, "rename")
+        assert rename_item["old_type"] is None
+        assert rename_item["new_type"] is None
+        type_change_item = await self._find_metadata_item(client, user.user_id, "type_change")
+        assert type_change_item["old_title"] is None
+        assert type_change_item["new_title"] is None
+
     async def test_non_metadata_rows_have_null_linked_tag_fields(
         self, client: AsyncClient, db_session: AsyncSession
     ) -> None:
@@ -969,3 +979,5 @@ class TestUserHistoryLinkedTags:
         assert item["parent_tag"] is None
         assert item["source_tag"] is None
         assert item["character_tag"] is None
+        assert item["old_type"] is None
+        assert item["new_type"] is None

--- a/tests/api/v1/test_user_history_endpoint.py
+++ b/tests/api/v1/test_user_history_endpoint.py
@@ -859,6 +859,36 @@ class TestUserHistoryLinkedTags:
         assert item["alias_tag"] is None
         assert item["parent_tag"] is None
 
+    async def test_type_change_includes_old_and_new_type(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        user = await self._make_user(db_session, "linkedtype")
+        tag = Tags(title="bunny ears", type=TagType.CHARACTER)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=tag.tag_id,
+                user_id=user.user_id,
+                action_type=TagAuditActionType.TYPE_CHANGE,
+                old_type=TagType.THEME,
+                new_type=TagType.CHARACTER,
+            )
+        )
+        await db_session.commit()
+
+        item = await self._find_metadata_item(client, user.user_id, "type_change")
+        assert item["old_type"] == TagType.THEME
+        assert item["new_type"] == TagType.CHARACTER
+        assert item["old_title"] is None
+        assert item["new_title"] is None
+        assert item["alias_tag"] is None
+        assert item["parent_tag"] is None
+        assert item["source_tag"] is None
+        assert item["character_tag"] is None
+
     async def test_self_contained_actions_have_null_linked_tag_fields(
         self, client: AsyncClient, db_session: AsyncSession
     ) -> None:


### PR DESCRIPTION
## Summary

- Mirror change to PR #223: the user activity feed at `/users/[id]/history` currently shows a `type_change` row with just the source tag chipped in its current type color, with no indication of what the type was before. The audit row already persists `old_type` / `new_type`, and `TagAuditLogResponse` already exposes them — this surfaces them on `UserHistoryItem` too.
- Two-line schema addition (`old_type` / `new_type` on `UserHistoryItem`) and a two-line serializer pass-through in `app/api/v1/history.py`, following the same pattern already in place for `old_title` / `new_title`.
- No migration, no new joins.

Frontend rendering ships in the matching shuushuu-frontend PR.

## Test plan

- [x] `test_type_change_includes_old_and_new_type` — new test asserting the fields land on the response with correct values and that the rest of the optional fields stay null.
- [x] Existing `test_self_contained_actions_have_null_linked_tag_fields` still passes (it already creates a type_change row; the schema additions don't affect its assertions).
- [x] Reviewer: spot-check a real user's `/history` payload after deploy to confirm the new fields appear on type_change rows.

Spec: shuushuu-frontend/docs/plans/2026-05-23-history-linked-tags-api-requirements.md (lands with the frontend PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)