### PR TITLE
chore(deps): bump pip 26.1 -> 26.1.2 (PYSEC-2026-196)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1572,11 +1572,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Bumps `pip` `26.1` → `26.1.2` in `uv.lock` to clear **PYSEC-2026-196**, which `pip-audit` (the CI **Security Scan** job) flagged on `main`.

## Why
`pip` is a transitive **dev** dependency (`pip-audit` → `pip-api` → `pip`), so it isn't a runtime dependency. Bumped via `uv lock --upgrade-package pip` — lock-only, no other packages changed.

## Verification
```
$ uv run pip-audit
No known vulnerabilities found
$ echo $?
0
```
(The "could not audit shuushuu-api (not on PyPI)" line is the project itself — informational, exit 0.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)