### PR TITLE
feat(images): reported=true filter for list_images (mods only)

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -308,6 +308,7 @@ class _FeedFilters:
     commenter: int | None = None
     commentsearch: str | None = None
     hascomments: bool | None = None
+    reported: bool | None = None
 
 
 async def _default_feed_total(
@@ -443,6 +444,13 @@ async def list_images(
     hascomments: Annotated[
         bool | None,
         Query(description="Filter to images that have comments (true) or no comments (false)"),
+    ] = None,
+    reported: Annotated[
+        bool | None,
+        Query(
+            description="Filter to images with a pending report. Requires report_view; "
+            "ignored for other viewers."
+        ),
     ] = None,
     db: AsyncSession = Depends(get_db),
     current_user: Users | None = Depends(get_optional_current_user),
@@ -702,6 +710,25 @@ async def list_images(
         # Filter to images WITHOUT comments using posts counter
         query = query.where(Images.posts == 0)  # type: ignore[arg-type]
 
+    # Reported filtering: restrict to images that have a PENDING report. Mods only
+    # (REPORT_VIEW) so it never leaks the triage queue — silently a no-op for everyone else.
+    apply_reported = (
+        bool(reported)
+        and current_user is not None
+        and current_user.user_id is not None
+        and await has_any_permission(
+            db, current_user.user_id, [Permission.REPORT_VIEW], redis_client
+        )
+    )
+    if apply_reported:
+        query = query.where(
+            Images.image_id.in_(  # type: ignore[union-attr]
+                select(ImageReports.image_id).where(  # type: ignore[call-overload]
+                    ImageReports.status == ReportStatus.PENDING
+                )
+            )
+        )
+
     # Count total results. For the *bare* default feed (no content filter — only the
     # implicit visibility filter), count(visible OR mine) is a full-table scan; use the
     # fast hidden-complement count instead. ANY explicit filter falls back to the exact
@@ -725,6 +752,7 @@ async def list_images(
         commenter=commenter,
         commentsearch=commentsearch,
         hascomments=hascomments,
+        reported=apply_reported or None,
     )
     # Bare feed = every content filter empty. One comparison, so a field added to
     # _FeedFilters is covered automatically. Falsy strings (e.g. tags="") normalize to

--- a/tests/api/v1/test_feed_count.py
+++ b/tests/api/v1/test_feed_count.py
@@ -294,4 +294,5 @@ class TestFeedFilters:
             "commenter",
             "commentsearch",
             "hascomments",
+            "reported",
         }

--- a/tests/api/v1/test_open_report_flag.py
+++ b/tests/api/v1/test_open_report_flag.py
@@ -102,3 +102,67 @@ class TestHasOpenReportFlag:
         items = r.json()["images"]
         match = [i for i in items if i["image_id"] == reported.image_id]
         assert match and match[0]["has_open_report"] is True
+
+
+@pytest.mark.api
+class TestReportedFilter:
+    """`?reported=true` restricts list_images to pending-reported images — mods only."""
+
+    async def test_mod_filters_to_reported_images(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        owner = await _make_user(db_session, "repfowner")
+        reported = await _image(db_session, owner, "d" * 32)
+        clean = await _image(db_session, owner, "e" * 32)
+        db_session.add(
+            ImageReports(
+                image_id=reported.image_id,
+                user_id=owner.user_id,
+                category=2,
+                status=ReportStatus.PENDING,
+            )
+        )
+        await db_session.commit()
+
+        mod = await _make_user(db_session, "repfmod")
+        await _grant(db_session, mod.user_id, "report_view")
+        token = await _login(client, mod.username)
+
+        r = await client.get(
+            "/api/v1/images/?reported=true&per_page=100",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        ids = {i["image_id"] for i in r.json()["images"]}
+        assert reported.image_id in ids
+        assert clean.image_id not in ids
+
+    async def test_non_mod_reported_param_is_a_noop(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        owner = await _make_user(db_session, "repfplainowner")
+        reported = await _image(db_session, owner, "f" * 32)
+        clean = await _image(db_session, owner, "a1" + "0" * 30)
+        db_session.add(
+            ImageReports(
+                image_id=reported.image_id,
+                user_id=owner.user_id,
+                category=2,
+                status=ReportStatus.PENDING,
+            )
+        )
+        await db_session.commit()
+
+        plain = await _make_user(db_session, "repfplain")
+        token = await _login(client, plain.username)
+
+        # No report_view -> the filter is silently ignored (never leaks the queue),
+        # so both public images come back.
+        r = await client.get(
+            "/api/v1/images/?reported=true&per_page=100",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        ids = {i["image_id"] for i in r.json()["images"]}
+        assert reported.image_id in ids
+        assert clean.image_id in ids


### PR DESCRIPTION
## Summary

Backend for searching **reported images** (the frontend piece — a "Reported" option in the
search status builder — is a follow-up PR).

- New optional `reported` query param on `GET /images`. When **`true` AND the viewer has
  `REPORT_VIEW`**, the list is restricted to images with a *pending* report:
  `image_id IN (SELECT image_id FROM image_reports WHERE status = PENDING)`.
- For any other viewer the param is **silently a no-op** — it never reveals which images
  have open reports (the moderation triage queue stays mod-only). Reuses the same cached
  `REPORT_VIEW` check the existing `has_open_report` flag uses.
- Added `reported` to `_FeedFilters` so the bare-feed fast count correctly falls back to
  the exact count when the filter is active (and updated the field-set guard test — the
  whole point of that dataclass).

## Test plan
- [x] `TestReportedFilter`: a `report_view` mod with `?reported=true` gets only the reported
  image; a regular user with `?reported=true` gets everything (filter ignored, no leak).
- [x] `_FeedFilters` field-set guard updated for the new field.
- [x] `mypy app/` clean, `ruff` clean, `test_open_report_flag.py` + `test_feed_count.py` 14/14.

## Follow-up
Frontend: a `report_view`-gated "Reported" checkbox in the search status builder that emits
a `reported` chip/param, wired through chip-search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)