### PR TITLE
feat(tags): log description changes to the tag audit log

### DIFF
--- a/alembic/versions/f6ca8c400ab8_add_description_columns_to_tag_audit_log.py
+++ b/alembic/versions/f6ca8c400ab8_add_description_columns_to_tag_audit_log.py
@@ -1,0 +1,36 @@
+"""add description columns to tag_audit_log
+
+Revision ID: f6ca8c400ab8
+Revises: 6ff85692cb26
+Create Date: 2026-06-08 14:36:59.594209
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f6ca8c400ab8'
+down_revision: str | Sequence[str] | None = '6ff85692cb26'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add old_desc/new_desc columns so description edits can be audit-logged."""
+    op.add_column(
+        "tag_audit_log",
+        sa.Column("old_desc", sa.String(length=200), nullable=True),
+    )
+    op.add_column(
+        "tag_audit_log",
+        sa.Column("new_desc", sa.String(length=200), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("tag_audit_log", "new_desc")
+    op.drop_column("tag_audit_log", "old_desc")

--- a/app/api/v1/history.py
+++ b/app/api/v1/history.py
@@ -142,6 +142,8 @@ async def get_user_history(
             new_title=audit_log.new_title,
             old_type=audit_log.old_type,
             new_type=audit_log.new_type,
+            old_desc=audit_log.old_desc,
+            new_desc=audit_log.new_desc,
             created_at=timestamp,
             alias_tag=linked_tags_map.get(alias_target_id) if alias_target_id else None,
             parent_tag=linked_tags_map.get(parent_target_id) if parent_target_id else None,

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1038,7 +1038,7 @@ async def get_tag_history(
     Get tag metadata change history.
 
     Returns paginated list of all metadata changes (renames, type changes,
-    alias changes, inheritance changes, character-source links).
+    description changes, alias changes, inheritance changes, character-source links).
     """
     # Verify tag exists
     tag_result = await db.execute(select(Tags).where(Tags.tag_id == tag_id))  # type: ignore[arg-type]

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1126,6 +1126,8 @@ async def get_tag_history(
             new_title=audit.new_title,
             old_type=audit.old_type,
             new_type=audit.new_type,
+            old_desc=audit.old_desc,
+            new_desc=audit.new_desc,
             old_alias_of=audit.old_alias_of,
             new_alias_of=audit.new_alias_of,
             old_parent_id=audit.old_parent_id,
@@ -1320,6 +1322,7 @@ async def update_tag(
     # Store original values for audit logging
     original_title = tag.title
     original_type = tag.type
+    original_desc = tag.desc
     original_alias_of = tag.alias_of
     original_inheritedfrom_id = tag.inheritedfrom_id
 
@@ -1363,6 +1366,17 @@ async def update_tag(
             action_type=TagAuditActionType.RENAME,
             old_title=original_title,
             new_title=tag.title,
+            user_id=current_user.user_id,
+        )
+        db.add(audit_entry)
+
+    # Check for description change
+    if tag.desc != original_desc:
+        audit_entry = TagAuditLog(
+            tag_id=tag_id,
+            action_type=TagAuditActionType.DESCRIPTION_CHANGE,
+            old_desc=original_desc,
+            new_desc=tag.desc,
             user_id=current_user.user_id,
         )
         db.add(audit_entry)

--- a/app/config.py
+++ b/app/config.py
@@ -366,6 +366,7 @@ class TagAuditActionType:
 
     RENAME = "rename"
     TYPE_CHANGE = "type_change"
+    DESCRIPTION_CHANGE = "description_change"
     ALIAS_SET = "alias_set"
     ALIAS_REMOVED = "alias_removed"
     PARENT_SET = "parent_set"

--- a/app/models/tag_audit_log.py
+++ b/app/models/tag_audit_log.py
@@ -37,6 +37,10 @@ class TagAuditLogBase(SQLModel):
     old_type: int | None = Field(default=None)
     new_type: int | None = Field(default=None)
 
+    # Description change fields (max_length mirrors Tags.desc)
+    old_desc: str | None = Field(default=None, max_length=200)
+    new_desc: str | None = Field(default=None, max_length=200)
+
     # Alias change fields (FK to tags.tag_id)
     old_alias_of: int | None = Field(default=None)
     new_alias_of: int | None = Field(default=None)

--- a/app/models/tag_audit_log.py
+++ b/app/models/tag_audit_log.py
@@ -4,6 +4,7 @@ SQLModel-based TagAuditLog model for tracking tag metadata changes.
 This module tracks all changes to tag metadata including:
 - Renames (title changes)
 - Type changes
+- Description changes
 - Alias changes (setting/removing alias_of)
 - Inheritance changes (setting/removing parent)
 - Character-source link changes

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -42,6 +42,10 @@ class TagAuditLogResponse(BaseModel):
     old_type: int | None = None
     new_type: int | None = None
 
+    # Description change fields
+    old_desc: str | None = None
+    new_desc: str | None = None
+
     # Alias change fields
     old_alias_of: int | None = None
     new_alias_of: int | None = None
@@ -253,6 +257,10 @@ class UserHistoryItem(BaseModel):
     # For tag_metadata: type_change action
     old_type: int | None = None
     new_type: int | None = None
+
+    # For tag_metadata: description_change action
+    old_desc: str | None = None
+    new_desc: str | None = None
 
     # For tag_metadata: the *other* tag involved in the action. Populated per
     # action_type — alias_set/alias_removed → alias_tag, parent_set/parent_removed

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -223,8 +223,9 @@ class UserHistoryItem(BaseModel):
     The exact fields present depend on the `type` field:
 
     - tag_metadata: action_type, tag, old_title/new_title (for rename),
-      old_type/new_type (for type_change), alias_tag/parent_tag/source_tag/
-      character_tag (for the corresponding link/unlink actions), created_at
+      old_type/new_type (for type_change), old_desc/new_desc (for
+      description_change), alias_tag/parent_tag/source_tag/character_tag
+      (for the corresponding link/unlink actions), created_at
     - tag_usage: action, tag, image_id, date
     - status_change: image_id, old_status, new_status, new_status_label, created_at
     """

--- a/tests/api/v1/test_tag_audit_log.py
+++ b/tests/api/v1/test_tag_audit_log.py
@@ -165,6 +165,159 @@ class TestTagAuditLogRename:
 
 
 @pytest.mark.api
+class TestTagAuditLogDescriptionChange:
+    """Tests for tag description-change audit logging."""
+
+    async def test_description_change_creates_audit_log_entry(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Editing a tag's description creates a DESCRIPTION_CHANGE entry with old/new."""
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        admin = Users(
+            username="descadmin",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="descadmin@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        user_perm = UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1)
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        tag = Tags(title="stable name", desc="old description", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "descadmin", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        update_data = {
+            "title": "stable name",
+            "desc": "new description",
+            "type": TagType.THEME,
+        }
+        response = await client.put(
+            f"/api/v1/tags/{tag.tag_id}",
+            json=update_data,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+
+        audit_result = await db_session.execute(
+            select(TagAuditLog).where(
+                TagAuditLog.tag_id == tag.tag_id,
+                TagAuditLog.action_type == TagAuditActionType.DESCRIPTION_CHANGE,
+            )
+        )
+        audit_entries = audit_result.scalars().all()
+
+        assert len(audit_entries) == 1
+        entry = audit_entries[0]
+        assert entry.old_desc == "old description"
+        assert entry.new_desc == "new description"
+        assert entry.user_id == admin.user_id
+
+    async def test_same_description_creates_no_audit_log(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Updating a tag without changing its description logs no DESCRIPTION_CHANGE."""
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        admin = Users(
+            username="descadmin2",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="descadmin2@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        user_perm = UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1)
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        tag = Tags(title="old name", desc="same description", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "descadmin2", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Change only the title; the description stays the same.
+        update_data = {
+            "title": "new name",
+            "desc": "same description",
+            "type": TagType.THEME,
+        }
+        response = await client.put(
+            f"/api/v1/tags/{tag.tag_id}",
+            json=update_data,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+
+        audit_result = await db_session.execute(
+            select(TagAuditLog).where(
+                TagAuditLog.tag_id == tag.tag_id,
+                TagAuditLog.action_type == TagAuditActionType.DESCRIPTION_CHANGE,
+            )
+        )
+        audit_entries = audit_result.scalars().all()
+        assert len(audit_entries) == 0
+
+    async def test_history_endpoint_returns_description_change(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """GET /tags/{id}/history surfaces a description_change with old_desc/new_desc."""
+        tag = Tags(title="some tag", desc="new description", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        audit = TagAuditLog(
+            tag_id=tag.tag_id,
+            action_type=TagAuditActionType.DESCRIPTION_CHANGE,
+            old_desc="old description",
+            new_desc="new description",
+        )
+        db_session.add(audit)
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}/history")
+        assert response.status_code == 200
+
+        items = [i for i in response.json()["items"] if i["action_type"] == "description_change"]
+        assert len(items) == 1
+        assert items[0]["old_desc"] == "old description"
+        assert items[0]["new_desc"] == "new description"
+
+
+@pytest.mark.api
 class TestTagAuditLogTypeChange:
     """Tests for tag type change audit logging."""
 

--- a/tests/api/v1/test_tag_audit_log.py
+++ b/tests/api/v1/test_tag_audit_log.py
@@ -140,7 +140,9 @@ class TestTagAuditLogRename:
         )
         access_token = login_response.json()["access_token"]
 
-        # Update tag without changing name (only description)
+        # Update tag without changing name (only the description). The description
+        # change now emits its own DESCRIPTION_CHANGE entry; this test deliberately
+        # asserts only that no RENAME entry is created.
         update_data = {
             "title": "unchanged name",
             "desc": "new description",
@@ -315,6 +317,67 @@ class TestTagAuditLogDescriptionChange:
         assert len(items) == 1
         assert items[0]["old_desc"] == "old description"
         assert items[0]["new_desc"] == "new description"
+
+    async def test_adding_description_from_none_logs_old_desc_null(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Setting a description on a tag that had none logs old_desc=None → new."""
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        admin = Users(
+            username="descadmin3",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="descadmin3@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        user_perm = UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1)
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        # Tag created with no description.
+        tag = Tags(title="no desc tag", desc=None, type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "descadmin3", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        update_data = {
+            "title": "no desc tag",
+            "desc": "now it has one",
+            "type": TagType.THEME,
+        }
+        response = await client.put(
+            f"/api/v1/tags/{tag.tag_id}",
+            json=update_data,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+
+        audit_result = await db_session.execute(
+            select(TagAuditLog).where(
+                TagAuditLog.tag_id == tag.tag_id,
+                TagAuditLog.action_type == TagAuditActionType.DESCRIPTION_CHANGE,
+            )
+        )
+        entries = audit_result.scalars().all()
+        assert len(entries) == 1
+        assert entries[0].old_desc is None
+        assert entries[0].new_desc == "now it has one"
 
 
 @pytest.mark.api

--- a/tests/api/v1/test_user_history_endpoint.py
+++ b/tests/api/v1/test_user_history_endpoint.py
@@ -87,6 +87,51 @@ class TestGetUserHistory:
         assert item["new_title"] == "Cirno"
         assert item["created_at"] is not None
 
+    async def test_returns_description_change_items_correctly(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """Should return description_change items with old_desc/new_desc (parity)."""
+        user = Users(
+            username="histdescuser",
+            password="hashed",
+            password_type="bcrypt",
+            salt="",
+            email="histdesc@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        tag = Tags(title="Cirno", type=TagType.CHARACTER)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        audit_log = TagAuditLog(
+            tag_id=tag.tag_id,
+            user_id=user.user_id,
+            action_type=TagAuditActionType.DESCRIPTION_CHANGE,
+            old_desc="the strongest",
+            new_desc="the strongest ice fairy",
+        )
+        db_session.add(audit_log)
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/users/{user.user_id}/history")
+        assert response.status_code == 200
+
+        items = [
+            item
+            for item in response.json()["items"]
+            if item["type"] == "tag_metadata" and item["action_type"] == "description_change"
+        ]
+        assert len(items) == 1
+        item = items[0]
+        assert item["old_desc"] == "the strongest"
+        assert item["new_desc"] == "the strongest ice fairy"
+        assert item["tag"]["tag_id"] == tag.tag_id
+
     async def test_returns_tag_usage_items_correctly(
         self, client: AsyncClient, db_session: AsyncSession
     ) -> None:


### PR DESCRIPTION
## Summary

Tag descriptions (`Tags.desc`) are editable via `PUT /tags/{id}` (the edit form sends `desc`), but the change was never recorded — the audit log only diffed title, type, alias, and parent. A description edit silently changed the tag with no history trace.

This adds a `description_change` action, following the existing rename pattern at every layer:

- **Migration + model** — `old_desc` / `new_desc` columns on `tag_audit_log` (`VARCHAR(200)`, matching `Tags.desc`).
- **`config.py`** — `TagAuditActionType.DESCRIPTION_CHANGE`.
- **`update_tag`** — capture `original_desc`, write a `description_change` entry when `tag.desc` changes (mirrors the rename block).
- **Schemas + builders** — `old_desc`/`new_desc` on `TagAuditLogResponse` (per-tag `GET /tags/{id}/history`) and `UserHistoryItem` (combined user-history feed), wired in both response builders for parity with the other tag metadata actions.

## Test Plan

- [x] New `TestTagAuditLogDescriptionChange`: a desc change logs one entry (old/new/user); no entry when desc is unchanged; `GET /tags/{id}/history` returns `old_desc`/`new_desc`.
- [x] New `test_returns_description_change_items_correctly` in the user-history endpoint tests (parity).
- [x] Full API suite: **1741 passed, 9 skipped**.
- [x] mypy clean on changed modules; ruff clean (migration is under the existing `alembic/versions` exclude).

The frontend (display in `old → new` format with truncation, on both the tag history page and the user history page) lands in a follow-up PR once these types are published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)