### PR TITLE
chore(deps): bump pyjwt 2.12.1 → 2.13.0 (PYSEC-2026-175/177/178/179)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1818,11 +1818,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps **pyjwt 2.12.1 → 2.13.0** to clear four freshly-disclosed advisories (PYSEC-2026-175 / -177 / -178 / -179) that `pip-audit` (the Security Scan CI job) flags on every branch.

- **Lockfile-only change** — the existing constraint `pyjwt<3.0.0,>=2.8.0` already permitted 2.13.0.
- pyjwt is used only for JWT auth; the auth suite (40 tests) passes on 2.13.0.
- `uv run pip-audit` → **no known vulnerabilities found**.

Independent of the image-moderation redesign work — targets `main` directly so the project-wide advisory is cleared everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)