### PR TITLE
Activity timeline backend: status-history report/review FKs, per-image reports endpoint, has_open_report flag

### DIFF
--- a/alembic/versions/1cdaf1ec0250_status_history_report_review_fk.py
+++ b/alembic/versions/1cdaf1ec0250_status_history_report_review_fk.py
@@ -1,0 +1,63 @@
+"""status_history report review fk
+
+Revision ID: 1cdaf1ec0250
+Revises: 4a93ca80f7f6
+Create Date: 2026-06-04 14:41:26.288558
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1cdaf1ec0250'
+down_revision: str | Sequence[str] | None = '4a93ca80f7f6'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add nullable report_id/review_id FKs to image_status_history."""
+    op.add_column("image_status_history", sa.Column("report_id", mysql.INTEGER(unsigned=True), nullable=True))
+    op.add_column("image_status_history", sa.Column("review_id", mysql.INTEGER(unsigned=True), nullable=True))
+    op.create_index(
+        "idx_image_status_history_report_id", "image_status_history", ["report_id"]
+    )
+    op.create_index(
+        "idx_image_status_history_review_id", "image_status_history", ["review_id"]
+    )
+    op.create_foreign_key(
+        "fk_image_status_history_report_id",
+        "image_status_history",
+        "image_reports",
+        ["report_id"],
+        ["report_id"],
+        ondelete="SET NULL",
+        onupdate="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_image_status_history_review_id",
+        "image_status_history",
+        "image_reviews",
+        ["review_id"],
+        ["review_id"],
+        ondelete="SET NULL",
+        onupdate="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    """Drop report_id/review_id FKs from image_status_history."""
+    op.drop_constraint(
+        "fk_image_status_history_review_id", "image_status_history", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "fk_image_status_history_report_id", "image_status_history", type_="foreignkey"
+    )
+    op.drop_index("idx_image_status_history_review_id", table_name="image_status_history")
+    op.drop_index("idx_image_status_history_report_id", table_name="image_status_history")
+    op.drop_column("image_status_history", "review_id")
+    op.drop_column("image_status_history", "report_id")

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -50,6 +50,7 @@ from app.config import (
 from app.core.auth import CurrentUser, VerifiedUser, get_current_user, get_optional_current_user
 from app.core.database import get_db
 from app.core.logging import get_logger
+from app.core.permission_deps import require_permission
 from app.core.permissions import Permission, has_any_permission, has_permission
 from app.core.r2_constants import R2Location
 from app.core.redis import get_redis
@@ -96,7 +97,13 @@ from app.schemas.image import (
     SimilarImagesResponse,
     SimilarImagesUploadResponse,
 )
-from app.schemas.report import ReportCreate, ReportResponse, SkippedTagsInfo, TagSuggestion
+from app.schemas.report import (
+    ReportCreate,
+    ReportListResponse,
+    ReportResponse,
+    SkippedTagsInfo,
+    TagSuggestion,
+)
 from app.schemas.tag import LinkedTag
 from app.schemas.user import (
     ImageRatingsListResponse,
@@ -1396,6 +1403,77 @@ async def get_image_reviews(
     ]
 
     return ImageReviewListResponse(
+        total=total,
+        page=pagination.page,
+        per_page=pagination.per_page,
+        items=items,
+    )
+
+
+@router.get("/{image_id}/reports", response_model=ReportListResponse)
+async def get_image_reports(
+    image_id: Annotated[int, Path(description="Image ID")],
+    pagination: Annotated[PaginationParams, Depends()],
+    current_user: Annotated[Users, Depends(get_current_user)],
+    _: Annotated[None, Depends(require_permission(Permission.REPORT_VIEW))],
+    db: AsyncSession = Depends(get_db),
+) -> ReportListResponse:
+    """
+    Get the reports filed against an image (pending + resolved), newest first.
+
+    Mod-only (REPORT_VIEW) — powers the moderation activity timeline. Returns the
+    reporter, category, reason, and status for each report. Resolution/tag-suggestion
+    detail is intentionally omitted (the timeline shows the resulting status-change
+    event alongside).
+    """
+    image_result = await db.execute(select(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
+    if not image_result.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    base_query = select(ImageReports).where(ImageReports.image_id == image_id)  # type: ignore[arg-type]
+    total = (
+        await db.execute(select(func.count()).select_from(base_query.subquery()))
+    ).scalar() or 0
+
+    query = (
+        select(ImageReports, Users)
+        .outerjoin(Users, ImageReports.user_id == Users.user_id)  # type: ignore[arg-type]
+        .options(selectinload(Users.user_groups).selectinload(UserGroups.group))  # type: ignore[arg-type]
+        .where(ImageReports.image_id == image_id)  # type: ignore[arg-type]
+        .order_by(
+            desc(ImageReports.created_at),  # type: ignore[arg-type]
+            desc(ImageReports.report_id),  # type: ignore[arg-type]
+        )
+        .offset(pagination.offset)
+        .limit(pagination.per_page)
+    )
+
+    items = []
+    for report, user in (await db.execute(query)).all():
+        reporter = None
+        if user:
+            reporter = UserSummary(
+                user_id=user.user_id,
+                username=user.username,
+                avatar=user.avatar,
+                avatar_in_r2=user.avatar_in_r2,
+                user_title=user.user_title,
+                groups=user.groups,
+            )
+        items.append(
+            ReportResponse(
+                report_id=report.report_id,
+                image_id=report.image_id,
+                user=reporter,
+                category=report.category,
+                reason_text=report.reason_text,
+                status=report.status,
+                created_at=report.created_at,
+                reviewed_at=report.reviewed_at,
+            )
+        )
+
+    return ReportListResponse(
         total=total,
         page=pagination.page,
         per_page=pagination.per_page,

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -245,6 +245,30 @@ async def check_similar_by_upload(
             logger.warning("check_similar_cleanup_failed", temp_dir=temp_dir)
 
 
+async def _open_report_image_ids(
+    db: AsyncSession, image_ids: list[int | None], viewer: Users | None
+) -> set[int]:
+    """Subset of `image_ids` that have a PENDING report — only for REPORT_VIEW viewers.
+
+    One query for the whole page (not N+1). Returns an empty set for non-mods so the
+    has_open_report flag never leaks to regular users.
+    """
+    ids = [i for i in image_ids if i is not None]
+    if not ids or viewer is None or viewer.user_id is None:
+        return set()
+    if not await has_any_permission(db, viewer.user_id, [Permission.REPORT_VIEW]):
+        return set()
+    rows = await db.execute(
+        select(ImageReports.image_id)  # type: ignore[call-overload]
+        .where(
+            ImageReports.image_id.in_(ids),  # type: ignore[attr-defined]
+            ImageReports.status == ReportStatus.PENDING,
+        )
+        .distinct()
+    )
+    return {r[0] for r in rows.all()}
+
+
 @router.get("/", response_model=ImageDetailedListResponse, include_in_schema=False)
 @router.get("", response_model=ImageDetailedListResponse)
 async def list_images(
@@ -662,6 +686,11 @@ async def list_images(
         )
         favorited_ids = set(fav_result.scalars().all())
 
+    # Mod-only open-report indicator (single query for the page).
+    open_report_ids = await _open_report_image_ids(
+        db, [img.image_id for img in images], current_user
+    )
+
     return ImageDetailedListResponse(
         total=total or 0,
         page=pagination.page,
@@ -670,6 +699,7 @@ async def list_images(
             ImageDetailedResponse.from_db_model(
                 img,
                 is_favorited=img.image_id in favorited_ids,
+                has_open_report=img.image_id in open_report_ids,
             )
             for img in images
         ],
@@ -807,12 +837,14 @@ async def get_image(
     )
     next_image_id = next_id_result.scalar_one_or_none()
 
+    open_report_ids = await _open_report_image_ids(db, [image_id], current_user)
     return ImageDetailedResponse.from_db_model(
         image,
         is_favorited=is_favorited,
         user_rating=user_rating,
         prev_image_id=prev_image_id,
         next_image_id=next_image_id,
+        has_open_report=image_id in open_report_ids,
     )
 
 

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1235,9 +1235,15 @@ async def get_image_status_history(
     owner_id = image.user_id
 
     is_privileged_viewer = False
+    can_see_report_links = False
     if current_user is not None and current_user.user_id is not None:
         is_privileged_viewer = current_user.user_id == owner_id or await has_any_permission(
             db, current_user.user_id, [Permission.IMAGE_EDIT, Permission.REVIEW_VIEW]
+        )
+        # The originating report/review link is moderation context — REPORT_VIEW only
+        # (independent of the reason gate, which follows the owner/visible-status rule).
+        can_see_report_links = await has_any_permission(
+            db, current_user.user_id, [Permission.REPORT_VIEW]
         )
 
     # Query status history with user info
@@ -1309,6 +1315,8 @@ async def get_image_status_history(
                 new_status_label=ImageStatus.get_label(history.new_status),
                 reason_category=history.reason_category,
                 reason=history.reason if can_see_reason else None,
+                report_id=history.report_id if can_see_report_links else None,
+                review_id=history.review_id if can_see_report_links else None,
                 user=user_summary,
                 created_at=history.created_at,
             )

--- a/app/models/image_status_history.py
+++ b/app/models/image_status_history.py
@@ -12,6 +12,7 @@ Visibility rules:
 from datetime import datetime
 
 from sqlalchemy import Column, ForeignKeyConstraint, Index, text
+from sqlalchemy.dialects.mysql import INTEGER as MySQLInteger
 from sqlmodel import Field, SQLModel
 
 from app.models.types import UtcDateTime
@@ -85,8 +86,14 @@ class ImageStatusHistory(ImageStatusHistoryBase, table=True):
 
     # Originating report/review for this transition (set on the triage/review-close
     # paths; NULL for direct mod changes and legacy rows). Exposed mods-only in the API.
-    report_id: int | None = Field(default=None)
-    review_id: int | None = Field(default=None)
+    # Unsigned to match the image_reports/image_reviews PK types (and the migration),
+    # so an ORM-created schema matches a migration-created one.
+    report_id: int | None = Field(
+        default=None, sa_column=Column(MySQLInteger(unsigned=True), nullable=True)
+    )
+    review_id: int | None = Field(
+        default=None, sa_column=Column(MySQLInteger(unsigned=True), nullable=True)
+    )
 
     # Timestamp
     created_at: datetime | None = Field(

--- a/app/models/image_status_history.py
+++ b/app/models/image_status_history.py
@@ -51,9 +51,25 @@ class ImageStatusHistory(ImageStatusHistoryBase, table=True):
             onupdate="CASCADE",
             name="fk_image_status_history_user_id",
         ),
+        ForeignKeyConstraint(
+            ["report_id"],
+            ["image_reports.report_id"],
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+            name="fk_image_status_history_report_id",
+        ),
+        ForeignKeyConstraint(
+            ["review_id"],
+            ["image_reviews.review_id"],
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+            name="fk_image_status_history_review_id",
+        ),
         Index("idx_image_status_history_image_id", "image_id"),
         Index("idx_image_status_history_user_id", "user_id"),
         Index("idx_image_status_history_created_at", "created_at"),
+        Index("idx_image_status_history_report_id", "report_id"),
+        Index("idx_image_status_history_review_id", "review_id"),
     )
 
     # Primary key
@@ -66,6 +82,11 @@ class ImageStatusHistory(ImageStatusHistoryBase, table=True):
     # at the time of the change). Nullable: legacy rows and non-deactivation transitions.
     reason_category: int | None = Field(default=None)
     reason: str | None = Field(default=None, max_length=1000)
+
+    # Originating report/review for this transition (set on the triage/review-close
+    # paths; NULL for direct mod changes and legacy rows). Exposed mods-only in the API.
+    report_id: int | None = Field(default=None)
+    review_id: int | None = Field(default=None)
 
     # Timestamp
     created_at: datetime | None = Field(

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -155,6 +155,11 @@ class ImageStatusHistoryResponse(BaseModel):
     reason_category: int | None = None
     reason: str | None = None
 
+    # Originating report/review for this transition — exposed to REPORT_VIEW
+    # mods only (gated by the endpoint); NULL for everyone else.
+    report_id: int | None = None
+    review_id: int | None = None
+
     # Who made the change (may be null for hidden statuses)
     user: UserSummary | None = None
 

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -162,6 +162,7 @@ class ImageDetailedResponse(ImageResponse):
     user_rating: int | None = None  # The rating given by the current user (if any)
     prev_image_id: int | None = None  # ID of the previous image (chronological)
     next_image_id: int | None = None  # ID of the next image (chronological)
+    has_open_report: bool = False  # Mod-only (REPORT_VIEW): a pending report exists
 
     model_config = {"from_attributes": True}
 
@@ -173,6 +174,7 @@ class ImageDetailedResponse(ImageResponse):
         user_rating: int | None = None,
         prev_image_id: int | None = None,
         next_image_id: int | None = None,
+        has_open_report: bool = False,
     ) -> ImageDetailedResponse:
         """Create response from database model with relationships"""
         data = ImageResponse.model_validate(image).model_dump()
@@ -196,6 +198,7 @@ class ImageDetailedResponse(ImageResponse):
         data["user_rating"] = user_rating
         data["prev_image_id"] = prev_image_id
         data["next_image_id"] = next_image_id
+        data["has_open_report"] = has_open_report
 
         return cls(**data)
 

--- a/app/services/image_status.py
+++ b/app/services/image_status.py
@@ -148,6 +148,8 @@ async def change_image_status(
                 user_id=actor_id,
                 reason_category=image.reason_category,
                 reason=image.status_reason,
+                report_id=report_id,
+                review_id=review_id,
             )
         )
 

--- a/tests/api/v1/test_image_reports_endpoint.py
+++ b/tests/api/v1/test_image_reports_endpoint.py
@@ -1,0 +1,107 @@
+"""Tests for GET /images/{image_id}/reports — mod-only per-image reports."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ReportStatus
+from app.core.security import get_password_hash
+from app.models.image import Images
+from app.models.image_report import ImageReports
+from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
+from app.models.user import Users
+
+
+async def _make_user(db, username, password="TestPassword123!"):
+    user = Users(username=username, password=get_password_hash(password),
+                 password_type="bcrypt", salt="", email=f"{username}@example.com", active=1)
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _grant(db, user_id, perm_title):
+    perm = (await db.execute(select(Perms).where(Perms.title == perm_title))).scalar_one_or_none()
+    if not perm:
+        perm = Perms(title=perm_title, desc=perm_title)
+        db.add(perm)
+        await db.flush()
+    group = Groups(title=f"{perm_title}_{user_id}", desc="g")
+    db.add(group)
+    await db.flush()
+    db.add(GroupPerms(group_id=group.group_id, perm_id=perm.perm_id, permvalue=1))
+    db.add(UserGroups(user_id=user_id, group_id=group.group_id))
+    await db.commit()
+
+
+async def _login(client, username, password="TestPassword123!"):
+    r = await client.post("/api/v1/auth/login", json={"username": username, "password": password})
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+async def _img_with_report(db, owner, md5):
+    img = Images(filename="rep", ext="jpg", md5_hash=md5, user_id=owner.user_id,
+                 width=10, height=10, filesize=100, status=1)
+    db.add(img)
+    await db.commit()
+    await db.refresh(img)
+    report = ImageReports(image_id=img.image_id, user_id=owner.user_id, category=2,
+                          reason_text="looks AI", status=ReportStatus.PENDING)
+    db.add(report)
+    await db.commit()
+    await db.refresh(report)
+    return img, report
+
+
+@pytest.mark.api
+class TestGetImageReports:
+    async def test_mod_sees_image_reports(self, client: AsyncClient, db_session: AsyncSession):
+        owner = await _make_user(db_session, "irowner")
+        img, report = await _img_with_report(db_session, owner, "a" * 32)
+        mod = await _make_user(db_session, "irmod")
+        await _grant(db_session, mod.user_id, "report_view")
+        token = await _login(client, mod.username)
+
+        r = await client.get(
+            f"/api/v1/images/{img.image_id}/reports",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 1
+        item = data["items"][0]
+        assert item["report_id"] == report.report_id
+        assert item["category"] == 2
+        assert item["reason_text"] == "looks AI"
+        assert item["status"] == ReportStatus.PENDING
+        assert item["user"]["username"] == "irowner"
+
+    async def test_regular_user_forbidden(self, client: AsyncClient, db_session: AsyncSession):
+        owner = await _make_user(db_session, "irowner2")
+        img, _ = await _img_with_report(db_session, owner, "b" * 32)
+        user = await _make_user(db_session, "irplain")
+        token = await _login(client, user.username)
+        r = await client.get(
+            f"/api/v1/images/{img.image_id}/reports",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 403
+
+    async def test_anonymous_forbidden(self, client: AsyncClient, db_session: AsyncSession):
+        owner = await _make_user(db_session, "irowner3")
+        img, _ = await _img_with_report(db_session, owner, "c" * 32)
+        r = await client.get(f"/api/v1/images/{img.image_id}/reports")
+        assert r.status_code in (401, 403)
+
+    async def test_404_for_nonexistent_image(self, client: AsyncClient, db_session: AsyncSession):
+        mod = await _make_user(db_session, "irmod4")
+        await _grant(db_session, mod.user_id, "report_view")
+        token = await _login(client, mod.username)
+        r = await client.get(
+            "/api/v1/images/99999999/reports",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 404

--- a/tests/api/v1/test_image_status_history_endpoint.py
+++ b/tests/api/v1/test_image_status_history_endpoint.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import DeactivationReason, ImageStatus
 from app.core.security import get_password_hash
 from app.models.image import Images
+from app.models.image_report import ImageReports
 from app.models.image_status_history import ImageStatusHistory
 from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
 from app.models.user import Users
@@ -590,6 +591,20 @@ async def _grant_image_edit(db_session, user_id):
     await db_session.commit()
 
 
+async def _grant_report_view(db_session, user_id):
+    perm = (await db_session.execute(select(Perms).where(Perms.title == "report_view"))).scalar_one_or_none()
+    if not perm:
+        perm = Perms(title="report_view", desc="view reports")
+        db_session.add(perm)
+        await db_session.flush()
+    group = Groups(title=f"hist_rv_{user_id}", desc="hist report-view group")
+    db_session.add(group)
+    await db_session.flush()
+    db_session.add(GroupPerms(group_id=group.group_id, perm_id=perm.perm_id, permvalue=1))
+    db_session.add(UserGroups(user_id=user_id, group_id=group.group_id))
+    await db_session.commit()
+
+
 async def _login(client, username, password="TestPassword123!"):
     r = await client.post("/api/v1/auth/login", json={"username": username, "password": password})
     assert r.status_code == 200
@@ -697,3 +712,38 @@ class TestStatusHistoryReasonVisibility:
         r = await client.get(f"/api/v1/images/{image.image_id}/status-history")
         assert r.status_code == 200
         assert r.json()["items"][0]["reason"] == "not actually a spoiler"
+
+    async def test_report_id_visible_to_mod_hidden_from_anon(self, client, db_session):
+        """The originating report_id is exposed to REPORT_VIEW mods, NULL to others."""
+        owner = await _make_user(db_session, "histreport1")
+        image = Images(filename="histrep", ext="jpg", md5_hash="f" * 32,
+                       user_id=owner.user_id, width=100, height=100, filesize=1000,
+                       status=ImageStatus.DEACTIVATED)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+        report = ImageReports(image_id=image.image_id, user_id=owner.user_id, category=2, status=1)
+        db_session.add(report)
+        await db_session.commit()
+        await db_session.refresh(report)
+        db_session.add(ImageStatusHistory(
+            image_id=image.image_id, old_status=ImageStatus.ACTIVE,
+            new_status=ImageStatus.DEACTIVATED, user_id=owner.user_id,
+            reason_category=DeactivationReason.INAPPROPRIATE, reason="x",
+            report_id=report.report_id))
+        await db_session.commit()
+
+        # Anonymous: report_id hidden.
+        r = await client.get(f"/api/v1/images/{image.image_id}/status-history")
+        assert r.status_code == 200
+        assert r.json()["items"][0]["report_id"] is None
+
+        # Mod with report_view: report_id exposed.
+        mod = await _make_user(db_session, "histreportmod1")
+        await _grant_report_view(db_session, mod.user_id)
+        token = await _login(client, mod.username)
+        r = await client.get(
+            f"/api/v1/images/{image.image_id}/status-history",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.json()["items"][0]["report_id"] == report.report_id

--- a/tests/api/v1/test_open_report_flag.py
+++ b/tests/api/v1/test_open_report_flag.py
@@ -1,0 +1,104 @@
+"""Tests for the mod-only has_open_report flag on image responses."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ReportStatus
+from app.core.security import get_password_hash
+from app.models.image import Images
+from app.models.image_report import ImageReports
+from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
+from app.models.user import Users
+
+
+async def _make_user(db, username, password="TestPassword123!"):
+    user = Users(username=username, password=get_password_hash(password),
+                 password_type="bcrypt", salt="", email=f"{username}@example.com", active=1)
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _grant(db, user_id, perm_title):
+    perm = (await db.execute(select(Perms).where(Perms.title == perm_title))).scalar_one_or_none()
+    if not perm:
+        perm = Perms(title=perm_title, desc=perm_title)
+        db.add(perm)
+        await db.flush()
+    group = Groups(title=f"{perm_title}_{user_id}", desc="g")
+    db.add(group)
+    await db.flush()
+    db.add(GroupPerms(group_id=group.group_id, perm_id=perm.perm_id, permvalue=1))
+    db.add(UserGroups(user_id=user_id, group_id=group.group_id))
+    await db.commit()
+
+
+async def _login(client, username, password="TestPassword123!"):
+    r = await client.post("/api/v1/auth/login", json={"username": username, "password": password})
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+async def _image(db, owner, md5):
+    img = Images(filename="orf", ext="jpg", md5_hash=md5, user_id=owner.user_id,
+                 width=10, height=10, filesize=100, status=1)
+    db.add(img)
+    await db.commit()
+    await db.refresh(img)
+    return img
+
+
+@pytest.mark.api
+class TestHasOpenReportFlag:
+    async def test_detail_flag_visible_to_mod_only(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        owner = await _make_user(db_session, "orfowner")
+        reported = await _image(db_session, owner, "a" * 32)
+        clean = await _image(db_session, owner, "b" * 32)
+        db_session.add(ImageReports(image_id=reported.image_id, user_id=owner.user_id,
+                                    category=2, status=ReportStatus.PENDING))
+        await db_session.commit()
+
+        mod = await _make_user(db_session, "orfmod")
+        await _grant(db_session, mod.user_id, "report_view")
+        token = await _login(client, mod.username)
+        h = {"Authorization": f"Bearer {token}"}
+
+        r = await client.get(f"/api/v1/images/{reported.image_id}", headers=h)
+        assert r.status_code == 200
+        assert r.json()["has_open_report"] is True
+
+        r = await client.get(f"/api/v1/images/{clean.image_id}", headers=h)
+        assert r.json()["has_open_report"] is False
+
+        # Regular user never sees the flag set, even on a reported image.
+        plain = await _make_user(db_session, "orfplain")
+        token2 = await _login(client, plain.username)
+        r = await client.get(
+            f"/api/v1/images/{reported.image_id}",
+            headers={"Authorization": f"Bearer {token2}"},
+        )
+        assert r.json()["has_open_report"] is False
+
+    async def test_list_flag_for_mod(self, client: AsyncClient, db_session: AsyncSession):
+        owner = await _make_user(db_session, "orflistowner")
+        reported = await _image(db_session, owner, "c" * 32)
+        db_session.add(ImageReports(image_id=reported.image_id, user_id=owner.user_id,
+                                    category=2, status=ReportStatus.PENDING))
+        await db_session.commit()
+
+        mod = await _make_user(db_session, "orflistmod")
+        await _grant(db_session, mod.user_id, "report_view")
+        token = await _login(client, mod.username)
+
+        r = await client.get(
+            "/api/v1/images/?per_page=100", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert r.status_code == 200
+        items = r.json()["images"]
+        match = [i for i in items if i["image_id"] == reported.image_id]
+        assert match and match[0]["has_open_report"] is True

--- a/tests/services/test_image_status_service.py
+++ b/tests/services/test_image_status_service.py
@@ -165,3 +165,24 @@ async def test_noop_call_rejected(db_session: AsyncSession):
     img = await _mk_image(db_session, actor.user_id)
     with pytest.raises(ValueError):
         await change_image_status(db_session, img, actor)
+
+
+async def test_status_history_row_records_report_id(db_session: AsyncSession):
+    """The originating report_id is persisted on the public status-history row."""
+    actor = (await db_session.execute(select(Users).where(Users.user_id == 1))).scalar_one()
+    img = await _mk_image(db_session, actor.user_id)
+    report = ImageReports(image_id=img.image_id, user_id=actor.user_id, category=2, status=0)
+    db_session.add(report)
+    await db_session.commit()
+    await db_session.refresh(report)
+    await change_image_status(
+        db_session, img, actor, new_status=ImageStatus.DEACTIVATED,
+        reason_category=DeactivationReason.INAPPROPRIATE, reason="x",
+        action_type=AdminActionType.REPORT_ACTION, report_id=report.report_id,
+    )
+    await db_session.commit()
+    hist = (await db_session.execute(
+        select(ImageStatusHistory).where(ImageStatusHistory.image_id == img.image_id)
+    )).scalars().all()
+    assert hist[0].report_id == report.report_id
+    assert hist[0].review_id is None


### PR DESCRIPTION
Backend for the image **activity timeline + open-report indicator** (spec/plan in shuushuu-frontend `docs/plans/2026-06-04-image-activity-timeline-*`). Stacked on the moderation umbrella — **targets `image-moderation-redesign`, not main** (the timeline builds on the un-merged moderation model; everything stays in feature branches until validated together).

## Changes
1. **Status-history report/review FKs** — nullable `report_id`/`review_id` on `image_status_history` (+ migration, unsigned to match the PK types). The `change_image_status` service already had the ids in hand on the triage/review-close paths; it now writes them onto the public row too. Forward-only (legacy rows stay NULL). Exposed in the status-history response **REPORT_VIEW only** (mods see the "via report/review" link source; everyone else gets NULL).
2. **`GET /images/{id}/reports`** — mod-only (`REPORT_VIEW`, 403 otherwise); the timeline's report events. Reporter + category + reason + status, newest first.
3. **`has_open_report`** — mod-only boolean on the image list + detail responses (one `EXISTS`-style query per page, not N+1; never set for non-mods). Powers the open-report badge.

## Testing
- New tests for each (FK persistence, mod-vs-anon FK visibility, the reports endpoint's 200/403/404 matrix, the flag's mod-only visibility on list + detail).
- **Full suite 1705 passed, 9 skipped; mypy clean; migration round-trips.**

Frontend (timeline UI + badge) follows on `image-activity-timeline-web` → `image-moderation-frontend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)