### PR TITLE
Plan 1 — image status model: DEACTIVATED + unified status-change service

### DIFF
--- a/alembic/versions/ba007b19d0f1_image_status_deactivated.py
+++ b/alembic/versions/ba007b19d0f1_image_status_deactivated.py
@@ -67,6 +67,12 @@ def upgrade() -> None:
           AND JSON_EXTRACT(aa.details, '$.previous_status') IS NOT NULL
           AND CAST(JSON_EXTRACT(aa.details, '$.previous_status') AS SIGNED)
               <> CAST(JSON_EXTRACT(aa.details, '$.new_status') AS SIGNED)
+          AND NOT EXISTS (
+              SELECT 1 FROM image_status_history ish
+              WHERE ish.image_id = aa.image_id
+                AND ish.created_at = aa.created_at
+                AND ish.user_id = aa.user_id
+          )
         """
     )
 

--- a/alembic/versions/ba007b19d0f1_image_status_deactivated.py
+++ b/alembic/versions/ba007b19d0f1_image_status_deactivated.py
@@ -1,0 +1,78 @@
+"""image status deactivated
+
+Revision ID: ba007b19d0f1
+Revises: 301d283488cc
+Create Date: 2026-06-03 14:18:15.002341
+
+"""
+from typing import Sequence
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ba007b19d0f1'
+down_revision: str | Sequence[str] | None = '301d283488cc'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add reason columns; convert legacy disable statuses to DEACTIVATED; backfill triage history."""
+    # --- Schema: add columns ---
+    # images is large: metadata-only adds, INSTANT algorithm, no lock.
+    op.execute(
+        "ALTER TABLE images "
+        "ADD COLUMN reason_category INT NULL, "
+        "ADD COLUMN status_reason VARCHAR(1000) NULL, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )
+    op.execute(
+        "ALTER TABLE image_status_history "
+        "ADD COLUMN reason_category INT NULL, "
+        "ADD COLUMN reason VARCHAR(1000) NULL, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )
+
+    # --- Data: backfill reason_category for deactivated images ---
+    # DEACTIVATED == 0, so existing status=0 (old OTHER/disabled) images stay at 0 and
+    # only gain a reason_category; legacy -2/-3 images move to 0 + their category.
+    # status_reason stays NULL: the old system never captured a reason.
+    # ORDER MATTERS: backfill the existing 0-rows FIRST, then convert -2/-3 to 0 —
+    # otherwise the cat-4 backfill would clobber the just-converted -2/-3 rows.
+    #  0 (was OTHER)   -> stay 0 (DEACTIVATED) + cat 4 (Other)
+    # -2 INAPPROPRIATE -> 0 (DEACTIVATED)      + cat 1 (Inappropriate)
+    # -3 LOW_QUALITY   -> 0 (DEACTIVATED)      + cat 2 (Low Quality)
+    op.execute("UPDATE images SET reason_category = 4 WHERE status = 0")
+    op.execute("UPDATE images SET status = 0, reason_category = 1 WHERE status = -2")
+    op.execute("UPDATE images SET status = 0, reason_category = 2 WHERE status = -3")
+
+    # --- Data: backfill triage-gap history rows ---
+    # action_report (admin_actions.action_type = 2 = REPORT_ACTION) historically updated
+    # image status WITHOUT writing an image_status_history row. Reconstruct those rows from
+    # the audit log so the public history is complete. Use the ORIGINAL recorded int values
+    # (do NOT convert to DEACTIVATED) — history must reflect what happened at the time.
+    op.execute(
+        """
+        INSERT INTO image_status_history (image_id, old_status, new_status, user_id, created_at)
+        SELECT aa.image_id,
+               CAST(JSON_EXTRACT(aa.details, '$.previous_status') AS SIGNED),
+               CAST(JSON_EXTRACT(aa.details, '$.new_status') AS SIGNED),
+               aa.user_id,
+               aa.created_at
+        FROM admin_actions aa
+        WHERE aa.action_type = 2
+          AND aa.image_id IS NOT NULL
+          AND JSON_EXTRACT(aa.details, '$.new_status') IS NOT NULL
+          AND JSON_EXTRACT(aa.details, '$.previous_status') IS NOT NULL
+          AND CAST(JSON_EXTRACT(aa.details, '$.previous_status') AS SIGNED)
+              <> CAST(JSON_EXTRACT(aa.details, '$.new_status') AS SIGNED)
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop the added columns. Legacy status conversion and backfilled history rows are
+    not reverted — they represent real, historically-accurate events."""
+    op.execute("ALTER TABLE image_status_history DROP COLUMN reason, DROP COLUMN reason_category")
+    op.execute("ALTER TABLE images DROP COLUMN status_reason, DROP COLUMN reason_category")

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -103,9 +103,13 @@ from app.schemas.report import (
     UnifiedReportListResponse,
     VoteResponse,
 )
-from app.services.image_status import enqueue_r2_sync_on_status_change
+from app.services.image_status import (
+    change_image_status as apply_image_status_change,
+)
+from app.services.image_status import (
+    enqueue_r2_sync_on_status_change,
+)
 from app.services.rating import schedule_rating_recalculation
-from app.services.repost import migrate_repost_data
 from app.services.review_jobs import check_early_close
 from app.services.tag_type_flags import refresh_image_tag_type_flags
 
@@ -738,75 +742,20 @@ async def change_image_status(
         raise HTTPException(status_code=404, detail="Image not found")
 
     previous_status = image.status
-    previous_locked = image.locked
 
-    migration_result: dict[str, int] = {}
-
-    # Handle status change if provided
-    if status_data.status is not None:
-        # Handle repost status
-        if status_data.status == ImageStatus.REPOST:
-            if status_data.replacement_id is None:
-                raise HTTPException(
-                    status_code=400,
-                    detail="replacement_id is required when marking as repost",
-                )
-            if status_data.replacement_id == image_id:
-                raise HTTPException(
-                    status_code=400,
-                    detail="An image cannot be a repost of itself",
-                )
-            # Verify original image exists
-            original_result = await db.execute(
-                select(Images).where(Images.image_id == status_data.replacement_id)  # type: ignore[arg-type]
-            )
-            if not original_result.scalar_one_or_none():
-                raise HTTPException(
-                    status_code=404,
-                    detail="Original image not found",
-                )
-            image.replacement_id = status_data.replacement_id
-
-            # Migrate favorites, ratings, and tags to the original image
-            migration_result = await migrate_repost_data(image_id, status_data.replacement_id, db)
-        else:
-            # Clear replacement_id when not a repost
-            image.replacement_id = None
-
-        # Update image status
-        image.status = status_data.status
-        image.status_user_id = current_user.user_id
-        image.status_updated = datetime.now(UTC)
-
-    # Handle locked change if provided
-    if status_data.locked is not None:
-        image.locked = 1 if status_data.locked else 0
-
-    # Log to public status history (only if status actually changed)
-    if status_data.status is not None and status_data.status != previous_status:
-        status_history = ImageStatusHistory(
-            image_id=image_id,
-            old_status=previous_status,
-            new_status=image.status,
-            user_id=current_user.user_id,
-        )
-        db.add(status_history)
-
-    # Log admin action
-    action = AdminActions(
-        user_id=current_user.user_id,
-        action_type=AdminActionType.IMAGE_STATUS_CHANGE,
-        image_id=image_id,
-        details={
-            "previous_status": previous_status,
-            "new_status": image.status,
-            "previous_locked": previous_locked,
-            "new_locked": image.locked,
-            "replacement_id": image.replacement_id,
-            **migration_result,
-        },
+    # All mutation + audit logging goes through the unified service so this
+    # endpoint and the report-triage path stay consistent. (Imported under an
+    # alias because this route handler shares the service's name.)
+    await apply_image_status_change(
+        db,
+        image,
+        current_user,
+        new_status=status_data.status,
+        reason_category=status_data.reason_category,
+        reason=status_data.reason,
+        replacement_id=status_data.replacement_id,
+        locked=status_data.locked,
     )
-    db.add(action)
 
     await db.commit()
     await db.refresh(image)

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1235,7 +1235,7 @@ async def get_image_status_history(
     owner_id = image.user_id
 
     is_privileged_viewer = False
-    if current_user is not None:
+    if current_user is not None and current_user.user_id is not None:
         is_privileged_viewer = current_user.user_id == owner_id or await has_any_permission(
             db, current_user.user_id, [Permission.IMAGE_EDIT, Permission.REVIEW_VIEW]
         )

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -50,7 +50,7 @@ from app.config import (
 from app.core.auth import CurrentUser, VerifiedUser, get_current_user, get_optional_current_user
 from app.core.database import get_db
 from app.core.logging import get_logger
-from app.core.permissions import Permission, has_permission
+from app.core.permissions import Permission, has_any_permission, has_permission
 from app.core.r2_constants import R2Location
 from app.core.redis import get_redis
 from app.models import (
@@ -1216,6 +1216,7 @@ async def get_image_tag_history(
 async def get_image_status_history(
     image_id: Annotated[int, Path(description="Image ID")],
     pagination: Annotated[PaginationParams, Depends()],
+    current_user: Annotated[Users | None, Depends(get_optional_current_user)],
     db: AsyncSession = Depends(get_db),
 ) -> ImageStatusHistoryListResponse:
     """
@@ -1223,11 +1224,21 @@ async def get_image_status_history(
 
     Returns paginated list of status changes.
     User info is shown only for public status changes (repost, spoiler, active).
+    The free-text reason is shown only for public-destination transitions, or to
+    the image owner / moderators; the reason_category is always shown.
     """
     # Verify image exists
     image_result = await db.execute(select(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
-    if not image_result.scalar_one_or_none():
+    image = image_result.scalar_one_or_none()
+    if not image:
         raise HTTPException(status_code=404, detail="Image not found")
+    owner_id = image.user_id
+
+    is_privileged_viewer = False
+    if current_user is not None:
+        is_privileged_viewer = current_user.user_id == owner_id or await has_any_permission(
+            db, current_user.user_id, [Permission.IMAGE_EDIT, Permission.REVIEW_VIEW]
+        )
 
     # Query status history with user info
     # Eager load user groups for UserSummary
@@ -1278,6 +1289,12 @@ async def get_image_status_history(
                 groups=user.groups if user else [],
             )
 
+        # The free-text reason describes the *destination* state, so it is public
+        # only when the new status is publicly visible; otherwise owner/mods only.
+        # reason_category is always exposed.
+        reason_is_public = history.new_status in ImageStatus.VISIBLE_USER_STATUSES
+        can_see_reason = reason_is_public or is_privileged_viewer
+
         items.append(
             ImageStatusHistoryResponse(
                 id=history.id,
@@ -1286,6 +1303,8 @@ async def get_image_status_history(
                 old_status_label=ImageStatus.get_label(history.old_status),
                 new_status=history.new_status,
                 new_status_label=ImageStatus.get_label(history.new_status),
+                reason_category=history.reason_category,
+                reason=history.reason if can_see_reason else None,
                 user=user_summary,
                 created_at=history.created_at,
             )

--- a/app/config.py
+++ b/app/config.py
@@ -265,24 +265,25 @@ class ImageStatus:
     """Image status constants"""
 
     REVIEW = -4
-    LOW_QUALITY = -3
-    INAPPROPRIATE = -2
+    LOW_QUALITY = -3  # legacy: no longer settable; kept for historical rows
+    INAPPROPRIATE = -2  # legacy: no longer settable; kept for historical rows
     REPOST = -1
-    OTHER = 0
+    DEACTIVATED = 0  # reuses the historical generic "disable" bucket (was OTHER)
+    OTHER = 0  # DEPRECATED alias of DEACTIVATED; remove once test refs migrate
     ACTIVE = 1
     SPOILER = 2
 
     # Status values where we show the user who made the change in public audit
     # Show for: REPOST (-1), SPOILER (2), ACTIVE (1)
-    # Hide for: REVIEW (-4), LOW_QUALITY (-3), INAPPROPRIATE (-2), OTHER (0)
+    # Hide for: REVIEW (-4), LOW_QUALITY (-3), INAPPROPRIATE (-2), DEACTIVATED (0)
     VISIBLE_USER_STATUSES: set[int] = {REPOST, SPOILER, ACTIVE}
 
     LABELS: dict[int, str] = {
         REVIEW: "review",
-        LOW_QUALITY: "low_quality",
-        INAPPROPRIATE: "inappropriate",
+        LOW_QUALITY: "low_quality",  # legacy label for historical rows
+        INAPPROPRIATE: "inappropriate",  # legacy label for historical rows
         REPOST: "repost",
-        OTHER: "other",
+        DEACTIVATED: "deactivated",  # key 0 — replaces the old "other" label
         ACTIVE: "active",
         SPOILER: "spoiler",
     }
@@ -291,6 +292,30 @@ class ImageStatus:
     def get_label(cls, status: int) -> str:
         """Get human-readable label for image status."""
         return cls.LABELS.get(status, "unknown")
+
+
+class DeactivationReason:
+    """Reason categories for a DEACTIVATED image. Shown publicly."""
+
+    INAPPROPRIATE = 1
+    LOW_QUALITY = 2
+    SPAM = 3
+    OTHER = 4
+
+    LABELS: dict[int, str] = {
+        INAPPROPRIATE: "Inappropriate",
+        LOW_QUALITY: "Low Quality",
+        SPAM: "Spam",
+        OTHER: "Other",
+    }
+
+    VALID: set[int] = {INAPPROPRIATE, LOW_QUALITY, SPAM, OTHER}
+
+    @classmethod
+    def get_label(cls, value: int | None) -> str:
+        if value is None:
+            return ""
+        return cls.LABELS.get(value, "unknown")
 
 
 class ReportStatus:

--- a/app/models/image.py
+++ b/app/models/image.py
@@ -134,10 +134,10 @@ class ImageBase(SQLModel):
         """Validate that status is one of the allowed ImageStatus constants."""
         valid_statuses = {
             ImageStatus.REVIEW,
-            ImageStatus.LOW_QUALITY,
-            ImageStatus.INAPPROPRIATE,
+            ImageStatus.LOW_QUALITY,  # legacy value, still loadable from old rows
+            ImageStatus.INAPPROPRIATE,  # legacy value, still loadable from old rows
             ImageStatus.REPOST,
-            ImageStatus.OTHER,
+            ImageStatus.DEACTIVATED,  # == 0 (formerly OTHER)
             ImageStatus.ACTIVE,
             ImageStatus.SPOILER,
         }
@@ -257,6 +257,11 @@ class Images(ImageBase, table=True):
     # Internal metadata
     total_pixels: Decimal | None = Field(default=None)
     replacement_id: int | None = Field(default=None, foreign_key="images.image_id")
+
+    # Deactivation detail (set when status == DEACTIVATED)
+    reason_category: int | None = Field(default=None)
+    # Free-text reason for the current status (visibility scoped at the API layer)
+    status_reason: str | None = Field(default=None, max_length=1000)
 
     # Denormalized tag-type presence (maintained by app.services.tag_type_flags).
     # Internal cache of "image has >=1 tag of this type"; source of truth is tag_links + tags.type.

--- a/app/models/image_status_history.py
+++ b/app/models/image_status_history.py
@@ -62,6 +62,11 @@ class ImageStatusHistory(ImageStatusHistoryBase, table=True):
     # User who made the change (nullable for system actions)
     user_id: int | None = Field(default=None)
 
+    # Reason metadata for this transition (mirrors images.reason_category / status_reason
+    # at the time of the change). Nullable: legacy rows and non-deactivation transitions.
+    reason_category: int | None = Field(default=None)
+    reason: str | None = Field(default=None, max_length=1000)
+
     # Timestamp
     created_at: datetime | None = Field(
         default=None,

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -251,11 +251,23 @@ class ImageStatusUpdate(BaseModel):
 
     status: int | None = Field(
         None,
-        description="New status: -4=Review, -2=Inappropriate, -1=Repost, 0=Other, 1=Active, 2=Spoiler",
+        description="New status: 0=Deactivated, -4=Review, -1=Repost, 1=Active, 2=Spoiler",
     )
     replacement_id: int | None = Field(
         None,
         description="Original image ID when marking as repost (required when status=-1)",
+    )
+    reason_category: int | None = Field(
+        None,
+        description=(
+            "Deactivation reason (required when status=0): "
+            "1=Inappropriate, 2=Low Quality, 3=Spam, 4=Other"
+        ),
+    )
+    reason: str | None = Field(
+        None,
+        max_length=1000,
+        description="Free-text reason (required when status=0)",
     )
     locked: bool | None = Field(
         None,
@@ -265,32 +277,52 @@ class ImageStatusUpdate(BaseModel):
     @field_validator("status")
     @classmethod
     def validate_status(cls, v: int | None) -> int | None:
-        """Validate status is one of the allowed ImageStatus constants."""
+        """Validate status is one of the settable ImageStatus constants.
+
+        Legacy INAPPROPRIATE(-2)/LOW_QUALITY(-3) are no longer settable — they
+        collapse into DEACTIVATED(0) + a reason_category.
+        """
         if v is None:
             return v
 
         from app.config import ImageStatus
 
-        valid_statuses = {
+        settable = {
+            ImageStatus.DEACTIVATED,
             ImageStatus.REVIEW,
-            ImageStatus.INAPPROPRIATE,
             ImageStatus.REPOST,
-            ImageStatus.OTHER,
             ImageStatus.ACTIVE,
             ImageStatus.SPOILER,
         }
-        if v not in valid_statuses:
+        if v not in settable:
             raise ValueError(
                 f"Invalid status: {v}. Must be one of: "
-                "-4=Review, -2=Inappropriate, -1=Repost, 0=Other, 1=Active, 2=Spoiler"
+                "0=Deactivated, -4=Review, -1=Repost, 1=Active, 2=Spoiler"
             )
         return v
 
+    @field_validator("reason")
+    @classmethod
+    def strip_reason(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        return v.strip() or None
+
     @model_validator(mode="after")
-    def require_at_least_one_field(self) -> ImageStatusUpdate:
-        """Require at least one of status or locked to be provided."""
+    def validate_combination(self) -> ImageStatusUpdate:
+        """Require status or locked; require category+reason for deactivation."""
+        from app.config import DeactivationReason, ImageStatus
+
         if self.status is None and self.locked is None:
             raise ValueError("At least one of 'status' or 'locked' must be provided")
+
+        if self.status == ImageStatus.DEACTIVATED:
+            if self.reason_category not in DeactivationReason.VALID:
+                raise ValueError("reason_category is required and must be valid when deactivating")
+            if not self.reason:
+                raise ValueError("reason is required when deactivating")
+        elif self.reason_category is not None:
+            raise ValueError("reason_category is only valid when status is Deactivated")
         return self
 
 
@@ -301,6 +333,8 @@ class ImageStatusResponse(BaseModel):
     status: int
     locked: int
     replacement_id: int | None
+    reason_category: int | None = None
+    status_reason: str | None = None
     status_user_id: int | None
     status_updated: UTCDatetimeOptional = None
 

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -321,8 +321,11 @@ class ImageStatusUpdate(BaseModel):
                 raise ValueError("reason_category is required and must be valid when deactivating")
             if not self.reason:
                 raise ValueError("reason is required when deactivating")
-        elif self.reason_category is not None:
-            raise ValueError("reason_category is only valid when status is Deactivated")
+        else:
+            if self.reason_category is not None:
+                raise ValueError("reason_category is only valid when status is Deactivated")
+            if self.status is None and self.reason is not None:
+                raise ValueError("reason requires a status change")
         return self
 
 

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -150,6 +150,11 @@ class ImageStatusHistoryResponse(BaseModel):
     new_status: int
     new_status_label: str
 
+    # Deactivation reason category (shown to everyone); free-text reason is
+    # owner/mod-only for hidden-status transitions (gated by the endpoint).
+    reason_category: int | None = None
+    reason: str | None = None
+
     # Who made the change (may be null for hidden statuses)
     user: UserSummary | None = None
 

--- a/app/services/image_status.py
+++ b/app/services/image_status.py
@@ -7,8 +7,19 @@ a public→protected transition leaves the image reachable via CDN until the
 edge TTL expires.
 """
 
-from app.config import settings
+from datetime import UTC, datetime
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import AdminActionType, ImageStatus, settings
 from app.core.r2_constants import PUBLIC_IMAGE_STATUSES_FOR_R2
+from app.models.admin_action import AdminActions
+from app.models.image import Images
+from app.models.image_status_history import ImageStatusHistory
+from app.models.user import Users
+from app.services.repost import migrate_repost_data
 from app.tasks.queue import enqueue_job
 
 
@@ -37,3 +48,97 @@ async def enqueue_r2_sync_on_status_change(
         old_status=old_status,
         new_status=new_status,
     )
+
+
+async def change_image_status(
+    db: AsyncSession,
+    image: Images,
+    actor: Users,
+    *,
+    new_status: int | None = None,
+    reason_category: int | None = None,
+    reason: str | None = None,
+    replacement_id: int | None = None,
+    locked: bool | None = None,
+) -> dict[str, int]:
+    """Apply a moderation status and/or lock change to an image.
+
+    Writes the public status-history row (when the status actually changes) and
+    the internal admin-action audit row. Does NOT commit — the caller owns the
+    transaction and any post-commit side effects (R2 sync enqueue, rating
+    recalculation). Raises HTTPException on invalid transitions.
+
+    Returns the repost migration_result dict (empty unless a repost was processed).
+    """
+    previous_status = image.status
+    previous_locked = image.locked
+    migration_result: dict[str, int] = {}
+
+    if new_status is not None:
+        if new_status == ImageStatus.REPOST:
+            if replacement_id is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="replacement_id is required when marking as repost",
+                )
+            if replacement_id == image.image_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail="An image cannot be a repost of itself",
+                )
+            original = (
+                await db.execute(select(Images).where(Images.image_id == replacement_id))
+            ).scalar_one_or_none()
+            if not original:
+                raise HTTPException(status_code=404, detail="Original image not found")
+            image.replacement_id = replacement_id
+            migration_result = await migrate_repost_data(image.image_id, replacement_id, db)
+        else:
+            # Clear replacement_id when not a repost
+            image.replacement_id = None
+
+        # reason_category only applies to DEACTIVATED; reason may accompany any status
+        if new_status == ImageStatus.DEACTIVATED:
+            image.reason_category = reason_category
+        else:
+            image.reason_category = None
+        image.status_reason = reason
+
+        image.status = new_status
+        image.status_user_id = actor.user_id
+        image.status_updated = datetime.now(UTC)
+
+    if locked is not None:
+        image.locked = 1 if locked else 0
+
+    # Public status-history row only when the status actually changed
+    if new_status is not None and new_status != previous_status:
+        db.add(
+            ImageStatusHistory(
+                image_id=image.image_id,
+                old_status=previous_status,
+                new_status=new_status,
+                user_id=actor.user_id,
+                reason_category=image.reason_category,
+                reason=image.status_reason,
+            )
+        )
+
+    db.add(
+        AdminActions(
+            user_id=actor.user_id,
+            action_type=AdminActionType.IMAGE_STATUS_CHANGE,
+            image_id=image.image_id,
+            details={
+                "previous_status": previous_status,
+                "new_status": image.status,
+                "previous_locked": previous_locked,
+                "new_locked": image.locked,
+                "replacement_id": image.replacement_id,
+                "reason_category": image.reason_category,
+                **migration_result,
+            },
+        )
+    )
+
+    return migration_result

--- a/app/services/image_status.py
+++ b/app/services/image_status.py
@@ -70,6 +70,7 @@ async def change_image_status(
 
     Returns the repost migration_result dict (empty unless a repost was processed).
     """
+    assert image.image_id is not None  # caller passes a persisted image
     previous_status = image.status
     previous_locked = image.locked
     migration_result: dict[str, int] = {}
@@ -87,7 +88,9 @@ async def change_image_status(
                     detail="An image cannot be a repost of itself",
                 )
             original = (
-                await db.execute(select(Images).where(Images.image_id == replacement_id))
+                await db.execute(
+                    select(Images).where(Images.image_id == replacement_id)  # type: ignore[arg-type]
+                )
             ).scalar_one_or_none()
             if not original:
                 raise HTTPException(status_code=404, detail="Original image not found")
@@ -136,6 +139,7 @@ async def change_image_status(
                 "new_locked": image.locked,
                 "replacement_id": image.replacement_id,
                 "reason_category": image.reason_category,
+                "reason": image.status_reason,
                 **migration_result,
             },
         )

--- a/tests/api/v1/test_admin_images.py
+++ b/tests/api/v1/test_admin_images.py
@@ -9,7 +9,7 @@ from httpx import AsyncClient
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import AdminActionType, ImageStatus, ReportStatus, TagType
+from app.config import AdminActionType, DeactivationReason, ImageStatus, ReportStatus, TagType
 from app.core.security import get_password_hash
 from app.models.admin_action import AdminActions
 from app.models.favorite import Favorites
@@ -835,3 +835,57 @@ class TestApplyTagSuggestionsUpdatesTagTypeFlags:
         # Fresh read to bypass stale ORM identity-map state
         await db_session.refresh(image)
         assert image.has_artist is False
+
+
+@pytest.mark.api
+class TestDeactivateImage:
+    """Tests for the DEACTIVATED status contract on PATCH /api/v1/admin/images/{id}."""
+
+    async def test_deactivate_requires_category_and_reason(self, client, db_session):
+        admin, pw = await create_admin_user(db_session)
+        await grant_permission(db_session, admin.user_id, "image_edit")
+        image = await create_test_image(db_session, admin.user_id)
+        token = await login_user(client, admin.username, pw)
+
+        # Missing category + reason -> 422 (schema validation)
+        r = await client.patch(
+            f"/api/v1/admin/images/{image.image_id}",
+            json={"status": ImageStatus.DEACTIVATED},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 422
+
+    async def test_deactivate_success(self, client, db_session):
+        admin, pw = await create_admin_user(db_session)
+        await grant_permission(db_session, admin.user_id, "image_edit")
+        image = await create_test_image(db_session, admin.user_id)
+        token = await login_user(client, admin.username, pw)
+
+        r = await client.patch(
+            f"/api/v1/admin/images/{image.image_id}",
+            json={
+                "status": ImageStatus.DEACTIVATED,
+                "reason_category": DeactivationReason.LOW_QUALITY,
+                "reason": "blurry",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == ImageStatus.DEACTIVATED
+        assert data["reason_category"] == DeactivationReason.LOW_QUALITY
+        assert data["status_reason"] == "blurry"
+
+    async def test_legacy_statuses_no_longer_settable(self, client, db_session):
+        admin, pw = await create_admin_user(db_session)
+        await grant_permission(db_session, admin.user_id, "image_edit")
+        image = await create_test_image(db_session, admin.user_id)
+        token = await login_user(client, admin.username, pw)
+        # -2/-3 are legacy (history-only) and must be rejected. 0 is now DEACTIVATED (settable).
+        for legacy in (ImageStatus.INAPPROPRIATE, ImageStatus.LOW_QUALITY):
+            r = await client.patch(
+                f"/api/v1/admin/images/{image.image_id}",
+                json={"status": legacy, "reason": "x"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert r.status_code == 422, f"status {legacy} should be rejected"

--- a/tests/api/v1/test_admin_images.py
+++ b/tests/api/v1/test_admin_images.py
@@ -889,3 +889,16 @@ class TestDeactivateImage:
                 headers={"Authorization": f"Bearer {token}"},
             )
             assert r.status_code == 422, f"status {legacy} should be rejected"
+
+    async def test_reason_without_status_change_rejected(self, client, db_session):
+        admin, pw = await create_admin_user(db_session)
+        await grant_permission(db_session, admin.user_id, "image_edit")
+        image = await create_test_image(db_session, admin.user_id)
+        token = await login_user(client, admin.username, pw)
+        # lock-only update must not silently accept (and drop) a free-text reason
+        r = await client.patch(
+            f"/api/v1/admin/images/{image.image_id}",
+            json={"locked": True, "reason": "should be rejected"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 422

--- a/tests/api/v1/test_image_status_history_endpoint.py
+++ b/tests/api/v1/test_image_status_history_endpoint.py
@@ -529,8 +529,8 @@ class TestGetImageStatusHistory:
             (ImageStatus.REVIEW, ImageStatus.LOW_QUALITY, "review", "low_quality"),
             (ImageStatus.LOW_QUALITY, ImageStatus.INAPPROPRIATE, "low_quality", "inappropriate"),
             (ImageStatus.INAPPROPRIATE, ImageStatus.REPOST, "inappropriate", "repost"),
-            (ImageStatus.REPOST, ImageStatus.OTHER, "repost", "other"),
-            (ImageStatus.OTHER, ImageStatus.ACTIVE, "other", "active"),
+            (ImageStatus.REPOST, ImageStatus.OTHER, "repost", "deactivated"),
+            (ImageStatus.OTHER, ImageStatus.ACTIVE, "deactivated", "active"),
             (ImageStatus.ACTIVE, ImageStatus.SPOILER, "active", "spoiler"),
         ]
 

--- a/tests/api/v1/test_image_status_history_endpoint.py
+++ b/tests/api/v1/test_image_status_history_endpoint.py
@@ -11,11 +11,14 @@ User visibility rules:
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import ImageStatus
+from app.config import DeactivationReason, ImageStatus
+from app.core.security import get_password_hash
 from app.models.image import Images
 from app.models.image_status_history import ImageStatusHistory
+from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
 from app.models.user import Users
 
 
@@ -562,3 +565,99 @@ class TestGetImageStatusHistory:
             assert item is not None, f"Missing entry for {old_status} -> {new_status}"
             assert item["old_status_label"] == old_label
             assert item["new_status_label"] == new_label
+
+
+async def _make_user(db_session, username, password="TestPassword123!"):
+    user = Users(username=username, password=get_password_hash(password),
+                 password_type="bcrypt", salt="", email=f"{username}@example.com", active=1)
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+async def _grant_image_edit(db_session, user_id):
+    perm = (await db_session.execute(select(Perms).where(Perms.title == "image_edit"))).scalar_one_or_none()
+    if not perm:
+        perm = Perms(title="image_edit", desc="edit images")
+        db_session.add(perm)
+        await db_session.flush()
+    group = Groups(title=f"hist_mod_{user_id}", desc="hist mod group")
+    db_session.add(group)
+    await db_session.flush()
+    db_session.add(GroupPerms(group_id=group.group_id, perm_id=perm.perm_id, permvalue=1))
+    db_session.add(UserGroups(user_id=user_id, group_id=group.group_id))
+    await db_session.commit()
+
+
+async def _login(client, username, password="TestPassword123!"):
+    r = await client.post("/api/v1/auth/login", json={"username": username, "password": password})
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+async def _seed_deactivation(db_session, owner):
+    image = Images(filename="histvis", ext="jpg", md5_hash="a" * 32,
+                   user_id=owner.user_id, width=100, height=100, filesize=1000,
+                   status=ImageStatus.DEACTIVATED,
+                   reason_category=DeactivationReason.LOW_QUALITY,
+                   status_reason="blurry and low res")
+    db_session.add(image)
+    await db_session.commit()
+    await db_session.refresh(image)
+    db_session.add(ImageStatusHistory(
+        image_id=image.image_id, old_status=ImageStatus.ACTIVE,
+        new_status=ImageStatus.DEACTIVATED, user_id=owner.user_id,
+        reason_category=DeactivationReason.LOW_QUALITY, reason="blurry and low res"))
+    await db_session.commit()
+    return image
+
+
+@pytest.mark.api
+class TestStatusHistoryReasonVisibility:
+    """reason_category is public; free-text reason is owner/mod-only for hidden-status transitions."""
+
+    async def test_reason_hidden_from_anonymous_for_deactivation(self, client, db_session):
+        owner = await _make_user(db_session, "histowner1")
+        image = await _seed_deactivation(db_session, owner)
+
+        r = await client.get(f"/api/v1/images/{image.image_id}/status-history")
+        assert r.status_code == 200
+        row = r.json()["items"][0]
+        assert row["reason_category"] == DeactivationReason.LOW_QUALITY  # category always shown
+        assert row["reason"] is None  # free-text hidden from anonymous on a hidden-status transition
+
+    async def test_reason_visible_to_owner_and_mod(self, client, db_session):
+        owner = await _make_user(db_session, "histowner2")
+        image = await _seed_deactivation(db_session, owner)
+
+        owner_token = await _login(client, owner.username)
+        r = await client.get(f"/api/v1/images/{image.image_id}/status-history",
+                             headers={"Authorization": f"Bearer {owner_token}"})
+        assert r.json()["items"][0]["reason"] == "blurry and low res"
+
+        mod = await _make_user(db_session, "histmod2")
+        await _grant_image_edit(db_session, mod.user_id)
+        mod_token = await _login(client, mod.username)
+        r = await client.get(f"/api/v1/images/{image.image_id}/status-history",
+                             headers={"Authorization": f"Bearer {mod_token}"})
+        assert r.json()["items"][0]["reason"] == "blurry and low res"
+
+    async def test_reason_public_for_spoiler_transition(self, client, db_session):
+        owner = await _make_user(db_session, "histowner3")
+        image = Images(filename="histspoil", ext="jpg", md5_hash="b" * 32,
+                       user_id=owner.user_id, width=100, height=100, filesize=1000,
+                       status=ImageStatus.SPOILER, status_reason="mild nudity")
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        db_session.add(ImageStatusHistory(
+            image_id=image.image_id, old_status=ImageStatus.ACTIVE,
+            new_status=ImageStatus.SPOILER, user_id=owner.user_id, reason="mild nudity"))
+        await db_session.commit()
+
+        r = await client.get(f"/api/v1/images/{image.image_id}/status-history")
+        assert r.status_code == 200
+        row = r.json()["items"][0]
+        assert row["reason"] == "mild nudity"  # public: destination status is publicly visible
+        assert row["reason_category"] is None

--- a/tests/services/test_image_status_service.py
+++ b/tests/services/test_image_status_service.py
@@ -52,6 +52,7 @@ async def test_deactivate_sets_fields_history_and_audit(db_session: AsyncSession
     )).scalar_one()
     assert action.action_type == AdminActionType.IMAGE_STATUS_CHANGE
     assert action.details["new_status"] == ImageStatus.DEACTIVATED
+    assert action.details["reason"] == "advertising"  # free-text reason in the audit row itself
 
 
 async def test_repost_requires_replacement(db_session: AsyncSession):

--- a/tests/services/test_image_status_service.py
+++ b/tests/services/test_image_status_service.py
@@ -1,0 +1,74 @@
+"""Tests for the unified change_image_status service."""
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import AdminActionType, DeactivationReason, ImageStatus
+from app.models.admin_action import AdminActions
+from app.models.image import Images
+from app.models.image_status_history import ImageStatusHistory
+from app.models.user import Users
+from app.services.image_status import change_image_status
+
+
+async def _mk_image(db: AsyncSession, user_id: int, status: int = ImageStatus.ACTIVE) -> Images:
+    img = Images(user_id=user_id, filename="x", ext="jpg", md5_hash="a" * 32, status=status)
+    db.add(img)
+    await db.commit()
+    await db.refresh(img)
+    return img
+
+
+async def test_deactivate_sets_fields_history_and_audit(db_session: AsyncSession):
+    actor = (await db_session.execute(select(Users).where(Users.user_id == 1))).scalar_one()
+    img = await _mk_image(db_session, actor.user_id)
+
+    await change_image_status(
+        db_session, img, actor,
+        new_status=ImageStatus.DEACTIVATED,
+        reason_category=DeactivationReason.SPAM,
+        reason="advertising",
+    )
+    await db_session.commit()
+    await db_session.refresh(img)
+
+    assert img.status == ImageStatus.DEACTIVATED
+    assert img.reason_category == DeactivationReason.SPAM
+    assert img.status_reason == "advertising"
+    assert img.status_user_id == actor.user_id
+
+    hist = (await db_session.execute(
+        select(ImageStatusHistory).where(ImageStatusHistory.image_id == img.image_id)
+    )).scalars().all()
+    assert len(hist) == 1
+    assert hist[0].new_status == ImageStatus.DEACTIVATED
+    assert hist[0].reason_category == DeactivationReason.SPAM
+    assert hist[0].reason == "advertising"
+
+    action = (await db_session.execute(
+        select(AdminActions).where(AdminActions.image_id == img.image_id)
+    )).scalar_one()
+    assert action.action_type == AdminActionType.IMAGE_STATUS_CHANGE
+    assert action.details["new_status"] == ImageStatus.DEACTIVATED
+
+
+async def test_repost_requires_replacement(db_session: AsyncSession):
+    actor = (await db_session.execute(select(Users).where(Users.user_id == 1))).scalar_one()
+    img = await _mk_image(db_session, actor.user_id)
+    with pytest.raises(HTTPException) as exc:
+        await change_image_status(db_session, img, actor, new_status=ImageStatus.REPOST)
+    assert exc.value.status_code == 400
+
+
+async def test_no_history_row_when_status_unchanged(db_session: AsyncSession):
+    actor = (await db_session.execute(select(Users).where(Users.user_id == 1))).scalar_one()
+    img = await _mk_image(db_session, actor.user_id)
+    await change_image_status(db_session, img, actor, locked=True)  # lock only
+    await db_session.commit()
+    hist = (await db_session.execute(
+        select(ImageStatusHistory).where(ImageStatusHistory.image_id == img.image_id)
+    )).scalars().all()
+    assert hist == []
+    assert img.locked == 1

--- a/tests/unit/test_config_status.py
+++ b/tests/unit/test_config_status.py
@@ -1,6 +1,11 @@
 """Unit tests for image status / deactivation-reason constants and model plumbing."""
 
+import pytest
+from pydantic import ValidationError
+
 from app.config import DeactivationReason, ImageStatus
+from app.models.image import Images
+from app.models.image_status_history import ImageStatusHistory
 
 
 def test_deactivated_status_exists_and_labels():
@@ -20,3 +25,34 @@ def test_deactivation_reason_labels():
     assert DeactivationReason.OTHER == 4
     assert DeactivationReason.get_label(DeactivationReason.SPAM) == "Spam"
     assert DeactivationReason.get_label(999) == "unknown"
+
+
+def test_images_model_accepts_deactivated():
+    img = Images(user_id=1, filename="x", ext="jpg", md5_hash="a" * 32, status=ImageStatus.DEACTIVATED)
+    assert img.status == ImageStatus.DEACTIVATED
+    assert img.reason_category is None
+    assert img.status_reason is None
+
+
+def test_images_model_still_loads_legacy_statuses():
+    # Old rows may still construct with legacy values during/after migration.
+    # (0/DEACTIVATED is current, not legacy — covered by test_images_model_accepts_deactivated.)
+    for legacy in (ImageStatus.INAPPROPRIATE, ImageStatus.LOW_QUALITY):
+        assert Images(user_id=1, filename="x", ext="jpg", md5_hash="a" * 32, status=legacy).status == legacy
+
+
+def test_images_model_rejects_unknown_status():
+    with pytest.raises(ValidationError):
+        Images(user_id=1, filename="x", ext="jpg", md5_hash="a" * 32, status=99)
+
+
+def test_status_history_has_reason_fields():
+    h = ImageStatusHistory(
+        image_id=1, old_status=ImageStatus.ACTIVE, new_status=ImageStatus.DEACTIVATED,
+        reason_category=DeactivationReason.SPAM, reason="ad spam",
+    )
+    assert h.reason_category == DeactivationReason.SPAM
+    assert h.reason == "ad spam"
+    h2 = ImageStatusHistory(image_id=1, old_status=1, new_status=2)
+    assert h2.reason_category is None
+    assert h2.reason is None

--- a/tests/unit/test_config_status.py
+++ b/tests/unit/test_config_status.py
@@ -1,0 +1,22 @@
+"""Unit tests for image status / deactivation-reason constants and model plumbing."""
+
+from app.config import DeactivationReason, ImageStatus
+
+
+def test_deactivated_status_exists_and_labels():
+    assert ImageStatus.DEACTIVATED == 0  # reuses the historical "disable" bucket
+    assert ImageStatus.OTHER == 0  # deprecated alias kept for backward-compat
+    assert ImageStatus.get_label(ImageStatus.DEACTIVATED) == "deactivated"
+    assert ImageStatus.get_label(0) == "deactivated"  # 0 now renders "deactivated"
+    # Legacy values must still resolve for historical rows
+    assert ImageStatus.get_label(ImageStatus.INAPPROPRIATE) == "inappropriate"
+    assert ImageStatus.get_label(ImageStatus.LOW_QUALITY) == "low_quality"
+
+
+def test_deactivation_reason_labels():
+    assert DeactivationReason.INAPPROPRIATE == 1
+    assert DeactivationReason.LOW_QUALITY == 2
+    assert DeactivationReason.SPAM == 3
+    assert DeactivationReason.OTHER == 4
+    assert DeactivationReason.get_label(DeactivationReason.SPAM) == "Spam"
+    assert DeactivationReason.get_label(999) == "unknown"


### PR DESCRIPTION
Part 1 of 3 of the image-moderation redesign. **Targets the `image-moderation-redesign` umbrella branch, not `main`** — main stays untouched until all three plans are validated together.

## What this does
Splits the overloaded image `status` int into three axes and unifies the status-change path.

- **`DEACTIVATED = 0`** — reuses the historical OTHER/disable slot (no renumbering); `OTHER` kept as a deprecated alias. `INAPPROPRIATE`(-2)/`LOW_QUALITY`(-3) become history-only legacy labels, no longer settable.
- **`DeactivationReason`** enum (Inappropriate / Low Quality / Spam / Other) + new columns: `images.reason_category` / `.status_reason`, and `image_status_history.reason_category` / `.reason`.
- **Unified `change_image_status()` service** (`app/services/image_status.py`) — the direct mod endpoint `PATCH /admin/images/{id}` now routes through it (the report-triage path joins in Plan 2). Deactivation requires `{reason_category, reason}`.
- **Status-history reason visibility**: `reason_category` shown to everyone; free-text `reason` is public for spoiler/repost transitions but owner/mod-only for deactivated/review transitions. Actor-identity rule unchanged.
- **Migration `ba007b19d0f1`**: adds the columns; converts existing `-2/-3 → 0 + category` and backfills `reason_category` for existing `0` images; **backfills the previously-missing triage status-history rows** from `admin_actions` (the old `action_report` path never wrote them). Forward-only.

## Out of scope (later plans)
- **Plan 2:** route `action_report` / `escalate` / `create_review` through the service, store report resolutions + mod reason, require review reasons, remove `review_type`.
- **Plan 3:** frontend (deactivate dialog, triage UI, report dialog, reviews UI).

## Verification
- TDD throughout; full suite **1672 passed, 9 skipped** (skips pre-existing).
- Migration data-backfill verified against seeded rows (`-2→(0,1)`, `-3→(0,2)`, `0→(0,4)`, triage history reconstructed).
- `test_reports.py` / `test_reviews.py` pass unchanged — the deferred triage/review paths still work.

Plan doc: `docs/plans/2026-06-03-image-status-model-impl.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)