### PR TITLE
perf(images): fast default-feed pagination count (hidden-complement + TTL cache)

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -111,6 +111,7 @@ from app.schemas.user import (
     UserResponse,
     UserWithRatingResponse,
 )
+from app.services.feed_count_cache import get_feed_counts
 from app.services.image_processing import (
     create_thumbnail,
     get_image_dimensions,
@@ -271,6 +272,52 @@ async def _open_report_image_ids(
         .distinct()
     )
     return {r[0] for r in rows.all()}
+
+
+async def _default_feed_total(
+    db: AsyncSession,
+    current_user: Users | None,
+    redis_client: redis.Redis | None = None,  # type: ignore[type-arg]
+) -> int:
+    """Fast pagination total for the *bare* default feed (visibility filter only).
+
+    The naive count is ``count(visible OR mine)``, where ``visible`` is ~99% of the
+    table — no index can serve the OR, so it's a full clustered-index scan (seconds on
+    a 1M-row table). Instead, count from the small *hidden* complement::
+
+        total = count(all) - count(hidden AND not-mine)
+              = count(visible) + count(viewer's own hidden images)
+
+    The two global counts come from a short-TTL cache (they lag a mutation by at most the
+    TTL); the per-viewer ``own hidden`` slice is tiny and queried live. Branches mirror
+    the visibility filter in list_images exactly:
+    show_all_images=1 => no filter; anonymous => public only; otherwise public + own.
+    """
+    total_all, hidden_count = await get_feed_counts(db, redis_client)
+
+    # show_all_images=1: no visibility filter at all — every image counts.
+    if current_user is not None and current_user.show_all_images == 1:
+        return total_all
+
+    visible_count = total_all - hidden_count
+
+    # Logged-in + show_all=0: also count the viewer's own (hidden) images. Equality on
+    # user_id (not `!= me`) keeps NULL-owner rows correct.
+    if current_user is not None and current_user.user_id is not None:
+        my_hidden_count = (
+            await db.execute(
+                select(func.count())
+                .select_from(Images)
+                .where(
+                    Images.status.notin_(PUBLIC_IMAGE_STATUSES),  # type: ignore[attr-defined]
+                    Images.user_id == current_user.user_id,  # type: ignore[arg-type]
+                )
+            )
+        ).scalar() or 0
+        return visible_count + my_hidden_count
+
+    # Anonymous: public statuses only.
+    return visible_count
 
 
 @router.get("/", response_model=ImageDetailedListResponse, include_in_schema=False)
@@ -605,10 +652,36 @@ async def list_images(
         # Filter to images WITHOUT comments using posts counter
         query = query.where(Images.posts == 0)  # type: ignore[arg-type]
 
-    # Count total results
-    count_query = select(func.count()).select_from(query.subquery())
-    total_result = await db.execute(count_query)
-    total = total_result.scalar()
+    # Count total results. For the *bare* default feed (no content filter — only the
+    # implicit visibility filter), count(visible OR mine) is a full-table scan; use the
+    # fast hidden-complement count instead. ANY explicit filter falls back to the exact
+    # subquery count. IMPORTANT: keep this in sync with the filters applied above — a
+    # missing check here would return a wrong total for that filtered query.
+    is_bare_default_feed = (
+        image_status is None
+        and user_id is None
+        and favorited_by_user_id is None
+        and not tags
+        and not exclude_tags
+        and not missing_tag_types
+        and date_from is None
+        and date_to is None
+        and min_width is None
+        and max_width is None
+        and min_height is None
+        and max_height is None
+        and min_rating is None
+        and min_favorites is None
+        and min_num_ratings is None
+        and commenter is None
+        and commentsearch is None
+        and hascomments is None
+    )
+    if is_bare_default_feed:
+        total = await _default_feed_total(db, current_user, redis_client)
+    else:
+        count_query = select(func.count()).select_from(query.subquery())
+        total = (await db.execute(count_query)).scalar() or 0
 
     # Performance optimization: Two-stage query for fast filtering and sorting
     #

--- a/app/services/feed_count_cache.py
+++ b/app/services/feed_count_cache.py
@@ -1,0 +1,55 @@
+"""TTL-cached global image counts for the default-feed pagination total.
+
+``list_images`` computes the bare default-feed total as ``count(visible) + count(my
+own hidden)``, where ``count(visible) = count(all) - count(hidden)``. The two global
+counts (``count(all)`` and ``count(hidden)``) are the same for every viewer, so we
+cache them with a short TTL rather than recomputing per request. The cached total can
+lag an image create/delete/status-change by up to the TTL — a non-issue for a
+pagination counter over a million-row feed, and not worth the invalidation coupling.
+"""
+
+import redis.asyncio as redis
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.image import Images
+from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
+
+# Safety-net TTL. Explicit invalidation keeps the value exact; the TTL just bounds
+# staleness if a mutation path ever fails to invalidate.
+FEED_COUNT_TTL = 60
+
+_KEY_TOTAL = "feed:count:total"
+_KEY_HIDDEN = "feed:count:hidden"
+
+
+async def get_feed_counts(
+    db: AsyncSession,
+    redis_client: redis.Redis | None = None,  # type: ignore[type-arg]
+) -> tuple[int, int]:
+    """Return ``(count_all, count_hidden)``, cache-backed when a Redis client is given.
+
+    On a cache hit returns the stored values; on a miss (or no client) computes both
+    from the DB and caches them. ``status NOT IN PUBLIC`` is index-backed (idx_status),
+    so the miss path is still cheap relative to the naive OR scan.
+    """
+    if redis_client is not None:
+        cached_total = await redis_client.get(_KEY_TOTAL)
+        cached_hidden = await redis_client.get(_KEY_HIDDEN)
+        if cached_total is not None and cached_hidden is not None:
+            return int(cached_total), int(cached_hidden)
+
+    total = (await db.execute(select(func.count()).select_from(Images))).scalar() or 0
+    hidden = (
+        await db.execute(
+            select(func.count())
+            .select_from(Images)
+            .where(Images.status.notin_(PUBLIC_IMAGE_STATUSES))  # type: ignore[attr-defined]
+        )
+    ).scalar() or 0
+
+    if redis_client is not None:
+        await redis_client.setex(_KEY_TOTAL, FEED_COUNT_TTL, total)
+        await redis_client.setex(_KEY_HIDDEN, FEED_COUNT_TTL, hidden)
+
+    return total, hidden

--- a/app/services/feed_count_cache.py
+++ b/app/services/feed_count_cache.py
@@ -15,8 +15,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.image import Images
 from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 
-# Safety-net TTL. Explicit invalidation keeps the value exact; the TTL just bounds
-# staleness if a mutation path ever fails to invalidate.
+# TTL-only — no per-mutation invalidation. The count can lag a create/delete/status
+# change by at most FEED_COUNT_TTL seconds; acceptable for a pagination counter.
 FEED_COUNT_TTL = 60
 
 _KEY_TOTAL = "feed:count:total"

--- a/scripts/bench_feed_count.py
+++ b/scripts/bench_feed_count.py
@@ -54,6 +54,9 @@ def main() -> None:
             "logged-in show_all=0": (naive_mine, [all_count, hidden, hidden_mine]),
             "logged-in show_all=1": (all_count, [all_count]),
         }
+        # "after" is the cache-MISS path (the raw DB cost of the hidden-complement
+        # counts). In production these globals are TTL-cached (feed_count_cache), so a
+        # warm hit is a couple of single-digit-ms Redis reads — faster still.
         print(f"{'scenario':24}  {'before':>10}  {'after':>10}  {'speedup':>8}")
         print("-" * 60)
         for name, (naive, fast_parts) in scenarios.items():

--- a/scripts/bench_feed_count.py
+++ b/scripts/bench_feed_count.py
@@ -1,0 +1,67 @@
+"""Benchmark: naive vs fast default-feed pagination COUNT.
+
+Quantifies the list_images count optimization (hidden-complement instead of the
+`count(visible OR mine)` full-table scan). Runs against the configured DB
+(DATABASE_URL_SYNC — point it at a production-like dataset).
+
+    uv run python scripts/bench_feed_count.py
+"""
+
+import time
+
+from sqlalchemy import create_engine, text
+
+from app.config import settings
+
+VISIBLE = "(-1, 1, 2)"  # PUBLIC_IMAGE_STATUSES: REPOST, ACTIVE, SPOILER
+
+
+def _time_ms(conn, sql: str, runs: int = 3) -> float:
+    conn.execute(text(sql)).scalar()  # warm
+    best = float("inf")
+    for _ in range(runs):
+        t = time.perf_counter()
+        conn.execute(text(sql)).scalar()
+        best = min(best, (time.perf_counter() - t) * 1000)
+    return best
+
+
+def _explain_type(conn, sql: str) -> str:
+    row = conn.execute(text("EXPLAIN " + sql)).mappings().first()
+    return f"{row['type']}/{row['key']}/{row['rows']} rows" if row else "?"
+
+
+def main() -> None:
+    engine = create_engine(settings.DATABASE_URL_SYNC)
+    with engine.connect() as c:
+        uid = c.execute(
+            text("SELECT user_id FROM images GROUP BY user_id ORDER BY COUNT(*) DESC LIMIT 1")
+        ).scalar()
+        total = c.execute(text("SELECT COUNT(*) FROM images")).scalar()
+        print(f"images = {total:,}   sample_user = {uid}\n")
+
+        naive_all = f"SELECT COUNT(*) FROM images WHERE status IN {VISIBLE}"
+        naive_mine = f"SELECT COUNT(*) FROM images WHERE status IN {VISIBLE} OR user_id = {uid}"
+        all_count = "SELECT COUNT(*) FROM images"
+        hidden = f"SELECT COUNT(*) FROM images WHERE status NOT IN {VISIBLE}"
+        hidden_mine = f"SELECT COUNT(*) FROM images WHERE status NOT IN {VISIBLE} AND user_id = {uid}"
+
+        print(f"  naive OR plan : {_explain_type(c, naive_mine)}")
+        print(f"  hidden  plan  : {_explain_type(c, hidden)}\n")
+
+        scenarios = {
+            "anonymous": (naive_all, [all_count, hidden]),
+            "logged-in show_all=0": (naive_mine, [all_count, hidden, hidden_mine]),
+            "logged-in show_all=1": (all_count, [all_count]),
+        }
+        print(f"{'scenario':24}  {'before':>10}  {'after':>10}  {'speedup':>8}")
+        print("-" * 60)
+        for name, (naive, fast_parts) in scenarios.items():
+            before = _time_ms(c, naive)
+            after = sum(_time_ms(c, p) for p in fast_parts)
+            speedup = before / after if after else 0.0
+            print(f"{name:24}  {before:8.1f}ms  {after:8.1f}ms  {speedup:6.1f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/api/v1/test_feed_count.py
+++ b/tests/api/v1/test_feed_count.py
@@ -15,8 +15,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.security import get_password_hash
 from app.models.image import Images
 from app.models.user import Users
+from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 
-VISIBLE = [-1, 1, 2]  # REPOST, ACTIVE, SPOILER (PUBLIC_IMAGE_STATUSES)
+# Import the source of truth rather than re-listing the statuses, so this test
+# can't silently diverge if the public-status set ever changes.
+VISIBLE = sorted(PUBLIC_IMAGE_STATUSES)
 
 
 async def _user(db, username, show_all=0):

--- a/tests/api/v1/test_feed_count.py
+++ b/tests/api/v1/test_feed_count.py
@@ -1,0 +1,165 @@
+"""Equivalence tests for the fast default-feed pagination count.
+
+list_images replaces the naive `count(visible OR mine)` (a full-table scan) with a
+hidden-complement count for the *bare* default feed. These tests assert the endpoint's
+`total` equals an independent ground-truth count for every viewer type AND that any
+explicit filter falls back to the exact count (i.e. the fast path is never wrongly
+applied). Correctness here is data-independent, so it holds on the small test DB.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import get_password_hash
+from app.models.image import Images
+from app.models.user import Users
+
+VISIBLE = [-1, 1, 2]  # REPOST, ACTIVE, SPOILER (PUBLIC_IMAGE_STATUSES)
+
+
+async def _user(db, username, show_all=0):
+    u = Users(
+        username=username,
+        password=get_password_hash("TestPassword123!"),
+        password_type="bcrypt",
+        salt="",
+        email=f"{username}@example.com",
+        active=1,
+        show_all_images=show_all,
+    )
+    db.add(u)
+    await db.commit()
+    await db.refresh(u)
+    return u
+
+
+async def _img(db, owner, md5, status):
+    img = Images(
+        filename="fc",
+        ext="jpg",
+        md5_hash=md5,
+        user_id=owner.user_id,
+        width=10,
+        height=10,
+        filesize=100,
+        status=status,
+    )
+    db.add(img)
+    await db.commit()
+    return img
+
+
+async def _login(client, username):
+    r = await client.post("/api/v1/auth/login", json={"username": username, "password": "TestPassword123!"})
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+async def _ground_truth(db: AsyncSession, where=None) -> int:
+    q = select(func.count()).select_from(Images)
+    if where is not None:
+        q = q.where(where)
+    return (await db.execute(q)).scalar() or 0
+
+
+async def _seed(db, a, b):
+    # a: 2 visible (active, spoiler) + 2 hidden (deactivated, review)
+    await _img(db, a, "a" * 32, 1)
+    await _img(db, a, "a1" + "0" * 30, 2)
+    await _img(db, a, "a2" + "0" * 30, 0)
+    await _img(db, a, "a3" + "0" * 30, -4)
+    # b: 3 visible (active, active, repost) + 1 hidden (deactivated)
+    await _img(db, b, "b" * 32, 1)
+    await _img(db, b, "b1" + "0" * 30, 1)
+    await _img(db, b, "b2" + "0" * 30, -1)
+    await _img(db, b, "b3" + "0" * 30, 0)
+
+
+@pytest.mark.api
+class TestFastFeedCount:
+    async def test_bare_feed_total_matches_ground_truth_all_viewers(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        a = await _user(db_session, "fcA", show_all=0)
+        b = await _user(db_session, "fcB", show_all=0)
+        await _seed(db_session, a, b)
+
+        # Anonymous: only public statuses.
+        expected_anon = await _ground_truth(db_session, Images.status.in_(VISIBLE))
+        r = await client.get("/api/v1/images/?per_page=1")
+        assert r.json()["total"] == expected_anon
+
+        # Logged-in, show_all=0: public OR own (incl. own hidden).
+        expected_a = await _ground_truth(
+            db_session, or_(Images.status.in_(VISIBLE), Images.user_id == a.user_id)
+        )
+        token = await _login(client, a.username)
+        r = await client.get("/api/v1/images/?per_page=1", headers={"Authorization": f"Bearer {token}"})
+        assert r.json()["total"] == expected_a
+        # sanity: a has hidden images, so this strictly exceeds the anon total
+        assert expected_a > expected_anon
+
+    async def test_bare_feed_show_all_counts_everything(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        a = await _user(db_session, "fcShowAll", show_all=1)
+        b = await _user(db_session, "fcShowAllB", show_all=0)
+        await _seed(db_session, a, b)
+
+        expected_all = await _ground_truth(db_session)
+        token = await _login(client, a.username)
+        r = await client.get("/api/v1/images/?per_page=1", headers={"Authorization": f"Bearer {token}"})
+        assert r.json()["total"] == expected_all
+
+    async def test_explicit_filters_fall_back_to_exact_count(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        # show_all=1 viewer so a content filter composes cleanly with no visibility OR.
+        viewer = await _user(db_session, "fcFilterV", show_all=1)
+        b = await _user(db_session, "fcFilterB", show_all=0)
+        await _seed(db_session, viewer, b)
+        token = await _login(client, viewer.username)
+        h = {"Authorization": f"Bearer {token}"}
+
+        # Explicit status overrides visibility entirely -> exact count of that status,
+        # NOT the whole-feed fast count. (Guards against the fast path wrongly applying.)
+        expected_deact = await _ground_truth(db_session, Images.status == 0)
+        assert expected_deact > 0
+        r = await client.get("/api/v1/images/?status=0&per_page=1", headers=h)
+        assert r.json()["total"] == expected_deact
+
+        # Uploader filter under show_all=1 -> exact count for that user (no visibility OR).
+        expected_b = await _ground_truth(db_session, Images.user_id == b.user_id)
+        r = await client.get(f"/api/v1/images/?user_id={b.user_id}&per_page=1", headers=h)
+        assert r.json()["total"] == expected_b
+
+
+@pytest.mark.api
+class TestFeedCountCache:
+    async def test_global_counts_cached_within_ttl(self, db_session: AsyncSession, redis_client):
+        """The two global counts are TTL-cached (no per-mutation invalidation): a new
+        image isn't reflected until the entry expires or is cleared. Also guards the
+        str<->int round-trip through Redis."""
+        from app.services.feed_count_cache import _KEY_HIDDEN, _KEY_TOTAL, get_feed_counts
+
+        await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN)
+        try:
+            a = await _user(db_session, "fcCache", show_all=0)
+            await _img(db_session, a, "c" * 32, 1)
+            await _img(db_session, a, "c1" + "0" * 30, 0)
+
+            total1, hidden1 = await get_feed_counts(db_session, redis_client)
+            assert isinstance(total1, int) and isinstance(hidden1, int)  # parsed back from str
+
+            # New image is NOT reflected while the cache is warm (TTL, no invalidation).
+            await _img(db_session, a, "c2" + "0" * 30, 1)
+            assert await get_feed_counts(db_session, redis_client) == (total1, hidden1)
+
+            # Once the entry is gone, a recompute picks the new image up.
+            await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN)
+            total3, _h = await get_feed_counts(db_session, redis_client)
+            assert total3 == total1 + 1
+        finally:
+            await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN)


### PR DESCRIPTION
## Problem
With **Show all images** off, the `/` feed's pagination `COUNT(*)` is `count(status IN visible OR user_id=me)` — that matches ~99% of rows, and no index can serve the OR, so it's a **full clustered scan** (~2.6s cold on 1.1M images on the under-provisioned test box; the reported slow feed).

## Fix
For the **bare** default feed (no content filter — only the implicit visibility filter), compute the total from the small *hidden* complement instead:

```
total = count(all) − count(hidden AND not-mine)
      = count(visible) + count(viewer's own hidden)
```

`count(hidden)` is `status NOT IN PUBLIC` — a ~1% `idx_status` range, not a scan. The two **global** counts (`count(all)`, `count(hidden)`) are the same for every viewer, so they're **TTL-cached (60s)** in Redis; the per-viewer *own-hidden* slice is queried live. **Any explicit filter** (tags/status/user/date/…) falls back to the exact subquery count.

### Staleness (deliberate)
TTL-only — no per-mutation invalidation. The total can lag a create/delete/visible↔hidden change by **≤ the TTL** (`FEED_COUNT_TTL`, 60s). For a pagination counter over a 1.1M-row feed that's a non-issue, and it avoids threading Redis invalidation through every mutation path. New images still appear on the feed immediately (the row `SELECT` is live; only the *count* is cached).

## Benchmark — `scripts/bench_feed_count.py`
```
                              before       after     speedup
logged-in show_all=0         163.9ms      93.2ms       1.8x   (warm, table in RAM)
anonymous                     98.1ms      75.5ms       1.3x
naive OR plan : ALL / (no index) / 1,002,885 rows   ← full clustered scan
hidden  plan  : range / idx_status / 30,399 rows
```
Cold (table > buffer pool — the actual reported condition) the same `show_all=0` count was measured at **2,613ms → ~183ms (≈14×)**. Cache hits drop it to single-digit ms.

## Tests
- Equivalence: endpoint `total` == independent ground-truth count for anon / show_all=0 (with own hidden) / show_all=1, **and** filters fall back to the exact count (guards against the fast path wrongly applying).
- Real-Redis cache round-trip + TTL-staleness behavior.

Addresses the "Perf (deferred)" item in todo.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)