### PR TITLE
Zero-downtime app deploys via docker-rollout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,15 @@ COMPOSE_PROD = docker compose -f docker-compose.yml -f docker-compose.prod.yml -
 
 # Zero-downtime rollout via the docker-rollout CLI plugin. Same files/env as
 # COMPOSE_PROD so it acts on the identical merged config. Install once on the
-# host (see docs/deployment.md):
-#   curl -fsSL https://raw.githubusercontent.com/wowu/docker-rollout/main/docker-rollout \
+# host (see docs/deployment.md); pinned to a release tag, not main, to avoid
+# silently picking up upstream changes:
+#   curl -fsSL https://raw.githubusercontent.com/wowu/docker-rollout/v0.13/docker-rollout \
 #     -o ~/.docker/cli-plugins/docker-rollout && chmod +x ~/.docker/cli-plugins/docker-rollout
-ROLLOUT_PROD = docker rollout -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.prod
+#
+# --timeout 90: the new replica's healthcheck can take up to ~50s to pass
+# (start_period 20s + interval 10s x 3 retries); 90 leaves headroom above that
+# and self-documents the expected window (plugin default is only 60s).
+ROLLOUT_PROD = docker rollout --timeout 90 -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.prod
 
 # App services that support zero-downtime rollout: stateless, fronted by nginx
 # which re-resolves their service name via Docker DNS at request time. Override

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Ensure bash is used for all commands (required for read -p in clean target)
 SHELL := /bin/bash
 
-.PHONY: help dev dev-up dev-down dev-logs dev-ps test test-up test-down test-logs test-ps test-build-frontend prod prod-up prod-down prod-logs prod-ps prod-build prod-build-frontend prod-restart prod-deploy clean
+.PHONY: help dev dev-up dev-down dev-logs dev-ps test test-up test-down test-logs test-ps test-build-frontend prod prod-up prod-down prod-logs prod-ps prod-build prod-build-frontend prod-migrate prod-restart prod-deploy clean
 
 # Capture extra arguments for logs commands (e.g., `make dev-logs api`)
 ARGS = $(filter-out $@,$(MAKECMDGOALS))
@@ -36,8 +36,9 @@ help:
 	@echo "  prod-ps      Show running containers"
 	@echo "  prod-build   Build all production images"
 	@echo "  prod-build-frontend  Rebuild frontend image"
-	@echo "  prod-restart Recreate service(s) (e.g., make prod-restart frontend)"
-	@echo "  prod-deploy  Build and recreate service(s) (e.g., make prod-deploy api frontend)"
+	@echo "  prod-migrate Apply DB migrations (run BEFORE prod-deploy when a release has one)"
+	@echo "  prod-deploy  Zero-downtime rollout of app service(s) (default: api frontend)"
+	@echo "  prod-restart Force-recreate service(s) — CAUSES DOWNTIME; use for nginx/infra"
 	@echo ""
 	@echo "Other:"
 	@echo "  clean        Stop all and remove volumes (DESTRUCTIVE)"
@@ -51,6 +52,19 @@ help:
 COMPOSE_DEV = docker compose -f docker-compose.yml -f docker-compose.override.yml
 COMPOSE_TEST = docker compose -f docker-compose.yml -f docker-compose.test.yml --env-file .env.test
 COMPOSE_PROD = docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.prod
+
+# Zero-downtime rollout via the docker-rollout CLI plugin. Same files/env as
+# COMPOSE_PROD so it acts on the identical merged config. Install once on the
+# host (see docs/deployment.md):
+#   curl -fsSL https://raw.githubusercontent.com/wowu/docker-rollout/main/docker-rollout \
+#     -o ~/.docker/cli-plugins/docker-rollout && chmod +x ~/.docker/cli-plugins/docker-rollout
+ROLLOUT_PROD = docker rollout -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.prod
+
+# App services that support zero-downtime rollout: stateless, fronted by nginx
+# which re-resolves their service name via Docker DNS at request time. Override
+# by passing service names, e.g. `make prod-deploy api`.
+ROLLOUT_SERVICES = api frontend
+DEPLOY_SERVICES = $(if $(ARGS),$(ARGS),$(ROLLOUT_SERVICES))
 
 # Development targets
 dev:
@@ -109,11 +123,32 @@ prod-build:
 prod-build-frontend:
 	$(COMPOSE_PROD) build --no-cache frontend
 
-prod-restart:
-	$(COMPOSE_PROD) up -d --force-recreate $(ARGS)
+# Apply database migrations as an explicit, gated step. Run this BEFORE
+# prod-deploy when a release includes a migration. Migrations must be
+# backward-compatible (expand/contract): during the rollout the old and new app
+# versions briefly run against the same DB at once, so a column the old code
+# still reads must not disappear yet. Defer destructive (contract) changes to a
+# later release, once no old container remains.
+prod-migrate:
+	$(COMPOSE_PROD) build api
+	$(COMPOSE_PROD) run --rm --no-deps api uv run --no-project alembic upgrade head
 
+# Zero-downtime deploy: build the app image(s), then roll each service one at a
+# time. docker-rollout starts a new replica, waits for its healthcheck, then
+# drains the old one — nginx re-resolves the service name via Docker DNS, so no
+# requests are dropped. Does NOT run migrations (see prod-migrate).
 prod-deploy:
-	$(COMPOSE_PROD) build $(ARGS)
+	$(COMPOSE_PROD) build $(DEPLOY_SERVICES)
+	@for svc in $(DEPLOY_SERVICES); do \
+		echo "==> Rolling out $$svc (zero-downtime)"; \
+		$(ROLLOUT_PROD) $$svc || exit 1; \
+	done
+
+# Force-recreate service(s). This is the OLD deploy path and CAUSES a brief
+# outage (stop-then-start with no overlap), and with no args it recreates nginx
+# and everything else. Use it for nginx/config/infra changes, not app code —
+# for api/frontend use prod-deploy.
+prod-restart:
 	$(COMPOSE_PROD) up -d --force-recreate $(ARGS)
 
 # Cleanup (removes volumes - use with caution)

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,9 @@ prod-build-frontend:
 # still reads must not disappear yet. Defer destructive (contract) changes to a
 # later release, once no old container remains.
 prod-migrate:
+	# prod-deploy rebuilds too; this build ensures the migrator runs the NEW
+	# migration code even if prod-migrate is run on its own. The duplicate
+	# build is a cache-cheap no-op.
 	$(COMPOSE_PROD) build api
 	$(COMPOSE_PROD) run --rm --no-deps api uv run --no-project alembic upgrade head
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -66,9 +66,10 @@ services:
         - PUBLIC_API_URL=http://api:8000
         - PUBLIC_DEBUG=false
         - PUBLIC_TURNSTILE_SITE_KEY=${TURNSTILE_SITE_KEY}
-    container_name: shuushuu-frontend-prod
-    ports: !override
-      - "127.0.0.1:3000:3000"
+    # No container_name / host port: docker-rollout scales this to two replicas
+    # transiently during a zero-downtime deploy. nginx reaches it over the
+    # compose network (frontend:3000), so the host publish was debug-only.
+    ports: !override []
     environment:
       - PUBLIC_ENVIRONMENT=production
       - PUBLIC_API_URL=http://api:8000
@@ -142,11 +143,16 @@ services:
     logging: *default-logging
 
   api:
-    container_name: shuushuu-api-prod
+    # No container_name: docker-rollout scales this service to two replicas
+    # transiently during a zero-downtime deploy, so its name can't be fixed.
+    # !reset drops the base service's container_name from the merged config.
+    container_name: !reset null
     user: "1003:1003"  # shuushuu user — matches storage directory ownership
     command: uv run --no-project uvicorn app.main:app --host 0.0.0.0 --port 8000
-    ports: !override
-      - "127.0.0.1:8000:8000"
+    # No host port publish: two replicas can't bind the same host port during a
+    # rollout, and nginx reaches the api over the compose network (api:8000), so
+    # the publish was debug-only. Use `docker compose exec api …` for host access.
+    ports: !override []
     # !override replaces (rather than merges with) the base service's
     # env_file list; without it, compose tries to load both .env and
     # .env.prod and errors out when the dev-only .env is absent.
@@ -160,6 +166,15 @@ services:
       - PYTHONDONTWRITEBYTECODE=1
     volumes:
       - ${STORAGE_PATH:-/shuushuu/images}:${STORAGE_PATH:-/shuushuu/images}
+    # docker-rollout waits for this healthcheck on the new replica before
+    # draining the old one — without it the rollout can't tell when uvicorn is
+    # actually serving and would cut over into a still-booting container.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     # List form replaces base depends_on entirely (removes mariadb dependency)
     depends_on:
       - redis

--- a/docker/alloy/config.alloy
+++ b/docker/alloy/config.alloy
@@ -34,32 +34,44 @@ discovery.docker "containers" {
 }
 
 // Map container metadata into the labels we want.
-// Container name like "/shuushuu-api-prod" becomes service="api".
+// `service` comes from the compose service label (e.g. "api", "frontend").
 discovery.relabel "containers" {
   targets = discovery.docker.containers.targets
 
-  // Strip leading slash from container name
+  // Strip leading slash from container name (kept as a display label).
   rule {
     source_labels = ["__meta_docker_container_name"]
     regex         = "/(.*)"
     target_label  = "container_name"
   }
 
-  // Derive `service` label by stripping shuushuu- prefix and -prod suffix
+  // Derive `service` from the compose service label rather than parsing the
+  // container name. This survives docker-rollout, which scales api/frontend to
+  // two replicas transiently (named `<project>-<service>-<n>`) and drops their
+  // fixed `container_name` — neither of which the old `shuushuu-(.*)-prod` name
+  // regex would have matched, so their logs would have silently vanished.
   rule {
-    source_labels = ["container_name"]
-    regex         = "shuushuu-(.*)-prod"
+    source_labels = ["__meta_docker_container_label_com_docker_compose_service"]
     target_label  = "service"
   }
 
-  // Keep only containers whose name matched `shuushuu-(.*)-prod`.
-  // This intentionally drops:
-  //   - The mariadb busybox stub (named `shuushuu-mariadb`, no `-prod` suffix; stub has no useful logs anyway)
-  //   - Any one-off `docker run` debug containers a human might launch on the host
+  // Keep only containers that belong to a compose service. This drops any
+  // one-off `docker run` debug container a human launches on the host (no
+  // compose label → empty `service`).
   rule {
     source_labels = ["service"]
     regex         = ".+"
     action        = "keep"
+  }
+
+  // Drop the mariadb/redis busybox stubs: they exist only to keep depends_on
+  // chains merging and run `sleep infinity`, so they emit no useful logs.
+  // (The old name-based filter dropped them implicitly; the compose-label
+  // filter above would otherwise keep them.)
+  rule {
+    source_labels = ["service"]
+    regex         = "mariadb|redis"
+    action        = "drop"
   }
 
   // Carry through compose project label for multi-project hosts

--- a/docker/alloy/config.alloy
+++ b/docker/alloy/config.alloy
@@ -108,13 +108,9 @@ loki.process "containers" {
   }
 
   // Default `level` to "info" when JSON parsing didn't extract one
-  // (non-structlog services like redis, iqdb, frontend plain text).
-  //
-  // NOTE: redis emits its own pseudo-structured `# warning / * notice / . debug /
-  // - info` markers. We deliberately do not parse them: redis logs are very low
-  // volume on this host and the markers are searchable via raw text grep
-  // (`{service="redis"} |~ "^[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +# "` etc.).
-  // If redis logs grow noisy, revisit by adding a stage.match selector + regex.
+  // (non-structlog services like iqdb and the frontend emit plain text).
+  // Note: the mariadb/redis stubs are dropped upstream at discovery.relabel,
+  // so they never reach this pipeline.
   stage.template {
     source   = "level"
     template = "{{ if .Value }}{{ .Value }}{{ else }}info{{ end }}"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -37,13 +37,19 @@ This required (see `docker-compose.prod.yml`):
 
 Install the plugin on the production host:
 
+Pin to a release tag (not `main`) so a host doesn't silently pick up upstream
+changes to a script that runs against production:
+
 ```bash
 mkdir -p ~/.docker/cli-plugins
-curl -fsSL https://raw.githubusercontent.com/wowu/docker-rollout/main/docker-rollout \
+curl -fsSL https://raw.githubusercontent.com/wowu/docker-rollout/v0.13/docker-rollout \
   -o ~/.docker/cli-plugins/docker-rollout
 chmod +x ~/.docker/cli-plugins/docker-rollout
-docker rollout --help   # verify
+docker rollout --help   # verify it loaded
 ```
+
+When bumping the pin, update the version in both this doc and the `ROLLOUT_PROD`
+comment in the `Makefile`.
 
 ## Deploying app changes
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,7 +8,7 @@ CLI plugin.
 ## How zero-downtime works here
 
 nginx proxies `/api/` to `api:8000` and `/` to `frontend:3000` using the
-*variable* form of `proxy_pass` plus `resolver 127.0.0.1:11 valid=10s`
+*variable* form of `proxy_pass` plus `resolver 127.0.0.11 valid=10s`
 (`docker/nginx/nginx.conf`). That means nginx re-resolves those service names
 against Docker's embedded DNS every ≤10s, at request time, instead of pinning
 an IP at config load.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,88 @@
+# Production deployment
+
+Production runs `shuushuu-api` and `shuushuu-frontend` (sibling repos) as a
+single Docker Compose stack fronted by an nginx TLS edge. App code is deployed
+with **zero downtime** via the [`docker-rollout`](https://github.com/wowu/docker-rollout)
+CLI plugin.
+
+## How zero-downtime works here
+
+nginx proxies `/api/` to `api:8000` and `/` to `frontend:3000` using the
+*variable* form of `proxy_pass` plus `resolver 127.0.0.1:11 valid=10s`
+(`docker/nginx/nginx.conf`). That means nginx re-resolves those service names
+against Docker's embedded DNS every ≤10s, at request time, instead of pinning
+an IP at config load.
+
+`docker rollout api` exploits this:
+
+1. Scales `api` to two replicas — a new container (new image) starts alongside
+   the running one. Neither publishes a host port, so they coexist.
+2. Waits for the new replica's healthcheck (`GET /health`) to pass.
+3. Removes the old replica. nginx's next DNS refresh drops it from rotation.
+
+No requests are dropped, and nginx is never restarted. The same applies to
+`frontend` (it already has a healthcheck).
+
+This required (see `docker-compose.prod.yml`):
+
+- `api` / `frontend` have **no `container_name`** (can't fix a name across two
+  replicas) and **no host port publish** (two replicas can't bind one port).
+  Reach them on the host via `docker compose exec`, or through nginx.
+- `api` has a compose `healthcheck` against `/health`.
+- Alloy derives its `service` log label from the compose service label rather
+  than the container name (`docker/alloy/config.alloy`), so logs survive the
+  rename and the transient second replica.
+
+## One-time host setup
+
+Install the plugin on the production host:
+
+```bash
+mkdir -p ~/.docker/cli-plugins
+curl -fsSL https://raw.githubusercontent.com/wowu/docker-rollout/main/docker-rollout \
+  -o ~/.docker/cli-plugins/docker-rollout
+chmod +x ~/.docker/cli-plugins/docker-rollout
+docker rollout --help   # verify
+```
+
+## Deploying app changes
+
+```bash
+# 1. Pull latest on the changed repo(s)
+git -C ~/shuushuu-api pull        # and/or ~/shuushuu-frontend
+
+# 2. If the release includes a DB migration, apply it FIRST (see below)
+make prod-migrate
+
+# 3. Zero-downtime rollout (default rolls api + frontend)
+make prod-deploy                  # or: make prod-deploy api  /  make prod-deploy frontend
+```
+
+## Migrations are a gated step
+
+`prod-deploy` does **not** run migrations. Run `make prod-migrate` explicitly
+when a release contains one, *before* `prod-deploy`.
+
+Because a rollout briefly runs the old and new app versions against the **same
+database at once**, migrations must be **backward-compatible** for the duration
+of the overlap (expand/contract):
+
+- **Safe to ship with a rollout:** additive changes — new nullable columns, new
+  tables, new indexes. The still-running old container ignores them.
+- **NOT safe in the same release:** dropping or renaming a column/table the old
+  code still reads, or tightening a constraint the old code can still violate.
+  Split these: deploy code that no longer uses the column first, then drop it in
+  a *later* release once no old container remains.
+
+## nginx / infra changes (cause brief downtime)
+
+`docker-rollout` is only for stateless app services behind nginx. For nginx
+config, TLS, mediawiki, or other infra services, use:
+
+```bash
+make prod-restart nginx           # force-recreate a specific service
+```
+
+`make prod-restart` with **no arguments** force-recreates *everything*,
+including nginx — that drops the TLS edge for its boot and is the source of the
+old 30–60s outage. Scope it to the service you changed.


### PR DESCRIPTION
## Problem

`make prod-restart` / `prod-deploy` force-recreate containers (stop-then-start with no overlap), making the site unavailable for ~30–60s. The no-arg `prod-restart` also recreated nginx itself, dropping the TLS edge.

## Approach

nginx already proxies to `api:8000` / `frontend:3000` using the variable form of `proxy_pass` plus `resolver 127.0.0.1:11 valid=10s`, so it re-resolves upstreams via Docker DNS at request time. That's the prerequisite for swapping containers underneath nginx. This PR adopts the [`docker-rollout`](https://github.com/wowu/docker-rollout) CLI plugin to start a new replica, wait for its healthcheck, then drain the old one — no dropped requests, no nginx restart.

## Changes

- **`docker-compose.prod.yml`** — `api`/`frontend` drop their fixed `container_name` (`api` uses `!reset null`) and host port publishes so they can transiently run two replicas; add an `api` healthcheck on `/health` for the rollout to wait on.
- **`docker/alloy/config.alloy`** — derive the `service` log label from the compose service label instead of the container name, so api/frontend logs keep flowing to Loki after the rename/scaling (otherwise they'd silently stop).
- **`Makefile`** — `prod-deploy` now rolls out app services with zero downtime (default `api frontend`); new gated `prod-migrate`; `prod-restart` relabeled as the downtime infra/nginx path.
- **`docs/deployment.md`** — workflow, one-time plugin install, and the expand/contract migration ordering rule.

## Behavior changes / notes

- `api`/`frontend` no longer publish host ports (`127.0.0.1:8000`/`:3000`). Reach them via `docker compose exec` or through nginx.
- **Migrations are gated:** `prod-deploy` does not migrate. Run `make prod-migrate` first when a release has one. During a rollout old+new code share the DB, so migrations must be backward-compatible (expand/contract).
- Requires installing the `docker-rollout` plugin once on the prod host (see `docs/deployment.md`).

## Validation

- `docker compose -f docker-compose.yml -f docker-compose.prod.yml config` exits 0; confirmed both container_names removed, no host ports published, api healthcheck present.
- `make -n prod-deploy` / `prod-migrate` expand correctly.
- Not yet exercised against the live prod host — first real rollout should be done during low traffic with `make prod-logs nginx api` open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)