### PR TITLE
feat(images): filter by missing tag type(s) via denormalized presence flags

### DIFF
--- a/alembic/versions/301d283488cc_add_tag_type_flags_to_images.py
+++ b/alembic/versions/301d283488cc_add_tag_type_flags_to_images.py
@@ -1,0 +1,47 @@
+"""add tag-type flags to images
+
+Revision ID: 301d283488cc
+Revises: 2e5fae0fd9a5
+Create Date: 2026-05-31 07:19:15.237178
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '301d283488cc'
+down_revision: str | Sequence[str] | None = '2e5fae0fd9a5'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Metadata-only column add (INSTANT) on the 1.1M-row table.
+    op.execute(
+        "ALTER TABLE images "
+        "ADD COLUMN has_theme BOOLEAN NOT NULL DEFAULT 0, "
+        "ADD COLUMN has_source BOOLEAN NOT NULL DEFAULT 0, "
+        "ADD COLUMN has_artist BOOLEAN NOT NULL DEFAULT 0, "
+        "ADD COLUMN has_character BOOLEAN NOT NULL DEFAULT 0, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )
+    # Online index builds (INPLACE, non-blocking).
+    for col in ("has_theme", "has_source", "has_artist", "has_character"):
+        op.execute(
+            f"CREATE INDEX idx_images_{col} ON images ({col}, image_id) "
+            "ALGORITHM INPLACE LOCK NONE"
+        )
+
+
+def downgrade() -> None:
+    for col in ("has_theme", "has_source", "has_artist", "has_character"):
+        op.execute(f"DROP INDEX idx_images_{col} ON images")
+    op.execute(
+        "ALTER TABLE images "
+        "DROP COLUMN has_theme, DROP COLUMN has_source, "
+        "DROP COLUMN has_artist, DROP COLUMN has_character, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -107,6 +107,7 @@ from app.services.image_status import enqueue_r2_sync_on_status_change
 from app.services.rating import schedule_rating_recalculation
 from app.services.repost import migrate_repost_data
 from app.services.review_jobs import check_early_close
+from app.services.tag_type_flags import refresh_image_tag_type_flags
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -1619,6 +1620,8 @@ async def apply_tag_suggestions(
         },
     )
     db.add(action)
+
+    await refresh_image_tag_type_flags(db, report.image_id)
 
     await db.commit()
 

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -463,7 +463,9 @@ async def list_images(
         # Reject any token that is not a valid type ID (non-digit or out of range), rather
         # than silently dropping it. Empty tokens are ignored (empty param = no filter).
         raw_tokens = [t.strip() for t in missing_tag_types.split(",") if t.strip()]
-        invalid = [t for t in raw_tokens if not (t.isdigit() and int(t) in {1, 2, 3, 4})]
+        # isdecimal() (not isdigit()): int() only parses decimal digits, while isdigit()
+        # also matches chars like '²' that int() rejects (would otherwise 500 on int()).
+        invalid = [t for t in raw_tokens if not (t.isdecimal() and int(t) in {1, 2, 3, 4})]
         if invalid:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -464,15 +464,25 @@ async def list_images(
             {int(t.strip()) for t in missing_tag_types.split(",") if t.strip().isdigit()}
         )
         if missing_type_ids:
-            # Missing ANY listed type
-            def lacks_type(type_id: int) -> Any:
-                return Images.image_id.notin_(  # type: ignore[union-attr]
-                    select(TagLinks.image_id)  # type: ignore[call-overload]
-                    .join(Tags, TagLinks.tag_id == Tags.tag_id)
-                    .where(Tags.type == type_id)
+            if missing_tag_types_mode == "all":
+                # Missing ALL listed types: no tag of any listed type
+                query = query.where(
+                    Images.image_id.notin_(  # type: ignore[union-attr]
+                        select(TagLinks.image_id)  # type: ignore[call-overload]
+                        .join(Tags, TagLinks.tag_id == Tags.tag_id)
+                        .where(Tags.type.in_(missing_type_ids))  # type: ignore[attr-defined]
+                    )
                 )
+            else:
+                # Missing ANY listed type
+                def lacks_type(type_id: int) -> Any:
+                    return Images.image_id.notin_(  # type: ignore[union-attr]
+                        select(TagLinks.image_id)  # type: ignore[call-overload]
+                        .join(Tags, TagLinks.tag_id == Tags.tag_id)
+                        .where(Tags.type == type_id)
+                    )
 
-            query = query.where(or_(*(lacks_type(t) for t in missing_type_ids)))
+                query = query.where(or_(*(lacks_type(t) for t in missing_type_ids)))
 
     # Date filtering
     if date_from:

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -464,6 +464,15 @@ async def list_images(
             {int(t.strip()) for t in missing_tag_types.split(",") if t.strip().isdigit()}
         )
         if missing_type_ids:
+            invalid = [t for t in missing_type_ids if t not in {1, 2, 3, 4}]
+            if invalid:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"Invalid tag type(s): {', '.join(map(str, invalid))}. "
+                        "Valid types are 1=Theme, 2=Source, 3=Artist, 4=Character."
+                    ),
+                )
             if missing_tag_types_mode == "all":
                 # Missing ALL listed types: no tag of any listed type
                 query = query.where(

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -274,6 +274,16 @@ async def list_images(
     exclude_tags: Annotated[
         str | None, Query(description="Comma-separated tag IDs to exclude (e.g., '4,5,6')")
     ] = None,
+    missing_tag_types: Annotated[
+        str | None,
+        Query(
+            description="Comma-separated tag type IDs the image must be MISSING "
+            "(1=Theme, 2=Source, 3=Artist, 4=Character)."
+        ),
+    ] = None,
+    missing_tag_types_mode: Annotated[
+        str, Query(pattern="^(any|all)$", description="Match ANY or ALL missing types")
+    ] = "any",
     # Date filtering
     date_from: Annotated[str | None, Query(description="Start date (YYYY-MM-DD)")] = None,
     date_to: Annotated[str | None, Query(description="End date (YYYY-MM-DD)")] = None,
@@ -446,6 +456,23 @@ async def list_images(
                     select(TagLinks.image_id).where(TagLinks.tag_id.in_(resolved_exclude_ids))  # type: ignore[call-overload,attr-defined]
                 )
             )
+
+    # Missing tag-type filtering (images lacking a tag of the given type[s]).
+    # Aliases are intentionally NOT resolved here: the applied tag's own `type` is authoritative.
+    if missing_tag_types:
+        missing_type_ids = sorted(
+            {int(t.strip()) for t in missing_tag_types.split(",") if t.strip().isdigit()}
+        )
+        if missing_type_ids:
+            # Missing ANY listed type
+            def lacks_type(type_id: int) -> Any:
+                return Images.image_id.notin_(  # type: ignore[union-attr]
+                    select(TagLinks.image_id)  # type: ignore[call-overload]
+                    .join(Tags, TagLinks.tag_id == Tags.tag_id)
+                    .where(Tags.type == type_id)
+                )
+
+            query = query.where(or_(*(lacks_type(t) for t in missing_type_ids)))
 
     # Date filtering
     if date_from:

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -460,19 +460,20 @@ async def list_images(
     # Missing tag-type filtering (images lacking a tag of the given type[s]).
     # Aliases are intentionally NOT resolved here: the applied tag's own `type` is authoritative.
     if missing_tag_types:
-        missing_type_ids = sorted(
-            {int(t.strip()) for t in missing_tag_types.split(",") if t.strip().isdigit()}
-        )
+        # Reject any token that is not a valid type ID (non-digit or out of range), rather
+        # than silently dropping it. Empty tokens are ignored (empty param = no filter).
+        raw_tokens = [t.strip() for t in missing_tag_types.split(",") if t.strip()]
+        invalid = [t for t in raw_tokens if not (t.isdigit() and int(t) in {1, 2, 3, 4})]
+        if invalid:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Invalid tag type(s): {', '.join(invalid)}. "
+                    "Valid types are 1=Theme, 2=Source, 3=Artist, 4=Character."
+                ),
+            )
+        missing_type_ids = sorted({int(t) for t in raw_tokens})
         if missing_type_ids:
-            invalid = [t for t in missing_type_ids if t not in {1, 2, 3, 4}]
-            if invalid:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=(
-                        f"Invalid tag type(s): {', '.join(map(str, invalid))}. "
-                        "Valid types are 1=Theme, 2=Source, 3=Artist, 4=Character."
-                    ),
-                )
             if missing_tag_types_mode == "all":
                 # Missing ALL listed types: no tag of any listed type
                 query = query.where(

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -115,6 +115,7 @@ from app.services.iqdb import check_iqdb_similarity, check_iqdb_similarity_by_ha
 from app.services.rate_limit import check_similarity_rate_limit
 from app.services.rating import recalculate_image_ratings
 from app.services.search import sync_tag_to_search
+from app.services.tag_type_flags import refresh_image_tag_type_flags
 from app.services.upload import check_upload_rate_limit, link_tags_to_image, save_uploaded_image
 from app.tasks.queue import enqueue_job
 
@@ -1820,6 +1821,7 @@ async def add_tag_to_image(
     )
     db.add(history_entry)
 
+    await refresh_image_tag_type_flags(db, image_id)
     await db.commit()
 
     # Re-fetch tag to get updated usage_count (maintained by DB trigger)
@@ -1892,6 +1894,7 @@ async def remove_tag_from_image(
             TagLinks.tag_id == tag_id,  # type: ignore[arg-type]
         )
     )
+    await refresh_image_tag_type_flags(db, image_id)
     await db.commit()
 
     # Re-fetch tag to get updated usage_count (maintained by DB trigger)

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -389,7 +389,8 @@ async def list_images(
     # Tag filtering
     tag_ids: list[int] = []
     if tags:
-        tag_ids = [int(tid.strip()) for tid in tags.split(",") if tid.strip().isdigit()]
+        # isdecimal() (not isdigit()): int() rejects chars like '²' that isdigit() matches.
+        tag_ids = [int(tid.strip()) for tid in tags.split(",") if tid.strip().isdecimal()]
         if len(tag_ids) > settings.MAX_SEARCH_TAGS:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -432,8 +433,9 @@ async def list_images(
 
     # Exclude tag filtering (always exact match, no hierarchy expansion)
     if exclude_tags:
+        # isdecimal() (not isdigit()): int() rejects chars like '²' that isdigit() matches.
         exclude_tag_ids = [
-            int(tid.strip()) for tid in exclude_tags.split(",") if tid.strip().isdigit()
+            int(tid.strip()) for tid in exclude_tags.split(",") if tid.strip().isdecimal()
         ]
         if exclude_tag_ids:
             # Enforce shared MAX_SEARCH_TAGS limit across include + exclude

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -478,25 +478,21 @@ async def list_images(
             )
         missing_type_ids = sorted({int(t) for t in raw_tokens})
         if missing_type_ids:
+            type_column = {
+                1: Images.has_theme,
+                2: Images.has_source,
+                3: Images.has_artist,
+                4: Images.has_character,
+            }
+            # "missing type T" == that image's has_<type> flag is False.
+            clauses = [
+                type_column[t] == False  # noqa: E712
+                for t in missing_type_ids
+            ]
             if missing_tag_types_mode == "all":
-                # Missing ALL listed types: no tag of any listed type
-                query = query.where(
-                    Images.image_id.notin_(  # type: ignore[union-attr]
-                        select(TagLinks.image_id)  # type: ignore[call-overload]
-                        .join(Tags, TagLinks.tag_id == Tags.tag_id)
-                        .where(Tags.type.in_(missing_type_ids))  # type: ignore[attr-defined]
-                    )
-                )
+                query = query.where(and_(*clauses))  # type: ignore[arg-type]  # missing every listed type
             else:
-                # Missing ANY listed type
-                def lacks_type(type_id: int) -> Any:
-                    return Images.image_id.notin_(  # type: ignore[union-attr]
-                        select(TagLinks.image_id)  # type: ignore[call-overload]
-                        .join(Tags, TagLinks.tag_id == Tags.tag_id)
-                        .where(Tags.type == type_id)
-                    )
-
-                query = query.where(or_(*(lacks_type(t) for t in missing_type_ids)))
+                query = query.where(or_(*clauses))  # type: ignore[arg-type]  # missing at least one listed type
 
     # Date filtering
     if date_from:

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1463,6 +1463,12 @@ async def update_tag(
     if tag.alias_of is not None and tag.alias_of != original_alias_of:
         canonical_id = tag.alias_of
 
+        # Capture affected image_ids before any deletes/moves for flag recompute
+        flag_affected = await db.execute(
+            select(TagLinks.image_id).where(TagLinks.tag_id == tag_id)  # type: ignore[call-overload]
+        )
+        flag_affected_ids = [row[0] for row in flag_affected]
+
         # Find images already linked to canonical tag (to avoid PK conflicts)
         existing_result = await db.execute(
             select(TagLinks.image_id).where(TagLinks.tag_id == canonical_id)  # type: ignore[call-overload]
@@ -1494,6 +1500,9 @@ async def update_tag(
             await db.execute(
                 update(Tags).where(Tags.tag_id == tid).values(usage_count=count_result.scalar())  # type: ignore[arg-type]
             )
+
+        # Idempotent drift-guard: links moved alias->canonical (same type), recompute flags.
+        await refresh_images_tag_type_flags(db, flag_affected_ids)
 
         # Migrate external links from alias to canonical tag
         existing_urls_result = await db.execute(

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1368,6 +1368,13 @@ async def update_tag(
         )
         db.add(audit_entry)
 
+        # A type change shifts every linked image between has_<old> and has_<new>;
+        # recompute all images linked to this tag (set-based, bounded by usage).
+        affected = await db.execute(
+            select(TagLinks.image_id).where(TagLinks.tag_id == tag_id)  # type: ignore[call-overload]
+        )
+        await refresh_images_tag_type_flags(db, [row[0] for row in affected])
+
     # Check for alias change
     if tag.alias_of != original_alias_of:
         if original_alias_of is None and tag.alias_of is not None:

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -53,6 +53,7 @@ from app.schemas.tag import (
 from app.schemas.tag_suggestion_stats import TagSuggestionStatsResponse, TagSuggestionUserStats
 from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 from app.services.search import sync_tag_delete_to_search, sync_tag_to_search
+from app.services.tag_type_flags import refresh_images_tag_type_flags
 
 SUGGESTION_STATS_MIN_THRESHOLD = 5
 
@@ -1589,7 +1590,15 @@ async def delete_tag(
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")
 
+    # Capture images linked to this tag BEFORE the FK CASCADE removes the links.
+    affected = await db.execute(
+        select(TagLinks.image_id).where(TagLinks.tag_id == tag_id)  # type: ignore[call-overload]
+    )
+    affected_image_ids = [row[0] for row in affected]
+
     await db.delete(tag)
+    await db.flush()  # apply the FK CASCADE within this transaction before recompute
+    await refresh_images_tag_type_flags(db, affected_image_ids)
     await db.commit()
 
     await sync_tag_delete_to_search(tag_id)

--- a/app/models/image.py
+++ b/app/models/image.py
@@ -209,6 +209,10 @@ class Images(ImageBase, table=True):
         Index("idx_status", "status"),
         Index("idx_top_images", "num_ratings"),
         Index("idx_total_pixels", "total_pixels"),
+        Index("idx_images_has_theme", "has_theme", "image_id"),
+        Index("idx_images_has_source", "has_source", "image_id"),
+        Index("idx_images_has_artist", "has_artist", "image_id"),
+        Index("idx_images_has_character", "has_character", "image_id"),
     )
 
     # Primary key
@@ -253,6 +257,13 @@ class Images(ImageBase, table=True):
     # Internal metadata
     total_pixels: Decimal | None = Field(default=None)
     replacement_id: int | None = Field(default=None, foreign_key="images.image_id")
+
+    # Denormalized tag-type presence (maintained by app.services.tag_type_flags).
+    # Internal cache of "image has >=1 tag of this type"; source of truth is tag_links + tags.type.
+    has_theme: bool = Field(default=False)
+    has_source: bool = Field(default=False)
+    has_artist: bool = Field(default=False)
+    has_character: bool = Field(default=False)
 
     # R2 sync state. NONE=0 means object is not yet in R2; the finalizer
     # or `r2_sync.py reconcile` will flip it to PUBLIC or PRIVATE.

--- a/app/services/batch_tag.py
+++ b/app/services/batch_tag.py
@@ -15,6 +15,7 @@ from app.schemas.tag import (
     BatchTagSkippedItem,
 )
 from app.services.search import sync_tags_to_search
+from app.services.tag_type_flags import refresh_images_tag_type_flags
 
 logger = get_logger(__name__)
 
@@ -131,6 +132,8 @@ async def batch_add_tags(
 
             # Track as existing to prevent duplicates within same batch
             existing_links.add((image_id, resolved_tag_id))
+
+    await refresh_images_tag_type_flags(db, {item.image_id for item in added})
 
     try:
         await db.commit()
@@ -271,6 +274,8 @@ async def batch_remove_tags(
                     user_id=user_id,
                 )
             )
+
+    await refresh_images_tag_type_flags(db, {item.image_id for item in removed})
 
     try:
         await db.commit()

--- a/app/services/repost.py
+++ b/app/services/repost.py
@@ -12,6 +12,7 @@ from app.models.favorite import Favorites
 from app.models.image import Images
 from app.models.image_rating import ImageRatings
 from app.models.tag_link import TagLinks
+from app.services.tag_type_flags import refresh_images_tag_type_flags
 
 
 async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession) -> dict[str, int]:
@@ -150,6 +151,8 @@ async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession
             TagLinks.image_id == repost_id  # type: ignore[arg-type]
         )
     )
+
+    await refresh_images_tag_type_flags(db, [original_id, repost_id])
 
     return {
         "favorites_moved": favorites_moved,

--- a/app/services/tag_type_flags.py
+++ b/app/services/tag_type_flags.py
@@ -1,0 +1,57 @@
+"""Maintain denormalized per-image tag-type presence flags on the images table.
+
+Source of truth is tag_links + tags.type; these helpers recompute the cached
+has_theme/has_source/has_artist/has_character columns from it (idempotent).
+"""
+
+from collections.abc import Collection
+
+from sqlalchemy import bindparam, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Single set-based recompute over a set of image_ids. MariaDB multi-table UPDATE;
+# MAX(t.type = N) is a boolean aggregate (1 if any tag of that type, else 0).
+_RECOMPUTE_SQL = text(
+    """
+    UPDATE images i
+    LEFT JOIN (
+        SELECT tl.image_id,
+               MAX(t.type = 1) AS ht,
+               MAX(t.type = 2) AS hs,
+               MAX(t.type = 3) AS ha,
+               MAX(t.type = 4) AS hc
+        FROM tag_links tl
+        JOIN tags t ON tl.tag_id = t.tag_id
+        WHERE tl.image_id IN :ids
+        GROUP BY tl.image_id
+    ) agg ON agg.image_id = i.image_id
+    SET i.has_theme = COALESCE(agg.ht, 0),
+        i.has_source = COALESCE(agg.hs, 0),
+        i.has_artist = COALESCE(agg.ha, 0),
+        i.has_character = COALESCE(agg.hc, 0)
+    WHERE i.image_id IN :ids
+    """
+).bindparams(bindparam("ids", expanding=True))
+
+
+async def refresh_images_tag_type_flags(db: AsyncSession, image_ids: Collection[int]) -> None:
+    """Recompute the 4 tag-type presence flags for the given images from tag_links.
+
+    Idempotent. Does NOT commit — joins the caller's transaction. Flushes first
+    because the session is autoflush=False and add-tag paths leave pending,
+    unflushed TagLinks the recompute SELECT must see.
+
+    Bypasses the ORM identity map — any Images instance already loaded in the
+    session keeps stale has_* attributes until refresh/expire. Assert by
+    re-querying, not on a pre-fetched object.
+    """
+    ids = list({int(i) for i in image_ids})
+    if not ids:
+        return
+    await db.flush()
+    await db.execute(_RECOMPUTE_SQL, {"ids": ids})
+
+
+async def refresh_image_tag_type_flags(db: AsyncSession, image_id: int) -> None:
+    """Convenience wrapper for a single image."""
+    await refresh_images_tag_type_flags(db, [image_id])

--- a/app/services/upload.py
+++ b/app/services/upload.py
@@ -13,6 +13,7 @@ from app.config import settings
 from app.core.logging import get_logger
 from app.models import Images, TagLinks, Tags
 from app.services.image_processing import calculate_md5, validate_image_file
+from app.services.tag_type_flags import refresh_image_tag_type_flags
 
 logger = get_logger(__name__)
 
@@ -155,3 +156,5 @@ async def link_tags_to_image(
             user_id=user_id,
         )
         db.add(tag_link)
+
+    await refresh_image_tag_type_flags(db, image_id)

--- a/docs/plans/2026-05-29-missing-tag-type-filter-design.md
+++ b/docs/plans/2026-05-29-missing-tag-type-filter-design.md
@@ -1,0 +1,129 @@
+# Filter Images by Missing Tag Type(s)
+
+**Date:** 2026-05-29
+
+## Problem
+
+The image search endpoint (`GET /api/v1/images`) can filter by tags present on an image (`tags`, `exclude_tags`), but it cannot filter by the *absence* of a tag type. There is no way to ask "which images have no artist tag yet?" or "which images lack a source?"
+
+This is useful both as a general search filter and as the basis for a moderation/cleanup queue surfacing under-tagged images.
+
+Tag types are defined in `app/config.py`:
+
+```python
+class TagType:
+    ALL = 0
+    THEME = 1
+    SOURCE = 2
+    ARTIST = 3
+    CHARACTER = 4
+```
+
+Each tag carries a `type` column; `tag_links` joins images to tags. There is a `type_alias` index on `tags(type, alias_of)`, so filtering tags by `type` is indexed.
+
+## API surface
+
+Two new optional query params on `list_images` (`app/api/v1/images.py`):
+
+| Param | Type | Description |
+|---|---|---|
+| `missing_tag_types` | `str \| None` | Comma-separated tag type IDs the image must be *missing*. Valid: `1`=Theme, `2`=Source, `3`=Artist, `4`=Character. |
+| `missing_tag_types_mode` | `str` | `"any"` (default) or `"all"`. Mirrors the existing `tags_mode` param. |
+
+Type IDs (not names) are used, consistent with the existing `tags`/`exclude_tags` params. The frontend constructs the API call.
+
+## Semantics
+
+"Image lacks a tag of type X" is expressed as:
+
+```sql
+Images.image_id NOT IN (
+    SELECT tl.image_id
+    FROM tag_links tl
+    JOIN tags t ON tl.tag_id = t.tag_id
+    WHERE t.type = X
+)
+```
+
+- **`any` (default):** image is missing *at least one* of the specified types → OR of the per-type `NOT IN` clauses. Example: `missing_tag_types=2,3` returns images lacking a source **or** an artist. This is the "needs work" queue behavior.
+
+- **`all`:** image is missing *all* the specified types → a single `NOT IN` against `t.type IN (...)`. If an image has zero tags whose type is in the set, it is missing all of them. This is simpler and cheaper than AND-ing separate per-type clauses.
+
+These clauses compose with `AND` against all existing filters (`tags`, `exclude_tags`, date filters, etc.), the same as every other where-clause in the handler.
+
+## Validation & errors
+
+- Parse `missing_tag_types` like `exclude_tags`: split on comma, keep digit tokens, dedupe.
+- Reject any value outside `{1, 2, 3, 4}` (type `0`/"All" is not a real per-image tag type) → `400 Bad Request` with a message listing the valid IDs.
+- Invalid `missing_tag_types_mode` (not `any`/`all`) → `400`. Match however `tags_mode` is validated (`Query(pattern=...)` vs. manual check) — confirm during implementation.
+- Empty/whitespace `missing_tag_types` → treated as absent (no filter applied), matching how `tags`/`exclude_tags` behave.
+
+## Implementation
+
+Approach: inline block in `list_images`, immediately after the existing `exclude_tags` block (~line 448), matching that block's style and `# type: ignore` annotations.
+
+```python
+# Missing tag-type filtering (images lacking a tag of the given type[s])
+if missing_tag_types:
+    missing_type_ids = sorted({
+        int(t.strip())
+        for t in missing_tag_types.split(",")
+        if t.strip().isdigit()
+    })
+    if missing_type_ids:
+        invalid = [t for t in missing_type_ids if t not in {1, 2, 3, 4}]
+        if invalid:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Invalid tag type(s): {invalid}. "
+                    "Valid types are 1=Theme, 2=Source, 3=Artist, 4=Character."
+                ),
+            )
+
+        def lacks_type(type_id: int):
+            return Images.image_id.notin_(
+                select(TagLinks.image_id)
+                .join(Tags, TagLinks.tag_id == Tags.tag_id)
+                .where(Tags.type == type_id)
+            )
+
+        if missing_tag_types_mode == "all":
+            # Missing ALL listed types: no tag of any listed type
+            query = query.where(
+                Images.image_id.notin_(
+                    select(TagLinks.image_id)
+                    .join(Tags, TagLinks.tag_id == Tags.tag_id)
+                    .where(Tags.type.in_(missing_type_ids))
+                )
+            )
+        else:
+            # Missing ANY listed type
+            query = query.where(or_(*(lacks_type(t) for t in missing_type_ids)))
+```
+
+(Final form will match exact imports and `# type: ignore` comments already used in the file.)
+
+Requires `Tags` and `or_` to be imported in `app/api/v1/images.py` — confirm and add if missing.
+
+### Note on handler size
+
+`list_images` is already ~360 lines, well over the 50-line guideline, with all tag filtering inline. Extracting the tag-filter building into a helper is worthwhile but is a pre-existing concern best handled in its own dedicated refactor, not bundled into this feature. This change follows the file's established inline pattern.
+
+## Tests
+
+API tests (TDD) in the images search test module. Seed a small fixture set:
+
+- An image tagged with all four types.
+- An image missing only an artist tag.
+- An image missing only a source tag.
+- An image with no tags at all.
+
+Cases:
+
+1. `missing_tag_types=3` → returns images lacking an artist tag; excludes the fully-tagged image.
+2. `missing_tag_types=2,3&missing_tag_types_mode=any` → images lacking a source OR an artist.
+3. `missing_tag_types=2,3&missing_tag_types_mode=all` → only images lacking both.
+4. Combined with a `tags=` include filter → both filters apply (AND).
+5. Validation: `missing_tag_types=0` → 400; `missing_tag_types=99` → 400; invalid mode → 400.
+6. Omitted param → unchanged behavior (no filtering).

--- a/docs/plans/2026-05-29-missing-tag-type-filter-design.md
+++ b/docs/plans/2026-05-29-missing-tag-type-filter-design.md
@@ -32,6 +32,18 @@ Two new optional query params on `list_images` (`app/api/v1/images.py`):
 
 Type IDs (not names) are used, consistent with the existing `tags`/`exclude_tags` params. The frontend constructs the API call.
 
+Added to the `list_images` signature mirroring the existing `tags_mode` style:
+
+```python
+missing_tag_types: Annotated[
+    str | None,
+    Query(description="Comma-separated tag type IDs the image must be missing (1=Theme,2=Source,3=Artist,4=Character)"),
+] = None,
+missing_tag_types_mode: Annotated[
+    str, Query(pattern="^(any|all)$", description="Match ANY or ALL missing types")
+] = "any",
+```
+
 ## Semantics
 
 "Image lacks a tag of type X" is expressed as:
@@ -51,11 +63,15 @@ Images.image_id NOT IN (
 
 These clauses compose with `AND` against all existing filters (`tags`, `exclude_tags`, date filters, etc.), the same as every other where-clause in the handler.
 
+### Aliases are intentionally not resolved
+
+Unlike `tags`/`exclude_tags`, this filter does **not** resolve tag aliases. The presence of a tag type on an image is determined by the `type` of the tag actually applied (`tag_links.tag_id → tags.type`). An alias tag carries its own `type` column, and the API enforces that an alias and its canonical share a type. So an image whose only artist tag is itself an *alias* tag correctly counts as "has an artist tag" and is excluded by `missing_tag_types=3`. Resolving aliases here would be wrong: the applied tag's own type is authoritative.
+
 ## Validation & errors
 
 - Parse `missing_tag_types` like `exclude_tags`: split on comma, keep digit tokens, dedupe.
 - Reject any value outside `{1, 2, 3, 4}` (type `0`/"All" is not a real per-image tag type) → `400 Bad Request` with a message listing the valid IDs.
-- Invalid `missing_tag_types_mode` (not `any`/`all`) → `400`. Match however `tags_mode` is validated (`Query(pattern=...)` vs. manual check) — confirm during implementation.
+- Invalid `missing_tag_types_mode` (not `any`/`all`) → handled by `Query(pattern="^(any|all)$")`, which mirrors the existing `tags_mode` param and yields a **`422 Unprocessable Entity`** automatically — no manual check or `400` branch.
 - Empty/whitespace `missing_tag_types` → treated as absent (no filter applied), matching how `tags`/`exclude_tags` behave.
 
 ## Implementation
@@ -76,25 +92,25 @@ if missing_tag_types:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
-                    f"Invalid tag type(s): {invalid}. "
+                    f"Invalid tag type(s): {', '.join(map(str, invalid))}. "
                     "Valid types are 1=Theme, 2=Source, 3=Artist, 4=Character."
                 ),
             )
 
         def lacks_type(type_id: int):
-            return Images.image_id.notin_(
+            return Images.image_id.notin_(  # type: ignore[union-attr]
                 select(TagLinks.image_id)
-                .join(Tags, TagLinks.tag_id == Tags.tag_id)
-                .where(Tags.type == type_id)
+                .join(Tags, TagLinks.tag_id == Tags.tag_id)  # type: ignore[arg-type]
+                .where(Tags.type == type_id)  # type: ignore[arg-type]
             )
 
         if missing_tag_types_mode == "all":
             # Missing ALL listed types: no tag of any listed type
             query = query.where(
-                Images.image_id.notin_(
+                Images.image_id.notin_(  # type: ignore[union-attr]
                     select(TagLinks.image_id)
-                    .join(Tags, TagLinks.tag_id == Tags.tag_id)
-                    .where(Tags.type.in_(missing_type_ids))
+                    .join(Tags, TagLinks.tag_id == Tags.tag_id)  # type: ignore[arg-type]
+                    .where(Tags.type.in_(missing_type_ids))  # type: ignore[attr-defined]
                 )
             )
         else:
@@ -102,22 +118,31 @@ if missing_tag_types:
             query = query.where(or_(*(lacks_type(t) for t in missing_type_ids)))
 ```
 
-(Final form will match exact imports and `# type: ignore` comments already used in the file.)
+`# type: ignore` annotations follow the existing tag-subquery blocks in this file (the `exclude_tags` block uses `[union-attr]` on `Images.image_id.notin_` and `[call-overload,attr-defined]` on the inner select); the exact codes will be reconciled against `mypy` during implementation.
 
-Requires `Tags` and `or_` to be imported in `app/api/v1/images.py` — confirm and add if missing.
+Both `Tags` (`images.py:67`) and `or_` (`images.py:28`) are already imported — no new imports needed.
+
+### Count and pagination
+
+The filter is added to the shared `query` object before the count query (`select(func.count()).select_from(query.subquery())`) and the pagination subquery are derived from it, so the `total` and the returned page both reflect the filter. This matches placement of the existing `exclude_tags` clause.
 
 ### Note on handler size
 
 `list_images` is already ~360 lines, well over the 50-line guideline, with all tag filtering inline. Extracting the tag-filter building into a helper is worthwhile but is a pre-existing concern best handled in its own dedicated refactor, not bundled into this feature. This change follows the file's established inline pattern.
 
+### Performance
+
+The `tags → tag_links` subquery is index-friendly: `WHERE tags.type = X` uses the `type_alias` index (leading column `type`), and the join is covered by the `tag_links` composite PK `(tag_id, image_id)`. The cost is the anti-join (`NOT IN`) against the images set — the same shape as the existing `exclude_tags` clause. In `all` mode this is a single anti-join; in `any` mode it is up to four OR'd anti-joins. This is within established patterns, but during implementation run `EXPLAIN` on one `any`-mode query to confirm the planner uses the indexes rather than a full anti-join scan.
+
 ## Tests
 
-API tests (TDD) in the images search test module. Seed a small fixture set:
+API tests (TDD) in the images search test module. Seed a small fixture set, all with a public `status` (the `sample_image_data` fixture uses `status=1`, so tests run unauthenticated — do not seed non-public statuses):
 
 - An image tagged with all four types.
 - An image missing only an artist tag.
 - An image missing only a source tag.
 - An image with no tags at all.
+- An image whose only artist tag is an **alias** tag (link points at the alias row, not the canonical).
 
 Cases:
 
@@ -125,5 +150,7 @@ Cases:
 2. `missing_tag_types=2,3&missing_tag_types_mode=any` → images lacking a source OR an artist.
 3. `missing_tag_types=2,3&missing_tag_types_mode=all` → only images lacking both.
 4. Combined with a `tags=` include filter → both filters apply (AND).
-5. Validation: `missing_tag_types=0` → 400; `missing_tag_types=99` → 400; invalid mode → 400.
-6. Omitted param → unchanged behavior (no filtering).
+5. Alias: the image whose only artist tag is an alias is **not** returned by `missing_tag_types=3` (alias resolution is intentionally skipped; the applied tag's `type` is authoritative).
+6. The no-tags image appears for every `missing_tag_types` value in both modes.
+7. Validation: `missing_tag_types=0` → 400; `missing_tag_types=99` → 400; invalid mode (e.g. `missing_tag_types_mode=foo`) → **422** (from the `Query` pattern).
+8. Omitted param → unchanged behavior (no filtering).

--- a/docs/plans/2026-05-29-missing-tag-type-filter-design.md
+++ b/docs/plans/2026-05-29-missing-tag-type-filter-design.md
@@ -97,13 +97,6 @@ if missing_tag_types:
                 ),
             )
 
-        def lacks_type(type_id: int):
-            return Images.image_id.notin_(  # type: ignore[union-attr]
-                select(TagLinks.image_id)
-                .join(Tags, TagLinks.tag_id == Tags.tag_id)  # type: ignore[arg-type]
-                .where(Tags.type == type_id)  # type: ignore[arg-type]
-            )
-
         if missing_tag_types_mode == "all":
             # Missing ALL listed types: no tag of any listed type
             query = query.where(
@@ -115,6 +108,13 @@ if missing_tag_types:
             )
         else:
             # Missing ANY listed type
+            def lacks_type(type_id: int):
+                return Images.image_id.notin_(  # type: ignore[union-attr]
+                    select(TagLinks.image_id)
+                    .join(Tags, TagLinks.tag_id == Tags.tag_id)  # type: ignore[arg-type]
+                    .where(Tags.type == type_id)  # type: ignore[arg-type]
+                )
+
             query = query.where(or_(*(lacks_type(t) for t in missing_type_ids)))
 ```
 

--- a/docs/plans/2026-05-29-missing-tag-type-filter-design.md
+++ b/docs/plans/2026-05-29-missing-tag-type-filter-design.md
@@ -69,10 +69,10 @@ Unlike `tags`/`exclude_tags`, this filter does **not** resolve tag aliases. The 
 
 ## Validation & errors
 
-- Parse `missing_tag_types` like `exclude_tags`: split on comma, keep digit tokens, dedupe.
-- Reject any value outside `{1, 2, 3, 4}` (type `0`/"All" is not a real per-image tag type) → `400 Bad Request` with a message listing the valid IDs.
+- Split `missing_tag_types` on comma and strip; ignore empty tokens.
+- Reject any non-empty token that is not a valid type ID — whether non-digit (`artist`) or numeric-but-out-of-range (`0`/"All", `99`) → `400 Bad Request` with the offending token(s) echoed. This is a single unified check: unlike `tags`/`exclude_tags` (which silently drop non-digit tokens), this param has a strict "invalid → 400" contract, so silently dropping garbage would be internally inconsistent and could mask a caller's typo (e.g. `3,artist` quietly filtering only on artist).
 - Invalid `missing_tag_types_mode` (not `any`/`all`) → handled by `Query(pattern="^(any|all)$")`, which mirrors the existing `tags_mode` param and yields a **`422 Unprocessable Entity`** automatically — no manual check or `400` branch.
-- Empty/whitespace `missing_tag_types` → treated as absent (no filter applied), matching how `tags`/`exclude_tags` behave.
+- Empty/whitespace `missing_tag_types` → treated as absent (no filter applied).
 
 ## Implementation
 

--- a/docs/plans/2026-05-29-missing-tag-type-filter-impl.md
+++ b/docs/plans/2026-05-29-missing-tag-type-filter-impl.md
@@ -1,0 +1,433 @@
+# Missing Tag Type Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `missing_tag_types` + `missing_tag_types_mode` query params to `GET /api/v1/images` so callers can find images that lack a tag of a given type (Theme/Source/Artist/Character).
+
+**Architecture:** Two new optional query params on the existing `list_images` handler. The filter adds anti-join (`NOT IN`) where-clauses against `tag_links → tags` filtered by `tags.type`, composed with `AND` into the shared `query` (so count + pagination both honor it). `any` mode = missing at least one listed type (OR of per-type `NOT IN`); `all` mode = missing every listed type (single `NOT IN` over `type IN (...)`). Aliases are intentionally NOT resolved — the applied tag's own `type` is authoritative. Inline block mirrors the existing `exclude_tags` block.
+
+**Tech Stack:** FastAPI, SQLModel/SQLAlchemy async, MariaDB, pytest (async), `uv` for all Python execution.
+
+**Spec:** `docs/plans/2026-05-29-missing-tag-type-filter-design.md`
+
+---
+
+## Reference: existing code to mirror
+
+- Signature params group `# Tag filtering` in `app/api/v1/images.py` — the `tags_mode` param shows the exact `Query(pattern="^(any|all)$")` style to copy (`images.py:261-263`).
+- The `exclude_tags` where-block (`app/api/v1/images.py:424-448`) — the `Images.image_id.notin_(select(...))` pattern and `# type: ignore` codes to mirror.
+- Imports already present: `or_` (`images.py:28`), `Tags` (`images.py:67`), `TagLinks` (`images.py:66`), `HTTPException`/`status`/`Query`/`Annotated`. No new imports needed.
+- Test patterns: `tests/api/v1/test_images.py` class `TestExcludeTags` (`test_images.py:455`). Use fixtures `client`, `db_session`, `sample_image_data`. Create images with `Images(**{**sample_image_data, "filename": "<unique>", "md5_hash": "<32 unique chars>"})`, `await db_session.flush()` to get IDs, create `Tags(title=, desc=, type=)`, flush, then `TagLinks(image_id=, tag_id=, user_id=1)`, then `await db_session.commit()`. The test DB is empty per test (transactional rollback), so an image with no tags will match a missing-type filter for every type — assert on `image_id` membership, not exact `total`, wherever the no-tag image participates.
+
+## Insertion anchors
+
+- **Signature:** add the two new params immediately after the `exclude_tags` Query param and before the `# Date filtering` comment in the `list_images` signature.
+- **Where-block:** add the filter block immediately after the `exclude_tags` where-block (after its closing `)` ~`images.py:448`) and before the `# Date filtering` / `if date_from:` block.
+
+---
+
+## Chunk 1: Missing-tag-type filter
+
+### Task 1: Add params + ANY-mode filter (single type)
+
+**Files:**
+- Modify: `app/api/v1/images.py` (signature + where-block)
+- Test: `tests/api/v1/test_images.py` (new `TestMissingTagTypes` class, appended after `TestExcludeTags`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append a new test class after `TestExcludeTags` in `tests/api/v1/test_images.py`. `TagType` is already imported in this file; confirm `from app.config import TagType` is at the top (it is used by existing tests).
+
+```python
+class TestMissingTagTypes:
+    """Tests for missing_tag_types / missing_tag_types_mode params on image search."""
+
+    async def test_missing_single_type_excludes_images_that_have_it(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """missing_tag_types=3 returns images lacking an artist tag, excludes those that have one."""
+        has_artist = Images(**{**sample_image_data, "filename": "mtt_a1", "md5_hash": "a" * 32})
+        no_artist = Images(**{**sample_image_data, "filename": "mtt_a2", "md5_hash": "b" * 32})
+        db_session.add_all([has_artist, no_artist])
+        await db_session.flush()
+
+        artist_tag = Tags(title="some artist", desc="Artist", type=TagType.ARTIST)
+        theme_tag = Tags(title="some theme", desc="Theme", type=TagType.THEME)
+        db_session.add_all([artist_tag, theme_tag])
+        await db_session.flush()
+
+        db_session.add(TagLinks(image_id=has_artist.image_id, tag_id=artist_tag.tag_id, user_id=1))
+        db_session.add(TagLinks(image_id=no_artist.image_id, tag_id=theme_tag.tag_id, user_id=1))
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images?missing_tag_types={TagType.ARTIST}")
+
+        assert response.status_code == 200
+        image_ids = [img["image_id"] for img in response.json()["images"]]
+        assert no_artist.image_id in image_ids
+        assert has_artist.image_id not in image_ids
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/api/v1/test_images.py::TestMissingTagTypes::test_missing_single_type_excludes_images_that_have_it -v`
+Expected: FAIL — without the param, FastAPI ignores the unknown query string and `has_artist` is returned (assertion `has_artist.image_id not in image_ids` fails).
+
+- [ ] **Step 3: Add the two params to the `list_images` signature**
+
+Insert after the `exclude_tags` Query param (before `# Date filtering`):
+
+```python
+    missing_tag_types: Annotated[
+        str | None,
+        Query(
+            description="Comma-separated tag type IDs the image must be MISSING "
+            "(1=Theme, 2=Source, 3=Artist, 4=Character)."
+        ),
+    ] = None,
+    missing_tag_types_mode: Annotated[
+        str, Query(pattern="^(any|all)$", description="Match ANY or ALL missing types")
+    ] = "any",
+```
+
+- [ ] **Step 4: Add the where-block (ANY branch only for now)**
+
+Insert immediately after the `exclude_tags` where-block (before `# Date filtering`):
+
+```python
+    # Missing tag-type filtering (images lacking a tag of the given type[s]).
+    # Aliases are intentionally NOT resolved here: the applied tag's own `type` is authoritative.
+    if missing_tag_types:
+        missing_type_ids = sorted(
+            {int(t.strip()) for t in missing_tag_types.split(",") if t.strip().isdigit()}
+        )
+        if missing_type_ids:
+            # Missing ANY listed type
+            def lacks_type(type_id: int):
+                return Images.image_id.notin_(  # type: ignore[union-attr]
+                    select(TagLinks.image_id)
+                    .join(Tags, TagLinks.tag_id == Tags.tag_id)  # type: ignore[arg-type]
+                    .where(Tags.type == type_id)  # type: ignore[arg-type]
+                )
+
+            query = query.where(or_(*(lacks_type(t) for t in missing_type_ids)))
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/api/v1/test_images.py::TestMissingTagTypes::test_missing_single_type_excludes_images_that_have_it -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/v1/images.py tests/api/v1/test_images.py
+git commit -m "feat(images): add missing_tag_types filter (any mode)"
+```
+
+---
+
+### Task 2: ALL-mode
+
+**Files:**
+- Modify: `app/api/v1/images.py` (where-block)
+- Test: `tests/api/v1/test_images.py` (`TestMissingTagTypes`)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+    async def test_missing_all_mode_requires_all_types_absent(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """mode=all returns only images missing EVERY listed type."""
+        missing_both = Images(**{**sample_image_data, "filename": "mtt_all1", "md5_hash": "c" * 32})
+        missing_source_only = Images(
+            **{**sample_image_data, "filename": "mtt_all2", "md5_hash": "d" * 32}
+        )
+        db_session.add_all([missing_both, missing_source_only])
+        await db_session.flush()
+
+        artist_tag = Tags(title="artist x", desc="Artist", type=TagType.ARTIST)
+        theme_tag = Tags(title="theme x", desc="Theme", type=TagType.THEME)
+        db_session.add_all([artist_tag, theme_tag])
+        await db_session.flush()
+
+        # missing_both: only a theme tag -> lacks both source and artist
+        db_session.add(TagLinks(image_id=missing_both.image_id, tag_id=theme_tag.tag_id, user_id=1))
+        # missing_source_only: has an artist tag -> lacks source but NOT artist
+        db_session.add(
+            TagLinks(image_id=missing_source_only.image_id, tag_id=artist_tag.tag_id, user_id=1)
+        )
+        await db_session.commit()
+
+        response = await client.get(
+            f"/api/v1/images?missing_tag_types={TagType.SOURCE},{TagType.ARTIST}"
+            "&missing_tag_types_mode=all"
+        )
+
+        assert response.status_code == 200
+        image_ids = [img["image_id"] for img in response.json()["images"]]
+        assert missing_both.image_id in image_ids
+        assert missing_source_only.image_id not in image_ids
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/api/v1/test_images.py::TestMissingTagTypes::test_missing_all_mode_requires_all_types_absent -v`
+Expected: FAIL — with only the ANY branch, `mode=all` is ignored and `missing_source_only` (missing source) is wrongly returned.
+
+- [ ] **Step 3: Add the ALL branch**
+
+Wrap the existing ANY logic in an if/else on the mode. Replace the `# Missing ANY listed type` block from Task 1 so the full block reads:
+
+```python
+        if missing_type_ids:
+            if missing_tag_types_mode == "all":
+                # Missing ALL listed types: no tag of any listed type
+                query = query.where(
+                    Images.image_id.notin_(  # type: ignore[union-attr]
+                        select(TagLinks.image_id)
+                        .join(Tags, TagLinks.tag_id == Tags.tag_id)  # type: ignore[arg-type]
+                        .where(Tags.type.in_(missing_type_ids))  # type: ignore[attr-defined]
+                    )
+                )
+            else:
+                # Missing ANY listed type
+                def lacks_type(type_id: int):
+                    return Images.image_id.notin_(  # type: ignore[union-attr]
+                        select(TagLinks.image_id)
+                        .join(Tags, TagLinks.tag_id == Tags.tag_id)  # type: ignore[arg-type]
+                        .where(Tags.type == type_id)  # type: ignore[arg-type]
+                    )
+
+                query = query.where(or_(*(lacks_type(t) for t in missing_type_ids)))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/api/v1/test_images.py::TestMissingTagTypes::test_missing_all_mode_requires_all_types_absent -v`
+Expected: PASS
+
+- [ ] **Step 5: Re-run Task 1 test to confirm no regression**
+
+Run: `uv run pytest "tests/api/v1/test_images.py::TestMissingTagTypes" -v`
+Expected: both tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/v1/images.py tests/api/v1/test_images.py
+git commit -m "feat(images): support missing_tag_types_mode=all"
+```
+
+---
+
+### Task 3: Validation of type IDs (invalid → 400)
+
+**Files:**
+- Modify: `app/api/v1/images.py` (where-block)
+- Test: `tests/api/v1/test_images.py` (`TestMissingTagTypes`)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+    async def test_missing_invalid_type_id_returns_400(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Type IDs outside 1-4 (incl. 0=All) are rejected with 400."""
+        for bad in ("0", "99", "3,0"):
+            response = await client.get(f"/api/v1/images?missing_tag_types={bad}")
+            assert response.status_code == 400, f"expected 400 for {bad!r}"
+            assert "Valid types are" in response.json()["detail"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/api/v1/test_images.py::TestMissingTagTypes::test_missing_invalid_type_id_returns_400 -v`
+Expected: FAIL — currently invalid IDs yield 200 (no validation).
+
+- [ ] **Step 3: Add the validation check**
+
+Insert immediately after `if missing_type_ids:` and before the mode branch:
+
+```python
+            invalid = [t for t in missing_type_ids if t not in {1, 2, 3, 4}]
+            if invalid:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"Invalid tag type(s): {', '.join(map(str, invalid))}. "
+                        "Valid types are 1=Theme, 2=Source, 3=Artist, 4=Character."
+                    ),
+                )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/api/v1/test_images.py::TestMissingTagTypes::test_missing_invalid_type_id_returns_400 -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/v1/images.py tests/api/v1/test_images.py
+git commit -m "feat(images): validate missing_tag_types IDs (400 on invalid)"
+```
+
+---
+
+### Task 4: Lock in remaining spec cases (regression tests)
+
+These confirm behavior already guaranteed by Tasks 1-3 (alias non-resolution, AND with include filter, no-tag image, 422 on bad mode, omitted param). They should pass immediately — they guard against regressions. If any fails, STOP and treat it as a real defect to root-cause, not a test to weaken.
+
+**Files:**
+- Test: `tests/api/v1/test_images.py` (`TestMissingTagTypes`)
+
+- [ ] **Step 1: Write the tests**
+
+```python
+    async def test_missing_artist_does_not_resolve_alias(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """An image whose only artist tag is an ALIAS still counts as having an artist tag."""
+        aliased = Images(**{**sample_image_data, "filename": "mtt_alias", "md5_hash": "e" * 32})
+        db_session.add(aliased)
+        await db_session.flush()
+
+        canonical = Tags(title="canon artist", desc="Artist", type=TagType.ARTIST)
+        db_session.add(canonical)
+        await db_session.flush()
+        alias = Tags(
+            title="alias artist", desc="Alias", type=TagType.ARTIST, alias_of=canonical.tag_id
+        )
+        db_session.add(alias)
+        await db_session.flush()
+
+        # Image is linked to the ALIAS tag, not the canonical one
+        db_session.add(TagLinks(image_id=aliased.image_id, tag_id=alias.tag_id, user_id=1))
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images?missing_tag_types={TagType.ARTIST}")
+
+        assert response.status_code == 200
+        image_ids = [img["image_id"] for img in response.json()["images"]]
+        assert aliased.image_id not in image_ids
+
+    async def test_missing_combined_with_include_tags(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """tags= include filter AND missing_tag_types both apply."""
+        keep = Images(**{**sample_image_data, "filename": "mtt_cmb1", "md5_hash": "f" * 32})
+        drop = Images(**{**sample_image_data, "filename": "mtt_cmb2", "md5_hash": "0" * 32})
+        db_session.add_all([keep, drop])
+        await db_session.flush()
+
+        theme_tag = Tags(title="cmb theme", desc="Theme", type=TagType.THEME)
+        artist_tag = Tags(title="cmb artist", desc="Artist", type=TagType.ARTIST)
+        db_session.add_all([theme_tag, artist_tag])
+        await db_session.flush()
+
+        # keep: has the theme tag, no artist -> matches include + missing artist
+        db_session.add(TagLinks(image_id=keep.image_id, tag_id=theme_tag.tag_id, user_id=1))
+        # drop: has theme tag AND an artist tag -> matches include but NOT missing artist
+        db_session.add(TagLinks(image_id=drop.image_id, tag_id=theme_tag.tag_id, user_id=1))
+        db_session.add(TagLinks(image_id=drop.image_id, tag_id=artist_tag.tag_id, user_id=1))
+        await db_session.commit()
+
+        response = await client.get(
+            f"/api/v1/images?tags={theme_tag.tag_id}&missing_tag_types={TagType.ARTIST}"
+        )
+
+        assert response.status_code == 200
+        image_ids = [img["image_id"] for img in response.json()["images"]]
+        assert keep.image_id in image_ids
+        assert drop.image_id not in image_ids
+
+    async def test_image_with_no_tags_matches_every_type_both_modes(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """An image with no tags is missing every type, in both any and all modes."""
+        untagged = Images(**{**sample_image_data, "filename": "mtt_none", "md5_hash": "1" * 32})
+        db_session.add(untagged)
+        await db_session.commit()
+
+        for query in (
+            f"missing_tag_types={TagType.ARTIST}",
+            f"missing_tag_types={TagType.SOURCE},{TagType.ARTIST}&missing_tag_types_mode=any",
+            f"missing_tag_types={TagType.SOURCE},{TagType.ARTIST}&missing_tag_types_mode=all",
+        ):
+            response = await client.get(f"/api/v1/images?{query}")
+            assert response.status_code == 200, query
+            image_ids = [img["image_id"] for img in response.json()["images"]]
+            assert untagged.image_id in image_ids, query
+
+    async def test_missing_invalid_mode_returns_422(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Invalid mode is rejected by the Query pattern with 422."""
+        response = await client.get(
+            f"/api/v1/images?missing_tag_types={TagType.ARTIST}&missing_tag_types_mode=foo"
+        )
+        assert response.status_code == 422
+
+    async def test_omitted_param_does_not_filter(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Without the param, behavior is unchanged (image is returned)."""
+        img = Images(**{**sample_image_data, "filename": "mtt_omit", "md5_hash": "2" * 32})
+        db_session.add(img)
+        await db_session.commit()
+
+        response = await client.get("/api/v1/images")
+
+        assert response.status_code == 200
+        image_ids = [i["image_id"] for i in response.json()["images"]]
+        assert img.image_id in image_ids
+```
+
+- [ ] **Step 2: Run the full class**
+
+Run: `uv run pytest "tests/api/v1/test_images.py::TestMissingTagTypes" -v`
+Expected: all tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/api/v1/test_images.py
+git commit -m "test(images): cover missing_tag_types alias/combine/no-tag/422 cases"
+```
+
+---
+
+### Task 5: Type-check, lint, and full-module verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Reconcile mypy ignore codes**
+
+Run: `uv run mypy app/api/v1/images.py`
+Expected: no new errors. If mypy reports an unused-ignore or a different error code on the new lines, adjust the `# type: ignore[...]` codes to match exactly what mypy reports (the codes in this plan mirror the `exclude_tags` block but the join/`Tags.type` lines may differ). Re-run until clean.
+
+- [ ] **Step 2: Run the full images test module**
+
+Run: `uv run pytest tests/api/v1/test_images.py -v`
+Expected: all PASS (no regression in `TestExcludeTags`, `TestTagSearchValidation`, etc.).
+
+- [ ] **Step 3: Lint (matches pre-commit)**
+
+Run: `uv run ruff check app/api/v1/images.py tests/api/v1/test_images.py && uv run ruff format --check app/api/v1/images.py tests/api/v1/test_images.py`
+Expected: pass. If `ruff format` rewrites anything, stage the result.
+
+- [ ] **Step 4: Commit any fixups**
+
+```bash
+git add -A
+git commit -m "chore(images): mypy/lint fixups for missing_tag_types" || echo "nothing to commit"
+```
+
+---
+
+## Optional follow-up (not part of this PR)
+
+- **Query-plan spot check (spec performance note):** with a populated DB, `EXPLAIN` one `any`-mode query (e.g. `missing_tag_types=2,3,4`) to confirm the planner uses the `type_alias` index and the `tag_links` PK rather than a full anti-join scan. Record findings in the PR description if run.
+- **Handler extraction:** `list_images` is ~360 lines. Extracting tag-filter building into a helper is a worthwhile separate refactor, intentionally out of scope here.

--- a/docs/plans/2026-05-29-missing-tag-type-filter-impl.md
+++ b/docs/plans/2026-05-29-missing-tag-type-filter-impl.md
@@ -39,6 +39,7 @@
 Append a new test class after `TestExcludeTags` in `tests/api/v1/test_images.py`. `TagType` is already imported in this file; confirm `from app.config import TagType` is at the top (it is used by existing tests).
 
 ```python
+@pytest.mark.api
 class TestMissingTagTypes:
     """Tests for missing_tag_types / missing_tag_types_mode params on image search."""
 
@@ -283,9 +284,49 @@ These confirm behavior already guaranteed by Tasks 1-3 (alias non-resolution, AN
 **Files:**
 - Test: `tests/api/v1/test_images.py` (`TestMissingTagTypes`)
 
+Note: confirm `import pytest` and `from app.config import TagType` are present at the top of `test_images.py` (both are — used by existing tests/classes). The class decorator `@pytest.mark.api` (added in Task 1) keeps these tests in the `api` marker set, matching every other class in the file.
+
 - [ ] **Step 1: Write the tests**
 
 ```python
+    async def test_missing_any_mode_returns_image_missing_only_one_type(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """mode=any returns an image that has one listed type but lacks another (OR, not AND).
+
+        Discriminates OR semantics: an image WITH an artist tag but WITHOUT a source must be
+        returned by missing_tag_types=2,3&mode=any, yet excluded by mode=all.
+        """
+        has_artist_no_source = Images(
+            **{**sample_image_data, "filename": "mtt_any1", "md5_hash": "3" * 32}
+        )
+        db_session.add(has_artist_no_source)
+        await db_session.flush()
+
+        artist_tag = Tags(title="any artist", desc="Artist", type=TagType.ARTIST)
+        db_session.add(artist_tag)
+        await db_session.flush()
+        db_session.add(
+            TagLinks(image_id=has_artist_no_source.image_id, tag_id=artist_tag.tag_id, user_id=1)
+        )
+        await db_session.commit()
+
+        types = f"{TagType.SOURCE},{TagType.ARTIST}"
+
+        any_resp = await client.get(
+            f"/api/v1/images?missing_tag_types={types}&missing_tag_types_mode=any"
+        )
+        assert any_resp.status_code == 200
+        any_ids = [img["image_id"] for img in any_resp.json()["images"]]
+        assert has_artist_no_source.image_id in any_ids  # missing source -> matched by ANY
+
+        all_resp = await client.get(
+            f"/api/v1/images?missing_tag_types={types}&missing_tag_types_mode=all"
+        )
+        assert all_resp.status_code == 200
+        all_ids = [img["image_id"] for img in all_resp.json()["images"]]
+        assert has_artist_no_source.image_id not in all_ids  # has artist -> excluded by ALL
+
     async def test_missing_artist_does_not_resolve_alias(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
     ):

--- a/docs/plans/2026-05-29-missing-tag-type-filter-impl.md
+++ b/docs/plans/2026-05-29-missing-tag-type-filter-impl.md
@@ -187,22 +187,24 @@ Wrap the existing ANY logic in an if/else on the mode. Replace the `# Missing AN
                 # Missing ALL listed types: no tag of any listed type
                 query = query.where(
                     Images.image_id.notin_(  # type: ignore[union-attr]
-                        select(TagLinks.image_id)
-                        .join(Tags, TagLinks.tag_id == Tags.tag_id)  # type: ignore[arg-type]
-                        .where(Tags.type.in_(missing_type_ids))  # type: ignore[attr-defined]
+                        select(TagLinks.image_id)  # type: ignore[call-overload]
+                        .join(Tags, TagLinks.tag_id == Tags.tag_id)
+                        .where(Tags.type.in_(missing_type_ids))
                     )
                 )
             else:
                 # Missing ANY listed type
-                def lacks_type(type_id: int):
+                def lacks_type(type_id: int) -> Any:
                     return Images.image_id.notin_(  # type: ignore[union-attr]
-                        select(TagLinks.image_id)
-                        .join(Tags, TagLinks.tag_id == Tags.tag_id)  # type: ignore[arg-type]
-                        .where(Tags.type == type_id)  # type: ignore[arg-type]
+                        select(TagLinks.image_id)  # type: ignore[call-overload]
+                        .join(Tags, TagLinks.tag_id == Tags.tag_id)
+                        .where(Tags.type == type_id)
                     )
 
                 query = query.where(or_(*(lacks_type(t) for t in missing_type_ids)))
 ```
+
+**mypy note:** these are the reconciled `# type: ignore` codes (verified mypy-clean for the any-branch in Task 1): `[union-attr]` on the `notin_` line, `[call-overload]` on the `select(...)` line, and NO ignore on `.join()`/`.where()`. `Any` is already imported (`images.py:12`). After editing, run `uv run mypy app/api/v1/images.py` and confirm zero errors before committing; the `Tags.type.in_(...)` line may need its own code reconciliation — let mypy's actual output drive it.
 
 - [ ] **Step 4: Run test to verify it passes**
 

--- a/docs/plans/2026-05-31-tag-type-presence-denormalization-design.md
+++ b/docs/plans/2026-05-31-tag-type-presence-denormalization-design.md
@@ -128,6 +128,8 @@ These change the type composition of *every image linked to the tag*. Gather the
 
 This is the highest-risk part: a missed site causes silent drift. The plan must enumerate and cover every site with a test, and the backfill script (below) doubles as a reconciliation tool if drift is ever suspected.
 
+**Standing risk:** flag correctness rests on two invariants — `tags.type` is authoritative (handled by the type-change hook) and an alias shares its canonical's type (API-enforced). Any future raw-SQL or bulk path that mutates `tag_links`/`tags.type` directly, or bypasses the alias type check, would drift the flags silently. The backfill script is the reconciliation path; a scheduled reconciliation job is intentionally out of scope for now (KISS).
+
 Note: the existing `tags.usage_count` increment/decrement triggers on `tag_links` are orthogonal to these flags — no interaction.
 
 ## Backfill

--- a/docs/plans/2026-05-31-tag-type-presence-denormalization-design.md
+++ b/docs/plans/2026-05-31-tag-type-presence-denormalization-design.md
@@ -22,20 +22,24 @@ Four boolean columns on `images` (the slow anti-join is replaced by reading thes
 | `has_artist` | image has ≥1 tag of type 3 |
 | `has_character` | image has ≥1 tag of type 4 |
 
-Type: `Boolean`/`TINYINT(1)`, `NOT NULL DEFAULT 0`, `server_default="0"`. These are internal fields on the `Images` table model — **not** added to `ImageBase`, so they are not exposed in public API schemas (per the project's inheritance-based security pattern).
+Type: `Boolean`/`TINYINT(1)`, `NOT NULL`. The model column carries `Field(default=False)` (ORM insert path); the DB-side `DEFAULT 0` safety-net lives in the migration's `ALTER` (matching the `in_r2` precedent, which keeps the server default in the migration rather than the model). These are internal fields on the `Images` table model — **not** added to `ImageBase`, so they are not exposed in public API schemas (per the project's inheritance-based security pattern).
 
 Source of truth remains `tag_links` + `tags.type`; these columns are a maintained cache.
 
 ### Indexes
 
-One composite index per flag to serve both the page (`... AND <flag>=0 ORDER BY image_id DESC LIMIT`) and the count:
+One composite index per flag, `(<flag>, image_id)`:
 
 ```
-Index("idx_images_has_theme",     "has_theme",     "status", "image_id")
-Index("idx_images_has_source",    "has_source",    "status", "image_id")
-Index("idx_images_has_artist",    "has_artist",    "status", "image_id")
-Index("idx_images_has_character", "has_character", "status", "image_id")
+Index("idx_images_has_theme",     "has_theme",     "image_id")
+Index("idx_images_has_source",    "has_source",    "image_id")
+Index("idx_images_has_artist",    "has_artist",    "image_id")
+Index("idx_images_has_character", "has_character", "image_id")
 ```
+
+Rationale: the page query is `WHERE status IN (...) AND <flag>=0 ORDER BY image_id DESC LIMIT n`. With `(has_X, image_id)`, MariaDB ranges on the `has_X=0` equality prefix and walks `image_id` descending **already ordered**, applying `status` as a cheap residual row filter — giving early-termination (no filesort). Putting the 3-value `status IN (...)` set (`PUBLIC_IMAGE_STATUSES`) *inside* the index between `has_X` and `image_id` would break the single ordered stream, so `status` is deliberately left out of the index. The count (`WHERE status IN (...) AND has_X=0`) range-scans the `has_X=0` prefix (~133k entries for artist) and filters `status` residually — fast.
+
+Caveat — `any` mode (`has_artist=0 OR has_source=0`): an OR across two columns can't use a single index cleanly and the matching set is large, so `ORDER BY image_id DESC LIMIT` may filesort/index-merge. The primary moderation query is single-type, which is well served; the plan must `EXPLAIN`-verify both single-type and `any`-mode page queries against real data (continuing #228's EXPLAIN discipline) and revisit if `any` mode is too slow.
 
 Trade-off: 4 secondary indexes add write cost on image insert and tag edits. On an image board those are far rarer than reads, so this is acceptable. (Open to indexing only artist/source if write cost is a concern.)
 
@@ -64,50 +68,75 @@ else:
 
 Because tag-link mutations are scattered (no single chokepoint) and `tags.type` is mutable, flags are recomputed from the source of truth (idempotent, drift-proof) rather than incrementally adjusted.
 
-New module `app/services/tag_type_flags.py`:
+New module `app/services/tag_type_flags.py`. A single set-based primitive recomputes all four flags for a set of image IDs from the source of truth; the single-image case is just a one-element set:
 
 ```python
+async def refresh_images_tag_type_flags(db: AsyncSession, image_ids: Collection[int]) -> None:
+    """Recompute has_theme/source/artist/character for the given images from tag_links.
+
+    Idempotent. Does NOT commit — participates in the caller's transaction so flag
+    updates are atomic with the link change.
+    """
+    if not image_ids:
+        return
+    await db.flush()  # REQUIRED: session uses autoflush=False, so pending db.add(TagLinks)
+                      # rows are invisible to the SELECT below until flushed.
+    # Single set-based statement over the id set:
+    #   UPDATE images i
+    #   LEFT JOIN (
+    #     SELECT tl.image_id,
+    #       MAX(t.type=1) ht, MAX(t.type=2) hs, MAX(t.type=3) ha, MAX(t.type=4) hc
+    #     FROM tag_links tl JOIN tags t ON tl.tag_id = t.tag_id
+    #     WHERE tl.image_id IN :ids GROUP BY tl.image_id
+    #   ) agg ON agg.image_id = i.image_id
+    #   SET i.has_theme=COALESCE(agg.ht,0), i.has_source=COALESCE(agg.hs,0),
+    #       i.has_artist=COALESCE(agg.ha,0), i.has_character=COALESCE(agg.hc,0)
+    #   WHERE i.image_id IN :ids;
+
 async def refresh_image_tag_type_flags(db: AsyncSession, image_id: int) -> None:
-    """Recompute has_theme/source/artist/character for one image from its tag_links."""
-    # SELECT which types this image currently has (one indexed query on tag_links(image_id))
-    # then UPDATE images SET has_* = ... WHERE image_id = :image_id
+    """Convenience wrapper: refresh_images_tag_type_flags(db, [image_id])."""
 ```
 
-```python
-async def refresh_images_for_tag(db: AsyncSession, tag_id: int) -> None:
-    """Recompute flags for every image linked to a given tag (bounded by the tag's usage).
-    Used when a tag is deleted, merged/reassigned, or its type changes."""
-```
+Two properties that the reviewer flagged as load-bearing:
 
-The single-image recompute is one small indexed query (`tag_links` by `image_id`, avg ~13 rows) plus one UPDATE — negligible per mutation. The helper does **not** commit; it participates in the caller's transaction so flag updates are atomic with the link change.
+- **Must `flush()` first.** The session is configured `autoflush=False` (`app/core/database.py`). The "add tag" paths do `db.add(TagLinks(...))` without flushing, so the recompute's SELECT would not see the just-added link and the flag would wrongly stay `0`. Flushing inside the helper fixes this for every caller (including test fixtures, which also use `db.add`).
+- **Set-based, not a per-image loop.** A single `UPDATE ... JOIN` over the id set bounds the cost of tag-level operations (see `tags.type` change below) to one statement instead of N round-trips, while still being correct for the single-image case.
 
-### Hook sites
+### Hook sites — per-image link mutations
 
-Call `refresh_image_tag_type_flags(db, image_id)` after the link change in each per-image mutation path:
+Call `refresh_image_tag_type_flags(db, image_id)` after the link change:
 
 | Site | File:line (approx) | Operation |
 |---|---|---|
 | Single add | `app/api/v1/images.py:1811` | add one tag → refresh that image |
 | Single remove | `app/api/v1/images.py:1894` | remove one tag → refresh that image |
-| Upload | `app/services/upload.py:152` | initial tagging → refresh after links inserted |
-| Batch add | `app/services/batch_tag.py:109` | refresh each affected image |
-| Batch remove | `app/services/batch_tag.py:257` | refresh each affected image |
-| Repost cleanup | `app/services/repost.py:149` | refresh affected image(s) |
+| Upload | `app/services/upload.py:152` | initial tagging → refresh after links added |
+| Batch add | `app/services/batch_tag.py:109` | refresh each affected image (pass the set) |
+| Batch remove | `app/services/batch_tag.py:257` | refresh each affected image (pass the set) |
+| Repost merge | `app/services/repost.py:129,148` | **refresh `original_id` (mandatory — it GAINS the repost's tags via the `INSERT ... SELECT` at ~line 129 and its flags can flip 0→1) and `repost_id`.** Place the call inside `migrate_repost_data` after the link statements so both callers (`images.py:1023`, `admin.py:770`) are covered atomically. |
 | Admin report-resolution | `app/api/v1/admin.py:1562,1588` | refresh affected image |
 
-Call `refresh_images_for_tag(db, tag_id)` (or refresh the affected image set) in each tag-level operation that changes type composition:
+### Hook sites — tag-level operations (use the set-based recompute)
 
-| Site | File:line (approx) | Operation |
+These change the type composition of *every image linked to the tag*. Gather the affected image IDs (`SELECT DISTINCT image_id FROM tag_links WHERE tag_id = :t`) and call `refresh_images_tag_type_flags(db, ids)`:
+
+| Site | File:line (approx) | Operation & sequencing |
 |---|---|---|
-| Tag delete | (tag delete endpoint / CASCADE) | links removed → refresh images that had the tag (capture image set before delete) |
-| Tag merge / alias reassignment | `app/api/v1/tags.py:1467,1475` | `tag_id` reassigned → refresh affected images |
-| Tag type change | tag update endpoint (`TagUpdate.type`) | refresh every image linked to the tag |
+| Tag delete | tag delete endpoint (`tags.py:~1592`) | There is **no** ORM Tags→TagLinks relationship; link cleanup is the DB-level `ondelete="CASCADE"` FK. Sequence: capture affected `image_id`s → `db.delete(tag)` → **`db.flush()`** (so the cascade is applied within the txn) → `refresh_images_tag_type_flags(db, ids)` → commit. Without the flush the recompute still sees the tag's links and computes stale `has_X=1`. |
+| Tag type change | tag update endpoint (`tags.py:~1360`, `TagUpdate.type`) | Recompute all images linked to the tag. **Single set-based UPDATE** (not a loop) — a popular artist tag has thousands of links; per-image round-trips inside one request would be pathological. Bounded by the tag's usage; acceptable as a synchronous in-transaction statement. |
+| Tag merge / alias reassignment | `app/api/v1/tags.py:1467,1475` | `tag_id` reassigned via `UPDATE tag_links`. Refresh affected images. **Nearly always a flag no-op** (the API enforces alias and canonical share a `type`, so moving artist→artist keeps `has_artist=1`); kept for drift-proofing/idempotency, not load-bearing. |
 
-This is the highest-risk part: a missed site causes silent drift. The plan must enumerate and cover every site with a test, and the backfill script (below) doubles as a periodic reconciliation tool if drift is ever suspected.
+This is the highest-risk part: a missed site causes silent drift. The plan must enumerate and cover every site with a test, and the backfill script (below) doubles as a reconciliation tool if drift is ever suspected.
+
+Note: the existing `tags.usage_count` increment/decrement triggers on `tag_links` are orthogonal to these flags — no interaction.
 
 ## Backfill
 
-The Alembic migration only **adds the columns + indexes** (column add is INSTANT/metadata-only; index builds are the heavier part of the migration but one-time). It does **not** backfill values inline (a single UPDATE over 14.7M tag_links risks long locks/timeouts).
+The Alembic migration only **adds the columns + indexes**. It does **not** backfill values inline (a single UPDATE over 14.7M tag_links risks long locks/timeouts). DDL must use online algorithms on the 1.1M-row InnoDB table (matching the existing precedent migration `7b2101b37080`):
+
+- Columns: `ALTER TABLE images ADD COLUMN has_* TINYINT(1) NOT NULL DEFAULT 0, ALGORITHM=INSTANT, LOCK=NONE` (metadata-only, instant). The `DEFAULT 0` safety-net lives in the migration's raw `ALTER`; the model column carries `Field(default=False)` for the ORM insert path.
+- Indexes: `ALGORITHM=INPLACE, LOCK=NONE` — without this, four `CREATE INDEX` on a 1.1M-row table block writes.
+- The `downgrade()` drops the four indexes then the four columns.
 
 A separate, idempotent, resumable script `scripts/backfill_tag_type_flags.py` populates existing rows in batches by `image_id` range:
 
@@ -137,6 +166,6 @@ This supersedes PR #228's query mechanism. Reused from #228: the `missing_tag_ty
 
 1. **Helper unit tests** — `refresh_image_tag_type_flags` sets each flag correctly for an image with/without each tag type; `refresh_images_for_tag` updates all linked images. Real DB, no mocks.
 2. **Maintenance integration tests** — for each hook site, exercise the real endpoint/service (add tag → `has_*` becomes 1; remove the last tag of a type → back to 0; remove one of two artist tags → stays 1; tag type change → flags flip; tag delete/merge → affected images updated).
-3. **Filter behavior tests** — the PR #228 `TestMissingTagTypes` cases still pass, but fixtures must set flags. Update fixtures to call `refresh_image_tag_type_flags(db, image_id)` after inserting `TagLinks` (this keeps tests honest by exercising the helper). The alias test still holds: the applied tag's `type` drives the recompute.
+3. **Filter behavior tests** — the PR #228 `TestMissingTagTypes` cases must keep passing, but their fixtures insert `TagLinks` directly via `db_session` and never set the flags, so post-migration they would break: `test_missing_single_type_*`, `test_missing_all_mode_*`, and `test_missing_any_mode_*` would FAIL (images with links but flags=0 wrongly appear as "missing"). Fix: each fixture calls `refresh_image_tag_type_flags(db, image_id)` after inserting links (works because the helper flushes internally; also exercises the real helper). The alias test still holds — the applied tag's own `type` drives the recompute. Note `test_image_with_no_tags_matches_every_type_both_modes` passes either way (default-0 == genuinely missing), so it is NOT the regression guard; the single/all/any tests are.
 4. **Count test** — `total` is correct and the query returns promptly (the original motivation).
 5. **Backfill script test** — on a seeded set, the script produces the same flags the helper would.

--- a/docs/plans/2026-05-31-tag-type-presence-denormalization-design.md
+++ b/docs/plans/2026-05-31-tag-type-presence-denormalization-design.md
@@ -1,0 +1,142 @@
+# Denormalized Per-Image Tag-Type Presence
+
+**Date:** 2026-05-31
+
+## Problem
+
+The `missing_tag_types` image-search filter (PR #228) finds images lacking a tag of a given type (Theme/Source/Artist/Character) via a live anti-join (`image_id NOT IN (...)` / `NOT EXISTS`). On production-sized data (1.1M images, 14.7M tag_links, 956k of ~1.09M visible images already have an artist tag) this **times out (>60s)**:
+
+- MariaDB 12 rewrites the anti-join into a **materialized semijoin**, building the ~956k "has-artist" image set every request, which defeats the primary-key-ordered early-termination that makes normal listing fast (0.4s).
+- Forcing per-row execution (`optimizer_switch='semijoin=off,materialization=off'`) makes the *page* fast but the **`total` count still can't early-terminate** and times out.
+
+Legacy (`shuu-php`) used the same anti-join but mitigated it with old-MySQL per-row execution + has-next pagination (no exact count), gated to mods. Rather than replicate those workarounds, we denormalize tag-type presence onto the image row so the filter becomes a cheap, indexed, sargable column predicate — fast page *and* exact total.
+
+## Data model
+
+Four boolean columns on `images` (the slow anti-join is replaced by reading these):
+
+| Column | Meaning |
+|---|---|
+| `has_theme` | image has ≥1 tag of type 1 |
+| `has_source` | image has ≥1 tag of type 2 |
+| `has_artist` | image has ≥1 tag of type 3 |
+| `has_character` | image has ≥1 tag of type 4 |
+
+Type: `Boolean`/`TINYINT(1)`, `NOT NULL DEFAULT 0`, `server_default="0"`. These are internal fields on the `Images` table model — **not** added to `ImageBase`, so they are not exposed in public API schemas (per the project's inheritance-based security pattern).
+
+Source of truth remains `tag_links` + `tags.type`; these columns are a maintained cache.
+
+### Indexes
+
+One composite index per flag to serve both the page (`... AND <flag>=0 ORDER BY image_id DESC LIMIT`) and the count:
+
+```
+Index("idx_images_has_theme",     "has_theme",     "status", "image_id")
+Index("idx_images_has_source",    "has_source",    "status", "image_id")
+Index("idx_images_has_artist",    "has_artist",    "status", "image_id")
+Index("idx_images_has_character", "has_character", "status", "image_id")
+```
+
+Trade-off: 4 secondary indexes add write cost on image insert and tag edits. On an image board those are far rarer than reads, so this is acceptable. (Open to indexing only artist/source if write cost is a concern.)
+
+## Filter rewrite (`missing_tag_types`)
+
+Replace the anti-join where-block in `list_images` (`app/api/v1/images.py`). The params, `isdecimal()` parsing, and `1–4` validation are unchanged. Map each requested type ID to its column and require it to be `False`:
+
+```python
+_MISSING_TYPE_COLUMN = {
+    1: Images.has_theme,
+    2: Images.has_source,
+    3: Images.has_artist,
+    4: Images.has_character,
+}
+# ... after parse + validation ...
+clauses = [_MISSING_TYPE_COLUMN[t] == False for t in missing_type_ids]  # noqa: E712
+if missing_tag_types_mode == "all":
+    query = query.where(and_(*clauses))   # missing every listed type
+else:
+    query = query.where(or_(*clauses))    # missing at least one listed type
+```
+
+`and_`/`or_` are already imported. The query now composes with the PK-ordered scan and the count, both fast. The observable API behavior (which images are returned, validation, 422 on bad mode) is identical to PR #228 — only the internal mechanism changes.
+
+## Maintenance: recompute-from-source helper
+
+Because tag-link mutations are scattered (no single chokepoint) and `tags.type` is mutable, flags are recomputed from the source of truth (idempotent, drift-proof) rather than incrementally adjusted.
+
+New module `app/services/tag_type_flags.py`:
+
+```python
+async def refresh_image_tag_type_flags(db: AsyncSession, image_id: int) -> None:
+    """Recompute has_theme/source/artist/character for one image from its tag_links."""
+    # SELECT which types this image currently has (one indexed query on tag_links(image_id))
+    # then UPDATE images SET has_* = ... WHERE image_id = :image_id
+```
+
+```python
+async def refresh_images_for_tag(db: AsyncSession, tag_id: int) -> None:
+    """Recompute flags for every image linked to a given tag (bounded by the tag's usage).
+    Used when a tag is deleted, merged/reassigned, or its type changes."""
+```
+
+The single-image recompute is one small indexed query (`tag_links` by `image_id`, avg ~13 rows) plus one UPDATE — negligible per mutation. The helper does **not** commit; it participates in the caller's transaction so flag updates are atomic with the link change.
+
+### Hook sites
+
+Call `refresh_image_tag_type_flags(db, image_id)` after the link change in each per-image mutation path:
+
+| Site | File:line (approx) | Operation |
+|---|---|---|
+| Single add | `app/api/v1/images.py:1811` | add one tag → refresh that image |
+| Single remove | `app/api/v1/images.py:1894` | remove one tag → refresh that image |
+| Upload | `app/services/upload.py:152` | initial tagging → refresh after links inserted |
+| Batch add | `app/services/batch_tag.py:109` | refresh each affected image |
+| Batch remove | `app/services/batch_tag.py:257` | refresh each affected image |
+| Repost cleanup | `app/services/repost.py:149` | refresh affected image(s) |
+| Admin report-resolution | `app/api/v1/admin.py:1562,1588` | refresh affected image |
+
+Call `refresh_images_for_tag(db, tag_id)` (or refresh the affected image set) in each tag-level operation that changes type composition:
+
+| Site | File:line (approx) | Operation |
+|---|---|---|
+| Tag delete | (tag delete endpoint / CASCADE) | links removed → refresh images that had the tag (capture image set before delete) |
+| Tag merge / alias reassignment | `app/api/v1/tags.py:1467,1475` | `tag_id` reassigned → refresh affected images |
+| Tag type change | tag update endpoint (`TagUpdate.type`) | refresh every image linked to the tag |
+
+This is the highest-risk part: a missed site causes silent drift. The plan must enumerate and cover every site with a test, and the backfill script (below) doubles as a periodic reconciliation tool if drift is ever suspected.
+
+## Backfill
+
+The Alembic migration only **adds the columns + indexes** (column add is INSTANT/metadata-only; index builds are the heavier part of the migration but one-time). It does **not** backfill values inline (a single UPDATE over 14.7M tag_links risks long locks/timeouts).
+
+A separate, idempotent, resumable script `scripts/backfill_tag_type_flags.py` populates existing rows in batches by `image_id` range:
+
+```sql
+-- per batch [lo, hi):
+UPDATE images i
+LEFT JOIN (
+  SELECT tl.image_id,
+    MAX(t.type = 1) ht, MAX(t.type = 2) hs,
+    MAX(t.type = 3) ha, MAX(t.type = 4) hc
+  FROM tag_links tl JOIN tags t ON tl.tag_id = t.tag_id
+  WHERE tl.image_id >= :lo AND tl.image_id < :hi
+  GROUP BY tl.image_id
+) agg ON i.image_id = agg.image_id
+SET i.has_theme = COALESCE(agg.ht, 0), i.has_source = COALESCE(agg.hs, 0),
+    i.has_artist = COALESCE(agg.ha, 0), i.has_character = COALESCE(agg.hc, 0)
+WHERE i.image_id >= :lo AND i.image_id < :hi;
+```
+
+Batched (e.g. 10k image_ids), logs progress, can be re-run safely (idempotent). Run by ops after the migration, before the feature is relied upon. Because the columns default to 0, the filter is harmless (over-reports "missing") until the backfill completes — note this ordering in the rollout.
+
+## Relationship to PR #228
+
+This supersedes PR #228's query mechanism. Reused from #228: the `missing_tag_types`/`missing_tag_types_mode` params, `isdecimal()` parsing, `1–4` validation (400), `422` on bad mode, and most behavioral tests. Replaced: the anti-join where-block → the flag-based predicate above. The `isdecimal()` fixes to `tags`/`exclude_tags` from #228 are independent and stay.
+
+## Testing (TDD)
+
+1. **Helper unit tests** — `refresh_image_tag_type_flags` sets each flag correctly for an image with/without each tag type; `refresh_images_for_tag` updates all linked images. Real DB, no mocks.
+2. **Maintenance integration tests** — for each hook site, exercise the real endpoint/service (add tag → `has_*` becomes 1; remove the last tag of a type → back to 0; remove one of two artist tags → stays 1; tag type change → flags flip; tag delete/merge → affected images updated).
+3. **Filter behavior tests** — the PR #228 `TestMissingTagTypes` cases still pass, but fixtures must set flags. Update fixtures to call `refresh_image_tag_type_flags(db, image_id)` after inserting `TagLinks` (this keeps tests honest by exercising the helper). The alias test still holds: the applied tag's `type` drives the recompute.
+4. **Count test** — `total` is correct and the query returns promptly (the original motivation).
+5. **Backfill script test** — on a seeded set, the script produces the same flags the helper would.

--- a/docs/plans/2026-05-31-tag-type-presence-denormalization-impl.md
+++ b/docs/plans/2026-05-31-tag-type-presence-denormalization-impl.md
@@ -1,0 +1,613 @@
+# Tag-Type Presence Denormalization Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the timing-out `missing_tag_types` anti-join with maintained per-image boolean flags (`has_theme/has_source/has_artist/has_character`) so the filter is a fast, sargable, indexed column predicate.
+
+**Architecture:** 4 internal boolean columns on `images` (migration + model), kept correct by a single flush-first, set-based recompute helper hooked into every tag-link mutation site and every tag-level operation that changes type composition. The filter rewrites to column predicates. A separate batched script backfills the 1.1M existing rows.
+
+**Tech Stack:** FastAPI, SQLModel/SQLAlchemy async, MariaDB 12, Alembic, pytest (async), `uv`.
+
+**Spec:** `docs/plans/2026-05-31-tag-type-presence-denormalization-design.md`
+
+## Key facts (verified against the codebase)
+
+- Test DB runs `alembic upgrade head` (`tests/conftest.py:229`), so the migration MUST be valid for the suite to have the columns.
+- Session is `autoflush=False` (`app/core/database.py`), so the recompute helper MUST `await db.flush()` before reading `tag_links`.
+- Services do NOT commit (routes/callers commit). The helper must NOT commit — it joins the caller's transaction. Call it BEFORE the `await db.commit()` in each path.
+- Migration DDL precedent (`alembic/versions/...add_in_r2_to_banners.py`): `op.execute("ALTER TABLE ... ADD COLUMN ... BOOLEAN NOT NULL DEFAULT 0, ALGORITHM=INSTANT, LOCK=NONE")`.
+- House idiom for boolean-column comparison: `Col == False  # noqa: E712` (e.g. `app/models/comment.py:95`). `and_`/`or_` already imported in `app/api/v1/images.py:28`.
+- Raw `text()` SQL is idiomatic here (cf. `get_tag_hierarchy` CTE in `tags.py`, repost `INSERT ... SELECT`).
+- Use `uv run` for all Python. Pre-commit runs ruff and blocks commits to `main` — work stays on branch `missing-tag-type-filter`.
+
+---
+
+## Chunk 1: Schema, model, recompute helper, filter rewrite
+
+### Task 1: Add the 4 columns + indexes (model + migration)
+
+**Files:**
+- Modify: `app/models/image.py` (Images table fields + `__table_args__`)
+- Create: `alembic/versions/<generated>_add_tag_type_flags_to_images.py`
+- Test: `tests/api/v1/test_images.py` (one assertion in a new test)
+
+- [ ] **Step 1: Add the model fields.** In `app/models/image.py`, in the `Images` table class with the other internal scalar fields (near `medium`/`large`/`total_pixels`, after `image_id`/scalar fields — match surrounding style), add:
+
+```python
+    # Denormalized tag-type presence (maintained by app.services.tag_type_flags).
+    # Internal cache of "image has >=1 tag of this type"; source of truth is tag_links + tags.type.
+    has_theme: bool = Field(default=False)
+    has_source: bool = Field(default=False)
+    has_artist: bool = Field(default=False)
+    has_character: bool = Field(default=False)
+```
+
+- [ ] **Step 2: Add the indexes** to `Images.__table_args__` (alongside the existing `Index(...)` entries):
+
+```python
+        Index("idx_images_has_theme", "has_theme", "image_id"),
+        Index("idx_images_has_source", "has_source", "image_id"),
+        Index("idx_images_has_artist", "has_artist", "image_id"),
+        Index("idx_images_has_character", "has_character", "image_id"),
+```
+
+- [ ] **Step 3: Generate the migration.**
+
+Run: `uv run alembic revision -m "add tag-type flags to images"`
+Edit the generated file so `upgrade()`/`downgrade()` are (keep the auto-generated `revision`/`down_revision`; do NOT hand-edit those):
+
+```python
+def upgrade() -> None:
+    # Metadata-only column add (INSTANT) — instant on the 1.1M-row table.
+    op.execute(
+        "ALTER TABLE images "
+        "ADD COLUMN has_theme TINYINT(1) NOT NULL DEFAULT 0, "
+        "ADD COLUMN has_source TINYINT(1) NOT NULL DEFAULT 0, "
+        "ADD COLUMN has_artist TINYINT(1) NOT NULL DEFAULT 0, "
+        "ADD COLUMN has_character TINYINT(1) NOT NULL DEFAULT 0, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )
+    # Online index builds (INPLACE, non-blocking).
+    for col in ("has_theme", "has_source", "has_artist", "has_character"):
+        op.execute(
+            f"CREATE INDEX idx_images_{col} ON images ({col}, image_id) "
+            "ALGORITHM=INPLACE, LOCK=NONE"
+        )
+
+
+def downgrade() -> None:
+    for col in ("has_theme", "has_source", "has_artist", "has_character"):
+        op.execute(f"DROP INDEX idx_images_{col} ON images")
+    op.execute(
+        "ALTER TABLE images "
+        "DROP COLUMN has_theme, DROP COLUMN has_source, "
+        "DROP COLUMN has_artist, DROP COLUMN has_character, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )
+```
+
+- [ ] **Step 4: Apply the migration locally.**
+
+Run: `uv run alembic upgrade head`
+Expected: succeeds. Then `uv run alembic downgrade -1 && uv run alembic upgrade head` to prove the down/up round-trips cleanly. (If your local dev DB is the large one and INPLACE index builds are slow, that's expected — the test DB is small.)
+
+- [ ] **Step 5: Write a test that the columns exist and default to False.**
+
+Append to `tests/api/v1/test_images.py` inside `TestMissingTagTypes` (it gets the migration via conftest):
+
+```python
+    async def test_new_image_defaults_tag_type_flags_false(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """The denormalized presence flags exist and default to False on a fresh image."""
+        img = Images(**{**sample_image_data, "filename": "flags_default", "md5_hash": "9c" * 16})
+        db_session.add(img)
+        await db_session.commit()
+        await db_session.refresh(img)
+        assert img.has_theme is False
+        assert img.has_source is False
+        assert img.has_artist is False
+        assert img.has_character is False
+```
+
+- [ ] **Step 6: Run it.** `uv run pytest tests/api/v1/test_images.py::TestMissingTagTypes::test_new_image_defaults_tag_type_flags_false -v` → PASS (proves the migration ran in the test DB and the model maps the columns).
+
+- [ ] **Step 7: mypy + commit.**
+
+Run: `uv run mypy app/models/image.py` → clean.
+```bash
+git add app/models/image.py alembic/versions/
+git commit -m "feat(images): add denormalized tag-type presence columns + indexes"
+```
+
+---
+
+### Task 2: Recompute-from-source helper
+
+**Files:**
+- Create: `app/services/tag_type_flags.py`
+- Test: `tests/unit/test_tag_type_flags.py` (new) — or `tests/api/v1/` if a DB session fixture is needed; use whichever fixture pattern gives an async `db_session` + ability to insert Images/Tags/TagLinks (mirror `tests/api/v1/test_images.py`).
+
+- [ ] **Step 1: Write the failing test.** Create `tests/api/v1/test_tag_type_flags.py`:
+
+```python
+import pytest
+from httpx import AsyncClient  # not used directly but keeps fixture parity if needed
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import TagType
+from app.models import Images, TagLinks, Tags
+from app.services.tag_type_flags import (
+    refresh_image_tag_type_flags,
+    refresh_images_tag_type_flags,
+)
+
+
+@pytest.mark.api
+class TestTagTypeFlagsHelper:
+    async def test_refresh_sets_flags_for_present_types(
+        self, db_session: AsyncSession, sample_image_data: dict
+    ):
+        img = Images(**{**sample_image_data, "filename": "ttf1", "md5_hash": "11" * 16})
+        db_session.add(img)
+        await db_session.flush()
+        artist = Tags(title="ttf artist", desc="a", type=TagType.ARTIST)
+        theme = Tags(title="ttf theme", desc="t", type=TagType.THEME)
+        db_session.add_all([artist, theme])
+        await db_session.flush()
+        # NOTE: links added but NOT flushed — exercises the helper's internal flush.
+        db_session.add(TagLinks(image_id=img.image_id, tag_id=artist.tag_id, user_id=1))
+        db_session.add(TagLinks(image_id=img.image_id, tag_id=theme.tag_id, user_id=1))
+
+        await refresh_image_tag_type_flags(db_session, img.image_id)
+
+        await db_session.refresh(img)
+        assert img.has_artist is True
+        assert img.has_theme is True
+        assert img.has_source is False
+        assert img.has_character is False
+
+    async def test_refresh_clears_flag_when_last_tag_of_type_gone(
+        self, db_session: AsyncSession, sample_image_data: dict
+    ):
+        img = Images(**{**sample_image_data, "filename": "ttf2", "md5_hash": "22" * 16})
+        db_session.add(img)
+        await db_session.flush()
+        artist = Tags(title="ttf artist2", desc="a", type=TagType.ARTIST)
+        db_session.add(artist)
+        await db_session.flush()
+        db_session.add(TagLinks(image_id=img.image_id, tag_id=artist.tag_id, user_id=1))
+        await refresh_image_tag_type_flags(db_session, img.image_id)
+        await db_session.refresh(img)
+        assert img.has_artist is True
+
+        from sqlalchemy import delete
+        await db_session.execute(
+            delete(TagLinks).where(
+                TagLinks.image_id == img.image_id, TagLinks.tag_id == artist.tag_id
+            )
+        )
+        await refresh_image_tag_type_flags(db_session, img.image_id)
+        await db_session.refresh(img)
+        assert img.has_artist is False
+
+    async def test_refresh_empty_set_is_noop(self, db_session: AsyncSession):
+        await refresh_images_tag_type_flags(db_session, [])  # must not raise
+```
+
+- [ ] **Step 2: Run → FAIL** (module doesn't exist). `uv run pytest tests/api/v1/test_tag_type_flags.py -v`
+
+- [ ] **Step 3: Implement** `app/services/tag_type_flags.py`:
+
+```python
+"""Maintain denormalized per-image tag-type presence flags on the images table.
+
+Source of truth is tag_links + tags.type; these helpers recompute the cached
+has_theme/has_source/has_artist/has_character columns from it (idempotent).
+"""
+
+from collections.abc import Collection
+
+from sqlalchemy import bindparam, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Single set-based recompute over a set of image_ids. MariaDB multi-table UPDATE;
+# MAX(t.type = N) is a boolean aggregate (1 if any tag of that type, else 0).
+_RECOMPUTE_SQL = text(
+    """
+    UPDATE images i
+    LEFT JOIN (
+        SELECT tl.image_id,
+               MAX(t.type = 1) AS ht,
+               MAX(t.type = 2) AS hs,
+               MAX(t.type = 3) AS ha,
+               MAX(t.type = 4) AS hc
+        FROM tag_links tl
+        JOIN tags t ON tl.tag_id = t.tag_id
+        WHERE tl.image_id IN :ids
+        GROUP BY tl.image_id
+    ) agg ON agg.image_id = i.image_id
+    SET i.has_theme = COALESCE(agg.ht, 0),
+        i.has_source = COALESCE(agg.hs, 0),
+        i.has_artist = COALESCE(agg.ha, 0),
+        i.has_character = COALESCE(agg.hc, 0)
+    WHERE i.image_id IN :ids
+    """
+).bindparams(bindparam("ids", expanding=True))
+
+
+async def refresh_images_tag_type_flags(
+    db: AsyncSession, image_ids: Collection[int]
+) -> None:
+    """Recompute the 4 tag-type presence flags for the given images from tag_links.
+
+    Idempotent. Does NOT commit — joins the caller's transaction. Flushes first
+    because the session is autoflush=False and add-tag paths leave pending,
+    unflushed TagLinks the recompute SELECT must see.
+    """
+    ids = list({int(i) for i in image_ids})
+    if not ids:
+        return
+    await db.flush()
+    await db.execute(_RECOMPUTE_SQL, {"ids": ids})
+
+
+async def refresh_image_tag_type_flags(db: AsyncSession, image_id: int) -> None:
+    """Convenience wrapper for a single image."""
+    await refresh_images_tag_type_flags(db, [image_id])
+```
+
+- [ ] **Step 4: Run → PASS.** `uv run pytest tests/api/v1/test_tag_type_flags.py -v`
+
+- [ ] **Step 5: mypy + commit.** `uv run mypy app/services/tag_type_flags.py` → clean.
+```bash
+git add app/services/tag_type_flags.py tests/api/v1/test_tag_type_flags.py
+git commit -m "feat(tags): add tag-type presence recompute helper"
+```
+
+---
+
+### Task 3: Rewrite the `missing_tag_types` filter to use the flags
+
+**Files:**
+- Modify: `app/api/v1/images.py` (the `missing_tag_types` where-block, ~lines 462–500)
+- Modify: `tests/api/v1/test_images.py` (`TestMissingTagTypes` fixtures must set flags)
+
+- [ ] **Step 1: Update the existing behavior tests' fixtures FIRST (they will fail against the new mechanism otherwise, but for the right reason).** In `tests/api/v1/test_images.py`, in each `TestMissingTagTypes` test that inserts `TagLinks` and then queries (`test_missing_single_type_*`, `test_missing_all_mode_*`, `test_missing_any_mode_*`, `test_missing_artist_does_not_resolve_alias`, `test_missing_combined_with_include_tags`), after the `await db_session.commit()` that persists the links, call the helper for every seeded image, then commit again. Add at the top of the file:
+
+```python
+from app.services.tag_type_flags import refresh_image_tag_type_flags
+```
+
+And after each fixture's link `commit()`, e.g.:
+
+```python
+        await db_session.commit()
+        # Maintain denormalized flags the filter now reads (prod does this via hooks).
+        for img in (has_artist, no_artist):
+            await refresh_image_tag_type_flags(db_session, img.image_id)
+        await db_session.commit()
+```
+
+(Apply to each test using the actual image variables it created. The no-tag and 422/omitted/validation/unicode tests need no change — no links to reflect.)
+
+- [ ] **Step 2: Run the class against the OLD implementation → still PASS** (anti-join still works; the helper-maintained flags are just unused so far). `uv run pytest "tests/api/v1/test_images.py::TestMissingTagTypes" -v`. This confirms the fixture edits didn't break anything before the rewrite.
+
+- [ ] **Step 3: Rewrite the where-block.** Replace the entire `if missing_type_ids:` body (the `all`/`else` branches with the `notin_`/`lacks_type` anti-joins) so the parse + validation stay and only the query construction changes:
+
+```python
+        missing_type_ids = sorted({int(t) for t in raw_tokens})
+        if missing_type_ids:
+            type_column = {
+                1: Images.has_theme,
+                2: Images.has_source,
+                3: Images.has_artist,
+                4: Images.has_character,
+            }
+            # "missing type T" == that image's has_<type> flag is False.
+            clauses = [type_column[t] == False for t in missing_type_ids]  # noqa: E712
+            if missing_tag_types_mode == "all":
+                query = query.where(and_(*clauses))  # missing every listed type
+            else:
+                query = query.where(or_(*clauses))  # missing at least one listed type
+```
+
+Leave the param definitions, `raw_tokens` parsing, `isdecimal()` validation, and the 400 raise unchanged.
+
+- [ ] **Step 4: Run the class → PASS.** `uv run pytest "tests/api/v1/test_images.py::TestMissingTagTypes" -v` (all behavior tests green against the new flag-based mechanism).
+
+- [ ] **Step 5: mypy/ruff reconcile.** `uv run mypy app/api/v1/images.py` → clean (the `== False` comparison may need a `# type: ignore[...]`; add exactly what mypy reports, mirroring the file's existing ignores). `uv run ruff check app/api/v1/images.py` → the `# noqa: E712` suppresses the comparison lint.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add app/api/v1/images.py tests/api/v1/test_images.py
+git commit -m "feat(images): filter missing_tag_types via denormalized flags"
+```
+
+---
+
+## Chunk 2: Maintenance hooks
+
+Pattern for every hook task: call the recompute helper for the affected image(s) **before** the path's `await db.commit()`, then add an integration test that drives the real endpoint/service and asserts the flag flips. Import inside the function or at module top, matching the file's import style.
+
+### Task 4: Single add/remove tag (images.py)
+
+**Files:**
+- Modify: `app/api/v1/images.py` (add handler ~line 1828 `await db.commit()`; remove handler ~line 1899 `await db.commit()`)
+- Test: `tests/api/v1/test_images.py`
+
+- [ ] **Step 1: Failing tests** — add to a suitable class (e.g. a new `TestTagTypeFlagMaintenance` in `test_images.py`). Use the real add/remove endpoints with an authenticated client (mirror existing add/remove-tag tests in the file for auth fixture usage; find them via `grep -n "tags\b" tests/api/v1/test_images.py` and the `/tags` POST/DELETE routes). Assert: after POST add of an artist tag, the image row `has_artist` is True; after DELETE of that tag, `has_artist` is False.
+
+- [ ] **Step 2: Run → FAIL** (flags not maintained yet).
+
+- [ ] **Step 3: Implement.** In the add handler, immediately before `await db.commit()` (the one at ~line 1828, after `db.add(history_entry)`):
+```python
+    await refresh_image_tag_type_flags(db, image_id)
+```
+In the remove handler, immediately before its `await db.commit()` (~line 1899, after the `delete(TagLinks)` execute):
+```python
+    await refresh_image_tag_type_flags(db, image_id)
+```
+Add `from app.services.tag_type_flags import refresh_image_tag_type_flags` to the imports.
+
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: mypy + commit.** `git commit -m "feat(images): maintain tag-type flags on single tag add/remove"`
+
+---
+
+### Task 5: Upload (initial tagging)
+
+**Files:**
+- Modify: `app/services/upload.py` (`link_tags_to_image`, loop ends ~line 157; function has no commit — caller commits)
+- Test: `tests/api/v1/` or `tests/unit/` — an upload-path test that asserts a freshly uploaded image with an artist tag has `has_artist=True`. Reuse existing upload test patterns (`grep -rn "link_tags_to_image\|upload" tests/`).
+
+- [ ] **Step 1: Failing test.** Drive `link_tags_to_image` (or the upload endpoint) with an artist tag; assert `has_artist` True after the caller commits.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement.** At the END of `link_tags_to_image`, after the `for` loop (all `db.add(TagLinks(...))` done), add:
+```python
+    await refresh_image_tag_type_flags(db, image_id)
+```
+Import the helper. (One call for the image; the helper flushes the pending links.)
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: mypy + commit.** `git commit -m "feat(upload): maintain tag-type flags on initial tagging"`
+
+---
+
+### Task 6: Batch add / remove (batch_tag.py)
+
+**Files:**
+- Modify: `app/services/batch_tag.py` (`batch_add_tags` before commit ~line 136; `batch_remove_tags` before commit ~line 276)
+- Test: `tests/` batch-tag tests (`grep -rn "batch_add_tags\|batch_remove_tags\|batch" tests/`)
+
+- [ ] **Step 1: Failing tests.** Batch-add an artist tag to two images → both `has_artist` True; batch-remove → both False.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement.** In each function, collect the set of affected `image_id`s processed (the images that actually got a link added/removed), and before the `await db.commit()` call:
+```python
+    await refresh_images_tag_type_flags(db, affected_image_ids)
+```
+For `batch_add_tags`, `affected_image_ids` = the image_ids for which a `TagLinks` was added (track in the existing add loop). For `batch_remove_tags`, the image_ids in `pairs_to_remove`. Import `refresh_images_tag_type_flags`.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: mypy + commit.** `git commit -m "feat(batch-tag): maintain tag-type flags on batch add/remove"`
+
+---
+
+### Task 7: Repost merge (repost.py)
+
+**Files:**
+- Modify: `app/services/repost.py` (`migrate_repost_data`, before `return` ~line 155; no commit — both callers commit)
+- Test: `tests/` repost tests (`grep -rn "migrate_repost_data\|repost" tests/`)
+
+- [ ] **Step 1: Failing test.** Set up `original_id` with NO artist tag and `repost_id` WITH an artist tag; run `migrate_repost_data`; commit; assert `original_id.has_artist` is now True (it gained the repost's tags) and `repost_id` flags all False (its links were deleted).
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement.** Immediately before the `return {...}` in `migrate_repost_data`, after the `delete(TagLinks)` for `repost_id`:
+```python
+    await refresh_images_tag_type_flags(db, [original_id, repost_id])
+```
+Import the helper. This covers both callers (`images.py:1023`, `admin.py:770`) atomically since neither commits before calling.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: mypy + commit.** `git commit -m "feat(repost): maintain tag-type flags on repost merge"`
+
+---
+
+### Task 8: Admin report-resolution (admin.py)
+
+**Files:**
+- Modify: `app/api/v1/admin.py` (the suggestion loop ~lines 1559–1595; find the handler's `await db.commit()` after the loop)
+- Test: `tests/api/v1/test_admin*.py`
+
+- [ ] **Step 1: Failing test.** Approve an "add artist tag" suggestion for a report's image → image `has_artist` True; approve a "remove" of the last artist tag → False.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement.** After the suggestion loop and before the handler's `await db.commit()`, add a single refresh for the report's image:
+```python
+    await refresh_image_tag_type_flags(db, report.image_id)
+```
+Import the helper.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: mypy + commit.** `git commit -m "feat(admin): maintain tag-type flags on report tag-suggestion resolution"`
+
+---
+
+### Task 9: Tag delete (tags.py)
+
+**Files:**
+- Modify: `app/api/v1/tags.py` (`delete_tag`, ~lines 1586–1593)
+- Test: `tests/api/v1/test_tags*.py` (or `test_images.py`)
+
+- [ ] **Step 1: Failing test.** Image has exactly one artist tag (`has_artist` True via the helper). DELETE that tag. Assert the image `has_artist` is now False (the cascade removed its only artist link).
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement.** Link cleanup is DB FK CASCADE (no ORM relationship), so capture affected images BEFORE deleting, flush so the cascade applies, then recompute:
+```python
+    # Capture images linked to this tag before the CASCADE removes the links.
+    affected = await db.execute(
+        select(TagLinks.image_id).where(TagLinks.tag_id == tag_id)  # type: ignore[call-overload]
+    )
+    affected_image_ids = [row[0] for row in affected]
+
+    await db.delete(tag)
+    await db.flush()  # apply the FK CASCADE within this transaction before recompute
+    await refresh_images_tag_type_flags(db, affected_image_ids)
+    await db.commit()
+```
+Import `refresh_images_tag_type_flags`.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: mypy + commit.** `git commit -m "feat(tags): maintain tag-type flags on tag delete"`
+
+---
+
+### Task 10: Tag type change (tags.py update_tag)
+
+**Files:**
+- Modify: `app/api/v1/tags.py` (`update_tag`, type-change branch ~line 1360; commit ~line 1558)
+- Test: `tests/api/v1/test_tags*.py`
+
+- [ ] **Step 1: Failing test.** Image linked to a tag of type ARTIST (`has_artist` True, `has_source` False). PATCH the tag's `type` to SOURCE. Assert the image is now `has_artist` False, `has_source` True.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement.** In the `if tag.type != original_type:` branch, gather the affected images and recompute (set-based; bounded by the tag's usage). Add before the handler's commit:
+```python
+    if tag.type != original_type:
+        # ... existing audit log ...
+        affected = await db.execute(
+            select(TagLinks.image_id).where(TagLinks.tag_id == tag_id)  # type: ignore[call-overload]
+        )
+        await refresh_images_tag_type_flags(db, [row[0] for row in affected])
+```
+(The helper flushes, so the in-session `tag.type` change is visible to the recompute JOIN.) Import the helper.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: mypy + commit.** `git commit -m "feat(tags): maintain tag-type flags on tag type change"`
+
+---
+
+### Task 11: Tag merge / alias reassignment (tags.py)
+
+**Files:**
+- Modify: `app/api/v1/tags.py` (alias-set branch ~lines 1455–1488)
+- Test: `tests/api/v1/test_tags*.py`
+
+- [ ] **Step 1: Failing/characterization test.** This is nearly always a flag no-op (API enforces alias & canonical share type), so the test mainly guards idempotency: image linked to an alias-artist tag (`has_artist` True). Set the alias's `alias_of` to a canonical artist tag (reassigns links). Assert the image still has `has_artist` True. (If it already passes once the recompute is added, that's the expected lock-in.)
+- [ ] **Step 2: Run → confirm behavior** (may pass even pre-change because flags don't move; the recompute makes it explicitly correct/drift-proof).
+- [ ] **Step 3: Implement.** Before the usage_count recompute block (after the `update(TagLinks).values(tag_id=canonical_id)`), capture and refresh the affected images:
+```python
+        # Refresh flags for images whose links moved (idempotent; types match so usually a no-op).
+        affected = await db.execute(
+            select(TagLinks.image_id).where(TagLinks.tag_id == canonical_id)  # type: ignore[call-overload]
+        )
+        await refresh_images_tag_type_flags(db, [row[0] for row in affected])
+```
+Import the helper.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: mypy + commit.** `git commit -m "feat(tags): refresh tag-type flags on alias reassignment"`
+
+---
+
+## Chunk 3: Backfill + verification
+
+### Task 12: Backfill script
+
+**Files:**
+- Create: `scripts/backfill_tag_type_flags.py`
+- Test: `tests/` — a test that seeds images+links, runs the batched recompute over a range, and asserts flags match.
+
+- [ ] **Step 1: Failing test.** Seed 2 images (one with an artist tag, one with none), call the script's batch function over their id range, assert flags correct.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** `scripts/backfill_tag_type_flags.py` — a resumable, batched, idempotent backfill. Reuse the same recompute SQL but keyed by an `image_id` range instead of an explicit id list (so it doesn't need the full id list in memory):
+
+```python
+"""Backfill images.has_theme/source/artist/character from tag_links.
+
+Idempotent and resumable. Run AFTER the migration that adds the columns.
+Usage: uv run python scripts/backfill_tag_type_flags.py [--batch 10000] [--start 0]
+"""
+import argparse
+import asyncio
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.config import settings  # confirm settings.DATABASE_URL is exported here
+
+_BATCH_SQL = text(
+    """
+    UPDATE images i
+    LEFT JOIN (
+        SELECT tl.image_id,
+               MAX(t.type = 1) AS ht, MAX(t.type = 2) AS hs,
+               MAX(t.type = 3) AS ha, MAX(t.type = 4) AS hc
+        FROM tag_links tl JOIN tags t ON tl.tag_id = t.tag_id
+        WHERE tl.image_id >= :lo AND tl.image_id < :hi
+        GROUP BY tl.image_id
+    ) agg ON agg.image_id = i.image_id
+    SET i.has_theme = COALESCE(agg.ht, 0), i.has_source = COALESCE(agg.hs, 0),
+        i.has_artist = COALESCE(agg.ha, 0), i.has_character = COALESCE(agg.hc, 0)
+    WHERE i.image_id >= :lo AND i.image_id < :hi
+    """
+)
+
+async def backfill(batch: int, start: int) -> None:
+    # Match the engine/session pattern in scripts/audit_alias_parent_violations.py.
+    engine = create_async_engine(settings.DATABASE_URL, echo=False)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as db:
+        max_id = (await db.execute(text("SELECT MAX(image_id) FROM images"))).scalar() or 0
+        lo = start
+        while lo <= max_id:
+            hi = lo + batch
+            await db.execute(_BATCH_SQL, {"lo": lo, "hi": hi})
+            await db.commit()
+            print(f"backfilled image_id [{lo}, {hi})  (max={max_id})", flush=True)
+            lo = hi
+    await engine.dispose()
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--batch", type=int, default=10000)
+    ap.add_argument("--start", type=int, default=0)
+    args = ap.parse_args()
+    asyncio.run(backfill(args.batch, args.start))
+
+if __name__ == "__main__":
+    main()
+```
+
+(Confirm the actual async session factory name in `app/core/database.py` — adjust the import. Match existing `scripts/*.py` conventions for session setup.)
+
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit.** `git commit -m "feat(scripts): batched backfill for tag-type presence flags"`
+
+---
+
+### Task 13: Whole-feature verification
+
+**Files:** none (verification + EXPLAIN evidence only)
+
+- [ ] **Step 1: Full suite of touched areas.** Run:
+```
+uv run pytest tests/api/v1/test_images.py tests/api/v1/test_tag_type_flags.py -q
+uv run pytest tests/api/v1/test_tags.py tests/api/v1/test_admin_images.py -q   # adjust to actual test files touched
+```
+Expected: all green.
+
+- [ ] **Step 2: mypy on all touched modules.**
+```
+uv run mypy app/api/v1/images.py app/api/v1/tags.py app/api/v1/admin.py app/services/tag_type_flags.py app/services/upload.py app/services/batch_tag.py app/services/repost.py app/models/image.py
+```
+Expected: clean.
+
+- [ ] **Step 3: EXPLAIN verification against the dev DB** (the original motivation). After backfilling the dev DB (`uv run python scripts/backfill_tag_type_flags.py`), confirm the page query is fast:
+```bash
+curl -s -m 10 -o /dev/null -w "missing_artist http=%{http_code} time=%{time_total}s\n" \
+  "http://localhost:8000/api/v1/images?missing_tag_types=3&per_page=20"
+```
+Expected: http=200, time well under 1s (vs the 60s+ timeout before). Run `EXPLAIN` on the single-type page query and confirm it uses `idx_images_has_artist` (no large filesort). Record the `any`-mode EXPLAIN too; if `any` mode is slow, note it (per the design's caveat) — it does not block single-type.
+
+- [ ] **Step 4: ruff.** `uv run ruff check <touched files>` and `uv run ruff format --check <touched files>` (only the lines this work added; pre-existing drift elsewhere is out of scope).
+
+- [ ] **Step 5: Final commit (if any fixups).** `git commit -m "chore: verification fixups for tag-type presence flags" || echo "nothing to commit"`
+
+---
+
+## Out of scope (not this PR)
+
+- Scheduled reconciliation job (the backfill script is the manual reconciliation tool).
+- Indexing fewer flags / write-cost tuning — revisit only if uploads measurably regress.
+- `any`-mode page-query optimization beyond EXPLAIN verification.

--- a/docs/plans/2026-05-31-tag-type-presence-denormalization-impl.md
+++ b/docs/plans/2026-05-31-tag-type-presence-denormalization-impl.md
@@ -61,10 +61,10 @@ def upgrade() -> None:
     # Metadata-only column add (INSTANT) — instant on the 1.1M-row table.
     op.execute(
         "ALTER TABLE images "
-        "ADD COLUMN has_theme TINYINT(1) NOT NULL DEFAULT 0, "
-        "ADD COLUMN has_source TINYINT(1) NOT NULL DEFAULT 0, "
-        "ADD COLUMN has_artist TINYINT(1) NOT NULL DEFAULT 0, "
-        "ADD COLUMN has_character TINYINT(1) NOT NULL DEFAULT 0, "
+        "ADD COLUMN has_theme BOOLEAN NOT NULL DEFAULT 0, "
+        "ADD COLUMN has_source BOOLEAN NOT NULL DEFAULT 0, "
+        "ADD COLUMN has_artist BOOLEAN NOT NULL DEFAULT 0, "
+        "ADD COLUMN has_character BOOLEAN NOT NULL DEFAULT 0, "
         "ALGORITHM=INSTANT, LOCK=NONE"
     )
     # Online index builds (INPLACE, non-blocking).
@@ -305,7 +305,10 @@ And after each fixture's link `commit()`, e.g.:
                 4: Images.has_character,
             }
             # "missing type T" == that image's has_<type> flag is False.
-            clauses = [type_column[t] == False for t in missing_type_ids]  # noqa: E712
+            clauses = [
+                type_column[t] == False  # type: ignore[arg-type]  # noqa: E712
+                for t in missing_type_ids
+            ]
             if missing_tag_types_mode == "all":
                 query = query.where(and_(*clauses))  # missing every listed type
             else:
@@ -316,7 +319,7 @@ Leave the param definitions, `raw_tokens` parsing, `isdecimal()` validation, and
 
 - [ ] **Step 4: Run the class → PASS.** `uv run pytest "tests/api/v1/test_images.py::TestMissingTagTypes" -v` (all behavior tests green against the new flag-based mechanism).
 
-- [ ] **Step 5: mypy/ruff reconcile.** `uv run mypy app/api/v1/images.py` → clean (the `== False` comparison may need a `# type: ignore[...]`; add exactly what mypy reports, mirroring the file's existing ignores). `uv run ruff check app/api/v1/images.py` → the `# noqa: E712` suppresses the comparison lint.
+- [ ] **Step 5: mypy/ruff reconcile.** `uv run mypy app/api/v1/images.py` → clean. The house idiom (verified at `app/api/v1/comments.py:95`) is `col == False  # type: ignore[arg-type]  # noqa: E712`; apply that to each clause (the `noqa` suppresses ruff E712, the `type: ignore[arg-type]` satisfies mypy). `uv run ruff check app/api/v1/images.py` → clean.
 
 - [ ] **Step 6: Commit.**
 ```bash
@@ -329,6 +332,8 @@ git commit -m "feat(images): filter missing_tag_types via denormalized flags"
 ## Chunk 2: Maintenance hooks
 
 Pattern for every hook task: call the recompute helper for the affected image(s) **before** the path's `await db.commit()`, then add an integration test that drives the real endpoint/service and asserts the flag flips. Import inside the function or at module top, matching the file's import style.
+
+**Test assertion caveat (applies to every Chunk 2 task):** the recompute is a raw `UPDATE` that bypasses the ORM, and conftest uses `expire_on_commit=False`, so a pre-fetched `Images` object keeps **stale** `has_*` attributes. Assert by **re-querying** the image (`select(Images).where(...)`) or `await db.refresh(img)` first — never on an `Images` instance loaded before the helper ran. (The filter tests in Task 3 are unaffected: they hit the SQL WHERE clause, not a Python object.)
 
 ### Task 4: Single add/remove tag (images.py)
 
@@ -381,11 +386,13 @@ Import the helper. (One call for the image; the helper flushes the pending links
 
 - [ ] **Step 1: Failing tests.** Batch-add an artist tag to two images → both `has_artist` True; batch-remove → both False.
 - [ ] **Step 2: Run → FAIL.**
-- [ ] **Step 3: Implement.** In each function, collect the set of affected `image_id`s processed (the images that actually got a link added/removed), and before the `await db.commit()` call:
+- [ ] **Step 3: Implement.** Reuse the bookkeeping each function already keeps (no new tracking needed), and call before the `await db.commit()`:
 ```python
     await refresh_images_tag_type_flags(db, affected_image_ids)
 ```
-For `batch_add_tags`, `affected_image_ids` = the image_ids for which a `TagLinks` was added (track in the existing add loop). For `batch_remove_tags`, the image_ids in `pairs_to_remove`. Import `refresh_images_tag_type_flags`.
+- `batch_add_tags`: `affected_image_ids = {i.image_id for i in added}` (the existing `added` result list; each item carries `image_id`).
+- `batch_remove_tags`: `affected_image_ids = {p[0] for p in pairs_to_remove}` (the existing `pairs_to_remove` set of `(image_id, tag_id)`).
+Import `refresh_images_tag_type_flags`.
 - [ ] **Step 4: Run → PASS.**
 - [ ] **Step 5: mypy + commit.** `git commit -m "feat(batch-tag): maintain tag-type flags on batch add/remove"`
 
@@ -413,9 +420,9 @@ Import the helper. This covers both callers (`images.py:1023`, `admin.py:770`) a
 
 **Files:**
 - Modify: `app/api/v1/admin.py` (the suggestion loop ~lines 1559–1595; find the handler's `await db.commit()` after the loop)
-- Test: `tests/api/v1/test_admin*.py`
+- Test: `tests/api/v1/test_admin_images.py` (report/suggestion setup) — there is no `admin_client` fixture; admin tests create an admin via the per-file `create_admin_user(db_session, "name")` helper (see `tests/api/v1/test_admin_actions.py:29`). Reuse that pattern and the report-setup fixtures already in `test_admin_images.py`.
 
-- [ ] **Step 1: Failing test.** Approve an "add artist tag" suggestion for a report's image → image `has_artist` True; approve a "remove" of the last artist tag → False.
+- [ ] **Step 1: Failing test.** Approve an "add artist tag" suggestion for a report's image → image `has_artist` True; approve a "remove" of the last artist tag → False. Assert by re-querying the image (see Chunk 2 caveat).
 - [ ] **Step 2: Run → FAIL.**
 - [ ] **Step 3: Implement.** After the suggestion loop and before the handler's `await db.commit()`, add a single refresh for the report's image:
 ```python
@@ -454,10 +461,12 @@ Import `refresh_images_tag_type_flags`.
 
 ---
 
+> **Note (Tasks 10 & 11):** `update_tag` has a SINGLE `await db.commit()` (~line 1558) covering both the type-change branch (~1360) and the alias branch (~1455). Don't look for two commits. Both recompute calls land before that one commit; a combined type+alias PATCH runs both (idempotent, harmless).
+
 ### Task 10: Tag type change (tags.py update_tag)
 
 **Files:**
-- Modify: `app/api/v1/tags.py` (`update_tag`, type-change branch ~line 1360; commit ~line 1558)
+- Modify: `app/api/v1/tags.py` (`update_tag`, type-change branch ~line 1360; single commit ~line 1558)
 - Test: `tests/api/v1/test_tags*.py`
 
 - [ ] **Step 1: Failing test.** Image linked to a tag of type ARTIST (`has_artist` True, `has_source` False). PATCH the tag's `type` to SOURCE. Assert the image is now `has_artist` False, `has_source` True.

--- a/scripts/backfill_tag_type_flags.py
+++ b/scripts/backfill_tag_type_flags.py
@@ -1,0 +1,71 @@
+"""Backfill images.has_theme/source/artist/character from tag_links.
+
+Idempotent and resumable. Run AFTER the migration that adds the columns.
+Until this completes, the columns default to 0, so the missing_tag_types filter
+harmlessly over-reports images as "missing" a type — don't rely on it for real
+results before the backfill finishes.
+Usage: uv run python scripts/backfill_tag_type_flags.py [--batch 10000] [--start 0]
+"""
+
+import argparse
+import asyncio
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.config import settings
+
+_BATCH_SQL = text(
+    """
+    UPDATE images i
+    LEFT JOIN (
+        SELECT tl.image_id,
+               MAX(t.type = 1) AS ht, MAX(t.type = 2) AS hs,
+               MAX(t.type = 3) AS ha, MAX(t.type = 4) AS hc
+        FROM tag_links tl JOIN tags t ON tl.tag_id = t.tag_id
+        WHERE tl.image_id >= :lo AND tl.image_id < :hi
+        GROUP BY tl.image_id
+    ) agg ON agg.image_id = i.image_id
+    SET i.has_theme = COALESCE(agg.ht, 0), i.has_source = COALESCE(agg.hs, 0),
+        i.has_artist = COALESCE(agg.ha, 0), i.has_character = COALESCE(agg.hc, 0)
+    WHERE i.image_id >= :lo AND i.image_id < :hi
+    """
+)
+
+
+async def backfill_range(db: AsyncSession, lo: int, hi: int) -> None:
+    """Recompute flags for all images with image_id in [lo, hi). Does not commit."""
+    await db.execute(_BATCH_SQL, {"lo": lo, "hi": hi})
+
+
+async def backfill(batch: int, start: int) -> None:
+    if batch <= 0:
+        raise ValueError("batch must be positive")
+    engine = create_async_engine(settings.DATABASE_URL, echo=False)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with async_session() as db:
+            max_id = (await db.execute(text("SELECT MAX(image_id) FROM images"))).scalar() or 0
+            lo = start
+            while lo <= max_id:
+                hi = lo + batch
+                await backfill_range(db, lo, hi)
+                await db.commit()
+                print(f"backfilled image_id [{lo}, {hi})  (max={max_id})", flush=True)
+                lo = hi
+    finally:
+        await engine.dispose()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--batch", type=int, default=10000)
+    ap.add_argument("--start", type=int, default=0)
+    args = ap.parse_args()
+    if args.batch <= 0:
+        ap.error("--batch must be positive")
+    asyncio.run(backfill(args.batch, args.start))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/api/v1/test_admin_images.py
+++ b/tests/api/v1/test_admin_images.py
@@ -9,12 +9,14 @@ from httpx import AsyncClient
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import AdminActionType, ImageStatus
+from app.config import AdminActionType, ImageStatus, ReportStatus, TagType
 from app.core.security import get_password_hash
 from app.models.admin_action import AdminActions
 from app.models.favorite import Favorites
 from app.models.image import Images
 from app.models.image_rating import ImageRatings
+from app.models.image_report import ImageReports
+from app.models.image_report_tag_suggestion import ImageReportTagSuggestions
 from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
 from app.models.tag import Tags
 from app.models.tag_link import TagLinks
@@ -693,3 +695,143 @@ class TestImageLocked:
         )
 
         assert response.status_code == 422  # Validation error
+
+
+@pytest.mark.api
+class TestApplyTagSuggestionsUpdatesTagTypeFlags:
+    """Tests for POST /api/v1/admin/reports/{report_id}/apply-tag-suggestions
+    ensuring that has_* tag-type flags on the image are updated when tag
+    suggestions are applied or removed.
+    """
+
+    async def test_add_artist_tag_sets_has_artist(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Approving an ADD suggestion for an artist tag sets has_artist=True."""
+        admin, password = await create_admin_user(
+            db_session, username="flagtest_add", email="flagtest_add@example.com"
+        )
+        await grant_permission(db_session, admin.user_id, "report_manage")
+        token = await login_user(client, admin.username, password)
+
+        # Image with no artist tag — has_artist should start False
+        image = Images(
+            user_id=admin.user_id,
+            filename="flagtest_add_img",
+            ext="jpg",
+            md5_hash="flagtest_add_md5hash00000001",
+            status=ImageStatus.ACTIVE,
+            has_artist=False,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        assert image.has_artist is False  # precondition
+
+        # Create an ARTIST-type tag
+        artist_tag = Tags(title="test_artist_add", type=TagType.ARTIST)
+        db_session.add(artist_tag)
+        await db_session.commit()
+        await db_session.refresh(artist_tag)
+
+        # Create a TAG_SUGGESTIONS report for this image
+        report = ImageReports(
+            image_id=image.image_id,
+            user_id=admin.user_id,
+            category=4,  # TAG_SUGGESTIONS
+            status=ReportStatus.PENDING,
+        )
+        db_session.add(report)
+        await db_session.flush()
+
+        suggestion = ImageReportTagSuggestions(
+            report_id=report.report_id,
+            tag_id=artist_tag.tag_id,
+            suggestion_type=1,  # add
+        )
+        db_session.add(suggestion)
+        await db_session.commit()
+        await db_session.refresh(suggestion)
+
+        # Resolve: approve the ADD suggestion
+        response = await client.post(
+            f"/api/v1/admin/reports/{report.report_id}/apply-tag-suggestions",
+            json={"approved_suggestion_ids": [suggestion.suggestion_id]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert artist_tag.tag_id in data["applied_tags"]
+
+        # Fresh read to bypass stale ORM identity-map state
+        await db_session.refresh(image)
+        assert image.has_artist is True
+
+    async def test_remove_artist_tag_clears_has_artist(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Approving a REMOVE suggestion for the only artist tag clears has_artist."""
+        admin, password = await create_admin_user(
+            db_session, username="flagtest_rem", email="flagtest_rem@example.com"
+        )
+        await grant_permission(db_session, admin.user_id, "report_manage")
+        token = await login_user(client, admin.username, password)
+
+        # Create an ARTIST-type tag
+        artist_tag = Tags(title="test_artist_rem", type=TagType.ARTIST)
+        db_session.add(artist_tag)
+        await db_session.commit()
+        await db_session.refresh(artist_tag)
+
+        # Image linked to the artist tag — has_artist starts True
+        image = Images(
+            user_id=admin.user_id,
+            filename="flagtest_rem_img",
+            ext="jpg",
+            md5_hash="flagtest_rem_md5hash00000001",
+            status=ImageStatus.ACTIVE,
+            has_artist=True,
+        )
+        db_session.add(image)
+        await db_session.flush()
+
+        tag_link = TagLinks(image_id=image.image_id, tag_id=artist_tag.tag_id)
+        db_session.add(tag_link)
+        await db_session.commit()
+        await db_session.refresh(image)
+        assert image.has_artist is True  # precondition
+
+        # Create a TAG_SUGGESTIONS report for this image
+        report = ImageReports(
+            image_id=image.image_id,
+            user_id=admin.user_id,
+            category=4,  # TAG_SUGGESTIONS
+            status=ReportStatus.PENDING,
+        )
+        db_session.add(report)
+        await db_session.flush()
+
+        suggestion = ImageReportTagSuggestions(
+            report_id=report.report_id,
+            tag_id=artist_tag.tag_id,
+            suggestion_type=2,  # remove
+        )
+        db_session.add(suggestion)
+        await db_session.commit()
+        await db_session.refresh(suggestion)
+
+        # Resolve: approve the REMOVE suggestion
+        response = await client.post(
+            f"/api/v1/admin/reports/{report.report_id}/apply-tag-suggestions",
+            json={"approved_suggestion_ids": [suggestion.suggestion_id]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert artist_tag.tag_id in data["removed_tags"]
+
+        # Fresh read to bypass stale ORM identity-map state
+        await db_session.refresh(image)
+        assert image.has_artist is False

--- a/tests/api/v1/test_backfill_tag_type_flags.py
+++ b/tests/api/v1/test_backfill_tag_type_flags.py
@@ -1,0 +1,182 @@
+"""Tests for scripts/backfill_tag_type_flags.py."""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.image import Images
+from app.models.tag import Tags
+from app.models.tag_link import TagLinks
+from app.models.user import Users
+from scripts.backfill_tag_type_flags import backfill_range
+
+
+async def _create_user(db: AsyncSession) -> Users:
+    user = Users(
+        username="backfill_test_user",
+        password="hashed",
+        password_type="bcrypt",
+        salt="saltsalt12345678",
+        email="backfill@example.com",
+        active=1,
+    )
+    db.add(user)
+    await db.flush()
+    await db.refresh(user)
+    return user
+
+
+async def _create_image(db: AsyncSession, user_id: int, md5_suffix: str) -> Images:
+    img = Images(
+        user_id=user_id,
+        filename=f"backfill-{md5_suffix}",
+        ext="jpg",
+        original_filename=f"backfill-{md5_suffix}.jpg",
+        md5_hash=f"{md5_suffix:0<32}",
+        filesize=1000,
+        width=100,
+        height=100,
+        status=1,
+        locked=0,
+    )
+    db.add(img)
+    await db.flush()
+    await db.refresh(img)
+    return img
+
+
+@pytest.mark.unit
+class TestBackfillTagTypeFlags:
+    """Tests for the backfill_range function in the backfill script."""
+
+    async def test_backfill_sets_artist_flag_and_leaves_untagged_image_clean(
+        self, db_session: AsyncSession
+    ):
+        """
+        Image A with an ARTIST tag gets has_artist=True after backfill.
+        Image B with no tags keeps all flags False after backfill.
+        All other flags on image A remain False.
+        """
+        user = await _create_user(db_session)
+
+        # Create two images — flags default to False (all 0)
+        image_a = await _create_image(db_session, user.user_id, "backfillA1")
+        image_b = await _create_image(db_session, user.user_id, "backfillB1")
+
+        # Add an ARTIST tag (type=3) to image A only
+        artist_tag = Tags(title="Test Backfill Artist", type=3)  # 3 = Artist
+        db_session.add(artist_tag)
+        await db_session.flush()
+        await db_session.refresh(artist_tag)
+
+        db_session.add(
+            TagLinks(
+                tag_id=artist_tag.tag_id,
+                image_id=image_a.image_id,
+                user_id=user.user_id,
+            )
+        )
+        await db_session.flush()
+
+        # Confirm precondition: flags are all False (not yet backfilled)
+        pre_a = (
+            await db_session.execute(
+                select(Images)
+                .where(Images.image_id == image_a.image_id)
+                .execution_options(populate_existing=True)
+            )
+        ).scalar_one()
+        assert pre_a.has_artist is False, "precondition: has_artist should be False before backfill"
+
+        # Run the backfill over the range covering both images
+        lo = min(image_a.image_id, image_b.image_id)
+        hi = max(image_a.image_id, image_b.image_id) + 1
+        await backfill_range(db_session, lo=lo, hi=hi)
+        await db_session.commit()
+
+        # Fresh-read image A — should have has_artist=True, others False
+        fresh_a = (
+            await db_session.execute(
+                select(Images)
+                .where(Images.image_id == image_a.image_id)
+                .execution_options(populate_existing=True)
+            )
+        ).scalar_one()
+        assert fresh_a.has_artist is True, "image A should have has_artist=True after backfill"
+        assert fresh_a.has_theme is False, "image A should have has_theme=False (no theme tag)"
+        assert fresh_a.has_source is False, "image A should have has_source=False (no source tag)"
+        assert fresh_a.has_character is False, "image A should have has_character=False (no character tag)"
+
+        # Fresh-read image B — all flags should remain False
+        fresh_b = (
+            await db_session.execute(
+                select(Images)
+                .where(Images.image_id == image_b.image_id)
+                .execution_options(populate_existing=True)
+            )
+        ).scalar_one()
+        assert fresh_b.has_artist is False, "image B should have has_artist=False (no tags)"
+        assert fresh_b.has_theme is False, "image B should have has_theme=False (no tags)"
+        assert fresh_b.has_source is False, "image B should have has_source=False (no tags)"
+        assert fresh_b.has_character is False, "image B should have has_character=False (no tags)"
+
+    async def test_backfill_sets_all_four_flag_types(
+        self, db_session: AsyncSession
+    ):
+        """Image with tags of all four types gets all four flags set after backfill."""
+        user = await _create_user(db_session)
+        image = await _create_image(db_session, user.user_id, "backfillAll1")
+
+        # Add one tag of each type (1=Theme, 2=Source, 3=Artist, 4=Character)
+        for tag_type, title in [(1, "BfTheme"), (2, "BfSource"), (3, "BfArtist"), (4, "BfChar")]:
+            tag = Tags(title=title, type=tag_type)
+            db_session.add(tag)
+            await db_session.flush()
+            await db_session.refresh(tag)
+            db_session.add(TagLinks(tag_id=tag.tag_id, image_id=image.image_id, user_id=user.user_id))
+        await db_session.flush()
+
+        await backfill_range(db_session, lo=image.image_id, hi=image.image_id + 1)
+        await db_session.commit()
+
+        fresh = (
+            await db_session.execute(
+                select(Images)
+                .where(Images.image_id == image.image_id)
+                .execution_options(populate_existing=True)
+            )
+        ).scalar_one()
+        assert fresh.has_theme is True
+        assert fresh.has_source is True
+        assert fresh.has_artist is True
+        assert fresh.has_character is True
+
+    async def test_backfill_is_idempotent(
+        self, db_session: AsyncSession
+    ):
+        """Running backfill_range twice produces the same result."""
+        user = await _create_user(db_session)
+        image = await _create_image(db_session, user.user_id, "backfillIdem1")
+
+        source_tag = Tags(title="BfIdempotentSource", type=2)
+        db_session.add(source_tag)
+        await db_session.flush()
+        await db_session.refresh(source_tag)
+        db_session.add(TagLinks(tag_id=source_tag.tag_id, image_id=image.image_id, user_id=user.user_id))
+        await db_session.flush()
+
+        # Run twice
+        await backfill_range(db_session, lo=image.image_id, hi=image.image_id + 1)
+        await db_session.commit()
+        await backfill_range(db_session, lo=image.image_id, hi=image.image_id + 1)
+        await db_session.commit()
+
+        fresh = (
+            await db_session.execute(
+                select(Images)
+                .where(Images.image_id == image.image_id)
+                .execution_options(populate_existing=True)
+            )
+        ).scalar_one()
+        assert fresh.has_source is True
+        assert fresh.has_artist is False

--- a/tests/api/v1/test_batch_tag.py
+++ b/tests/api/v1/test_batch_tag.py
@@ -2,6 +2,7 @@
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import TagType
@@ -11,6 +12,7 @@ from app.models.permissions import Perms, UserPerms
 from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
+from app.services.tag_type_flags import refresh_image_tag_type_flags
 
 
 async def _create_user_with_tag_permission(
@@ -317,8 +319,6 @@ class TestBatchTagAdd:
         self, client: AsyncClient, db_session: AsyncSession
     ):
         """Each new tag link creates a tag history entry."""
-        from sqlalchemy import func, select
-
         from app.models.tag_history import TagHistory
 
         user = await _create_user_with_tag_permission(db_session)
@@ -482,8 +482,6 @@ class TestBatchTagRemove:
         self, client: AsyncClient, db_session: AsyncSession
     ):
         """Each removed tag link creates a tag history entry with action 'r'."""
-        from sqlalchemy import func, select
-
         from app.models.tag_history import TagHistory
 
         user = await _create_user_with_tag_permission(db_session, ["image_tag_remove"])
@@ -559,8 +557,6 @@ class TestBatchTagRemove:
         assert data["removed"][0]["tag_id"] == canonical.tag_id
 
         # Verify the link was actually deleted
-        from sqlalchemy import select
-
         link_result = await db_session.execute(
             select(TagLinks).where(
                 TagLinks.image_id == images[0].image_id,
@@ -594,3 +590,112 @@ class TestBatchTagRemove:
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 403
+
+
+@pytest.mark.api
+class TestBatchTagTypeFlags:
+    """Tests that batch add/remove keep has_* tag-type flags correct."""
+
+    async def test_batch_add_sets_has_artist_flag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Batch-adding an ARTIST tag sets has_artist=True on all affected images."""
+        user = await _create_user_with_tag_permission(db_session, ["image_tag_add"])
+        token = create_access_token(user.id)
+        images = await _create_test_images(db_session, user, 2)
+
+        artist_tag = Tags(title="Test Artist", type=TagType.ARTIST)
+        db_session.add(artist_tag)
+        await db_session.commit()
+        await db_session.refresh(artist_tag)
+
+        response = await client.post(
+            "/api/v1/tags/batch",
+            json={
+                "action": "add",
+                "tag_ids": [artist_tag.tag_id],
+                "image_ids": [img.image_id for img in images],
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        assert len(response.json()["added"]) == 2
+
+        # Fresh reads — bypass identity map
+        for img in images:
+            result = await db_session.execute(
+                select(Images)
+                .where(Images.image_id == img.image_id)
+                .execution_options(populate_existing=True)
+            )
+            fresh = result.scalar_one()
+            assert fresh.has_artist is True, (
+                f"image {img.image_id} has_artist should be True after batch add"
+            )
+
+    async def test_batch_remove_clears_has_artist_flag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Batch-removing the only ARTIST tag clears has_artist=False on all affected images."""
+        user = await _create_user_with_tag_permission(
+            db_session, ["image_tag_add", "image_tag_remove"]
+        )
+        token = create_access_token(user.id)
+        images = await _create_test_images(db_session, user, 2)
+
+        artist_tag = Tags(title="Test Artist Remove", type=TagType.ARTIST)
+        db_session.add(artist_tag)
+        await db_session.commit()
+        await db_session.refresh(artist_tag)
+
+        # Pre-link the artist tag to both images
+        for img in images:
+            db_session.add(
+                TagLinks(
+                    image_id=img.image_id,
+                    tag_id=artist_tag.tag_id,
+                    user_id=user.user_id,
+                )
+            )
+        await db_session.commit()
+
+        # Establish the real pre-state: recompute flags so has_artist=True
+        for img in images:
+            await refresh_image_tag_type_flags(db_session, img.image_id)
+        await db_session.commit()
+
+        # Precondition: has_artist must be True before the remove
+        for img in images:
+            result = await db_session.execute(
+                select(Images)
+                .where(Images.image_id == img.image_id)
+                .execution_options(populate_existing=True)
+            )
+            pre = result.scalar_one()
+            assert pre.has_artist is True, (
+                f"image {img.image_id} has_artist should be True before batch remove"
+            )
+
+        response = await client.post(
+            "/api/v1/tags/batch",
+            json={
+                "action": "remove",
+                "tag_ids": [artist_tag.tag_id],
+                "image_ids": [img.image_id for img in images],
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        assert len(response.json()["removed"]) == 2
+
+        # Fresh reads — bypass identity map
+        for img in images:
+            result = await db_session.execute(
+                select(Images)
+                .where(Images.image_id == img.image_id)
+                .execution_options(populate_existing=True)
+            )
+            fresh = result.scalar_one()
+            assert fresh.has_artist is False, (
+                f"image {img.image_id} has_artist should be False after batch remove"
+            )

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -757,6 +757,20 @@ class TestMissingTagTypes:
         assert missing_both.image_id in image_ids
         assert missing_source_only.image_id not in image_ids
 
+    async def test_missing_invalid_type_id_returns_400(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Type IDs outside 1-4 (incl. 0=All) are rejected with 400 echoing the bad id(s)."""
+        for bad in ("0", "99", "3,0"):
+            response = await client.get(f"/api/v1/images?missing_tag_types={bad}")
+            assert response.status_code == 400, f"expected 400 for {bad!r}"
+            detail = response.json()["detail"]
+            assert "Valid types are" in detail
+            # the offending id(s) are echoed back to the client
+            expected_invalid = [t for t in bad.split(",") if int(t) not in {1, 2, 3, 4}]
+            for bad_id in expected_invalid:
+                assert bad_id in detail, f"{bad_id} not echoed in detail for {bad!r}: {detail}"
+
 
 @pytest.mark.api
 class TestTagHierarchySearch:

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -9,6 +9,7 @@ These tests cover the /api/v1/images endpoints including:
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import TagType, settings
@@ -2424,6 +2425,100 @@ class TestTagUsageCount:
         assert response.status_code == 204
         await db_session.refresh(tag)
         assert tag.usage_count == 2
+
+@pytest.mark.api
+class TestTagTypeFlagMaintenance:
+    """Tests that the denormalized has_* flags are updated by the add/remove-tag endpoints."""
+
+    async def test_add_artist_tag_sets_has_artist(
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
+        sample_user: Users,
+        sample_image_data: dict,
+    ):
+        """Adding an ARTIST tag via the endpoint sets has_artist=True on the image."""
+        image_data = sample_image_data.copy()
+        image_data["user_id"] = sample_user.user_id
+        image_data["filename"] = "ttfm_add1"
+        image_data["md5_hash"] = "a1" * 16
+        image = Images(**image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        tag = Tags(title="ttfm_artist", type=TagType.ARTIST)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        response = await authenticated_client.post(
+            f"/api/v1/images/{image.image_id}/tags/{tag.tag_id}"
+        )
+        assert response.status_code == 201
+
+        # Re-query with populate_existing to bypass identity map (raw UPDATE skips ORM cache)
+        result = await db_session.execute(
+            select(Images)
+            .where(Images.image_id == image.image_id)
+            .execution_options(populate_existing=True)
+        )
+        fresh = result.scalar_one()
+        assert fresh.has_artist is True
+
+    async def test_remove_artist_tag_clears_has_artist(
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
+        sample_user: Users,
+        sample_image_data: dict,
+    ):
+        """Removing the last ARTIST tag via the endpoint sets has_artist=False on the image."""
+        image_data = sample_image_data.copy()
+        image_data["user_id"] = sample_user.user_id
+        image_data["filename"] = "ttfm_rem1"
+        image_data["md5_hash"] = "b2" * 16
+        image = Images(**image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        tag = Tags(title="ttfm_artist_rem", type=TagType.ARTIST)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        # Link the tag directly so has_artist starts True
+        tag_link = TagLinks(image_id=image.image_id, tag_id=tag.tag_id, user_id=sample_user.user_id)
+        db_session.add(tag_link)
+        await db_session.commit()
+        await refresh_image_tag_type_flags(db_session, image.image_id)
+        await db_session.commit()
+
+        # Confirm the flag is set before the removal (populate_existing bypasses identity map)
+        pre = (
+            await db_session.execute(
+                select(Images)
+                .where(Images.image_id == image.image_id)
+                .execution_options(populate_existing=True)
+            )
+        ).scalar_one()
+        assert pre.has_artist is True
+
+        response = await authenticated_client.delete(
+            f"/api/v1/images/{image.image_id}/tags/{tag.tag_id}"
+        )
+        assert response.status_code == 204
+
+        # Re-query with populate_existing to bypass identity map (raw UPDATE skips ORM cache)
+        result = await db_session.execute(
+            select(Images)
+            .where(Images.image_id == image.image_id)
+            .execution_options(populate_existing=True)
+        )
+        fresh = result.scalar_one()
+        assert fresh.has_artist is False
+
 
 @pytest.mark.api
 class TestCommentFilters:

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -695,6 +695,36 @@ class TestExcludeTags:
 
 
 @pytest.mark.api
+class TestMissingTagTypes:
+    """Tests for missing_tag_types / missing_tag_types_mode params on image search."""
+
+    async def test_missing_single_type_excludes_images_that_have_it(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """missing_tag_types=3 returns images lacking an artist tag, excludes those that have one."""
+        has_artist = Images(**{**sample_image_data, "filename": "mtt_a1", "md5_hash": "a" * 32})
+        no_artist = Images(**{**sample_image_data, "filename": "mtt_a2", "md5_hash": "b" * 32})
+        db_session.add_all([has_artist, no_artist])
+        await db_session.flush()
+
+        artist_tag = Tags(title="some artist", desc="Artist", type=TagType.ARTIST)
+        theme_tag = Tags(title="some theme", desc="Theme", type=TagType.THEME)
+        db_session.add_all([artist_tag, theme_tag])
+        await db_session.flush()
+
+        db_session.add(TagLinks(image_id=has_artist.image_id, tag_id=artist_tag.tag_id, user_id=1))
+        db_session.add(TagLinks(image_id=no_artist.image_id, tag_id=theme_tag.tag_id, user_id=1))
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images?missing_tag_types={TagType.ARTIST}")
+
+        assert response.status_code == 200
+        image_ids = [img["image_id"] for img in response.json()["images"]]
+        assert no_artist.image_id in image_ids
+        assert has_artist.image_id not in image_ids
+
+
+@pytest.mark.api
 class TestTagHierarchySearch:
     """Tests for image search with tag hierarchy expansion.
 

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -977,6 +977,19 @@ class TestMissingTagTypes:
         image_ids = [i["image_id"] for i in response.json()["images"]]
         assert img.image_id in image_ids
 
+    async def test_new_image_defaults_tag_type_flags_false(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """The denormalized presence flags exist and default to False on a fresh image."""
+        img = Images(**{**sample_image_data, "filename": "flags_default", "md5_hash": "9c" * 16})
+        db_session.add(img)
+        await db_session.commit()
+        await db_session.refresh(img)
+        assert img.has_theme is False
+        assert img.has_source is False
+        assert img.has_artist is False
+        assert img.has_character is False
+
 
 @pytest.mark.api
 class TestTagHierarchySearch:

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import TagType, settings
 from app.models import Favorites, ImageRatings, Images, TagLinks, Tags, Users
 from app.models.permissions import Groups, UserGroups
+from app.services.tag_type_flags import refresh_image_tag_type_flags
 
 
 @pytest.mark.api
@@ -752,6 +753,11 @@ class TestMissingTagTypes:
         db_session.add(TagLinks(image_id=no_artist.image_id, tag_id=theme_tag.tag_id, user_id=1))
         await db_session.commit()
 
+        # Maintain the denormalized flags the filter now reads (prod does this via hooks).
+        for _img in (has_artist, no_artist):
+            await refresh_image_tag_type_flags(db_session, _img.image_id)
+        await db_session.commit()
+
         response = await client.get(f"/api/v1/images?missing_tag_types={TagType.ARTIST}")
 
         assert response.status_code == 200
@@ -781,6 +787,11 @@ class TestMissingTagTypes:
         db_session.add(
             TagLinks(image_id=missing_source_only.image_id, tag_id=artist_tag.tag_id, user_id=1)
         )
+        await db_session.commit()
+
+        # Maintain the denormalized flags the filter now reads (prod does this via hooks).
+        for _img in (missing_both, missing_source_only):
+            await refresh_image_tag_type_flags(db_session, _img.image_id)
         await db_session.commit()
 
         response = await client.get(
@@ -855,6 +866,11 @@ class TestMissingTagTypes:
         )
         await db_session.commit()
 
+        # Maintain the denormalized flags the filter now reads (prod does this via hooks).
+        for _img in (has_artist_no_source,):
+            await refresh_image_tag_type_flags(db_session, _img.image_id)
+        await db_session.commit()
+
         types = f"{TagType.SOURCE},{TagType.ARTIST}"
 
         any_resp = await client.get(
@@ -900,6 +916,11 @@ class TestMissingTagTypes:
         db_session.add(TagLinks(image_id=aliased.image_id, tag_id=alias.tag_id, user_id=1))
         await db_session.commit()
 
+        # Maintain the denormalized flags the filter now reads (prod does this via hooks).
+        for _img in (aliased,):
+            await refresh_image_tag_type_flags(db_session, _img.image_id)
+        await db_session.commit()
+
         response = await client.get(f"/api/v1/images?missing_tag_types={TagType.ARTIST}")
 
         assert response.status_code == 200
@@ -925,6 +946,11 @@ class TestMissingTagTypes:
         # drop: has theme tag AND an artist tag -> matches include but NOT missing artist
         db_session.add(TagLinks(image_id=drop.image_id, tag_id=theme_tag.tag_id, user_id=1))
         db_session.add(TagLinks(image_id=drop.image_id, tag_id=artist_tag.tag_id, user_id=1))
+        await db_session.commit()
+
+        # Maintain the denormalized flags the filter now reads (prod does this via hooks).
+        for _img in (keep, drop):
+            await refresh_image_tag_type_flags(db_session, _img.image_id)
         await db_session.commit()
 
         response = await client.get(

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -450,6 +450,24 @@ class TestTagSearchValidation:
         assert image1.image_id in found_ids
         assert image2.image_id in found_ids
 
+    async def test_tags_unicode_digit_token_does_not_500(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """A Unicode digit int() can't parse ('²') is dropped, not crashed on (no 500).
+
+        '²'.isdigit() is True but int('²') raises ValueError; the parser must use
+        isdecimal() so the token is silently ignored, leaving the filter a no-op.
+        """
+        image = Images(**{**sample_image_data, "filename": "uni_tags", "md5_hash": "7a" * 16})
+        db_session.add(image)
+        await db_session.commit()
+
+        response = await client.get("/api/v1/images?tags=²")
+
+        assert response.status_code == 200
+        image_ids = [img["image_id"] for img in response.json()["images"]]
+        assert image.image_id in image_ids  # token dropped -> no filtering
+
 
 @pytest.mark.api
 class TestExcludeTags:
@@ -692,6 +710,24 @@ class TestExcludeTags:
         data = response.json()
         image_ids = [img["image_id"] for img in data["images"]]
         assert image1.image_id not in image_ids, "Image with child tag should be excluded"
+
+    async def test_exclude_tags_unicode_digit_token_does_not_500(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """A Unicode digit int() can't parse ('²') is dropped, not crashed on (no 500).
+
+        '²'.isdigit() is True but int('²') raises ValueError; the parser must use
+        isdecimal() so the token is silently ignored, leaving the exclude a no-op.
+        """
+        image = Images(**{**sample_image_data, "filename": "uni_excl", "md5_hash": "8b" * 16})
+        db_session.add(image)
+        await db_session.commit()
+
+        response = await client.get("/api/v1/images?exclude_tags=²")
+
+        assert response.status_code == 200
+        image_ids = [img["image_id"] for img in response.json()["images"]]
+        assert image.image_id in image_ids  # token dropped -> nothing excluded
 
 
 @pytest.mark.api

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -771,6 +771,20 @@ class TestMissingTagTypes:
             for bad_id in expected_invalid:
                 assert bad_id in detail, f"{bad_id} not echoed in detail for {bad!r}: {detail}"
 
+    async def test_missing_non_digit_token_returns_400(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Non-digit tokens are rejected with 400, not silently dropped to a no-op filter."""
+        for bad in ("artist", "abc", "3,artist"):
+            response = await client.get(f"/api/v1/images?missing_tag_types={bad}")
+            assert response.status_code == 400, f"expected 400 for {bad!r}"
+            assert "Valid types are" in response.json()["detail"]
+        # the offending non-digit token is echoed back, even alongside a valid id
+        detail = (
+            await client.get("/api/v1/images?missing_tag_types=3,artist")
+        ).json()["detail"]
+        assert "artist" in detail, detail
+
     async def test_missing_any_mode_returns_image_missing_only_one_type(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
     ):

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -785,6 +785,18 @@ class TestMissingTagTypes:
         ).json()["detail"]
         assert "artist" in detail, detail
 
+    async def test_missing_unicode_digit_token_returns_400_not_500(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """A Unicode digit that int() cannot parse must 400, not crash with a 500.
+
+        '²' (superscript two) is str.isdigit()==True but int('²') raises ValueError,
+        so the token check must use isdecimal() to reject it cleanly.
+        """
+        response = await client.get("/api/v1/images?missing_tag_types=²")
+        assert response.status_code == 400
+        assert "Valid types are" in response.json()["detail"]
+
     async def test_missing_any_mode_returns_image_missing_only_one_type(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
     ):

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -771,6 +771,150 @@ class TestMissingTagTypes:
             for bad_id in expected_invalid:
                 assert bad_id in detail, f"{bad_id} not echoed in detail for {bad!r}: {detail}"
 
+    async def test_missing_any_mode_returns_image_missing_only_one_type(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """mode=any returns an image that has one listed type but lacks another (OR, not AND).
+
+        Discriminates OR semantics: an image WITH an artist tag but WITHOUT a source must be
+        returned by missing_tag_types=2,3&mode=any, yet excluded by mode=all.
+        """
+        has_artist_no_source = Images(
+            **{**sample_image_data, "filename": "mtt_any1", "md5_hash": "3" * 32}
+        )
+        db_session.add(has_artist_no_source)
+        await db_session.flush()
+
+        artist_tag = Tags(title="any artist", desc="Artist", type=TagType.ARTIST)
+        db_session.add(artist_tag)
+        await db_session.flush()
+        db_session.add(
+            TagLinks(image_id=has_artist_no_source.image_id, tag_id=artist_tag.tag_id, user_id=1)
+        )
+        await db_session.commit()
+
+        types = f"{TagType.SOURCE},{TagType.ARTIST}"
+
+        any_resp = await client.get(
+            f"/api/v1/images?missing_tag_types={types}&missing_tag_types_mode=any"
+        )
+        assert any_resp.status_code == 200
+        any_ids = [img["image_id"] for img in any_resp.json()["images"]]
+        assert has_artist_no_source.image_id in any_ids  # missing source -> matched by ANY
+
+        all_resp = await client.get(
+            f"/api/v1/images?missing_tag_types={types}&missing_tag_types_mode=all"
+        )
+        assert all_resp.status_code == 200
+        all_ids = [img["image_id"] for img in all_resp.json()["images"]]
+        assert has_artist_no_source.image_id not in all_ids  # has artist -> excluded by ALL
+
+    async def test_missing_artist_does_not_resolve_alias(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """The APPLIED tag's own type is authoritative; aliases are NOT resolved to canonical.
+
+        The image is linked to an alias whose own type is ARTIST, but whose canonical has a
+        DIFFERENT type (THEME). The filter must key off the applied tag's type (ARTIST), so the
+        image counts as having an artist tag and is excluded from missing_tag_types=3. If the
+        code resolved the alias to its canonical (THEME), the image would wrongly be returned.
+        """
+        aliased = Images(**{**sample_image_data, "filename": "mtt_alias", "md5_hash": "e" * 32})
+        db_session.add(aliased)
+        await db_session.flush()
+
+        # Canonical is THEME, deliberately different from the alias's ARTIST type, so the test
+        # discriminates "applied tag's type" from "canonical's type".
+        canonical = Tags(title="canon theme", desc="Theme", type=TagType.THEME)
+        db_session.add(canonical)
+        await db_session.flush()
+        alias = Tags(
+            title="alias artist", desc="Alias", type=TagType.ARTIST, alias_of=canonical.tag_id
+        )
+        db_session.add(alias)
+        await db_session.flush()
+
+        # Image is linked to the ALIAS tag (type ARTIST), not the canonical one
+        db_session.add(TagLinks(image_id=aliased.image_id, tag_id=alias.tag_id, user_id=1))
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images?missing_tag_types={TagType.ARTIST}")
+
+        assert response.status_code == 200
+        image_ids = [img["image_id"] for img in response.json()["images"]]
+        assert aliased.image_id not in image_ids
+
+    async def test_missing_combined_with_include_tags(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """tags= include filter AND missing_tag_types both apply."""
+        keep = Images(**{**sample_image_data, "filename": "mtt_cmb1", "md5_hash": "f" * 32})
+        drop = Images(**{**sample_image_data, "filename": "mtt_cmb2", "md5_hash": "0" * 32})
+        db_session.add_all([keep, drop])
+        await db_session.flush()
+
+        theme_tag = Tags(title="cmb theme", desc="Theme", type=TagType.THEME)
+        artist_tag = Tags(title="cmb artist", desc="Artist", type=TagType.ARTIST)
+        db_session.add_all([theme_tag, artist_tag])
+        await db_session.flush()
+
+        # keep: has the theme tag, no artist -> matches include + missing artist
+        db_session.add(TagLinks(image_id=keep.image_id, tag_id=theme_tag.tag_id, user_id=1))
+        # drop: has theme tag AND an artist tag -> matches include but NOT missing artist
+        db_session.add(TagLinks(image_id=drop.image_id, tag_id=theme_tag.tag_id, user_id=1))
+        db_session.add(TagLinks(image_id=drop.image_id, tag_id=artist_tag.tag_id, user_id=1))
+        await db_session.commit()
+
+        response = await client.get(
+            f"/api/v1/images?tags={theme_tag.tag_id}&missing_tag_types={TagType.ARTIST}"
+        )
+
+        assert response.status_code == 200
+        image_ids = [img["image_id"] for img in response.json()["images"]]
+        assert keep.image_id in image_ids
+        assert drop.image_id not in image_ids
+
+    async def test_image_with_no_tags_matches_every_type_both_modes(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """An image with no tags is missing every type, in both any and all modes."""
+        untagged = Images(**{**sample_image_data, "filename": "mtt_none", "md5_hash": "1" * 32})
+        db_session.add(untagged)
+        await db_session.commit()
+
+        for query in (
+            f"missing_tag_types={TagType.ARTIST}",
+            f"missing_tag_types={TagType.SOURCE},{TagType.ARTIST}&missing_tag_types_mode=any",
+            f"missing_tag_types={TagType.SOURCE},{TagType.ARTIST}&missing_tag_types_mode=all",
+        ):
+            response = await client.get(f"/api/v1/images?{query}")
+            assert response.status_code == 200, query
+            image_ids = [img["image_id"] for img in response.json()["images"]]
+            assert untagged.image_id in image_ids, query
+
+    async def test_missing_invalid_mode_returns_422(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Invalid mode is rejected by the Query pattern with 422."""
+        response = await client.get(
+            f"/api/v1/images?missing_tag_types={TagType.ARTIST}&missing_tag_types_mode=foo"
+        )
+        assert response.status_code == 422
+
+    async def test_omitted_param_does_not_filter(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Without the param, behavior is unchanged (image is returned)."""
+        img = Images(**{**sample_image_data, "filename": "mtt_omit", "md5_hash": "2" * 32})
+        db_session.add(img)
+        await db_session.commit()
+
+        response = await client.get("/api/v1/images")
+
+        assert response.status_code == 200
+        image_ids = [i["image_id"] for i in response.json()["images"]]
+        assert img.image_id in image_ids
+
 
 @pytest.mark.api
 class TestTagHierarchySearch:

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -723,6 +723,40 @@ class TestMissingTagTypes:
         assert no_artist.image_id in image_ids
         assert has_artist.image_id not in image_ids
 
+    async def test_missing_all_mode_requires_all_types_absent(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """mode=all returns only images missing EVERY listed type."""
+        missing_both = Images(**{**sample_image_data, "filename": "mtt_all1", "md5_hash": "c" * 32})
+        missing_source_only = Images(
+            **{**sample_image_data, "filename": "mtt_all2", "md5_hash": "d" * 32}
+        )
+        db_session.add_all([missing_both, missing_source_only])
+        await db_session.flush()
+
+        artist_tag = Tags(title="artist x", desc="Artist", type=TagType.ARTIST)
+        theme_tag = Tags(title="theme x", desc="Theme", type=TagType.THEME)
+        db_session.add_all([artist_tag, theme_tag])
+        await db_session.flush()
+
+        # missing_both: only a theme tag -> lacks both source and artist
+        db_session.add(TagLinks(image_id=missing_both.image_id, tag_id=theme_tag.tag_id, user_id=1))
+        # missing_source_only: has an artist tag -> lacks source but NOT artist
+        db_session.add(
+            TagLinks(image_id=missing_source_only.image_id, tag_id=artist_tag.tag_id, user_id=1)
+        )
+        await db_session.commit()
+
+        response = await client.get(
+            f"/api/v1/images?missing_tag_types={TagType.SOURCE},{TagType.ARTIST}"
+            "&missing_tag_types_mode=all"
+        )
+
+        assert response.status_code == 200
+        image_ids = [img["image_id"] for img in response.json()["images"]]
+        assert missing_both.image_id in image_ids
+        assert missing_source_only.image_id not in image_ids
+
 
 @pytest.mark.api
 class TestTagHierarchySearch:

--- a/tests/api/v1/test_tag_type_flags.py
+++ b/tests/api/v1/test_tag_type_flags.py
@@ -1,0 +1,61 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import TagType
+from app.models import Images, TagLinks, Tags
+from app.services.tag_type_flags import (
+    refresh_image_tag_type_flags,
+    refresh_images_tag_type_flags,
+)
+
+
+@pytest.mark.api
+class TestTagTypeFlagsHelper:
+    async def test_refresh_sets_flags_for_present_types(
+        self, db_session: AsyncSession, sample_image_data: dict
+    ):
+        img = Images(**{**sample_image_data, "filename": "ttf1", "md5_hash": "11" * 16})
+        db_session.add(img)
+        await db_session.flush()
+        artist = Tags(title="ttf artist", desc="a", type=TagType.ARTIST)
+        theme = Tags(title="ttf theme", desc="t", type=TagType.THEME)
+        db_session.add_all([artist, theme])
+        await db_session.flush()
+        # links added but NOT flushed — exercises the helper's internal flush.
+        db_session.add(TagLinks(image_id=img.image_id, tag_id=artist.tag_id, user_id=1))
+        db_session.add(TagLinks(image_id=img.image_id, tag_id=theme.tag_id, user_id=1))
+
+        await refresh_image_tag_type_flags(db_session, img.image_id)
+
+        await db_session.refresh(img)
+        assert img.has_artist is True
+        assert img.has_theme is True
+        assert img.has_source is False
+        assert img.has_character is False
+
+    async def test_refresh_clears_flag_when_last_tag_of_type_gone(
+        self, db_session: AsyncSession, sample_image_data: dict
+    ):
+        img = Images(**{**sample_image_data, "filename": "ttf2", "md5_hash": "22" * 16})
+        db_session.add(img)
+        await db_session.flush()
+        artist = Tags(title="ttf artist2", desc="a", type=TagType.ARTIST)
+        db_session.add(artist)
+        await db_session.flush()
+        db_session.add(TagLinks(image_id=img.image_id, tag_id=artist.tag_id, user_id=1))
+        await refresh_image_tag_type_flags(db_session, img.image_id)
+        await db_session.refresh(img)
+        assert img.has_artist is True
+
+        from sqlalchemy import delete
+        await db_session.execute(
+            delete(TagLinks).where(
+                TagLinks.image_id == img.image_id, TagLinks.tag_id == artist.tag_id
+            )
+        )
+        await refresh_image_tag_type_flags(db_session, img.image_id)
+        await db_session.refresh(img)
+        assert img.has_artist is False
+
+    async def test_refresh_empty_set_is_noop(self, db_session: AsyncSession):
+        await refresh_images_tag_type_flags(db_session, [])  # must not raise

--- a/tests/api/v1/test_tag_type_flags.py
+++ b/tests/api/v1/test_tag_type_flags.py
@@ -7,6 +7,7 @@ from app.services.tag_type_flags import (
     refresh_image_tag_type_flags,
     refresh_images_tag_type_flags,
 )
+from app.services.upload import link_tags_to_image
 
 
 @pytest.mark.api
@@ -90,3 +91,25 @@ class TestTagTypeFlagsHelper:
 
     async def test_refresh_empty_set_is_noop(self, db_session: AsyncSession):
         await refresh_images_tag_type_flags(db_session, [])  # must not raise
+
+
+@pytest.mark.api
+class TestUploadTagFlags:
+    async def test_link_tags_to_image_sets_tag_type_flags(
+        self, db_session: AsyncSession, sample_image_data: dict
+    ):
+        img = Images(**{**sample_image_data, "filename": "utf1", "md5_hash": "aa" * 16})
+        db_session.add(img)
+        await db_session.flush()
+        artist = Tags(title="utf artist", desc="a", type=TagType.ARTIST)
+        db_session.add(artist)
+        await db_session.flush()
+
+        await link_tags_to_image(img.image_id, [artist.tag_id], user_id=1, db=db_session)
+        await db_session.commit()
+
+        await db_session.refresh(img)
+        assert img.has_artist is True
+        assert img.has_theme is False
+        assert img.has_source is False
+        assert img.has_character is False

--- a/tests/api/v1/test_tag_type_flags.py
+++ b/tests/api/v1/test_tag_type_flags.py
@@ -57,5 +57,36 @@ class TestTagTypeFlagsHelper:
         await db_session.refresh(img)
         assert img.has_artist is False
 
+    async def test_refresh_keeps_flag_when_another_same_type_tag_remains(
+        self, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Removing one of two same-type tags must keep the flag True (recompute-from-source).
+
+        This is the defining property vs. a naive decrement: the flag tracks presence of
+        ANY tag of the type, so it only clears when the LAST one is gone.
+        """
+        img = Images(**{**sample_image_data, "filename": "ttf3", "md5_hash": "33" * 16})
+        db_session.add(img)
+        await db_session.flush()
+        artist_a = Tags(title="ttf artist a", desc="a", type=TagType.ARTIST)
+        artist_b = Tags(title="ttf artist b", desc="b", type=TagType.ARTIST)
+        db_session.add_all([artist_a, artist_b])
+        await db_session.flush()
+        db_session.add(TagLinks(image_id=img.image_id, tag_id=artist_a.tag_id, user_id=1))
+        db_session.add(TagLinks(image_id=img.image_id, tag_id=artist_b.tag_id, user_id=1))
+        await refresh_image_tag_type_flags(db_session, img.image_id)
+        await db_session.refresh(img)
+        assert img.has_artist is True
+
+        from sqlalchemy import delete
+        await db_session.execute(
+            delete(TagLinks).where(
+                TagLinks.image_id == img.image_id, TagLinks.tag_id == artist_a.tag_id
+            )
+        )
+        await refresh_image_tag_type_flags(db_session, img.image_id)
+        await db_session.refresh(img)
+        assert img.has_artist is True  # artist_b still linked -> flag stays True
+
     async def test_refresh_empty_set_is_noop(self, db_session: AsyncSession):
         await refresh_images_tag_type_flags(db_session, [])  # must not raise

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -3623,6 +3623,89 @@ class TestDeleteTag:
         )
         assert response.status_code == 403
 
+    async def test_delete_tag_clears_has_artist_flag(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Deleting the only artist tag linked to an image must reset has_artist to False."""
+        from app.services.tag_type_flags import refresh_image_tag_type_flags
+
+        # Fetch the pre-seeded tag_delete permission (seeded by sync_permissions at startup)
+        perm_result = await db_session.execute(
+            select(Perms).where(Perms.title == "tag_delete")  # type: ignore[call-overload]
+        )
+        perm = perm_result.scalar_one()
+
+        # Create admin user with TAG_DELETE permission
+        admin = Users(
+            username="admindeleteflags",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="admindeleteflags@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.flush()
+
+        user_perm = UserPerms(
+            user_id=admin.user_id,
+            perm_id=perm.perm_id,
+            permvalue=1,
+        )
+        db_session.add(user_perm)
+
+        # Create an ARTIST-type tag
+        artist_tag = Tags(title="artist for flag test", desc="", type=TagType.ARTIST)
+        db_session.add(artist_tag)
+        await db_session.flush()
+
+        # Create an image and link the artist tag to it
+        img_data = sample_image_data.copy()
+        img_data.update({"filename": "flag-test-img", "md5_hash": "flagtest0000000000000"})
+        img = Images(**img_data)
+        db_session.add(img)
+        await db_session.flush()
+
+        db_session.add(TagLinks(tag_id=artist_tag.tag_id, image_id=img.image_id))
+        await db_session.flush()
+
+        # Establish has_artist=True via the flag service, then commit
+        await refresh_image_tag_type_flags(db_session, img.image_id)
+        await db_session.commit()
+
+        # Precondition: confirm has_artist is True (fresh read to bypass identity map)
+        fresh_result = await db_session.execute(
+            select(Images)
+            .where(Images.image_id == img.image_id)
+            .execution_options(populate_existing=True)
+        )
+        pre_img = fresh_result.scalar_one()
+        assert pre_img.has_artist is True, "Precondition failed: has_artist should be True before delete"
+
+        # Login as admin
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "admindeleteflags", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # DELETE the artist tag via the real endpoint
+        response = await client.delete(
+            f"/api/v1/tags/{artist_tag.tag_id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 204
+
+        # Fresh-read the image; has_artist must now be False
+        post_result = await db_session.execute(
+            select(Images)
+            .where(Images.image_id == img.image_id)
+            .execution_options(populate_existing=True)
+        )
+        post_img = post_result.scalar_one()
+        assert post_img.has_artist is False, "has_artist should be False after the only artist tag is deleted"
+
 
 @pytest.mark.api
 class TestAddTagLink:

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -3608,6 +3608,92 @@ class TestUpdateTag:
         assert post_img.has_artist is False, "has_artist should be False after tag type changed from ARTIST to SOURCE"
         assert post_img.has_source is True, "has_source should be True after tag type changed from ARTIST to SOURCE"
 
+    async def test_alias_reassignment_preserves_tag_type_flags(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Setting alias_of must not corrupt tag-type flags on linked images.
+
+        The canonical and alias share the same type (API-enforced), so moving
+        tag_links from alias->canonical is a no-op for flag values.  This test
+        acts as a regression guard against any drift that could zero out the flag.
+        """
+        from app.services.tag_type_flags import refresh_image_tag_type_flags
+
+        # Create TAG_UPDATE permission
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Create admin user with TAG_UPDATE permission
+        admin = Users(
+            username="adminaliasflags",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="adminaliasflags@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.flush()
+
+        user_perm = UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1)
+        db_session.add(user_perm)
+
+        # Create canonical ARTIST tag and a soon-to-be-alias ARTIST tag
+        canonical_tag = Tags(title="canonical artist flag test", desc="", type=TagType.ARTIST)
+        alias_tag = Tags(title="alias artist flag test", desc="", type=TagType.ARTIST)
+        db_session.add_all([canonical_tag, alias_tag])
+        await db_session.flush()
+
+        # Create an image and link the soon-to-be-alias tag to it
+        img_data = sample_image_data.copy()
+        img_data.update({"filename": "alias-flag-test-img", "md5_hash": "aliasflagtst00000000"})
+        img = Images(**img_data)
+        db_session.add(img)
+        await db_session.flush()
+
+        db_session.add(TagLinks(tag_id=alias_tag.tag_id, image_id=img.image_id))
+        await db_session.flush()
+
+        # Establish has_artist=True via the flag service, then commit
+        await refresh_image_tag_type_flags(db_session, img.image_id)
+        await db_session.commit()
+
+        # Precondition: fresh-read confirms has_artist=True
+        pre_result = await db_session.execute(
+            select(Images)
+            .where(Images.image_id == img.image_id)
+            .execution_options(populate_existing=True)
+        )
+        pre_img = pre_result.scalar_one()
+        assert pre_img.has_artist is True, "Precondition failed: has_artist should be True before alias reassignment"
+
+        # Login as admin
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "adminaliasflags", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Set alias_of on the alias tag (triggers link migration alias->canonical)
+        response = await client.put(
+            f"/api/v1/tags/{alias_tag.tag_id}",
+            json={"title": "alias artist flag test", "alias_of": canonical_tag.tag_id},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+
+        # Fresh-read the image; has_artist must still be True (now via canonical tag)
+        post_result = await db_session.execute(
+            select(Images)
+            .where(Images.image_id == img.image_id)
+            .execution_options(populate_existing=True)
+        )
+        post_img = post_result.scalar_one()
+        assert post_img.has_artist is True, "has_artist should still be True after alias reassignment"
+
 
 @pytest.mark.api
 class TestDeleteTag:

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -3526,6 +3526,88 @@ class TestUpdateTag:
         assert response.status_code == 400
         assert "different type" in response.json()["detail"]
 
+    async def test_type_change_recomputes_tag_type_flags(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Changing a tag's type via PUT must recompute has_* flags for all linked images."""
+        from app.services.tag_type_flags import refresh_image_tag_type_flags
+
+        # Create TAG_UPDATE permission
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        # Create admin user with TAG_UPDATE permission
+        admin = Users(
+            username="admintypeflags",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="admintypeflags@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.flush()
+
+        user_perm = UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1)
+        db_session.add(user_perm)
+
+        # Create an ARTIST-type tag
+        artist_tag = Tags(title="artist for type-change flag test", desc="", type=TagType.ARTIST)
+        db_session.add(artist_tag)
+        await db_session.flush()
+
+        # Create an image and link the artist tag to it
+        img_data = sample_image_data.copy()
+        img_data.update({"filename": "type-change-flag-img", "md5_hash": "typechangeflg0000000"})
+        img = Images(**img_data)
+        db_session.add(img)
+        await db_session.flush()
+
+        db_session.add(TagLinks(tag_id=artist_tag.tag_id, image_id=img.image_id))
+        await db_session.flush()
+
+        # Establish has_artist=True via the flag service, then commit
+        await refresh_image_tag_type_flags(db_session, img.image_id)
+        await db_session.commit()
+
+        # Precondition: fresh-read confirms has_artist=True, has_source=False
+        pre_result = await db_session.execute(
+            select(Images)
+            .where(Images.image_id == img.image_id)
+            .execution_options(populate_existing=True)
+        )
+        pre_img = pre_result.scalar_one()
+        assert pre_img.has_artist is True, "Precondition failed: has_artist should be True before type change"
+        assert pre_img.has_source is False, "Precondition failed: has_source should be False before type change"
+
+        # Login as admin
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "admintypeflags", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Change the tag's type from ARTIST to SOURCE via the real endpoint
+        response = await client.put(
+            f"/api/v1/tags/{artist_tag.tag_id}",
+            json={"title": "artist for type-change flag test", "type": TagType.SOURCE},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+
+        # Fresh-read the image; has_artist must now be False, has_source must be True
+        post_result = await db_session.execute(
+            select(Images)
+            .where(Images.image_id == img.image_id)
+            .execution_options(populate_existing=True)
+        )
+        post_img = post_result.scalar_one()
+        assert post_img.has_artist is False, "has_artist should be False after tag type changed from ARTIST to SOURCE"
+        assert post_img.has_source is True, "has_source should be True after tag type changed from ARTIST to SOURCE"
+
 
 @pytest.mark.api
 class TestDeleteTag:

--- a/tests/unit/test_repost_cleanup.py
+++ b/tests/unit/test_repost_cleanup.py
@@ -11,6 +11,7 @@ from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
 from app.services.repost import migrate_repost_data
+from app.services.tag_type_flags import refresh_images_tag_type_flags
 
 
 async def _create_user(db: AsyncSession, username: str) -> Users:
@@ -264,3 +265,50 @@ class TestMigrateRepostData:
         assert result["favorites_moved"] == 0
         assert result["ratings_moved"] == 0
         assert result["tags_moved"] == 0
+
+    async def test_tag_type_flags_updated_after_migrate(self, db_session: AsyncSession):
+        """Tag-type flags must be refreshed after repost migration.
+
+        original gains an artist tag (has_artist 0→1);
+        repost loses its artist tag (has_artist 1→0).
+        """
+        user = await _create_user(db_session, "flaguser")
+        # original has only a theme tag (type=1) — no artist
+        original = await _create_image(db_session, user.user_id, "orig10")
+        theme_tag = Tags(title="a theme tag", type=1)
+        db_session.add(theme_tag)
+        await db_session.flush()
+        await db_session.refresh(theme_tag)
+        db_session.add(TagLinks(
+            tag_id=theme_tag.tag_id, image_id=original.image_id, user_id=user.user_id
+        ))
+
+        # repost has an artist tag (type=3)
+        repost = await _create_image(db_session, user.user_id, "repo10")
+        artist_tag = Tags(title="an artist tag", type=3)
+        db_session.add(artist_tag)
+        await db_session.flush()
+        await db_session.refresh(artist_tag)
+        db_session.add(TagLinks(
+            tag_id=artist_tag.tag_id, image_id=repost.image_id, user_id=user.user_id
+        ))
+
+        # Establish baseline flags
+        await refresh_images_tag_type_flags(db_session, [original.image_id, repost.image_id])
+        await db_session.commit()
+
+        # Precondition: original has no artist; repost has artist
+        await db_session.refresh(original)
+        await db_session.refresh(repost)
+        assert original.has_artist is False, "precondition: original should not have artist flag"
+        assert repost.has_artist is True, "precondition: repost should have artist flag"
+
+        # Migrate and commit
+        await migrate_repost_data(repost.image_id, original.image_id, db_session)
+        await db_session.commit()
+
+        # Fresh reads to bypass identity-map staleness
+        await db_session.refresh(original)
+        await db_session.refresh(repost)
+        assert original.has_artist is True, "original should gain artist flag after migration"
+        assert repost.has_artist is False, "repost should lose artist flag after migration"


### PR DESCRIPTION
## Summary

Adds a `missing_tag_types` filter to `GET /api/v1/images` to find images **lacking** a tag of a given type (1=Theme, 2=Source, 3=Artist, 4=Character) — for moderation/cleanup queues and as a general search filter:

- **`missing_tag_types`** — comma-separated type IDs the image must be missing.
- **`missing_tag_types_mode`** — `any` (default, missing ≥1 listed type) or `all` (missing every listed type).
- Validation: invalid type IDs (incl. non-digit/Unicode-digit tokens) → `400`; invalid mode → `422`.

### Architecture: denormalized presence flags (not a live anti-join)

The initial implementation used a live `NOT IN`/`NOT EXISTS` anti-join. On production-scale data (1.1M images, 14.7M tag_links, 956k images with an artist tag) **that timed out (60s+)**: MariaDB 12 materializes the anti-join and the `total` count can't early-terminate.

This PR instead maintains four denormalized boolean columns on `images` — `has_theme/has_source/has_artist/has_character` — so the filter is a sargable, indexed column predicate (`any` → `OR`, `all` → `AND` of `has_X = 0`). Both the page and the `total` count are now fast.

- **Migration** `301d283488cc`: adds the 4 columns (`ALGORITHM=INSTANT`) + `(flag, image_id)` indexes (online `INPLACE`).
- **Maintenance:** a flush-first, set-based recompute helper (`app/services/tag_type_flags.py`) hooked into **every** tag-link mutation site (single add/remove, upload, batch add/remove, repost merge, admin report-resolution) and every tag-level op (tag delete w/ FK-cascade flush ordering, type change, alias reassignment). Recompute-from-source = drift-proof and idempotent.
- **Backfill:** `scripts/backfill_tag_type_flags.py` — idempotent, resumable, range-batched; populates the 1.1M existing rows. Run **migrate → backfill → rely-on-filter** in that order (columns default 0, so the filter harmlessly over-reports "missing" until backfill completes).
- Aliases are intentionally **not** resolved: the applied tag's own `type` drives the flag.

Also fixes a latent `isdigit()` → `isdecimal()` bug in `tags`/`exclude_tags` parsing (a Unicode-digit like `²` would 500 on `int()`).

Design + plan: `docs/plans/2026-05-31-tag-type-presence-denormalization-{design,impl}.md` (and the original `2026-05-29-missing-tag-type-filter-*`).

## Test Plan

- [x] Full API + unit suites: **1586 passed, 5 pre-existing skips**; mypy clean on all touched modules.
- [x] Helper unit tests, per-hook integration tests (each asserting a genuine flag transition via fresh DB reads), filter behavior, validation, backfill, idempotency.
- [x] **Dev DB verification:** backfill of 1.1M rows in ~57s; `missing_tag_types=3` now returns in **0.26s** (was 60s+ timeout) with correct `total=134663`; `EXPLAIN` uses `idx_images_has_artist` with no filesort. `any`-mode multi-type ~0.5s (index-merge; acceptable).
- [ ] Production rollout: deploy migration → run `scripts/backfill_tag_type_flags.py` → filter is then accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)