### PR TITLE
Plan 2 — reports & reviews: unified status-change service + derived resolution

### DIFF
--- a/alembic/versions/4a93ca80f7f6_review_reason_category.py
+++ b/alembic/versions/4a93ca80f7f6_review_reason_category.py
@@ -1,0 +1,37 @@
+"""review reason_category
+
+Revision ID: 4a93ca80f7f6
+Revises: ba007b19d0f1
+Create Date: 2026-06-03 19:51:49.359506
+
+"""
+from typing import Sequence
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4a93ca80f7f6'
+down_revision: str | Sequence[str] | None = 'ba007b19d0f1'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Rename image_reviews.review_type -> reason_category.
+
+    Values are unchanged: the only prior value 1 (Appropriateness) now reads as
+    DeactivationReason.INAPPROPRIATE (1) — compatible meaning, no data conversion.
+    """
+    op.execute(
+        "ALTER TABLE image_reviews "
+        "CHANGE COLUMN review_type reason_category INT NOT NULL DEFAULT 1"
+    )
+
+
+def downgrade() -> None:
+    """Rename reason_category back to review_type."""
+    op.execute(
+        "ALTER TABLE image_reviews "
+        "CHANGE COLUMN reason_category review_type INT NOT NULL DEFAULT 1"
+    )

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -24,12 +24,12 @@ from sqlalchemy.orm import selectinload
 
 from app.config import (
     AdminActionType,
+    DeactivationReason,
     ImageStatus,
     ReportCategory,
     ReportStatus,
     ReviewOutcome,
     ReviewStatus,
-    ReviewType,
     SuspensionAction,
     settings,
 )
@@ -1775,7 +1775,7 @@ async def escalate_report(
         image_id=report.image_id,
         source_report_id=report_id,
         initiated_by=current_user.user_id,
-        review_type=ReviewType.APPROPRIATENESS,
+        reason_category=DeactivationReason.INAPPROPRIATE,
         deadline=deadline,
         status=ReviewStatus.OPEN,
         outcome=ReviewOutcome.PENDING,
@@ -2036,7 +2036,7 @@ async def create_review(
     review = ImageReviews(
         image_id=image_id,
         initiated_by=current_user.user_id,
-        review_type=ReviewType.APPROPRIATENESS,
+        reason_category=DeactivationReason.INAPPROPRIATE,
         deadline=deadline,
         status=ReviewStatus.OPEN,
         outcome=ReviewOutcome.PENDING,

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -2189,22 +2189,24 @@ async def close_review(
     review.closed_at = datetime.now(UTC)
     review.closed_by = current_user.user_id
 
-    # Apply outcome to image
+    # Apply outcome to image through the service (writes history + audit row)
     previous_image_status = image.status
     if close_data.outcome == ReviewOutcome.KEEP:
-        image.status = ImageStatus.ACTIVE
+        new_status, cat, why = ImageStatus.ACTIVE, None, None
     else:
-        image.status = ImageStatus.INAPPROPRIATE
-    image.status_user_id = current_user.user_id
-    image.status_updated = datetime.now(UTC)
-
-    # Log action
-    action = AdminActions(
-        user_id=current_user.user_id,
+        new_status = ImageStatus.DEACTIVATED
+        cat = review.reason_category
+        why = review.reason or "Removed by community review"
+    await apply_image_status_change(
+        db,
+        image,
+        current_user,
+        new_status=new_status,
+        reason_category=cat,
+        reason=why,
         action_type=AdminActionType.REVIEW_CLOSE,
         review_id=review_id,
-        image_id=review.image_id,
-        details={
+        extra_details={
             "outcome": close_data.outcome,
             "vote_count": vote_count,
             "keep_votes": keep_votes,
@@ -2212,7 +2214,6 @@ async def close_review(
             "early_close": True,
         },
     )
-    db.add(action)
 
     await db.commit()
     await db.refresh(review)
@@ -2220,7 +2221,7 @@ async def close_review(
     await enqueue_r2_sync_on_status_change(
         image_id=review.image_id,
         old_status=previous_image_status,
-        new_status=image.status,
+        new_status=new_status,
     )
 
     close_user_ids: set[int] = {current_user.id}

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -941,6 +941,8 @@ async def list_reports(
                 response.suggested_tags = suggestions_by_report[report.report_id]
             image_reports.append(response)
 
+        await _populate_report_resolutions(db, list(zip(image_reports, reports, strict=True)))
+
     # Fetch comment reports if requested
     if report_type in ("comment", "all"):
         # Build filtered query for CommentReports
@@ -1023,6 +1025,56 @@ async def list_reports(
         page=page,
         per_page=per_page,
     )
+
+
+async def _populate_report_resolutions(
+    db: AsyncSession, pairs: list[tuple[ReportResponse, ImageReports]]
+) -> None:
+    """Derive each resolved report's outcome from its AdminActions row (no stored duplicate).
+
+    REPORT_ACTION -> action + resulting status + mod reason; REVIEW_START -> escalated;
+    REPORT_DISMISS -> dismissed. Newest matching action wins.
+    """
+    resolved = {rep.report_id: resp for resp, rep in pairs if rep.status != ReportStatus.PENDING}
+    if not resolved:
+        return
+    rows = (
+        (
+            await db.execute(
+                select(AdminActions)
+                .where(AdminActions.report_id.in_(list(resolved.keys())))  # type: ignore[union-attr]
+                .where(
+                    AdminActions.action_type.in_(  # type: ignore[attr-defined]
+                        [
+                            AdminActionType.REPORT_ACTION,
+                            AdminActionType.REVIEW_START,
+                            AdminActionType.REPORT_DISMISS,
+                        ]
+                    )
+                )
+                .order_by(desc(AdminActions.created_at))  # type: ignore[arg-type]
+            )
+        )
+        .scalars()
+        .all()
+    )
+    seen: set[int] = set()
+    for act in rows:
+        if act.report_id is None or act.report_id in seen:
+            continue
+        seen.add(act.report_id)
+        resp = resolved[act.report_id]
+        details = act.details or {}
+        if act.action_type == AdminActionType.REPORT_ACTION:
+            ns = details.get("new_status")
+            resp.resolution_kind = "action"
+            resp.resolution_status = ns
+            resp.resolution_status_label = ImageStatus.get_label(ns) if ns is not None else None
+            resp.resolution_reason = details.get("reason")
+        elif act.action_type == AdminActionType.REVIEW_START:
+            resp.resolution_kind = "escalated"
+        elif act.action_type == AdminActionType.REPORT_DISMISS:
+            resp.resolution_kind = "dismissed"
 
 
 @router.get("/reports/{report_id}", response_model=ReportResponse)
@@ -1111,6 +1163,8 @@ async def get_report(
             )
             for suggestion, tag in suggestions
         ]
+
+    await _populate_report_resolutions(db, [(response, report)])
 
     return response
 

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -1620,25 +1620,25 @@ async def action_report(
 
     previous_status = image.status
 
-    # Update image status
-    image.status = action_data.new_status
-    image.status_user_id = current_user.user_id
-    image.status_updated = datetime.now(UTC)
+    # All mutation + audit logging goes through the unified service: writes the
+    # public history row, enforces replacement_id for repost, stamps report_id on
+    # the REPORT_ACTION audit row (the report's resolution is derived from it).
+    await apply_image_status_change(
+        db,
+        image,
+        current_user,
+        new_status=action_data.new_status,
+        reason_category=action_data.reason_category,
+        reason=action_data.reason,
+        replacement_id=action_data.replacement_id,
+        action_type=AdminActionType.REPORT_ACTION,
+        report_id=report_id,
+    )
 
     # Update report
     report.status = ReportStatus.REVIEWED
     report.reviewed_by = current_user.user_id
     report.reviewed_at = datetime.now(UTC)
-
-    # Log action
-    action = AdminActions(
-        user_id=current_user.user_id,
-        action_type=AdminActionType.REPORT_ACTION,
-        report_id=report_id,
-        image_id=report.image_id,
-        details={"previous_status": previous_status, "new_status": action_data.new_status},
-    )
-    db.add(action)
 
     await db.commit()
 
@@ -1647,6 +1647,8 @@ async def action_report(
         old_status=previous_status,
         new_status=action_data.new_status,
     )
+    if action_data.new_status == ImageStatus.REPOST and action_data.replacement_id:
+        await schedule_rating_recalculation(action_data.replacement_id)
 
     return MessageResponse(message="Report processed and image status updated")
 

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -24,7 +24,6 @@ from sqlalchemy.orm import selectinload
 
 from app.config import (
     AdminActionType,
-    DeactivationReason,
     ImageStatus,
     ReportCategory,
     ReportStatus,
@@ -46,7 +45,6 @@ from app.models.image import Images
 from app.models.image_report import ImageReports
 from app.models.image_report_tag_suggestion import ImageReportTagSuggestions
 from app.models.image_review import ImageReviews
-from app.models.image_status_history import ImageStatusHistory
 from app.models.permissions import GroupPerms, Groups, Perms, UserGroups, UserPerms
 from app.models.refresh_token import RefreshTokens
 from app.models.review_vote import ReviewVotes
@@ -1764,46 +1762,34 @@ async def escalate_report(
     report.reviewed_by = current_user.user_id
     report.reviewed_at = datetime.now(UTC)
 
-    # Set image to review status
     previous_status = image.status
-    image.status = ImageStatus.REVIEW
-    image.status_user_id = current_user.user_id
-    image.status_updated = datetime.now(UTC)
 
     # Create review
     review = ImageReviews(
         image_id=report.image_id,
         source_report_id=report_id,
         initiated_by=current_user.user_id,
-        reason_category=DeactivationReason.INAPPROPRIATE,
+        reason_category=escalate_data.reason_category,
         deadline=deadline,
         status=ReviewStatus.OPEN,
         outcome=ReviewOutcome.PENDING,
+        reason=escalate_data.reason,
     )
     db.add(review)
     await db.flush()  # Get review_id
 
-    # Log to public status history (skip if image was already in REVIEW
-    # without an open review — orphaned state should not record a no-op transition)
-    if previous_status != ImageStatus.REVIEW:
-        status_history = ImageStatusHistory(
-            image_id=report.image_id,
-            old_status=previous_status,
-            new_status=ImageStatus.REVIEW,
-            user_id=current_user.user_id,
-        )
-        db.add(status_history)
-
-    # Log action
-    action = AdminActions(
-        user_id=current_user.user_id,
+    # Set image to review status through the service (writes history + audit)
+    await apply_image_status_change(
+        db,
+        image,
+        current_user,
+        new_status=ImageStatus.REVIEW,
+        reason=escalate_data.reason,
         action_type=AdminActionType.REVIEW_START,
-        report_id=report_id,
         review_id=review.review_id,
-        image_id=report.image_id,
-        details={"previous_status": previous_status, "deadline_days": deadline_days},
+        report_id=report_id,
+        extra_details={"deadline_days": deadline_days},
     )
-    db.add(action)
 
     await db.commit()
     await db.refresh(review)
@@ -2026,49 +2012,32 @@ async def create_review(
     deadline_days = review_data.deadline_days or settings.REVIEW_DEADLINE_DAYS
     deadline = datetime.now(UTC) + timedelta(days=deadline_days)
 
-    # Set image to review status
     previous_status = image.status
-    image.status = ImageStatus.REVIEW
-    image.status_user_id = current_user.user_id
-    image.status_updated = datetime.now(UTC)
 
     # Create review
     review = ImageReviews(
         image_id=image_id,
         initiated_by=current_user.user_id,
-        reason_category=DeactivationReason.INAPPROPRIATE,
+        reason_category=review_data.reason_category,
         deadline=deadline,
         status=ReviewStatus.OPEN,
         outcome=ReviewOutcome.PENDING,
         reason=review_data.reason,
     )
     db.add(review)
-    await db.flush()
+    await db.flush()  # Get review_id
 
-    # Log to public status history (skip if image was already in REVIEW
-    # without an open review — orphaned state should not record a no-op transition)
-    if previous_status != ImageStatus.REVIEW:
-        status_history = ImageStatusHistory(
-            image_id=image_id,
-            old_status=previous_status,
-            new_status=ImageStatus.REVIEW,
-            user_id=current_user.user_id,
-        )
-        db.add(status_history)
-
-    # Log action
-    action = AdminActions(
-        user_id=current_user.user_id,
+    # Set image to review status through the service (writes history + audit)
+    await apply_image_status_change(
+        db,
+        image,
+        current_user,
+        new_status=ImageStatus.REVIEW,
+        reason=review_data.reason,
         action_type=AdminActionType.REVIEW_START,
         review_id=review.review_id,
-        image_id=image_id,
-        details={
-            "previous_status": previous_status,
-            "deadline_days": deadline_days,
-            "reason": review_data.reason,
-        },
+        extra_details={"deadline_days": deadline_days},
     )
-    db.add(action)
 
     await db.commit()
     await db.refresh(review)

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -39,12 +39,12 @@ from app.api.dependencies import (
 from app.api.v1.tags import get_tag_hierarchy, resolve_tag_alias
 from app.config import (
     AdminActionType,
+    DeactivationReason,
     ImageStatus,
     ReportCategory,
     ReportStatus,
     ReviewOutcome,
     ReviewStatus,
-    ReviewType,
     settings,
 )
 from app.core.auth import CurrentUser, VerifiedUser, get_current_user, get_optional_current_user
@@ -1318,14 +1318,6 @@ async def get_image_status_history(
     )
 
 
-def get_review_type_label(review_type: int) -> str:
-    """Get human-readable label for review type."""
-    review_type_labels = {
-        ReviewType.APPROPRIATENESS: "appropriateness",
-    }
-    return review_type_labels.get(review_type, "unknown")
-
-
 def get_review_outcome_label(outcome: int) -> str:
     """Get human-readable label for review outcome."""
     outcome_labels = {
@@ -1381,8 +1373,8 @@ async def get_image_reviews(
     items = [
         ImageReviewPublicResponse(
             review_id=review.review_id or 0,
-            review_type=review.review_type,
-            review_type_label=get_review_type_label(review.review_type),
+            reason_category=review.reason_category,
+            reason_category_label=DeactivationReason.get_label(review.reason_category),
             outcome=review.outcome,
             outcome_label=get_review_outcome_label(review.outcome),
             created_at=review.created_at,  # type: ignore[arg-type]  # server_default ensures non-null

--- a/app/config.py
+++ b/app/config.py
@@ -347,12 +347,6 @@ class ReviewOutcome:
     REMOVE = 2
 
 
-class ReviewType:
-    """Review type constants"""
-
-    APPROPRIATENESS = 1
-
-
 class AdminActionType:
     """Admin action type constants for audit logging"""
 

--- a/app/models/image_review.py
+++ b/app/models/image_review.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from sqlalchemy import Column, ForeignKey, Index, Integer, text
 from sqlmodel import Field, SQLModel
 
-from app.config import ReviewOutcome, ReviewStatus, ReviewType
+from app.config import DeactivationReason, ReviewOutcome, ReviewStatus
 from app.models.types import UtcDateTime
 
 
@@ -37,8 +37,9 @@ class ImageReviewBase(SQLModel):
     - API request schemas (ImageReviewCreate)
     """
 
-    # Review type (extensible for future types)
-    review_type: int = Field(default=ReviewType.APPROPRIATENESS)
+    # What the review is about, using the DeactivationReason taxonomy. Mod-set at
+    # creation/escalation; drives the deactivation reason_category if the outcome is REMOVE.
+    reason_category: int = Field(default=DeactivationReason.INAPPROPRIATE)
 
     # Status: 0=open, 1=closed
     status: int = Field(default=ReviewStatus.OPEN)

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -182,8 +182,8 @@ class ImageReviewPublicResponse(BaseModel):
     """Schema for public review outcome (hides votes and initiator)."""
 
     review_id: int
-    review_type: int
-    review_type_label: str
+    reason_category: int
+    reason_category_label: str
     outcome: int
     outcome_label: str
     created_at: UTCDatetime

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -140,12 +140,56 @@ class ReportDismissRequest(BaseModel):
 
 
 class ReportActionRequest(BaseModel):
-    """Schema for taking action on a report (changing image status)."""
+    """Schema for taking action on a report — mirrors the deactivate contract.
 
-    new_status: int = Field(
-        ...,
-        description="New image status (-4=review, -3=low_quality, -2=inappropriate, -1=repost, 1=active)",
+    Legacy INAPPROPRIATE(-2)/LOW_QUALITY(-3)/REVIEW(-4) are no longer settable here:
+    inappropriate/low-quality/spam all become DEACTIVATED + a reason_category, and
+    escalation to review is a separate endpoint.
+    """
+
+    new_status: int = Field(..., description="0=Deactivated, -1=Repost, 1=Active, 2=Spoiler")
+    replacement_id: int | None = Field(None, description="Required when new_status=-1 (repost)")
+    reason_category: int | None = Field(
+        None, description="Required when new_status=0: 1=Inappropriate,2=Low Quality,3=Spam,4=Other"
     )
+    reason: str | None = Field(None, max_length=1000, description="Required when new_status=0")
+
+    @field_validator("new_status")
+    @classmethod
+    def validate_status(cls, v: int) -> int:
+        from app.config import ImageStatus
+
+        settable = {
+            ImageStatus.DEACTIVATED,
+            ImageStatus.REPOST,
+            ImageStatus.ACTIVE,
+            ImageStatus.SPOILER,
+        }
+        if v not in settable:
+            raise ValueError(
+                "new_status must be one of: 0=Deactivated, -1=Repost, 1=Active, 2=Spoiler"
+            )
+        return v
+
+    @field_validator("reason")
+    @classmethod
+    def strip_reason(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        return v.strip() or None
+
+    @model_validator(mode="after")
+    def validate_combination(self) -> ReportActionRequest:
+        from app.config import DeactivationReason, ImageStatus
+
+        if self.new_status == ImageStatus.DEACTIVATED:
+            if self.reason_category not in DeactivationReason.VALID:
+                raise ValueError("reason_category is required and must be valid when deactivating")
+            if not self.reason:
+                raise ValueError("reason is required when deactivating")
+        elif self.reason_category is not None:
+            raise ValueError("reason_category is only valid when deactivating")
+        return self
 
 
 class ReportEscalateRequest(BaseModel):

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -8,6 +8,8 @@ These schemas handle:
 - Admin actions audit log
 """
 
+from typing import Literal
+
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.config import DeactivationReason, ReportCategory
@@ -102,7 +104,7 @@ class ReportResponse(BaseModel):
     suggested_tags: list[TagSuggestion] | None = None
     skipped_tags: SkippedTagsInfo | None = None  # Only in create response
     # Resolution, derived from the audit log for reviewed/dismissed reports
-    resolution_kind: str | None = None  # "action" | "escalated" | "dismissed"
+    resolution_kind: Literal["action", "escalated", "dismissed"] | None = None
     resolution_status: int | None = None
     resolution_status_label: str | None = None
     resolution_reason: str | None = None

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -203,6 +203,23 @@ class ReportEscalateRequest(BaseModel):
     deadline_days: int | None = Field(
         None, ge=1, le=30, description="Days until voting deadline (default: 7)"
     )
+    reason_category: int = Field(..., description="1=Inappropriate, 2=Low Quality, 3=Spam, 4=Other")
+    reason: str = Field(..., min_length=1, max_length=1000, description="Reason for the review")
+
+    @field_validator("reason_category")
+    @classmethod
+    def validate_reason_category(cls, v: int) -> int:
+        if v not in DeactivationReason.VALID:
+            raise ValueError("reason_category must be one of: 1, 2, 3, 4")
+        return v
+
+    @field_validator("reason")
+    @classmethod
+    def sanitize_reason(cls, v: str) -> str:
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("reason must not be empty")
+        return stripped
 
 
 # ===== Review Schemas =====
@@ -214,17 +231,26 @@ class ReviewCreate(BaseModel):
     deadline_days: int | None = Field(
         None, ge=1, le=30, description="Days until voting deadline (default: 7)"
     )
-    reason: str | None = Field(
-        None, max_length=1000, description="Optional reason for starting the review"
+    reason_category: int = Field(..., description="1=Inappropriate, 2=Low Quality, 3=Spam, 4=Other")
+    reason: str = Field(
+        ..., min_length=1, max_length=1000, description="Reason for starting the review"
     )
+
+    @field_validator("reason_category")
+    @classmethod
+    def validate_reason_category(cls, v: int) -> int:
+        if v not in DeactivationReason.VALID:
+            raise ValueError("reason_category must be one of: 1, 2, 3, 4")
+        return v
 
     @field_validator("reason")
     @classmethod
-    def sanitize_reason(cls, v: str | None) -> str | None:
+    def sanitize_reason(cls, v: str) -> str:
         """Sanitize review reason."""
-        if v is None:
-            return v
-        return v.strip() or None
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("reason must not be empty")
+        return stripped
 
 
 class ReviewVoteRequest(BaseModel):

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -101,6 +101,11 @@ class ReportResponse(BaseModel):
     admin_notes: str | None = None
     suggested_tags: list[TagSuggestion] | None = None
     skipped_tags: SkippedTagsInfo | None = None  # Only in create response
+    # Resolution, derived from the audit log for reviewed/dismissed reports
+    resolution_kind: str | None = None  # "action" | "escalated" | "dismissed"
+    resolution_status: int | None = None
+    resolution_status_label: str | None = None
+    resolution_reason: str | None = None
 
     model_config = {"from_attributes": True}
 

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -10,7 +10,7 @@ These schemas handle:
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from app.config import ReportCategory
+from app.config import DeactivationReason, ReportCategory
 from app.schemas.base import UTCDatetime, UTCDatetimeOptional
 from app.schemas.comment_report import CommentReportListItem
 from app.schemas.common import UserSummary
@@ -290,8 +290,8 @@ class ReviewResponse(BaseModel):
     reason: str | None = None
     initiated_by_user: UserSummary | None = None
     closed_by_user: UserSummary | None = None
-    review_type: int
-    review_type_label: str | None = None
+    reason_category: int
+    reason_category_label: str | None = None
     deadline: UTCDatetime
     extension_used: int
     status: int
@@ -309,9 +309,8 @@ class ReviewResponse(BaseModel):
 
     def model_post_init(self, __context: object) -> None:
         """Set computed label fields."""
-        # Review type
-        type_labels = {1: "Appropriateness"}
-        self.review_type_label = type_labels.get(self.review_type, "Unknown")
+        # Reason category
+        self.reason_category_label = DeactivationReason.get_label(self.reason_category)
         # Status
         status_labels = {0: "Open", 1: "Closed"}
         self.status_label = status_labels.get(self.status, "Unknown")

--- a/app/services/image_status.py
+++ b/app/services/image_status.py
@@ -140,6 +140,8 @@ async def change_image_status(
             review_id=review_id,
             image_id=image.image_id,
             details={
+                # extra_details first so the canonical base keys below always win
+                **(extra_details or {}),
                 "previous_status": previous_status,
                 "new_status": image.status,
                 "previous_locked": previous_locked,
@@ -147,7 +149,6 @@ async def change_image_status(
                 "replacement_id": image.replacement_id,
                 "reason_category": image.reason_category,
                 "reason": image.status_reason,
-                **(extra_details or {}),
                 **migration_result,
             },
         )

--- a/app/services/image_status.py
+++ b/app/services/image_status.py
@@ -53,13 +53,17 @@ async def enqueue_r2_sync_on_status_change(
 async def change_image_status(
     db: AsyncSession,
     image: Images,
-    actor: Users,
+    actor: Users | None,
     *,
     new_status: int | None = None,
     reason_category: int | None = None,
     reason: str | None = None,
     replacement_id: int | None = None,
     locked: bool | None = None,
+    action_type: int = AdminActionType.IMAGE_STATUS_CHANGE,
+    report_id: int | None = None,
+    review_id: int | None = None,
+    extra_details: dict[str, object] | None = None,
 ) -> dict[str, int]:
     """Apply a moderation status and/or lock change to an image.
 
@@ -71,6 +75,7 @@ async def change_image_status(
     Returns the repost migration_result dict (empty unless a repost was processed).
     """
     assert image.image_id is not None  # caller passes a persisted image
+    actor_id = actor.user_id if actor is not None else None  # None for system actions
     previous_status = image.status
     previous_locked = image.locked
     migration_result: dict[str, int] = {}
@@ -108,7 +113,7 @@ async def change_image_status(
         image.status_reason = reason
 
         image.status = new_status
-        image.status_user_id = actor.user_id
+        image.status_user_id = actor_id
         image.status_updated = datetime.now(UTC)
 
     if locked is not None:
@@ -121,7 +126,7 @@ async def change_image_status(
                 image_id=image.image_id,
                 old_status=previous_status,
                 new_status=new_status,
-                user_id=actor.user_id,
+                user_id=actor_id,
                 reason_category=image.reason_category,
                 reason=image.status_reason,
             )
@@ -129,8 +134,10 @@ async def change_image_status(
 
     db.add(
         AdminActions(
-            user_id=actor.user_id,
-            action_type=AdminActionType.IMAGE_STATUS_CHANGE,
+            user_id=actor_id,
+            action_type=action_type,
+            report_id=report_id,
+            review_id=review_id,
             image_id=image.image_id,
             details={
                 "previous_status": previous_status,
@@ -140,6 +147,7 @@ async def change_image_status(
                 "replacement_id": image.replacement_id,
                 "reason_category": image.reason_category,
                 "reason": image.status_reason,
+                **(extra_details or {}),
                 **migration_result,
             },
         )

--- a/app/services/review_jobs.py
+++ b/app/services/review_jobs.py
@@ -21,8 +21,8 @@ from app.config import (
 from app.models.admin_action import AdminActions
 from app.models.image import Images
 from app.models.image_review import ImageReviews
-from app.models.image_status_history import ImageStatusHistory
 from app.models.review_vote import ReviewVotes
+from app.services.image_status import change_image_status
 
 logger = logging.getLogger(__name__)
 
@@ -200,41 +200,34 @@ async def _close_review(
     review.outcome = outcome
     review.closed_at = now
 
-    # Update image status
+    # Update image status through the service (writes history + audit row)
     image = await db.get(Images, review.image_id)
     transition: tuple[int, int, int] | None = None
     if image:
         old_status = image.status
         if outcome == ReviewOutcome.KEEP:
-            image.status = ImageStatus.ACTIVE
+            new_status, cat, why = ImageStatus.ACTIVE, None, None
         else:  # REMOVE
-            image.status = ImageStatus.INAPPROPRIATE
-
-        # Log to public status history
-        status_history = ImageStatusHistory(
-            image_id=review.image_id,
-            old_status=ImageStatus.REVIEW,  # Was under review
-            new_status=image.status,
-            user_id=None,  # System action
+            new_status = ImageStatus.DEACTIVATED
+            cat = review.reason_category
+            why = review.reason or "Removed by community review"
+        await change_image_status(
+            db,
+            image,
+            None,  # system actor
+            new_status=new_status,
+            reason_category=cat,
+            reason=why,
+            action_type=AdminActionType.REVIEW_CLOSE,
+            review_id=review.review_id,
+            extra_details={
+                "outcome": outcome,
+                "outcome_label": "keep" if outcome == ReviewOutcome.KEEP else "remove",
+                "close_reason": reason,  # the close-CODE (was details["reason"])
+                "automatic": True,
+            },
         )
-        db.add(status_history)
-        transition = (review.image_id, old_status, image.status)
-
-    # Create audit log entry
-    action = AdminActions(
-        user_id=None,  # System action
-        action_type=AdminActionType.REVIEW_CLOSE,
-        review_id=review.review_id,
-        image_id=review.image_id,
-        details={
-            "outcome": outcome,
-            "outcome_label": "keep" if outcome == ReviewOutcome.KEEP else "remove",
-            "reason": reason,
-            "automatic": True,
-        },
-        created_at=now,
-    )
-    db.add(action)
+        transition = (review.image_id, old_status, new_status)
 
     logger.info(
         f"Closed review {review.review_id} with outcome "

--- a/tests/api/v1/test_admin_actions.py
+++ b/tests/api/v1/test_admin_actions.py
@@ -320,7 +320,7 @@ class TestReviewVoteAuditLog:
             deadline=datetime.now(UTC) + timedelta(days=7),
             status=ReviewStatus.OPEN,
             outcome=ReviewOutcome.PENDING,
-            review_type=1,
+            reason_category=DeactivationReason.INAPPROPRIATE,
         )
         db_session.add(review)
         await db_session.commit()
@@ -370,7 +370,7 @@ class TestReviewCloseAuditLog:
             deadline=datetime.now(UTC) + timedelta(days=7),
             status=ReviewStatus.OPEN,
             outcome=ReviewOutcome.PENDING,
-            review_type=1,
+            reason_category=DeactivationReason.INAPPROPRIATE,
         )
         db_session.add(review)
         await db_session.commit()
@@ -421,7 +421,7 @@ class TestReviewExtendAuditLog:
             status=ReviewStatus.OPEN,
             outcome=ReviewOutcome.PENDING,
             extension_used=0,
-            review_type=1,
+            reason_category=DeactivationReason.INAPPROPRIATE,
         )
         db_session.add(review)
         await db_session.commit()

--- a/tests/api/v1/test_admin_actions.py
+++ b/tests/api/v1/test_admin_actions.py
@@ -237,7 +237,11 @@ class TestReviewStartAuditLog:
 
         response = await client.post(
             f"/api/v1/admin/images/{image.image_id}/review",
-            json={"deadline_days": 7},
+            json={
+                "deadline_days": 7,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 201  # Created
@@ -279,7 +283,11 @@ class TestReviewStartAuditLog:
 
         response = await client.post(
             f"/api/v1/admin/reports/{report.report_id}/escalate",
-            json={"deadline_days": 7},
+            json={
+                "deadline_days": 7,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 200

--- a/tests/api/v1/test_admin_actions.py
+++ b/tests/api/v1/test_admin_actions.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import (
     AdminActionType,
+    DeactivationReason,
     ImageStatus,
     ReportStatus,
     ReviewOutcome,
@@ -194,7 +195,11 @@ class TestReportActionAuditLog:
 
         response = await client.post(
             f"/api/v1/admin/reports/{report.report_id}/action",
-            json={"new_status": ImageStatus.INAPPROPRIATE},
+            json={
+                "new_status": ImageStatus.DEACTIVATED,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "inappropriate content",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 200
@@ -212,7 +217,7 @@ class TestReportActionAuditLog:
         assert action.report_id == report.report_id
         assert action.image_id == image.image_id
         assert action.details is not None
-        assert action.details.get("new_status") == ImageStatus.INAPPROPRIATE
+        assert action.details.get("new_status") == ImageStatus.DEACTIVATED
         assert "previous_status" in action.details
 
 

--- a/tests/api/v1/test_image_reviews_endpoint.py
+++ b/tests/api/v1/test_image_reviews_endpoint.py
@@ -4,7 +4,7 @@ Tests for GET /images/{image_id}/reviews endpoint.
 Tests that completed image reviews (closed review sessions) can be retrieved
 with proper pagination and labels, while hiding internal fields.
 
-Fields shown: review_id, review_type, review_type_label, outcome, outcome_label, created_at, closed_at
+Fields shown: review_id, reason_category, reason_category_label, outcome, outcome_label, created_at, closed_at
 Fields hidden: initiated_by, deadline, status (always CLOSED), votes
 """
 
@@ -12,7 +12,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import ReviewOutcome, ReviewStatus, ReviewType
+from app.config import DeactivationReason, ReviewOutcome, ReviewStatus
 from app.models.image import Images
 from app.models.image_review import ImageReviews
 from app.models.user import Users
@@ -57,7 +57,7 @@ class TestGetImageReviews:
         # Create a closed review
         review = ImageReviews(
             image_id=image.image_id,
-            review_type=ReviewType.APPROPRIATENESS,
+            reason_category=DeactivationReason.INAPPROPRIATE,
             status=ReviewStatus.CLOSED,
             outcome=ReviewOutcome.KEEP,
             initiated_by=user.user_id,
@@ -81,7 +81,7 @@ class TestGetImageReviews:
         # Verify item contains expected fields
         item = data["items"][0]
         assert item["review_id"] == review.review_id
-        assert item["review_type"] == ReviewType.APPROPRIATENESS
+        assert item["reason_category"] == DeactivationReason.INAPPROPRIATE
         assert item["outcome"] == ReviewOutcome.KEEP
         assert "created_at" in item
 
@@ -120,7 +120,7 @@ class TestGetImageReviews:
         # Create an OPEN review (should be excluded)
         open_review = ImageReviews(
             image_id=image.image_id,
-            review_type=ReviewType.APPROPRIATENESS,
+            reason_category=DeactivationReason.INAPPROPRIATE,
             status=ReviewStatus.OPEN,
             outcome=ReviewOutcome.PENDING,
             initiated_by=user.user_id,
@@ -128,7 +128,7 @@ class TestGetImageReviews:
         # Create a CLOSED review (should be included)
         closed_review = ImageReviews(
             image_id=image.image_id,
-            review_type=ReviewType.APPROPRIATENESS,
+            reason_category=DeactivationReason.INAPPROPRIATE,
             status=ReviewStatus.CLOSED,
             outcome=ReviewOutcome.REMOVE,
             initiated_by=user.user_id,
@@ -193,7 +193,7 @@ class TestGetImageReviews:
     async def test_includes_correct_labels(
         self, client: AsyncClient, db_session: AsyncSession
     ) -> None:
-        """Should include human-readable labels for review_type and outcome."""
+        """Should include human-readable labels for reason_category and outcome."""
         # Create a user
         user = Users(
             username="labeluser",
@@ -225,14 +225,14 @@ class TestGetImageReviews:
         # Create reviews with different outcomes
         review_keep = ImageReviews(
             image_id=image.image_id,
-            review_type=ReviewType.APPROPRIATENESS,
+            reason_category=DeactivationReason.INAPPROPRIATE,
             status=ReviewStatus.CLOSED,
             outcome=ReviewOutcome.KEEP,
             initiated_by=user.user_id,
         )
         review_remove = ImageReviews(
             image_id=image.image_id,
-            review_type=ReviewType.APPROPRIATENESS,
+            reason_category=DeactivationReason.INAPPROPRIATE,
             status=ReviewStatus.CLOSED,
             outcome=ReviewOutcome.REMOVE,
             initiated_by=user.user_id,
@@ -250,9 +250,9 @@ class TestGetImageReviews:
         # Build map by outcome for verification
         items_by_outcome = {item["outcome"]: item for item in data["items"]}
 
-        # Check review_type_label
-        assert items_by_outcome[ReviewOutcome.KEEP]["review_type_label"] == "appropriateness"
-        assert items_by_outcome[ReviewOutcome.REMOVE]["review_type_label"] == "appropriateness"
+        # Check reason_category_label
+        assert items_by_outcome[ReviewOutcome.KEEP]["reason_category_label"] == "Inappropriate"
+        assert items_by_outcome[ReviewOutcome.REMOVE]["reason_category_label"] == "Inappropriate"
 
         # Check outcome_label
         assert items_by_outcome[ReviewOutcome.KEEP]["outcome_label"] == "keep"
@@ -293,7 +293,7 @@ class TestGetImageReviews:
         # Create a closed review with initiated_by set
         review = ImageReviews(
             image_id=image.image_id,
-            review_type=ReviewType.APPROPRIATENESS,
+            reason_category=DeactivationReason.INAPPROPRIATE,
             status=ReviewStatus.CLOSED,
             outcome=ReviewOutcome.KEEP,
             initiated_by=user.user_id,  # This should be hidden
@@ -317,8 +317,8 @@ class TestGetImageReviews:
 
         # These fields SHOULD be present
         assert "review_id" in item
-        assert "review_type" in item
-        assert "review_type_label" in item
+        assert "reason_category" in item
+        assert "reason_category_label" in item
         assert "outcome" in item
         assert "outcome_label" in item
         assert "created_at" in item
@@ -357,10 +357,10 @@ class TestGetImageReviews:
         await db_session.refresh(image)
 
         # Create 5 closed reviews
-        for i in range(5):
+        for _i in range(5):
             review = ImageReviews(
                 image_id=image.image_id,
-                review_type=ReviewType.APPROPRIATENESS,
+                reason_category=DeactivationReason.INAPPROPRIATE,
                 status=ReviewStatus.CLOSED,
                 outcome=ReviewOutcome.KEEP,
                 initiated_by=user.user_id,
@@ -433,7 +433,7 @@ class TestGetImageReviews:
         # review_id is auto-increment, so higher ID = more recent
         review1 = ImageReviews(
             image_id=image.image_id,
-            review_type=ReviewType.APPROPRIATENESS,
+            reason_category=DeactivationReason.INAPPROPRIATE,
             status=ReviewStatus.CLOSED,
             outcome=ReviewOutcome.KEEP,
             initiated_by=user.user_id,
@@ -444,7 +444,7 @@ class TestGetImageReviews:
 
         review2 = ImageReviews(
             image_id=image.image_id,
-            review_type=ReviewType.APPROPRIATENESS,
+            reason_category=DeactivationReason.INAPPROPRIATE,
             status=ReviewStatus.CLOSED,
             outcome=ReviewOutcome.REMOVE,
             initiated_by=user.user_id,
@@ -455,7 +455,7 @@ class TestGetImageReviews:
 
         review3 = ImageReviews(
             image_id=image.image_id,
-            review_type=ReviewType.APPROPRIATENESS,
+            reason_category=DeactivationReason.INAPPROPRIATE,
             status=ReviewStatus.CLOSED,
             outcome=ReviewOutcome.KEEP,
             initiated_by=user.user_id,

--- a/tests/api/v1/test_image_status_history.py
+++ b/tests/api/v1/test_image_status_history.py
@@ -381,7 +381,7 @@ class TestImageStatusHistoryOnReviewClose:
         result = await db_session.execute(
             select(ImageStatusHistory).where(
                 ImageStatusHistory.image_id == image_id,
-                ImageStatusHistory.new_status == ImageStatus.INAPPROPRIATE,
+                ImageStatusHistory.new_status == ImageStatus.DEACTIVATED,
             )
         )
         history = result.scalar_one_or_none()

--- a/tests/api/v1/test_image_status_history.py
+++ b/tests/api/v1/test_image_status_history.py
@@ -7,7 +7,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import ImageStatus, ReviewOutcome, ReviewStatus
+from app.config import DeactivationReason, ImageStatus, ReviewOutcome, ReviewStatus
 from app.core.security import get_password_hash
 from app.models.image import Images
 from app.models.image_review import ImageReviews
@@ -274,7 +274,7 @@ class TestImageStatusHistoryOnReviewClose:
             extension_used=0,
             status=ReviewStatus.OPEN,
             outcome=ReviewOutcome.PENDING,
-            review_type=1,
+            reason_category=DeactivationReason.INAPPROPRIATE,
             created_at=datetime.now(UTC),
         )
         db_session.add(review)
@@ -354,7 +354,7 @@ class TestImageStatusHistoryOnReviewClose:
             extension_used=0,
             status=ReviewStatus.OPEN,
             outcome=ReviewOutcome.PENDING,
-            review_type=1,
+            reason_category=DeactivationReason.INAPPROPRIATE,
             created_at=datetime.now(UTC),
         )
         db_session.add(review)

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sqlalchemy import select
 
-from app.config import ImageStatus, ReportStatus, ReviewStatus
+from app.config import DeactivationReason, ImageStatus, ReportStatus, ReviewStatus
 from app.core.security import get_password_hash
 from app.models.image import Images
 from app.models.image_report import ImageReports
@@ -945,7 +945,11 @@ class TestAdminReportAction:
 
         response = await client.post(
             f"/api/v1/admin/reports/{report.report_id}/action",
-            json={"new_status": ImageStatus.INAPPROPRIATE},
+            json={
+                "new_status": ImageStatus.DEACTIVATED,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "inappropriate content",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -953,7 +957,86 @@ class TestAdminReportAction:
 
         # Verify image status changed
         await db_session.refresh(image)
-        assert image.status == ImageStatus.INAPPROPRIATE
+        assert image.status == ImageStatus.DEACTIVATED
+
+    async def test_action_deactivate_requires_category_and_reason(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Deactivate via triage requires reason_category + reason (mirrors the mod dialog)."""
+        admin, password = await create_auth_user(db_session, username="admin", admin=True)
+        await grant_permission(db_session, admin.user_id, "report_manage")
+        token = await login_user(client, admin.username, password)
+        image = await create_test_image(db_session, admin.user_id)
+        report = ImageReports(
+            image_id=image.image_id, user_id=admin.user_id, category=2, status=ReportStatus.PENDING
+        )
+        db_session.add(report)
+        await db_session.commit()
+        await db_session.refresh(report)
+
+        r = await client.post(
+            f"/api/v1/admin/reports/{report.report_id}/action",
+            json={"new_status": ImageStatus.DEACTIVATED},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 422
+
+    async def test_action_repost_requires_replacement(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Marking repost via triage now enforces replacement_id (was silently allowed)."""
+        admin, password = await create_auth_user(db_session, username="admin", admin=True)
+        await grant_permission(db_session, admin.user_id, "report_manage")
+        token = await login_user(client, admin.username, password)
+        image = await create_test_image(db_session, admin.user_id)
+        report = ImageReports(
+            image_id=image.image_id, user_id=admin.user_id, category=1, status=ReportStatus.PENDING
+        )
+        db_session.add(report)
+        await db_session.commit()
+        await db_session.refresh(report)
+
+        r = await client.post(
+            f"/api/v1/admin/reports/{report.report_id}/action",
+            json={"new_status": ImageStatus.REPOST},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 400
+
+    async def test_action_deactivate_writes_history_with_reason(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Deactivate via triage writes a public history row carrying category + mod reason."""
+        admin, password = await create_auth_user(db_session, username="admin", admin=True)
+        await grant_permission(db_session, admin.user_id, "report_manage")
+        token = await login_user(client, admin.username, password)
+        image = await create_test_image(db_session, admin.user_id)
+        report = ImageReports(
+            image_id=image.image_id, user_id=admin.user_id, category=2, status=ReportStatus.PENDING
+        )
+        db_session.add(report)
+        await db_session.commit()
+        await db_session.refresh(report)
+        iid = image.image_id
+
+        r = await client.post(
+            f"/api/v1/admin/reports/{report.report_id}/action",
+            json={
+                "new_status": ImageStatus.DEACTIVATED,
+                "reason_category": DeactivationReason.LOW_QUALITY,
+                "reason": "too blurry",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        db_session.expire_all()
+        img = (await db_session.execute(select(Images).where(Images.image_id == iid))).scalar_one()
+        assert img.status == ImageStatus.DEACTIVATED
+        assert img.reason_category == DeactivationReason.LOW_QUALITY
+        hist = (await db_session.execute(
+            select(ImageStatusHistory).where(ImageStatusHistory.image_id == iid)
+        )).scalars().all()
+        assert any(h.new_status == ImageStatus.DEACTIVATED and h.reason == "too blurry" for h in hist)
 
 
 @pytest.mark.api
@@ -1167,7 +1250,11 @@ class TestReportPermissionDenials:
 
         response = await client.post(
             f"/api/v1/admin/reports/{report.report_id}/action",
-            json={"new_status": ImageStatus.INAPPROPRIATE},
+            json={
+                "new_status": ImageStatus.DEACTIVATED,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "x",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
 

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -1038,6 +1038,42 @@ class TestAdminReportAction:
         )).scalars().all()
         assert any(h.new_status == ImageStatus.DEACTIVATED and h.reason == "too blurry" for h in hist)
 
+    async def test_resolved_report_exposes_action_and_reason(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A resolved report exposes the action + mod reason (derived); reporter reason untouched."""
+        admin, password = await create_auth_user(db_session, username="admin", admin=True)
+        await grant_permission(db_session, admin.user_id, "report_manage")
+        await grant_permission(db_session, admin.user_id, "report_view")
+        token = await login_user(client, admin.username, password)
+        image = await create_test_image(db_session, admin.user_id)
+        report = ImageReports(
+            image_id=image.image_id, user_id=admin.user_id, category=2,
+            reason_text="i think this is AI", status=ReportStatus.PENDING,
+        )
+        db_session.add(report)
+        await db_session.commit()
+        await db_session.refresh(report)
+        rid = report.report_id
+
+        await client.post(
+            f"/api/v1/admin/reports/{rid}/action",
+            json={
+                "new_status": ImageStatus.DEACTIVATED,
+                "reason_category": DeactivationReason.LOW_QUALITY,
+                "reason": "not AI, low quality",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        r = await client.get(
+            f"/api/v1/admin/reports/{rid}", headers={"Authorization": f"Bearer {token}"}
+        )
+        data = r.json()
+        assert data["reason_text"] == "i think this is AI"  # reporter's reason untouched
+        assert data["resolution_kind"] == "action"
+        assert data["resolution_status"] == ImageStatus.DEACTIVATED  # action taken
+        assert data["resolution_reason"] == "not AI, low quality"  # mod's reason, distinct
+
 
 @pytest.mark.api
 class TestAdminReportEscalate:

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -1101,7 +1101,11 @@ class TestAdminReportEscalate:
 
         response = await client.post(
             f"/api/v1/admin/reports/{report.report_id}/escalate",
-            json={"deadline_days": 7},
+            json={
+                "deadline_days": 7,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -1137,7 +1141,11 @@ class TestAdminReportEscalate:
 
         response = await client.post(
             f"/api/v1/admin/reports/{report.report_id}/escalate",
-            json={"deadline_days": 7},
+            json={
+                "deadline_days": 7,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 200
@@ -1180,7 +1188,11 @@ class TestAdminReportEscalate:
 
         response = await client.post(
             f"/api/v1/admin/reports/{report.report_id}/escalate",
-            json={"deadline_days": 7},
+            json={
+                "deadline_days": 7,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 200
@@ -1226,12 +1238,79 @@ class TestAdminReportEscalate:
 
         response = await client.post(
             f"/api/v1/admin/reports/{report.report_id}/escalate",
-            json={},
+            json={
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
 
         assert response.status_code == 409
         assert "already has an open review" in response.json()["detail"]
+
+    async def test_escalate_requires_reason_and_category(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Escalating without reason/category is rejected with 422."""
+        admin, password = await create_auth_user(db_session, username="admin", admin=True)
+        await grant_permission(db_session, admin.user_id, "report_manage")
+        await grant_permission(db_session, admin.user_id, "review_start")
+        token = await login_user(client, admin.username, password)
+
+        image = await create_test_image(db_session, admin.user_id)
+        report = ImageReports(
+            image_id=image.image_id,
+            user_id=admin.user_id,
+            category=2,
+            status=ReportStatus.PENDING,
+        )
+        db_session.add(report)
+        await db_session.commit()
+        await db_session.refresh(report)
+
+        response = await client.post(
+            f"/api/v1/admin/reports/{report.report_id}/escalate",
+            json={"deadline_days": 7},  # no reason/category
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 422
+
+    async def test_escalate_stores_category_and_reason(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Escalating stores the mod-set reason_category and reason on the review."""
+        admin, password = await create_auth_user(db_session, username="admin", admin=True)
+        await grant_permission(db_session, admin.user_id, "report_manage")
+        await grant_permission(db_session, admin.user_id, "review_start")
+        token = await login_user(client, admin.username, password)
+
+        image = await create_test_image(db_session, admin.user_id)
+        report = ImageReports(
+            image_id=image.image_id,
+            user_id=admin.user_id,
+            category=2,
+            status=ReportStatus.PENDING,
+        )
+        db_session.add(report)
+        await db_session.commit()
+        await db_session.refresh(report)
+
+        response = await client.post(
+            f"/api/v1/admin/reports/{report.report_id}/escalate",
+            json={
+                "deadline_days": 7,
+                "reason_category": DeactivationReason.SPAM,
+                "reason": "advertising spam",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["reason_category"] == DeactivationReason.SPAM
+        assert data["reason_category_label"] == "Spam"
+        assert data["reason"] == "advertising spam"
 
 
 @pytest.mark.api
@@ -1317,7 +1396,11 @@ class TestReportPermissionDenials:
 
         response = await client.post(
             f"/api/v1/admin/reports/{report.report_id}/escalate",
-            json={"deadline_days": 7},
+            json={
+                "deadline_days": 7,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -1344,7 +1427,11 @@ class TestReportPermissionDenials:
 
         response = await client.post(
             f"/api/v1/admin/reports/{report.report_id}/escalate",
-            json={"deadline_days": 7},
+            json={
+                "deadline_days": 7,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
 

--- a/tests/api/v1/test_reviews.py
+++ b/tests/api/v1/test_reviews.py
@@ -654,7 +654,8 @@ class TestReviewVote:
         await db_session.refresh(image)
         assert review.status == ReviewStatus.CLOSED
         assert review.outcome == ReviewOutcome.REMOVE
-        assert image.status == ImageStatus.INAPPROPRIATE
+        assert image.status == ImageStatus.DEACTIVATED
+        assert image.reason_category == DeactivationReason.INAPPROPRIATE
 
     async def test_vote_no_early_close_when_margin_not_met(
         self, client: AsyncClient, db_session: AsyncSession
@@ -802,9 +803,10 @@ class TestReviewClose:
         data = response.json()
         assert data["outcome"] == ReviewOutcome.REMOVE
 
-        # Verify image status changed to INAPPROPRIATE
+        # Verify image status changed to DEACTIVATED with the review's category
         await db_session.refresh(image)
-        assert image.status == ImageStatus.INAPPROPRIATE
+        assert image.status == ImageStatus.DEACTIVATED
+        assert image.reason_category == DeactivationReason.INAPPROPRIATE
 
     async def test_close_review_automatic_has_null_closed_by(
         self, client: AsyncClient, db_session: AsyncSession

--- a/tests/api/v1/test_reviews.py
+++ b/tests/api/v1/test_reviews.py
@@ -12,7 +12,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import ImageStatus, ReviewOutcome, ReviewStatus
+from app.config import DeactivationReason, ImageStatus, ReviewOutcome, ReviewStatus
 from app.core.security import get_password_hash
 from app.models.image import Images
 from app.models.image_review import ImageReviews
@@ -206,7 +206,11 @@ class TestCreateReview:
 
         response = await client.post(
             f"/api/v1/admin/images/{image.image_id}/review",
-            json={"deadline_days": 10},
+            json={
+                "deadline_days": 10,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -233,7 +237,11 @@ class TestCreateReview:
 
         response = await client.post(
             f"/api/v1/admin/images/{image.image_id}/review",
-            json={"deadline_days": 7, "reason": "Borderline content needs community input"},
+            json={
+                "deadline_days": 7,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "Borderline content needs community input",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -244,7 +252,7 @@ class TestCreateReview:
     async def test_create_review_without_reason(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Test creating a review without reason returns null."""
+        """Test creating a review without a reason is rejected (reason is required)."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_start")
         token = await login_user(client, admin.username, password)
@@ -253,13 +261,11 @@ class TestCreateReview:
 
         response = await client.post(
             f"/api/v1/admin/images/{image.image_id}/review",
-            json={"deadline_days": 7},
+            json={"deadline_days": 7, "reason_category": DeactivationReason.INAPPROPRIATE},
             headers={"Authorization": f"Bearer {token}"},
         )
 
-        assert response.status_code == 201
-        data = response.json()
-        assert data["reason"] is None
+        assert response.status_code == 422
 
     async def test_create_review_writes_status_history(
         self, client: AsyncClient, db_session: AsyncSession
@@ -273,7 +279,11 @@ class TestCreateReview:
 
         response = await client.post(
             f"/api/v1/admin/images/{image.image_id}/review",
-            json={"deadline_days": 7},
+            json={
+                "deadline_days": 7,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 201
@@ -305,7 +315,11 @@ class TestCreateReview:
 
         response = await client.post(
             f"/api/v1/admin/images/{image.image_id}/review",
-            json={"deadline_days": 7},
+            json={
+                "deadline_days": 7,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 201
@@ -339,12 +353,58 @@ class TestCreateReview:
 
         response = await client.post(
             f"/api/v1/admin/images/{image.image_id}/review",
-            json={},
+            json={
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
 
         assert response.status_code == 409
         assert "already has an open review" in response.json()["detail"]
+
+    async def test_create_review_requires_reason_and_category(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Creating a review without reason/category is rejected with 422."""
+        admin, password = await create_auth_user(db_session, username="admin", admin=True)
+        await grant_permission(db_session, admin.user_id, "review_start")
+        token = await login_user(client, admin.username, password)
+
+        image = await create_test_image(db_session, admin.user_id)
+
+        response = await client.post(
+            f"/api/v1/admin/images/{image.image_id}/review",
+            json={"deadline_days": 10},  # no reason/category
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 422
+
+    async def test_create_review_stores_category_and_reason(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Creating a review stores the mod-set reason_category and reason."""
+        admin, password = await create_auth_user(db_session, username="admin", admin=True)
+        await grant_permission(db_session, admin.user_id, "review_start")
+        token = await login_user(client, admin.username, password)
+
+        image = await create_test_image(db_session, admin.user_id)
+
+        response = await client.post(
+            f"/api/v1/admin/images/{image.image_id}/review",
+            json={
+                "reason_category": DeactivationReason.LOW_QUALITY,
+                "reason": "borderline quality",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["reason_category"] == DeactivationReason.LOW_QUALITY
+        assert data["reason_category_label"] == "Low Quality"
+        assert data["reason"] == "borderline quality"
 
 
 @pytest.mark.api
@@ -1048,7 +1108,11 @@ class TestReviewPermissionDenials:
 
         response = await client.post(
             f"/api/v1/admin/images/{image.image_id}/review",
-            json={"deadline_days": 7},
+            json={
+                "deadline_days": 7,
+                "reason_category": DeactivationReason.INAPPROPRIATE,
+                "reason": "needs review",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
 

--- a/tests/integration/test_review_constraints.py
+++ b/tests/integration/test_review_constraints.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import ImageStatus, ReportStatus, ReviewOutcome, ReviewStatus
+from app.config import DeactivationReason, ImageStatus, ReportStatus, ReviewOutcome, ReviewStatus
 from app.models.image import Images
 from app.models.image_report import ImageReports
 from app.models.image_review import ImageReviews
@@ -192,7 +192,7 @@ class TestReviewConstraints:
             deadline=datetime.now(UTC) - timedelta(days=1),
             status=ReviewStatus.CLOSED,
             outcome=ReviewOutcome.KEEP,
-            review_type=1,
+            reason_category=DeactivationReason.INAPPROPRIATE,
             closed_at=datetime.now(UTC),
         )
         db_session.add(review1)
@@ -205,7 +205,7 @@ class TestReviewConstraints:
             deadline=datetime.now(UTC) + timedelta(days=7),
             status=ReviewStatus.OPEN,
             outcome=ReviewOutcome.PENDING,
-            review_type=1,
+            reason_category=DeactivationReason.INAPPROPRIATE,
         )
         db_session.add(review2)
         await db_session.commit()
@@ -251,7 +251,7 @@ class TestVoteConstraints:
             deadline=datetime.now(UTC) + timedelta(days=7),
             status=ReviewStatus.OPEN,
             outcome=ReviewOutcome.PENDING,
-            review_type=1,
+            reason_category=DeactivationReason.INAPPROPRIATE,
         )
         db_session.add(review)
         await db_session.commit()
@@ -298,7 +298,7 @@ class TestVoteConstraints:
             deadline=datetime.now(UTC) + timedelta(days=7),
             status=ReviewStatus.OPEN,
             outcome=ReviewOutcome.PENDING,
-            review_type=1,
+            reason_category=DeactivationReason.INAPPROPRIATE,
         )
         db_session.add(review1)
 
@@ -308,7 +308,7 @@ class TestVoteConstraints:
             deadline=datetime.now(UTC) + timedelta(days=7),
             status=ReviewStatus.OPEN,
             outcome=ReviewOutcome.PENDING,
-            review_type=1,
+            reason_category=DeactivationReason.INAPPROPRIATE,
         )
         db_session.add(review2)
         await db_session.commit()
@@ -380,7 +380,7 @@ class TestForeignKeyCascades:
             deadline=datetime.now(UTC) + timedelta(days=7),
             status=ReviewStatus.OPEN,
             outcome=ReviewOutcome.PENDING,
-            review_type=1,
+            reason_category=DeactivationReason.INAPPROPRIATE,
         )
         db_session.add(review)
         await db_session.commit()
@@ -407,7 +407,7 @@ class TestForeignKeyCascades:
             deadline=datetime.now(UTC) + timedelta(days=7),
             status=ReviewStatus.OPEN,
             outcome=ReviewOutcome.PENDING,
-            review_type=1,
+            reason_category=DeactivationReason.INAPPROPRIATE,
         )
         db_session.add(review)
         await db_session.commit()

--- a/tests/services/test_image_status_service.py
+++ b/tests/services/test_image_status_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import AdminActionType, DeactivationReason, ImageStatus
 from app.models.admin_action import AdminActions
 from app.models.image import Images
+from app.models.image_report import ImageReports
 from app.models.image_status_history import ImageStatusHistory
 from app.models.user import Users
 from app.services.image_status import change_image_status
@@ -73,3 +74,43 @@ async def test_no_history_row_when_status_unchanged(db_session: AsyncSession):
     )).scalars().all()
     assert hist == []
     assert img.locked == 1
+
+
+async def test_system_actor_writes_null_user(db_session: AsyncSession):
+    img = await _mk_image(db_session, 1, status=ImageStatus.REVIEW)
+    await change_image_status(
+        db_session, img, None, new_status=ImageStatus.ACTIVE,
+        action_type=AdminActionType.REVIEW_CLOSE, extra_details={"automatic": True},
+    )
+    await db_session.commit()
+    hist = (await db_session.execute(
+        select(ImageStatusHistory).where(ImageStatusHistory.image_id == img.image_id)
+    )).scalars().all()
+    assert hist and hist[0].user_id is None  # system action
+    action = (await db_session.execute(
+        select(AdminActions).where(AdminActions.image_id == img.image_id)
+    )).scalar_one()
+    assert action.action_type == AdminActionType.REVIEW_CLOSE
+    assert action.user_id is None
+    assert action.details["automatic"] is True
+
+
+async def test_report_id_stamped_on_audit_row(db_session: AsyncSession):
+    actor = (await db_session.execute(select(Users).where(Users.user_id == 1))).scalar_one()
+    img = await _mk_image(db_session, actor.user_id)
+    report = ImageReports(image_id=img.image_id, user_id=actor.user_id, category=2, status=0)
+    db_session.add(report)
+    await db_session.commit()
+    await db_session.refresh(report)
+
+    await change_image_status(
+        db_session, img, actor, new_status=ImageStatus.DEACTIVATED,
+        reason_category=DeactivationReason.SPAM, reason="ad",
+        action_type=AdminActionType.REPORT_ACTION, report_id=report.report_id,
+    )
+    await db_session.commit()
+    action = (await db_session.execute(
+        select(AdminActions).where(AdminActions.report_id == report.report_id)
+    )).scalar_one()
+    assert action.action_type == AdminActionType.REPORT_ACTION
+    assert action.details["reason"] == "ad"

--- a/tests/unit/test_config_status.py
+++ b/tests/unit/test_config_status.py
@@ -56,3 +56,11 @@ def test_status_history_has_reason_fields():
     h2 = ImageStatusHistory(image_id=1, old_status=1, new_status=2)
     assert h2.reason_category is None
     assert h2.reason is None
+
+
+def test_review_uses_reason_category():
+    from app.models.image_review import ImageReviews
+
+    r = ImageReviews(image_id=1, reason_category=DeactivationReason.LOW_QUALITY)
+    assert r.reason_category == DeactivationReason.LOW_QUALITY
+    assert not hasattr(r, "review_type")

--- a/tests/unit/test_review_deadline_job.py
+++ b/tests/unit/test_review_deadline_job.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import (
     AdminActionType,
+    DeactivationReason,
     ImageStatus,
     ReviewOutcome,
     ReviewStatus,
@@ -68,7 +69,7 @@ async def create_test_review(
         extension_used=extension_used,
         status=ReviewStatus.OPEN,
         outcome=ReviewOutcome.PENDING,
-        review_type=1,
+        reason_category=DeactivationReason.INAPPROPRIATE,
         created_at=datetime.now(UTC),
     )
     db_session.add(review)

--- a/tests/unit/test_review_deadline_job.py
+++ b/tests/unit/test_review_deadline_job.py
@@ -21,7 +21,9 @@ from app.models.image import Images
 from app.models.image_review import ImageReviews
 from app.models.review_vote import ReviewVotes
 from app.models.user import Users
+from app.models.image_status_history import ImageStatusHistory
 from app.services.review_jobs import (
+    _close_review,
     _get_vote_counts,
     check_early_close,
     check_review_deadlines,
@@ -167,7 +169,7 @@ class TestQuorumAndMajority:
         assert image.status == ImageStatus.ACTIVE
 
     async def test_unanimous_remove(self, db_session: AsyncSession):
-        """0 keep, 3 remove -> close with outcome=REMOVE, image status=INAPPROPRIATE."""
+        """0 keep, 3 remove -> close with outcome=REMOVE, image status=DEACTIVATED."""
         image = await create_test_image(db_session)
         review = await create_test_review(db_session, image.image_id)
         await add_votes(db_session, review.review_id, keep_count=0, remove_count=3)  # type: ignore[arg-type]
@@ -180,7 +182,8 @@ class TestQuorumAndMajority:
         assert result["closed"] == 1
         assert review.status == ReviewStatus.CLOSED
         assert review.outcome == ReviewOutcome.REMOVE
-        assert image.status == ImageStatus.INAPPROPRIATE
+        assert image.status == ImageStatus.DEACTIVATED
+        assert image.reason_category == DeactivationReason.INAPPROPRIATE
 
     async def test_majority_keep(self, db_session: AsyncSession):
         """2 keep, 1 remove -> close with outcome=KEEP (majority)."""
@@ -210,7 +213,64 @@ class TestQuorumAndMajority:
 
         assert result["closed"] == 1
         assert review.outcome == ReviewOutcome.REMOVE
-        assert image.status == ImageStatus.INAPPROPRIATE
+        assert image.status == ImageStatus.DEACTIVATED
+        assert image.reason_category == DeactivationReason.INAPPROPRIATE
+
+
+@pytest.mark.asyncio
+class TestRemoveDeactivates:
+    """A REMOVE outcome deactivates with the review's category + reason."""
+
+    async def test_review_remove_deactivates_with_category(self, db_session: AsyncSession):
+        """REMOVE -> DEACTIVATED + review's reason_category/reason + history + close_reason."""
+        from sqlalchemy import select
+
+        image = await create_test_image(db_session, status=ImageStatus.REVIEW)
+        review = await create_test_review(db_session, image.image_id)
+        review.reason_category = DeactivationReason.LOW_QUALITY
+        review.reason = "borderline"
+        await db_session.commit()
+        await db_session.refresh(review)
+
+        transition = await _close_review(
+            db_session, review, ReviewOutcome.REMOVE, "quorum_reached"
+        )
+        await db_session.commit()
+
+        await db_session.refresh(image)
+        assert transition == (image.image_id, ImageStatus.REVIEW, ImageStatus.DEACTIVATED)
+        assert image.status == ImageStatus.DEACTIVATED
+        assert image.reason_category == DeactivationReason.LOW_QUALITY
+        assert image.status_reason == "borderline"
+
+        # Public status history row carries the category + reason
+        hist = (
+            await db_session.execute(
+                select(ImageStatusHistory).where(
+                    ImageStatusHistory.image_id == image.image_id  # type: ignore[arg-type]
+                )
+            )
+        ).scalars().all()
+        assert any(
+            h.new_status == ImageStatus.DEACTIVATED
+            and h.reason_category == DeactivationReason.LOW_QUALITY
+            and h.reason == "borderline"
+            for h in hist
+        )
+
+        # Audit row keeps the close-CODE under close_reason
+        action = (
+            await db_session.execute(
+                select(AdminActions).where(
+                    AdminActions.review_id == review.review_id,
+                    AdminActions.action_type == AdminActionType.REVIEW_CLOSE,
+                )
+            )
+        ).scalar_one()
+        assert action.user_id is None  # system actor
+        assert action.details["close_reason"] == "quorum_reached"
+        assert action.details["outcome_label"] == "remove"
+        assert action.details["automatic"] is True
 
 
 @pytest.mark.asyncio
@@ -383,7 +443,7 @@ class TestAuditLogging:
         assert action is not None
         assert action.user_id is None  # System action
         assert action.details["automatic"] is True
-        assert action.details["reason"] == "quorum_reached"
+        assert action.details["close_reason"] == "quorum_reached"
 
     async def test_extend_creates_audit_log(self, db_session: AsyncSession):
         """Extending a review creates an admin_action entry."""
@@ -530,7 +590,8 @@ class TestEarlyClose:
         assert closed is not None
         assert review.status == ReviewStatus.CLOSED
         assert review.outcome == ReviewOutcome.REMOVE
-        assert image.status == ImageStatus.INAPPROPRIATE
+        assert image.status == ImageStatus.DEACTIVATED
+        assert image.reason_category == DeactivationReason.INAPPROPRIATE
 
     async def test_early_close_margin_not_met(self, db_session: AsyncSession):
         """2 keep, 1 remove (margin=1, needs 3) -> stays open."""
@@ -601,7 +662,7 @@ class TestEarlyClose:
         action = result.scalar_one_or_none()
 
         assert action is not None
-        assert action.details["reason"] == "early_close_margin"
+        assert action.details["close_reason"] == "early_close_margin"
         assert action.details["automatic"] is True
 
     async def test_early_close_no_votes(self, db_session: AsyncSession):

--- a/tests/unit/test_review_system.py
+++ b/tests/unit/test_review_system.py
@@ -157,15 +157,33 @@ class TestSchemaValidation:
 
     def test_review_create_schema(self):
         """Verify ReviewCreate schema validation."""
+        import pytest
+        from pydantic import ValidationError
+
         from app.schemas.report import ReviewCreate
 
-        # Default deadline
-        review = ReviewCreate()
+        # reason_category + reason are required
+        with pytest.raises(ValidationError):
+            ReviewCreate()
+
+        # Default deadline with required fields
+        review = ReviewCreate(reason_category=DeactivationReason.INAPPROPRIATE, reason="needs review")
         assert review.deadline_days is None
+        assert review.reason_category == DeactivationReason.INAPPROPRIATE
+        assert review.reason == "needs review"
 
         # Custom deadline
-        review = ReviewCreate(deadline_days=14)
+        review = ReviewCreate(
+            deadline_days=14,
+            reason_category=DeactivationReason.LOW_QUALITY,
+            reason="blurry",
+        )
         assert review.deadline_days == 14
+        assert review.reason_category == DeactivationReason.LOW_QUALITY
+
+        # Invalid reason_category is rejected
+        with pytest.raises(ValidationError):
+            ReviewCreate(reason_category=99, reason="bad category")
 
     def test_report_response_labels(self):
         """Verify ReportResponse computes correct labels."""

--- a/tests/unit/test_review_system.py
+++ b/tests/unit/test_review_system.py
@@ -8,11 +8,11 @@ from datetime import datetime
 
 from app.config import (
     AdminActionType,
+    DeactivationReason,
     ImageStatus,
     ReportStatus,
     ReviewOutcome,
     ReviewStatus,
-    ReviewType,
 )
 
 
@@ -41,9 +41,12 @@ class TestStatusConstants:
         assert ReviewOutcome.KEEP == 1
         assert ReviewOutcome.REMOVE == 2
 
-    def test_review_type_values(self):
-        """Verify ReviewType has expected values."""
-        assert ReviewType.APPROPRIATENESS == 1
+    def test_deactivation_reason_values(self):
+        """Verify DeactivationReason has expected values."""
+        assert DeactivationReason.INAPPROPRIATE == 1
+        assert DeactivationReason.LOW_QUALITY == 2
+        assert DeactivationReason.SPAM == 3
+        assert DeactivationReason.OTHER == 4
 
     def test_admin_action_type_values(self):
         """Verify AdminActionType has expected values."""
@@ -76,7 +79,7 @@ class TestModelDefaults:
         assert review.status == ReviewStatus.OPEN
         assert review.outcome == ReviewOutcome.PENDING
         assert review.extension_used == 0
-        assert review.review_type == ReviewType.APPROPRIATENESS
+        assert review.reason_category == DeactivationReason.INAPPROPRIATE
         assert review.source_report_id is None
 
     def test_review_vote_defaults(self):
@@ -191,7 +194,7 @@ class TestSchemaValidation:
             image_id=1,
             source_report_id=None,
             initiated_by=1,
-            review_type=1,  # Appropriateness
+            reason_category=1,  # Inappropriate
             deadline=datetime(2026, 1, 8, 0, 0, 0),
             extension_used=0,
             status=0,  # Open
@@ -199,7 +202,7 @@ class TestSchemaValidation:
             created_at=datetime(2026, 1, 1, 0, 0, 0),
             closed_at=None,
         )
-        assert response.review_type_label == "Appropriateness"
+        assert response.reason_category_label == "Inappropriate"
         assert response.status_label == "Open"
         assert response.outcome_label == "Pending"
 


### PR DESCRIPTION
Part 2 of 3 of the image-moderation redesign. **Targets the `image-moderation-redesign` umbrella, not `main`.** Builds on Plan 1 (#230).

## What this does
Makes `change_image_status` the single entry point for every image status change, then layers report/review behavior on top.

- **Unified service** — `change_image_status` now accepts a system/no-mod actor + audit context (`action_type`/`report_id`/`review_id`/`extra_details`). Direct mod, report triage, review start, and **both** review-close paths (auto-close job + manual early-close endpoint) route through it; each writes one correctly-typed `AdminActions` row + a public `ImageStatusHistory` row carrying reason/reason_category.
- **Report triage** (`action_report`) uses the deactivate contract `{new_status, reason_category?, reason?, replacement_id?}`: enforces `replacement_id` for repost (+ runs the repost data migration), writes public history, and captures the **mod's** reason — kept distinct from the reporter's `reason_text`.
- **Report resolution is derived** from the linked `AdminActions` row (action → resulting status + mod reason; escalated; dismissed) and exposed on `ReportResponse` — no new report columns, no duplicated reason. (2-year caveat: `admin_actions` pruning; the image's own status-history retains the transition permanently.)
- **Reviews** carry a mod-set **`reason_category`** (repurposed from the single-value `review_type`, now using the `DeactivationReason` taxonomy) + a required `reason` on both create and escalate. A REMOVE outcome deactivates with that category + reason — identical in shape to a direct mod deactivation.

## Migration
`4a93ca80f7f6` renames `image_reviews.review_type` → `reason_category` (value `1` Appropriateness → Inappropriate, same int — no data conversion). Chains off Plan 1's `ba007b19d0f1`.

## Verification
- TDD throughout; full suite **1685 passed, 9 skipped, 0 failures**; ruff + mypy clean.

## Not this PR
Plan 3 (frontend): deactivate dialog, triage UI showing the derived resolution, escalate/review dialogs sending category+reason, reviews UI, regenerated `api-generated.ts`.

Note: the Security Scan (pip-audit) red is the unrelated **pyjwt** advisory (separate PR #231 to main), present on every branch off the pre-pyjwt umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)