### PR TITLE
feat: per-user hide_reposts setting

### DIFF
--- a/alembic/versions/6ff85692cb26_add_hide_reposts_to_users.py
+++ b/alembic/versions/6ff85692cb26_add_hide_reposts_to_users.py
@@ -1,0 +1,34 @@
+"""add hide_reposts to users
+
+Revision ID: 6ff85692cb26
+Revises: 1cdaf1ec0250
+Create Date: 2026-06-05 22:14:59.531115
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6ff85692cb26'
+down_revision: str | Sequence[str] | None = '1cdaf1ec0250'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the hide_reposts preference column (0=show reposts, 1=hide). INSTANT/NONE for zero-downtime."""
+    op.execute(
+        "ALTER TABLE users ADD COLUMN hide_reposts TINYINT(1) NOT NULL DEFAULT 0, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )
+
+
+def downgrade() -> None:
+    """Drop the hide_reposts column."""
+    op.execute(
+        "ALTER TABLE users DROP COLUMN hide_reposts, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )

--- a/alembic/versions/6ff85692cb26_add_hide_reposts_to_users.py
+++ b/alembic/versions/6ff85692cb26_add_hide_reposts_to_users.py
@@ -8,7 +8,6 @@ Create Date: 2026-06-05 22:14:59.531115
 from typing import Sequence
 
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -470,6 +470,13 @@ async def list_images(
                 # Anonymous: only public statuses
                 query = query.where(Images.status.in_(PUBLIC_IMAGE_STATUSES))  # type: ignore[attr-defined]
 
+        # hide_reposts preference — applied in the no-explicit-status branch, outside the
+        # show_all sub-block so it covers both show_all=0 and show_all=1. This is a global
+        # exclusion (not ownership-aware), so the viewer's own reposts are dropped too.
+        # An explicit ?status= takes the other branch and overrides this.
+        if current_user is not None and current_user.hide_reposts == 1:
+            query = query.where(Images.status != ImageStatus.REPOST)  # type: ignore[arg-type]
+
     # Tag filtering
     tag_ids: list[int] = []
     if tags:

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -297,13 +297,16 @@ async def _default_feed_total(
     hide_reposts = current_user is not None and current_user.hide_reposts == 1
 
     # show_all_images=1: every image counts (minus reposts if the viewer hides them).
+    # max(0, ...): the three cached counts are separate queries, so a concurrent mutation
+    # between them could momentarily make repost_count exceed the base — clamp so the
+    # pagination total never goes negative.
     if current_user is not None and current_user.show_all_images == 1:
-        return total_all - (repost_count if hide_reposts else 0)
+        return max(0, total_all - (repost_count if hide_reposts else 0))
 
     visible_count = total_all - hidden_count  # count(PUBLIC) = active + spoiler + repost
     if hide_reposts:
         # All reposts are public/global, so this also removes the viewer's own reposts.
-        visible_count -= repost_count
+        visible_count = max(0, visible_count - repost_count)
 
     # Logged-in + show_all=0: also count the viewer's own (hidden) images. Equality on
     # user_id (not `!= me`) keeps NULL-owner rows correct.
@@ -840,7 +843,7 @@ async def random_images_page(
         )
 
     if current_user is not None and current_user.hide_reposts == 1:
-        count_query = count_query.where(Images.status != ImageStatus.REPOST)
+        count_query = count_query.where(Images.status != ImageStatus.REPOST)  # type: ignore[arg-type]
 
     result = await db.execute(count_query)
     total = result.scalar() or 0
@@ -2010,7 +2013,7 @@ async def get_bookmark_page(
         )
 
     if hide_reposts:
-        count_query = count_query.where(Images.status != ImageStatus.REPOST)
+        count_query = count_query.where(Images.status != ImageStatus.REPOST)  # type: ignore[arg-type]
 
     result = await db.execute(count_query)
     position = result.scalar() or 0

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -835,6 +835,9 @@ async def random_images_page(
             Images.status.in_(PUBLIC_IMAGE_STATUSES)  # type: ignore[attr-defined]
         )
 
+    if current_user is not None and current_user.hide_reposts == 1:
+        count_query = count_query.where(Images.status != ImageStatus.REPOST)
+
     result = await db.execute(count_query)
     total = result.scalar() or 0
 

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -293,13 +293,17 @@ async def _default_feed_total(
     the visibility filter in list_images exactly:
     show_all_images=1 => no filter; anonymous => public only; otherwise public + own.
     """
-    total_all, hidden_count = await get_feed_counts(db, redis_client)
+    total_all, hidden_count, repost_count = await get_feed_counts(db, redis_client)
+    hide_reposts = current_user is not None and current_user.hide_reposts == 1
 
-    # show_all_images=1: no visibility filter at all — every image counts.
+    # show_all_images=1: every image counts (minus reposts if the viewer hides them).
     if current_user is not None and current_user.show_all_images == 1:
-        return total_all
+        return total_all - (repost_count if hide_reposts else 0)
 
-    visible_count = total_all - hidden_count
+    visible_count = total_all - hidden_count  # count(PUBLIC) = active + spoiler + repost
+    if hide_reposts:
+        # All reposts are public/global, so this also removes the viewer's own reposts.
+        visible_count -= repost_count
 
     # Logged-in + show_all=0: also count the viewer's own (hidden) images. Equality on
     # user_id (not `!= me`) keeps NULL-owner rows correct.
@@ -316,7 +320,7 @@ async def _default_feed_total(
         ).scalar() or 0
         return visible_count + my_hidden_count
 
-    # Anonymous: public statuses only.
+    # Anonymous: public statuses only (anonymous users have no hide_reposts).
     return visible_count
 
 

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1924,19 +1924,21 @@ async def get_bookmark_page(
 
     # Build the same filter as list_images uses
     show_all = current_user.show_all_images == 1
+    hide_reposts = current_user.hide_reposts == 1
     images_per_page = current_user.images_per_page or 15
 
-    # Check if bookmark is visible under user's settings
-    # If not visible, return page: null (bookmark exists but won't appear in list)
-    if not show_all:
-        is_public = bookmark_image.status in PUBLIC_IMAGE_STATUSES
-        is_own_image = bookmark_image.user_id == current_user.user_id
-        if not is_public and not is_own_image:
-            return BookmarkPageResponse(
-                page=None,
-                image_id=bookmark_id,
-                images_per_page=images_per_page,
-            )
+    # Bookmark not visible under the user's settings -> page: null
+    is_public = bookmark_image.status in PUBLIC_IMAGE_STATUSES
+    is_own_image = bookmark_image.user_id == current_user.user_id
+    is_repost = bookmark_image.status == ImageStatus.REPOST
+    hidden_by_visibility = (not show_all) and (not is_public) and (not is_own_image)
+    hidden_by_repost_pref = hide_reposts and is_repost
+    if hidden_by_visibility or hidden_by_repost_pref:
+        return BookmarkPageResponse(
+            page=None,
+            image_id=bookmark_id,
+            images_per_page=images_per_page,
+        )
 
     # Get sort column and direction from user preferences
     sort_field = current_user.sorting_pref or "image_id"
@@ -2002,6 +2004,9 @@ async def get_bookmark_page(
                 Images.user_id == current_user.user_id,  # type: ignore[arg-type]
             )
         )
+
+    if hide_reposts:
+        count_query = count_query.where(Images.status != ImageStatus.REPOST)
 
     result = await db.execute(count_query)
     position = result.scalar() or 0

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -921,7 +921,7 @@ async def get_tag(
                 Images,
                 TagLinks.image_id == Images.image_id,  # type: ignore[arg-type]
             )
-        count_query = count_query.where(Images.status != ImageStatus.REPOST)  # type: ignore[attr-defined]
+        count_query = count_query.where(Images.status != ImageStatus.REPOST)  # type: ignore[arg-type]
     count_result = await db.execute(count_query)
     total_image_count = count_result.scalar()
 

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
 
 from app.api.dependencies import ImageSortParams, PaginationParams, TagSortParams
-from app.config import TagAuditActionType, TagType
+from app.config import ImageStatus, TagAuditActionType, TagType
 from app.core.auth import get_current_user, get_optional_current_user
 from app.core.database import get_db
 from app.core.permission_deps import require_permission
@@ -889,16 +889,19 @@ async def get_tag(
     tag_hierarchy = await get_tag_hierarchy(db, resolved_tag_id)
 
     # Count images tagged with any tag in the hierarchy
-    # Respect user's show_all_images setting (matches image search behavior)
+    # Respect user's show_all_images and hide_reposts settings (matches image search behavior)
     show_all = current_user is not None and current_user.show_all_images == 1
+    hide_reposts = current_user is not None and current_user.hide_reposts == 1
     count_query = select(func.count(TagLinks.image_id.distinct())).where(  # type: ignore[attr-defined]
         TagLinks.tag_id.in_(tag_hierarchy)  # type: ignore[attr-defined]
     )
+    joined = False
     if not show_all:
         count_query = count_query.join(
             Images,
             TagLinks.image_id == Images.image_id,  # type: ignore[arg-type]
         )
+        joined = True
         if current_user is not None:
             # Logged in: public statuses OR user's own images (any status)
             count_query = count_query.where(
@@ -912,6 +915,13 @@ async def get_tag(
             count_query = count_query.where(
                 Images.status.in_(PUBLIC_IMAGE_STATUSES)  # type: ignore[attr-defined]
             )
+    if hide_reposts:
+        if not joined:
+            count_query = count_query.join(
+                Images,
+                TagLinks.image_id == Images.image_id,  # type: ignore[arg-type]
+            )
+        count_query = count_query.where(Images.status != ImageStatus.REPOST)  # type: ignore[attr-defined]
     count_result = await db.execute(count_query)
     total_image_count = count_result.scalar()
 

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -691,7 +691,7 @@ async def get_user_images(
         query = query.where(Images.status.in_(PUBLIC_IMAGE_STATUSES))  # type: ignore[attr-defined]
 
     if current_user is not None and current_user.hide_reposts == 1:
-        query = query.where(Images.status != ImageStatus.REPOST)
+        query = query.where(Images.status != ImageStatus.REPOST)  # type: ignore[arg-type]
 
     # Count total
     count_query = select(func.count()).select_from(query.subquery())
@@ -810,7 +810,7 @@ async def get_user_favorites(
         query = query.where(Images.status.in_(PUBLIC_IMAGE_STATUSES))  # type: ignore[attr-defined]
 
     if current_user is not None and current_user.hide_reposts == 1:
-        query = query.where(Images.status != ImageStatus.REPOST)
+        query = query.where(Images.status != ImageStatus.REPOST)  # type: ignore[arg-type]
 
     # Count total
     count_query = select(func.count()).select_from(query.subquery())

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -27,7 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.api.dependencies import ImageSortParams, PaginationParams, UserSortParams
-from app.config import SuspensionAction, settings
+from app.config import ImageStatus, SuspensionAction, settings
 from app.core.auth import (
     get_client_ip,
     get_current_user,
@@ -690,6 +690,9 @@ async def get_user_images(
     else:
         query = query.where(Images.status.in_(PUBLIC_IMAGE_STATUSES))  # type: ignore[attr-defined]
 
+    if current_user is not None and current_user.hide_reposts == 1:
+        query = query.where(Images.status != ImageStatus.REPOST)
+
     # Count total
     count_query = select(func.count()).select_from(query.subquery())
     total_result = await db.execute(count_query)
@@ -805,6 +808,9 @@ async def get_user_favorites(
         )
     else:
         query = query.where(Images.status.in_(PUBLIC_IMAGE_STATUSES))  # type: ignore[attr-defined]
+
+    if current_user is not None and current_user.hide_reposts == 1:
+        query = query.where(Images.status != ImageStatus.REPOST)
 
     # Count total
     count_query = select(func.count()).select_from(query.subquery())

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -173,6 +173,7 @@ class Users(UserBase, table=True):
     sorting_pref_order: str = Field(default="DESC", max_length=10)
     images_per_page: int = Field(default=20)
     show_all_images: int = Field(default=0)
+    hide_reposts: int = Field(default=0)
     # Theme preferences (nullable — NULL means "no explicit preference,
     # frontend default applies"). theme_preset is validated against an
     # allowlist at the API layer (see app/schemas/user.py).

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -50,6 +50,7 @@ class UserUpdate(BaseModel):
 
     # User settings
     show_all_images: int | None = None
+    hide_reposts: int | None = None
     spoiler_warning_pref: int | None = None
 
     # Display preferences
@@ -90,7 +91,9 @@ class UserUpdate(BaseModel):
             raise ValueError("Gender must be 50 characters or less")
         return v
 
-    @field_validator("email_pm_pref", "show_all_images", "spoiler_warning_pref", "thumb_layout")
+    @field_validator(
+        "email_pm_pref", "show_all_images", "hide_reposts", "spoiler_warning_pref", "thumb_layout"
+    )
     @classmethod
     def validate_boolean_prefs(cls, v: int | None) -> int | None:
         """Validate boolean preference fields are 0 or 1"""
@@ -220,6 +223,7 @@ class UserPrivateResponse(UserResponse):
 
     # User settings
     show_all_images: int  # Show disabled/pending images (0=no, 1=yes)
+    hide_reposts: int  # Hide reposts from listings (0=no, 1=yes)
     spoiler_warning_pref: int  # Show spoiler warnings (0=disabled, 1=enabled)
 
     # Display preferences

--- a/app/services/feed_count_cache.py
+++ b/app/services/feed_count_cache.py
@@ -1,17 +1,19 @@
 """TTL-cached global image counts for the default-feed pagination total.
 
 ``list_images`` computes the bare default-feed total as ``count(visible) + count(my
-own hidden)``, where ``count(visible) = count(all) - count(hidden)``. The two global
-counts (``count(all)`` and ``count(hidden)``) are the same for every viewer, so we
-cache them with a short TTL rather than recomputing per request. The cached total can
-lag an image create/delete/status-change by up to the TTL — a non-issue for a
-pagination counter over a million-row feed, and not worth the invalidation coupling.
+own hidden)``, where ``count(visible) = count(all) - count(hidden)``. The three global
+counts (``count(all)``, ``count(hidden)``, and ``count(repost)``) are the same for
+every viewer, so we cache them with a short TTL rather than recomputing per request.
+The cached total can lag an image create/delete/status-change by up to the TTL — a
+non-issue for a pagination counter over a million-row feed, and not worth the
+invalidation coupling.
 """
 
 import redis.asyncio as redis
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import ImageStatus
 from app.models.image import Images
 from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 
@@ -21,23 +23,28 @@ FEED_COUNT_TTL = 60
 
 _KEY_TOTAL = "feed:count:total"
 _KEY_HIDDEN = "feed:count:hidden"
+_KEY_REPOST = "feed:count:repost"
 
 
 async def get_feed_counts(
     db: AsyncSession,
     redis_client: redis.Redis | None = None,  # type: ignore[type-arg]
-) -> tuple[int, int]:
-    """Return ``(count_all, count_hidden)``, cache-backed when a Redis client is given.
+) -> tuple[int, int, int]:
+    """Return ``(count_all, count_hidden, count_repost)``, cache-backed when a client is given.
 
-    On a cache hit returns the stored values; on a miss (or no client) computes both
-    from the DB and caches them. ``status NOT IN PUBLIC`` is index-backed (idx_status),
-    so the miss path is still cheap relative to the naive OR scan.
+    On a cache hit returns the stored values; on a miss (or no client) computes all
+    three from the DB and caches them. ``status NOT IN PUBLIC`` is index-backed
+    (idx_status), so the miss path is still cheap relative to the naive OR scan.
+    The ``status == REPOST`` equality scan hits the same index, so it is equally cheap.
     """
     if redis_client is not None:
+        # Three separate .get() calls (not .mget): the test mock_redis stubs .get but not
+        # .mget, so .mget would silently miss the cache in tests.
         cached_total = await redis_client.get(_KEY_TOTAL)
         cached_hidden = await redis_client.get(_KEY_HIDDEN)
-        if cached_total is not None and cached_hidden is not None:
-            return int(cached_total), int(cached_hidden)
+        cached_repost = await redis_client.get(_KEY_REPOST)
+        if cached_total is not None and cached_hidden is not None and cached_repost is not None:
+            return int(cached_total), int(cached_hidden), int(cached_repost)
 
     total = (await db.execute(select(func.count()).select_from(Images))).scalar() or 0
     hidden = (
@@ -47,9 +54,15 @@ async def get_feed_counts(
             .where(Images.status.notin_(PUBLIC_IMAGE_STATUSES))  # type: ignore[attr-defined]
         )
     ).scalar() or 0
+    repost = (
+        await db.execute(
+            select(func.count()).select_from(Images).where(Images.status == ImageStatus.REPOST)  # type: ignore[attr-defined]
+        )
+    ).scalar() or 0
 
     if redis_client is not None:
         await redis_client.setex(_KEY_TOTAL, FEED_COUNT_TTL, total)
         await redis_client.setex(_KEY_HIDDEN, FEED_COUNT_TTL, hidden)
+        await redis_client.setex(_KEY_REPOST, FEED_COUNT_TTL, repost)
 
-    return total, hidden
+    return total, hidden, repost

--- a/app/services/feed_count_cache.py
+++ b/app/services/feed_count_cache.py
@@ -56,7 +56,7 @@ async def get_feed_counts(
     ).scalar() or 0
     repost = (
         await db.execute(
-            select(func.count()).select_from(Images).where(Images.status == ImageStatus.REPOST)  # type: ignore[attr-defined]
+            select(func.count()).select_from(Images).where(Images.status == ImageStatus.REPOST)  # type: ignore[arg-type]
         )
     ).scalar() or 0
 

--- a/tests/api/v1/test_feed_count.py
+++ b/tests/api/v1/test_feed_count.py
@@ -9,9 +9,10 @@ applied). Correctness here is data-independent, so it holds on the small test DB
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import func, or_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import ImageStatus
 from app.core.security import get_password_hash
 from app.models.image import Images
 from app.models.user import Users
@@ -22,7 +23,7 @@ from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 VISIBLE = sorted(PUBLIC_IMAGE_STATUSES)
 
 
-async def _user(db, username, show_all=0):
+async def _user(db, username, show_all=0, hide_reposts=0):
     u = Users(
         username=username,
         password=get_password_hash("TestPassword123!"),
@@ -31,6 +32,7 @@ async def _user(db, username, show_all=0):
         email=f"{username}@example.com",
         active=1,
         show_all_images=show_all,
+        hide_reposts=hide_reposts,
     )
     db.add(u)
     await db.commit()
@@ -139,30 +141,88 @@ class TestFastFeedCount:
         assert r.json()["total"] == expected_b
 
 
+    async def test_bare_feed_total_excludes_reposts_for_hide_reposts_viewer(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        a = await _user(db_session, "fcHRa", show_all=0)
+        b = await _user(db_session, "fcHRb", show_all=0)
+        await _seed(db_session, a, b)  # b owns exactly 1 repost (status -1)
+        viewer = await _user(db_session, "fcHRview", show_all=0, hide_reposts=1)
+
+        expected = await _ground_truth(
+            db_session,
+            and_(
+                or_(Images.status.in_(VISIBLE), Images.user_id == viewer.user_id),
+                Images.status != ImageStatus.REPOST,
+            ),
+        )
+        token = await _login(client, viewer.username)
+        r = await client.get("/api/v1/images/?per_page=1", headers={"Authorization": f"Bearer {token}"})
+        assert r.json()["total"] == expected
+
+        # Sanity: hiding reposts strictly reduces the total (the seed has a repost).
+        expected_no_hide = await _ground_truth(
+            db_session, or_(Images.status.in_(VISIBLE), Images.user_id == viewer.user_id)
+        )
+        assert expected < expected_no_hide
+
+    async def test_own_repost_not_double_counted_for_hide_reposts(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        owner = await _user(db_session, "fcOwnRep", show_all=0, hide_reposts=1)
+        await _img(db_session, owner, "or0" + "0" * 29, 1)   # own active (visible)
+        await _img(db_session, owner, "or1" + "1" * 29, -1)  # own repost (public, hidden by pref)
+        await _img(db_session, owner, "or2" + "2" * 29, 0)   # own deactivated (hidden, but own -> visible)
+
+        expected = await _ground_truth(
+            db_session,
+            and_(
+                or_(Images.status.in_(VISIBLE), Images.user_id == owner.user_id),
+                Images.status != ImageStatus.REPOST,
+            ),
+        )
+        token = await _login(client, owner.username)
+        r = await client.get("/api/v1/images/?per_page=1", headers={"Authorization": f"Bearer {token}"})
+        assert r.json()["total"] == expected
+
+
 @pytest.mark.api
 class TestFeedCountCache:
     async def test_global_counts_cached_within_ttl(self, db_session: AsyncSession, redis_client):
-        """The two global counts are TTL-cached (no per-mutation invalidation): a new
+        """The three global counts are TTL-cached (no per-mutation invalidation): a new
         image isn't reflected until the entry expires or is cleared. Also guards the
         str<->int round-trip through Redis."""
-        from app.services.feed_count_cache import _KEY_HIDDEN, _KEY_TOTAL, get_feed_counts
+        from app.services.feed_count_cache import _KEY_HIDDEN, _KEY_REPOST, _KEY_TOTAL, get_feed_counts
 
-        await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN)
+        await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN, _KEY_REPOST)
         try:
             a = await _user(db_session, "fcCache", show_all=0)
             await _img(db_session, a, "c" * 32, 1)
             await _img(db_session, a, "c1" + "0" * 30, 0)
 
-            total1, hidden1 = await get_feed_counts(db_session, redis_client)
-            assert isinstance(total1, int) and isinstance(hidden1, int)  # parsed back from str
+            total1, hidden1, repost1 = await get_feed_counts(db_session, redis_client)
+            assert isinstance(total1, int) and isinstance(hidden1, int) and isinstance(repost1, int)  # parsed back from str
 
             # New image is NOT reflected while the cache is warm (TTL, no invalidation).
             await _img(db_session, a, "c2" + "0" * 30, 1)
-            assert await get_feed_counts(db_session, redis_client) == (total1, hidden1)
+            assert await get_feed_counts(db_session, redis_client) == (total1, hidden1, repost1)
 
             # Once the entry is gone, a recompute picks the new image up.
-            await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN)
-            total3, _h = await get_feed_counts(db_session, redis_client)
+            await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN, _KEY_REPOST)
+            total3, _h, _r = await get_feed_counts(db_session, redis_client)
             assert total3 == total1 + 1
         finally:
-            await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN)
+            await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN, _KEY_REPOST)
+
+    async def test_feed_counts_include_repost_count(self, db_session: AsyncSession, redis_client):
+        from app.services.feed_count_cache import _KEY_HIDDEN, _KEY_REPOST, _KEY_TOTAL, get_feed_counts
+
+        await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN, _KEY_REPOST)
+        try:
+            u = await _user(db_session, "fcRepost", show_all=0)
+            await _img(db_session, u, "fr0" + "0" * 29, 1)   # active
+            await _img(db_session, u, "fr1" + "1" * 29, -1)  # repost
+            total, hidden, repost = await get_feed_counts(db_session, redis_client)
+            assert isinstance(repost, int) and repost >= 1
+        finally:
+            await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN, _KEY_REPOST)

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -4177,3 +4177,31 @@ class TestHideReposts:
         viewer = await self._user(db_session, "hr_exp", show_all=0, hide_reposts=1)
         data = (await client.get("/api/v1/images?status=-1", headers=self._hdr(viewer))).json()
         assert {i["filename"] for i in data["images"]} == {"repost_img"}
+
+    async def test_random_excludes_reposts_when_hiding(self, client, db_session):
+        from app.config import ImageStatus
+        owner = await self._user(db_session, "hr_rand_owner")
+        viewer = await self._user(db_session, "hr_rand", show_all=0, hide_reposts=1)
+        for i in range(3):
+            db_session.add(Images(filename=f"r_rep{i}", ext="jpg", md5_hash=f"rr{i:030d}",
+                                  user_id=owner.user_id, width=10, height=10, filesize=100,
+                                  status=ImageStatus.REPOST))
+        await db_session.commit()
+        # Only reposts exist; with hide_reposts the visible count is 0 -> /random 404s.
+        resp = await client.get("/api/v1/images/random?per_page=1",
+                                headers=self._hdr(viewer), follow_redirects=False)
+        assert resp.status_code == 404
+
+    async def test_random_counts_reposts_when_not_hiding(self, client, db_session):
+        from app.config import ImageStatus
+        owner = await self._user(db_session, "hr_rand_owner2")
+        viewer = await self._user(db_session, "hr_rand2", show_all=0, hide_reposts=0)
+        for i in range(3):
+            db_session.add(Images(filename=f"r2_rep{i}", ext="jpg", md5_hash=f"rs{i:030d}",
+                                  user_id=owner.user_id, width=10, height=10, filesize=100,
+                                  status=ImageStatus.REPOST))
+        await db_session.commit()
+        # Control: reposts are public, so without hiding they ARE counted -> a page exists.
+        resp = await client.get("/api/v1/images/random?per_page=1",
+                                headers=self._hdr(viewer), follow_redirects=False)
+        assert resp.status_code == 302

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -4205,3 +4205,60 @@ class TestHideReposts:
         resp = await client.get("/api/v1/images/random?per_page=1",
                                 headers=self._hdr(viewer), follow_redirects=False)
         assert resp.status_code == 302
+
+    async def test_repost_bookmark_returns_null_page(self, client, db_session):
+        from app.config import ImageStatus
+        viewer = await self._user(db_session, "hr_bm", show_all=0, hide_reposts=1)
+        rep = Images(filename="bm_rep", ext="jpg", md5_hash="bm" + "0" * 30,
+                     user_id=viewer.user_id, width=10, height=10, filesize=100,
+                     status=ImageStatus.REPOST)
+        db_session.add(rep)
+        await db_session.commit()
+        await db_session.refresh(rep)
+        viewer.bookmark = rep.image_id
+        await db_session.commit()
+        data = (await client.get("/api/v1/images/bookmark/page", headers=self._hdr(viewer))).json()
+        assert data["page"] is None
+
+    async def test_bookmark_position_excludes_reposts_when_hiding(self, client, db_session):
+        from app.config import ImageStatus
+        owner = await self._user(db_session, "hr_bm_pos_owner")
+        viewer = await self._user(db_session, "hr_bm_pos", show_all=0, hide_reposts=1)
+        viewer.images_per_page = 2
+        bm = Images(filename="bm_active", ext="jpg", md5_hash="bp" + "0" * 30,
+                    user_id=owner.user_id, width=10, height=10, filesize=100,
+                    status=ImageStatus.ACTIVE)
+        db_session.add(bm)
+        await db_session.commit()
+        await db_session.refresh(bm)
+        # 3 reposts created AFTER bm -> higher image_ids -> sort BEFORE bm in DESC order.
+        for i in range(3):
+            db_session.add(Images(filename=f"bp_rep{i}", ext="jpg", md5_hash=f"bq{i:030d}",
+                                  user_id=owner.user_id, width=10, height=10, filesize=100,
+                                  status=ImageStatus.REPOST))
+        viewer.bookmark = bm.image_id
+        await db_session.commit()
+        # hide_reposts: the 3 reposts before bm aren't counted -> position 0 -> page 1.
+        data = (await client.get("/api/v1/images/bookmark/page", headers=self._hdr(viewer))).json()
+        assert data["page"] == 1
+
+    async def test_bookmark_position_counts_reposts_when_not_hiding(self, client, db_session):
+        from app.config import ImageStatus
+        owner = await self._user(db_session, "hr_bm_pos_owner2")
+        viewer = await self._user(db_session, "hr_bm_pos2", show_all=0, hide_reposts=0)
+        viewer.images_per_page = 2
+        bm = Images(filename="bm_active2", ext="jpg", md5_hash="bp2" + "0" * 29,
+                    user_id=owner.user_id, width=10, height=10, filesize=100,
+                    status=ImageStatus.ACTIVE)
+        db_session.add(bm)
+        await db_session.commit()
+        await db_session.refresh(bm)
+        for i in range(3):
+            db_session.add(Images(filename=f"bp2_rep{i}", ext="jpg", md5_hash=f"bz{i:030d}",
+                                  user_id=owner.user_id, width=10, height=10, filesize=100,
+                                  status=ImageStatus.REPOST))
+        viewer.bookmark = bm.image_id
+        await db_session.commit()
+        # Control: reposts counted -> 3 before bm -> position 3 -> page ceil(4/2)=2.
+        data = (await client.get("/api/v1/images/bookmark/page", headers=self._hdr(viewer))).json()
+        assert data["page"] == 2

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -4092,3 +4092,88 @@ class TestImageUserListsIncludeGroups:
         entry = next(u for u in response.json()["users"] if u["username"] == "rate_grp_user")
         assert "groups" in entry
         assert "Admins" in entry["groups"]
+
+
+@pytest.mark.api
+class TestHideReposts:
+    """hide_reposts removes status=-1 from listings; explicit status overrides."""
+
+    async def _seed(self, db, owner_id=None):
+        # owner defaults to a separate user so ownership rules don't explain the
+        # results — matrix tests must exercise the PUBLIC-status path, not own-image.
+        from app.config import ImageStatus
+        from app.core.security import get_password_hash
+        if owner_id is None:
+            owner = Users(username="hr_seed_owner", password=get_password_hash("TestPassword123!"),
+                          password_type="bcrypt", salt="", email="hr_seed_owner@test.com", active=1)
+            db.add(owner)
+            await db.commit()
+            await db.refresh(owner)
+            owner_id = owner.user_id
+        rows = [
+            (ImageStatus.ACTIVE, "active_img"),
+            (ImageStatus.SPOILER, "spoiler_img"),
+            (ImageStatus.REPOST, "repost_img"),
+            (ImageStatus.REVIEW, "review_img"),
+            (ImageStatus.DEACTIVATED, "deact_img"),
+        ]
+        for i, (st, fn) in enumerate(rows):
+            db.add(Images(filename=fn, ext="jpg", md5_hash=f"hr{i:030d}",
+                          user_id=owner_id, width=10, height=10, filesize=100, status=st))
+        await db.commit()
+
+    async def _user(self, db, name, show_all=0, hide_reposts=0):
+        from app.core.security import get_password_hash
+        u = Users(username=name, password=get_password_hash("TestPassword123!"),
+                  password_type="bcrypt", salt="", email=f"{name}@test.com",
+                  active=1, show_all_images=show_all, hide_reposts=hide_reposts)
+        db.add(u)
+        await db.commit()
+        await db.refresh(u)
+        return u
+
+    def _hdr(self, user):
+        from app.core.security import create_access_token
+        return {"Authorization": f"Bearer {create_access_token(user.user_id)}"}
+
+    async def test_show_all_0_hide_0_shows_repost(self, client, db_session):
+        await self._seed(db_session)  # images owned by a separate user (not the viewer)
+        viewer = await self._user(db_session, "hr_a_view", show_all=0, hide_reposts=0)
+        data = (await client.get("/api/v1/images", headers=self._hdr(viewer))).json()
+        fns = {i["filename"] for i in data["images"]}
+        assert {"active_img", "spoiler_img", "repost_img"} <= fns
+
+    async def test_show_all_0_hide_1_hides_repost(self, client, db_session):
+        await self._seed(db_session)
+        viewer = await self._user(db_session, "hr_b_view", show_all=0, hide_reposts=1)
+        data = (await client.get("/api/v1/images", headers=self._hdr(viewer))).json()
+        fns = {i["filename"] for i in data["images"]}
+        assert "repost_img" not in fns
+        assert {"active_img", "spoiler_img"} <= fns
+
+    async def test_show_all_1_hide_1_hides_only_repost(self, client, db_session):
+        await self._seed(db_session)
+        viewer = await self._user(db_session, "hr_c_view", show_all=1, hide_reposts=1)
+        data = (await client.get("/api/v1/images", headers=self._hdr(viewer))).json()
+        fns = {i["filename"] for i in data["images"]}
+        assert "repost_img" not in fns
+        assert {"active_img", "spoiler_img", "review_img", "deact_img"} <= fns
+
+    async def test_show_all_1_hide_0_shows_everything(self, client, db_session):
+        await self._seed(db_session)
+        viewer = await self._user(db_session, "hr_d_view", show_all=1, hide_reposts=0)
+        data = (await client.get("/api/v1/images", headers=self._hdr(viewer))).json()
+        fns = {i["filename"] for i in data["images"]}
+        assert {"active_img", "spoiler_img", "repost_img", "review_img", "deact_img"} <= fns
+
+    async def test_own_repost_is_hidden(self, client, db_session):
+        viewer = await self._user(db_session, "hr_own", show_all=0, hide_reposts=1)
+        await self._seed(db_session, viewer.user_id)  # reposts owned by the viewer
+        data = (await client.get("/api/v1/images", headers=self._hdr(viewer))).json()
+        assert "repost_img" not in {i["filename"] for i in data["images"]}
+
+    async def test_explicit_status_repost_overrides_hide(self, client, db_session):
+        await self._seed(db_session)
+        viewer = await self._user(db_session, "hr_exp", show_all=0, hide_reposts=1)
+        data = (await client.get("/api/v1/images?status=-1", headers=self._hdr(viewer))).json()
+        assert {i["filename"] for i in data["images"]} == {"repost_img"}

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -1595,6 +1595,101 @@ class TestGetTag:
         # 2 public (ACTIVE + SPOILER) + 1 own non-public = 3
         assert data["total_image_count"] == 3
 
+    async def test_total_image_count_hide_reposts_excludes_reposts(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """hide_reposts=1 (show_all=0) excludes REPOST images from total_image_count."""
+        from app.config import ImageStatus
+        from app.core.security import create_access_token
+
+        user = Users(
+            username="hidereposts_user",
+            email="hidereposts@test.com",
+            password=get_password_hash("Password123!"),
+            password_type="bcrypt",
+            salt="",
+            show_all_images=0,
+            hide_reposts=1,
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        tag = Tags(title="Hide Reposts Count Tag", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.flush()
+
+        statuses = [ImageStatus.ACTIVE, ImageStatus.ACTIVE, ImageStatus.SPOILER, ImageStatus.REPOST]
+        for i, status_val in enumerate(statuses):
+            img_data = sample_image_data.copy()
+            img_data.update({
+                "filename": f"hidereposts-{i}",
+                "md5_hash": f"hidereposts{i:015d}",
+                "status": status_val,
+            })
+            img = Images(**img_data)
+            db_session.add(img)
+            await db_session.flush()
+            db_session.add(TagLinks(tag_id=tag.tag_id, image_id=img.image_id))
+        await db_session.commit()
+
+        token = create_access_token(user.user_id)
+        response = await client.get(
+            f"/api/v1/tags/{tag.tag_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        # 2 ACTIVE + 1 SPOILER; the REPOST is excluded by hide_reposts.
+        assert response.json()["total_image_count"] == 3
+
+    async def test_total_image_count_show_all_with_hide_reposts(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """show_all_images=1 + hide_reposts=1: sees all statuses EXCEPT repost. Exercises the
+        join-added-by-hide_reposts path (show_all skips its own join)."""
+        from app.config import ImageStatus
+        from app.core.security import create_access_token
+
+        user = Users(
+            username="showall_hide_user",
+            email="showall_hide@test.com",
+            password=get_password_hash("Password123!"),
+            password_type="bcrypt",
+            salt="",
+            show_all_images=1,
+            hide_reposts=1,
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        tag = Tags(title="Show All Hide Reposts Tag", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.flush()
+
+        statuses = [ImageStatus.ACTIVE, ImageStatus.OTHER, ImageStatus.REPOST]
+        for i, status_val in enumerate(statuses):
+            img_data = sample_image_data.copy()
+            img_data.update({
+                "filename": f"showallhide-{i}",
+                "md5_hash": f"showallhide{i:015d}",
+                "status": status_val,
+            })
+            img = Images(**img_data)
+            db_session.add(img)
+            await db_session.flush()
+            db_session.add(TagLinks(tag_id=tag.tag_id, image_id=img.image_id))
+        await db_session.commit()
+
+        token = create_access_token(user.user_id)
+        response = await client.get(
+            f"/api/v1/tags/{tag.tag_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        # ACTIVE + OTHER visible (show_all), REPOST excluded by hide_reposts = 2
+        assert response.json()["total_image_count"] == 2
+
 
 @pytest.mark.api
 class TestGetImagesByTag:

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -1198,6 +1198,71 @@ class TestGetUserImages:
         data = response.json()
         assert data["total"] == 2
 
+    async def test_user_images_excludes_reposts_for_hide_reposts_viewer(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """A hide_reposts viewer doesn't see another user's reposts in their gallery."""
+        from app.core.security import create_access_token
+
+        subject = Users(username="hrg_subject", password=get_password_hash("TestPassword123!"),
+                        password_type="bcrypt", salt="", email="hrg_subject@test.com", active=1)
+        viewer = Users(username="hrg_viewer", password=get_password_hash("TestPassword123!"),
+                       password_type="bcrypt", salt="", email="hrg_viewer@test.com", active=1,
+                       hide_reposts=1)
+        db_session.add(subject)
+        db_session.add(viewer)
+        await db_session.commit()
+        await db_session.refresh(subject)
+        await db_session.refresh(viewer)
+
+        for name, status_val in [("active", 1), ("repost", -1), ("spoiler", 2)]:
+            data = sample_image_data.copy()
+            data["filename"] = f"hrg-{name}"
+            data["md5_hash"] = f"hrgi{name:0<20s}"
+            data["user_id"] = subject.user_id
+            data["status"] = status_val
+            db_session.add(Images(**data))
+        await db_session.commit()
+
+        token = create_access_token(viewer.user_id)
+        response = await client.get(f"/api/v1/users/{subject.user_id}/images",
+                                    headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert {img["status"] for img in data["images"]} == {1, 2}  # active + spoiler, no repost
+
+    async def test_user_images_hides_own_reposts(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """hide_reposts hides the viewer's OWN reposts but keeps own non-repost non-public images."""
+        from app.core.security import create_access_token
+
+        viewer = Users(username="hrg_own", password=get_password_hash("TestPassword123!"),
+                       password_type="bcrypt", salt="", email="hrg_own@test.com", active=1,
+                       hide_reposts=1)
+        db_session.add(viewer)
+        await db_session.commit()
+        await db_session.refresh(viewer)
+
+        for name, status_val in [("active", 1), ("repost", -1), ("review", -4)]:
+            data = sample_image_data.copy()
+            data["filename"] = f"hrgo-{name}"
+            data["md5_hash"] = f"hrgo{name:0<20s}"
+            data["user_id"] = viewer.user_id
+            data["status"] = status_val
+            db_session.add(Images(**data))
+        await db_session.commit()
+
+        token = create_access_token(viewer.user_id)
+        response = await client.get(f"/api/v1/users/{viewer.user_id}/images",
+                                    headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 200
+        data = response.json()
+        # own active (public) + own review (own non-public) visible; own repost hidden.
+        assert data["total"] == 2
+        assert {img["status"] for img in data["images"]} == {1, -4}
+
 
 @pytest.mark.api
 class TestGetUserFavorites:
@@ -1286,6 +1351,49 @@ class TestGetUserFavorites:
         data = response.json()
         assert data["total"] == 1
         assert data["images"][0]["status"] == 1
+
+    async def test_user_favorites_excludes_reposts_for_hide_reposts_viewer(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """A hide_reposts viewer doesn't see reposts in another user's favorites."""
+        from app.core.security import create_access_token
+
+        subject = Users(username="hrf_subject", password=get_password_hash("TestPassword123!"),
+                        password_type="bcrypt", salt="", email="hrf_subject@test.com", active=1)
+        viewer = Users(username="hrf_viewer", password=get_password_hash("TestPassword123!"),
+                       password_type="bcrypt", salt="", email="hrf_viewer@test.com", active=1,
+                       hide_reposts=1)
+        db_session.add(subject)
+        db_session.add(viewer)
+        await db_session.commit()
+        await db_session.refresh(subject)
+        await db_session.refresh(viewer)
+
+        active_data = sample_image_data.copy()
+        active_data.update({"filename": "hrf-active", "md5_hash": "hrfactive" + "0" * 15,
+                            "status": 1, "user_id": subject.user_id})
+        active_img = Images(**active_data)
+        repost_data = sample_image_data.copy()
+        repost_data.update({"filename": "hrf-repost", "md5_hash": "hrfrepost" + "0" * 15,
+                            "status": -1, "user_id": subject.user_id})
+        repost_img = Images(**repost_data)
+        db_session.add(active_img)
+        db_session.add(repost_img)
+        await db_session.commit()
+        await db_session.refresh(active_img)
+        await db_session.refresh(repost_img)
+
+        db_session.add(Favorites(user_id=subject.user_id, image_id=active_img.image_id))
+        db_session.add(Favorites(user_id=subject.user_id, image_id=repost_img.image_id))
+        await db_session.commit()
+
+        token = create_access_token(viewer.user_id)
+        response = await client.get(f"/api/v1/users/{subject.user_id}/favorites",
+                                    headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["images"][0]["status"] == 1  # active, repost excluded
 
 
 @pytest.mark.api

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -17,7 +17,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.security import get_password_hash
+from app.core.security import create_access_token, get_password_hash
 from app.models.favorite import Favorites
 from app.models.image import Images
 from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
@@ -2894,3 +2894,48 @@ class TestUserGroups:
         # Verify groups is empty list, not missing
         assert "groups" in data
         assert data["groups"] == []
+
+
+@pytest.mark.api
+class TestHideRepostsSetting:
+    """Tests for hide_reposts preference field."""
+
+    async def test_patch_persists_hide_reposts(self, client: AsyncClient, db_session: AsyncSession):
+        user = Users(
+            username="hr_persist", password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt", salt="", email="hr_persist@test.com", active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        token = create_access_token(user.user_id)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        me = await client.get("/api/v1/users/me", headers=headers)
+        assert me.json()["hide_reposts"] == 0
+
+        resp = await client.patch("/api/v1/users/me", json={"hide_reposts": 1}, headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["hide_reposts"] == 1
+
+        me2 = await client.get("/api/v1/users/me", headers=headers)
+        assert me2.json()["hide_reposts"] == 1
+
+        await db_session.refresh(user)
+        assert user.hide_reposts == 1
+
+    async def test_hide_reposts_rejects_non_boolean(self, client: AsyncClient, db_session: AsyncSession):
+        user = Users(
+            username="hr_valid", password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt", salt="", email="hr_valid@test.com", active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        token = create_access_token(user.user_id)
+
+        resp = await client.patch(
+            "/api/v1/users/me", json={"hide_reposts": 2},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Adds a per-user, opt-in `hide_reposts` setting (default `0`) that removes reposts (image status `-1`) from listings. It is **orthogonal** to `show_all_images`: a user can see moderated images while hiding reposts, or vice-versa.

Reposts are a *public* status (`PUBLIC_IMAGE_STATUSES = {REPOST, ACTIVE, SPOILER}`), so today every user sees them. This is a new capability, not a re-wiring of `show_all_images`.

**Changes**
- `users.hide_reposts` column (additive, non-locking `ALGORITHM=INSTANT, LOCK=NONE` migration, default 0) + `UserUpdate`/`UserPrivateResponse` schema + 0/1 validator.
- Residual `status != REPOST` filter (default-visibility path only; explicit `?status=` overrides; top-level so own reposts go too) at the **7 inline visibility sites**:
  - `list_images`, `random_images_page` count, `get_bookmark_page` (null page for a repost bookmark + position count), tag `total_image_count` (conditional `Images` join), and the two `/users/{id}/images|favorites` galleries.
  - **Feed-count cache rework** (`feed_count_cache.py`): `get_feed_counts` now returns a third cached `count(status == REPOST)` so the fast default-feed total can subtract reposts; own reposts subtracted exactly once; `hide_reposts=0` behavior is byte-identical to before.

## Test plan
- [x] 4-cell `show_all × hide_reposts` matrix on `list_images`; own-repost hidden; explicit `?status=-1` still returns reposts.
- [x] `/random` count (paired hiding/not-hiding controls); bookmark null-page + position count; tag count (incl. the `show_all=1` join path); feed-count triple + own-not-double-counted + cache TTL round-trip; both galleries (other-user and own reposts).
- [x] PATCH `/users/me` persists `hide_reposts`; rejects non-0/1 with 422.
- [x] Full suite: **362 passed, 1 skipped**.
- [x] Migration applies cleanly to head; `downgrade()` drops the column.

## Out of scope (follow-up)
`GET /tags/{id}/images` (`get_images_by_tag`) takes no `current_user` and applies **no** visibility filter at all — a pre-existing leak that publicly exposes hidden/deactivated images. Unrelated to reposts; worth its own security ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)