### PR TITLE
feat(users): expose theme_preset and dark_mode preferences

### DIFF
--- a/alembic/versions/2e5fae0fd9a5_add_theme_preset_and_dark_mode_to_users.py
+++ b/alembic/versions/2e5fae0fd9a5_add_theme_preset_and_dark_mode_to_users.py
@@ -1,0 +1,34 @@
+"""add theme_preset and dark_mode to users
+
+Revision ID: 2e5fae0fd9a5
+Revises: 7b2101b37080
+Create Date: 2026-05-23 15:56:42.813856
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2e5fae0fd9a5'
+down_revision: str | Sequence[str] | None = '7b2101b37080'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add theme_preset and dark_mode preference columns to users table.
+
+    Both columns are nullable with no default — NULL means "user hasn't picked",
+    so the frontend's localStorage value (or system default for dark mode) wins.
+    """
+    op.add_column('users', sa.Column('theme_preset', sa.String(length=32), nullable=True))
+    op.add_column('users', sa.Column('dark_mode', sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove theme_preset and dark_mode columns from users table."""
+    op.drop_column('users', 'dark_mode')
+    op.drop_column('users', 'theme_preset')

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -173,6 +173,11 @@ class Users(UserBase, table=True):
     sorting_pref_order: str = Field(default="DESC", max_length=10)
     images_per_page: int = Field(default=20)
     show_all_images: int = Field(default=0)
+    # Theme preferences (nullable — NULL means "no explicit preference,
+    # frontend default applies"). theme_preset is validated against an
+    # allowlist at the API layer (see app/schemas/user.py).
+    theme_preset: str | None = Field(default=None, max_length=32)
+    dark_mode: bool | None = Field(default=None)
 
     # Rate limiting
     maximgperday: int = Field(default=15)

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -2,7 +2,9 @@
 Pydantic schemas for User endpoints
 """
 
-from pydantic import BaseModel, EmailStr, StrictBool, computed_field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field, StrictBool, computed_field, field_validator
 
 from app.models.user import UserBase
 from app.schemas.base import UTCDatetime, UTCDatetimeOptional
@@ -60,10 +62,9 @@ class UserUpdate(BaseModel):
     bookmark: int | None = None  # Bookmarked image_id
 
     # Theme preferences
-    theme_preset: str | None = None
-    dark_mode: StrictBool | None = (
-        None  # Strict: reject "yes"/1/etc. — frontend sends real booleans
-    )
+    theme_preset: Annotated[str, Field(max_length=32)] | None = None
+    # Strict: reject "yes"/1/0/etc. — frontend sends real booleans.
+    dark_mode: StrictBool | None = None
 
     # Admin-only fields (requires USER_EDIT_PROFILE permission)
     maximgperday: int | None = None  # Max images per day upload limit

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -2,10 +2,16 @@
 Pydantic schemas for User endpoints
 """
 
-from pydantic import BaseModel, EmailStr, computed_field, field_validator
+from pydantic import BaseModel, EmailStr, StrictBool, computed_field, field_validator
 
 from app.models.user import UserBase
 from app.schemas.base import UTCDatetime, UTCDatetimeOptional
+
+# Canonical set of allowed theme presets. Adding a new preset requires:
+# 1) appending the id here, 2) adding the matching entry to the frontend
+# registry (src/lib/stores/themePresets.ts), 3) adding the CSS block to
+# src/routes/layout.css, and 4) extending the FOUC allowlist in src/app.html.
+THEME_PRESETS_ALLOWED: frozenset[str] = frozenset({"modern", "classic", "sakura"})
 
 
 class UserCreate(BaseModel):
@@ -52,6 +58,12 @@ class UserUpdate(BaseModel):
 
     # Navigation
     bookmark: int | None = None  # Bookmarked image_id
+
+    # Theme preferences
+    theme_preset: str | None = None
+    dark_mode: StrictBool | None = (
+        None  # Strict: reject "yes"/1/etc. — frontend sends real booleans
+    )
 
     # Admin-only fields (requires USER_EDIT_PROFILE permission)
     maximgperday: int | None = None  # Max images per day upload limit
@@ -135,6 +147,17 @@ class UserUpdate(BaseModel):
             raise ValueError("maximgperday must be a positive integer")
         return v
 
+    @field_validator("theme_preset")
+    @classmethod
+    def validate_theme_preset(cls, v: str | None) -> str | None:
+        """Validate theme_preset against the canonical allowlist."""
+        if v is None:
+            return v
+        if v not in THEME_PRESETS_ALLOWED:
+            allowed = ", ".join(sorted(THEME_PRESETS_ALLOWED))
+            raise ValueError(f"theme_preset must be one of: {allowed}")
+        return v
+
 
 class UserResponse(UserBase):
     """Schema for user response - what API returns"""
@@ -206,6 +229,10 @@ class UserPrivateResponse(UserResponse):
 
     # Navigation
     bookmark: int | None  # Bookmarked image_id (for "continue where I left off")
+
+    # Theme preferences (NULL = no explicit preference; frontend default applies)
+    theme_preset: str | None = None
+    dark_mode: bool | None = None
 
     # Computed at request time
     uploads_remaining_today: int = 0  # How many more images the user can upload today

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -1072,13 +1072,17 @@ class TestUpdateUserProfile:
         )
         access_token = login_response.json()["access_token"]
 
-        # Non-bool string rejected (we don't want JSON "true"/"false" to slip through)
-        response = await client.patch(
-            "/api/v1/users/me",
-            json={"dark_mode": "yes"},
-            headers={"Authorization": f"Bearer {access_token}"},
-        )
-        assert response.status_code == 422
+        # StrictBool rejects string and integer coercions. The integer cases
+        # are the more common JSON footgun — some serializers emit 0/1.
+        for bad_value in ("yes", "true", 1, 0):
+            response = await client.patch(
+                "/api/v1/users/me",
+                json={"dark_mode": bad_value},
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            assert response.status_code == 422, (
+                f"dark_mode={bad_value!r} should be rejected"
+            )
 
 
 @pytest.mark.api

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -947,6 +947,139 @@ class TestUpdateUserProfile:
         )
         assert response.status_code == 403
 
+    async def test_update_theme_preferences_via_me(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """PATCH /api/v1/users/me accepts theme_preset and dark_mode."""
+        user = Users(
+            username="themeprefs",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="themeprefs@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "themeprefs", "password": "TestPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Defaults are null on a brand-new user
+        me_response = await client.get(
+            "/api/v1/users/me",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert me_response.status_code == 200
+        assert me_response.json().get("theme_preset") is None
+        assert me_response.json().get("dark_mode") is None
+
+        # Set both preferences
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={"theme_preset": "sakura", "dark_mode": True},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("theme_preset") == "sakura"
+        assert data.get("dark_mode") is True
+
+        await db_session.refresh(user)
+        assert user.theme_preset == "sakura"
+        assert user.dark_mode is True
+
+        # Clearing via explicit null is supported (frontend uses this when
+        # a user resets to system default)
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={"theme_preset": None, "dark_mode": None},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+        await db_session.refresh(user)
+        assert user.theme_preset is None
+        assert user.dark_mode is None
+
+    async def test_theme_preset_allowlist(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """PATCH /api/v1/users/me rejects unknown theme_preset values."""
+        user = Users(
+            username="themeallowlist",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="themeallowlist@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "themeallowlist", "password": "TestPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # All three known presets accepted
+        for preset in ("modern", "classic", "sakura"):
+            response = await client.patch(
+                "/api/v1/users/me",
+                json={"theme_preset": preset},
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            assert response.status_code == 200, f"preset {preset!r} should be accepted"
+
+        # Unknown value rejected
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={"theme_preset": "purple"},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 422
+
+        # Non-string also rejected
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={"theme_preset": 5},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 422
+
+    async def test_dark_mode_type_validation(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """PATCH /api/v1/users/me requires dark_mode to be a boolean or null."""
+        user = Users(
+            username="darkmodevalidation",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="darkmodevalidation@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "darkmodevalidation", "password": "TestPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Non-bool string rejected (we don't want JSON "true"/"false" to slip through)
+        response = await client.patch(
+            "/api/v1/users/me",
+            json={"dark_mode": "yes"},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 422
+
 
 @pytest.mark.api
 class TestGetUserImages:


### PR DESCRIPTION
## Summary

Adds two nullable columns to the `users` table and exposes them on `UserPrivateResponse` / `PATCH /users/me`, enabling the frontend's per-user theme persistence:

- `theme_preset VARCHAR(32) NULL` — one of `modern | classic | sakura` (allowlist validated in the Pydantic schema)
- `dark_mode TINYINT(1) NULL` — strict boolean via `StrictBool` so coerced values like `"yes"` are rejected

Both are nullable with no default so `NULL` distinguishes "user hasn't picked" from "user explicitly chose the default" — important so the frontend can decide between server-wins-on-conflict and first-login carry-over.

Pairs with the shuushuu-frontend `theme-presets` branch. Merge this first.

## Changes

- Alembic migration adding the two columns
- `Users` model gains the new fields
- `UserUpdate` schema accepts `theme_preset` (allowlist-validated) and `dark_mode: StrictBool | None`
- `UserPrivateResponse` exposes both
- 3 new test cases in `tests/api/v1/test_users.py` covering acceptance, allowlist rejection, and StrictBool rejection

## Test plan

- [x] `uv run pytest tests/api/v1/test_users.py` — 46 pass (including the 3 new theme tests)
- [x] `uv run pytest tests/api/v1/test_users.py tests/unit/test_user_*.py` — 105 pass, no regressions
- [x] Schema migration applies and rolls back cleanly
- [x] Verified live API exposes the new fields on `/api/v1/users/me` and `PATCH /users/me`

## Notes

- No backfill: existing users get `NULL` for both columns. The frontend treats `NULL` as "no preference" and falls back to its default behavior. Backfilling later is fine if needed.
- The `theme_preset` allowlist (`{'modern', 'classic', 'sakura'}`) is hardcoded in `app/schemas/user.py`. Adding a new preset is a coordinated change with the frontend allowlist + registry — flagged in the doc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)