### PR TITLE
feat(images): show upload tags in image tag-history (read-side merge)

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1362,6 +1362,13 @@ async def get_image_tags(image_id: int, db: AsyncSession = Depends(get_db)) -> I
     )
 
 
+# Safety ceiling on tag_history rows loaded for a single image's history. The merge
+# pages in memory, and per-image churn is tiny in practice (well under this), so this
+# only guards a pathological image from loading an unbounded change log. If ever hit,
+# the oldest history events beyond the cap are dropped (most-recent-first).
+_IMAGE_TAG_HISTORY_CAP = 5000
+
+
 @router.get("/{image_id}/tag-history", response_model=ImageTagHistoryListResponse)
 async def get_image_tag_history(
     image_id: Annotated[int, Path(description="Image ID")],
@@ -1409,12 +1416,18 @@ async def get_image_tag_history(
 
     # tag_history → removals, plus the adds of tags that are no longer linked. Adds
     # of currently-linked tags are skipped: tag_links already represents them.
+    # Capped to the most-recent rows as a safety ceiling (see _IMAGE_TAG_HISTORY_CAP).
     hist_result = await db.execute(
         select(TagHistory, Tags, Users)
         .join(Tags, TagHistory.tag_id == Tags.tag_id)  # type: ignore[arg-type]
         .outerjoin(Users, TagHistory.user_id == Users.user_id)  # type: ignore[arg-type]
         .options(group_load)
         .where(TagHistory.image_id == image_id)  # type: ignore[arg-type]
+        .order_by(
+            desc(TagHistory.date),  # type: ignore[arg-type]
+            desc(TagHistory.tag_history_id),  # type: ignore[arg-type]
+        )
+        .limit(_IMAGE_TAG_HISTORY_CAP)
     )
     hist_rows = hist_result.all()
 
@@ -1449,8 +1462,14 @@ async def get_image_tag_history(
         )
 
     for history, tag, user in hist_rows:
+        # Skip add-history for a tag that's currently linked — the tag_link above
+        # already represents it. Edge case: for an add → remove → re-add tag (now
+        # linked again), this drops the ORIGINAL add too, so the timeline shows the
+        # current link's add + the removal but not the first add. Accepted as rare;
+        # do not "fix" by removing this skip without also de-duping vs tag_links, or
+        # currently-linked tags double-count.
         if history.action == "a" and history.tag_id in linked_tag_ids:
-            continue  # already represented by its tag_link above
+            continue
         events.append(
             (
                 history.date or epoch,

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1418,16 +1418,23 @@ async def get_image_tag_history(
     )
     hist_rows = hist_result.all()
 
-    # Merge in memory (event count is bounded by an image's tag count) and sort by
-    # date desc, then a stable tiebreak. Both date columns default to
-    # current_timestamp; the aware sentinel keeps the sort total if one is null.
+    # Merge in memory and sort by date desc, then a deterministic tiebreak. The
+    # row count loaded here is bounded by the image's own tag activity (its current
+    # tag_links plus its tag_history rows), which is small in practice — the same
+    # load-all-then-sort approach the user-history endpoint uses. The tiebreak is
+    # (source, id): tag_id for link events vs tag_history_id for history events live
+    # in separate ordinal lanes (0/1) so identical timestamps still order the same
+    # way across requests (the two id spaces are unrelated and could collide).
+    # Both date columns default to current_timestamp; the aware sentinel keeps the
+    # sort total if one is ever null.
     epoch = datetime(1, 1, 1, tzinfo=UTC)
-    events: list[tuple[datetime, int, ImageTagHistoryResponse]] = []
+    events: list[tuple[datetime, int, int, ImageTagHistoryResponse]] = []
 
     for link, tag, user in link_rows:
         events.append(
             (
                 link.date_linked or epoch,
+                0,  # source lane: link events
                 link.tag_id or 0,
                 ImageTagHistoryResponse(
                     tag_history_id=None,
@@ -1447,6 +1454,7 @@ async def get_image_tag_history(
         events.append(
             (
                 history.date or epoch,
+                1,  # source lane: history events
                 history.tag_history_id or 0,
                 ImageTagHistoryResponse(
                     tag_history_id=history.tag_history_id,
@@ -1460,11 +1468,11 @@ async def get_image_tag_history(
             )
         )
 
-    events.sort(key=lambda e: (e[0], e[1]), reverse=True)
+    events.sort(key=lambda e: (e[0], e[1], e[2]), reverse=True)
 
     total = len(events)
     start = pagination.offset
-    items = [event[2] for event in events[start : start + pagination.per_page]]
+    items = [event[3] for event in events[start : start + pagination.per_page]]
 
     return ImageTagHistoryListResponse(
         total=total,

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1371,67 +1371,100 @@ async def get_image_tag_history(
     """
     Get tag history for an image.
 
-    Returns paginated list of tags that were added or removed from this image.
+    Returns a paginated, most-recent-first list of tag add/remove events. "Added"
+    events are derived from the image's current tag_links — they carry who/when for
+    every tag still on the image, including tags set at upload that were never
+    written to tag_history. tag_history supplies removals and the adds of tags that
+    are no longer linked, so removed tags keep their full story.
     """
     # Verify image exists
     image_result = await db.execute(select(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
     if not image_result.scalar_one_or_none():
         raise HTTPException(status_code=404, detail="Image not found")
 
-    # Query tag history with joined tag and user info
-    # Eager load user groups for UserSummary
-    query = (
+    group_load = selectinload(Users.user_groups).selectinload(UserGroups.group)  # type: ignore[arg-type]
+
+    def to_summary(user: Users | None) -> UserSummary | None:
+        if user is None or user.user_id is None:
+            return None
+        return UserSummary(
+            user_id=user.user_id,
+            username=user.username,
+            avatar=user.avatar,
+            avatar_in_r2=user.avatar_in_r2,
+            user_title=user.user_title,
+            groups=user.groups,
+        )
+
+    # Current tag_links → "added" events. Authoritative for every tag still present.
+    links_result = await db.execute(
+        select(TagLinks, Tags, Users)
+        .join(Tags, TagLinks.tag_id == Tags.tag_id)  # type: ignore[arg-type]
+        .outerjoin(Users, TagLinks.user_id == Users.user_id)  # type: ignore[arg-type]
+        .options(group_load)
+        .where(TagLinks.image_id == image_id)  # type: ignore[arg-type]
+    )
+    link_rows = links_result.all()
+    linked_tag_ids = {link.tag_id for link, _, _ in link_rows}
+
+    # tag_history → removals, plus the adds of tags that are no longer linked. Adds
+    # of currently-linked tags are skipped: tag_links already represents them.
+    hist_result = await db.execute(
         select(TagHistory, Tags, Users)
         .join(Tags, TagHistory.tag_id == Tags.tag_id)  # type: ignore[arg-type]
         .outerjoin(Users, TagHistory.user_id == Users.user_id)  # type: ignore[arg-type]
-        .options(
-            selectinload(Users.user_groups).selectinload(UserGroups.group)  # type: ignore[arg-type]
-        )
+        .options(group_load)
         .where(TagHistory.image_id == image_id)  # type: ignore[arg-type]
     )
+    hist_rows = hist_result.all()
 
-    # Count total
-    count_query = select(func.count()).select_from(query.subquery())
-    total = (await db.execute(count_query)).scalar() or 0
+    # Merge in memory (event count is bounded by an image's tag count) and sort by
+    # date desc, then a stable tiebreak. Both date columns default to
+    # current_timestamp; the aware sentinel keeps the sort total if one is null.
+    epoch = datetime(1, 1, 1, tzinfo=UTC)
+    events: list[tuple[datetime, int, ImageTagHistoryResponse]] = []
 
-    # Paginate and order by most recent first
-    # Secondary sort by tag_history_id for stable ordering when timestamps match
-    query = (
-        query.order_by(
-            desc(TagHistory.date),  # type: ignore[arg-type]
-            desc(TagHistory.tag_history_id),  # type: ignore[arg-type]
-        )
-        .offset(pagination.offset)
-        .limit(pagination.per_page)
-    )
-
-    result = await db.execute(query)
-    rows = result.all()
-
-    items = []
-    for history, tag, user in rows:
-        user_summary = None
-        if user:
-            user_summary = UserSummary(
-                user_id=user.user_id,
-                username=user.username,
-                avatar=user.avatar,
-                avatar_in_r2=user.avatar_in_r2,
-                user_title=user.user_title,
-                groups=user.groups if user else [],
-            )
-
-        items.append(
-            ImageTagHistoryResponse(
-                tag_history_id=history.tag_history_id,
-                image_id=history.image_id,
-                tag_id=history.tag_id,
-                action="added" if history.action == "a" else "removed",
-                user=user_summary,
-                date=history.date,
-                tag=LinkedTag(tag_id=tag.tag_id, title=tag.title, type=tag.type) if tag else None,
+    for link, tag, user in link_rows:
+        events.append(
+            (
+                link.date_linked or epoch,
+                link.tag_id or 0,
+                ImageTagHistoryResponse(
+                    tag_history_id=None,
+                    image_id=image_id,
+                    tag_id=link.tag_id,
+                    action="added",
+                    user=to_summary(user),
+                    date=link.date_linked,
+                    tag=LinkedTag(tag_id=tag.tag_id, title=tag.title, type=tag.type),
+                ),
             )
         )
+
+    for history, tag, user in hist_rows:
+        if history.action == "a" and history.tag_id in linked_tag_ids:
+            continue  # already represented by its tag_link above
+        events.append(
+            (
+                history.date or epoch,
+                history.tag_history_id or 0,
+                ImageTagHistoryResponse(
+                    tag_history_id=history.tag_history_id,
+                    image_id=history.image_id,
+                    tag_id=history.tag_id,
+                    action="added" if history.action == "a" else "removed",
+                    user=to_summary(user),
+                    date=history.date,
+                    tag=LinkedTag(tag_id=tag.tag_id, title=tag.title, type=tag.type),
+                ),
+            )
+        )
+
+    events.sort(key=lambda e: (e[0], e[1]), reverse=True)
+
+    total = len(events)
+    start = pagination.offset
+    items = [event[2] for event in events[start : start + pagination.per_page]]
 
     return ImageTagHistoryListResponse(
         total=total,

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -126,6 +126,9 @@ class ImageTagHistoryResponse(TagHistoryResponse):
     # for every current tag, including those set at upload that were never written
     # to tag_history). Those synthesized events have no tag_history row, so the id
     # is nullable here (deliberately widening the base's non-null int).
+    # TODO: make TagHistoryResponse.tag_history_id `int | None` at the base and
+    # narrow it back in the callers that require it (tags + user-history endpoints),
+    # so this override can drop the type-ignore.
     tag_history_id: int | None = None  # type: ignore[assignment]
     tag: LinkedTag | None = None
 

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -122,6 +122,11 @@ class ImageTagHistoryResponse(TagHistoryResponse):
     Used when viewing an image's tag history where tag details are needed.
     """
 
+    # "Added" events for an image are derived from tag_links (which carry who/when
+    # for every current tag, including those set at upload that were never written
+    # to tag_history). Those synthesized events have no tag_history row, so the id
+    # is nullable here (deliberately widening the base's non-null int).
+    tag_history_id: int | None = None  # type: ignore[assignment]
     tag: LinkedTag | None = None
 
 

--- a/tests/api/v1/test_image_tag_history_endpoint.py
+++ b/tests/api/v1/test_image_tag_history_endpoint.py
@@ -13,6 +13,7 @@ from app.config import TagType, settings
 from app.models.image import Images
 from app.models.tag import Tags
 from app.models.tag_history import TagHistory
+from app.models.tag_link import TagLinks
 from app.models.user import Users
 
 
@@ -102,6 +103,175 @@ class TestGetImageTagHistory:
             assert "date" in item
             assert item["image_id"] == image.image_id
             assert item["action"] in ["added", "removed"]
+
+    async def test_upload_tags_appear_as_added_events(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """Tags linked at upload (tag_links, no tag_history) show as 'added' events.
+
+        This is the core fix: an image tagged only at upload has no tag_history rows,
+        but its tag_links carry who/when, so the history must derive 'added' events
+        from them instead of showing blank.
+        """
+        user = Users(
+            username="uploadtaguser",
+            password="hashed",
+            password_type="bcrypt",
+            salt="",
+            email="uploadtag@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        image = Images(
+            filename="uploadtaghist",
+            ext="jpg",
+            md5_hash="uploadtaghistmd5000000000000000",
+            user_id=user.user_id,
+            width=100,
+            height=100,
+            filesize=1000,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        tag1 = Tags(title="upload tag a", type=TagType.THEME)
+        tag2 = Tags(title="upload tag b", type=TagType.ARTIST)
+        db_session.add_all([tag1, tag2])
+        await db_session.commit()
+        await db_session.refresh(tag1)
+        await db_session.refresh(tag2)
+
+        # Only tag_links, exactly as link_tags_to_image does on upload — no history.
+        db_session.add_all(
+            [
+                TagLinks(tag_id=tag1.tag_id, image_id=image.image_id, user_id=user.user_id),
+                TagLinks(tag_id=tag2.tag_id, image_id=image.image_id, user_id=user.user_id),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{image.image_id}/tag-history")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total"] == 2
+        assert {item["action"] for item in data["items"]} == {"added"}
+        assert {item["tag_id"] for item in data["items"]} == {tag1.tag_id, tag2.tag_id}
+        for item in data["items"]:
+            assert item["user"]["user_id"] == user.user_id
+            assert item["date"] is not None
+            # Synthesized from a tag_link, so there is no tag_history row id.
+            assert item["tag_history_id"] is None
+            assert item["tag"]["tag_id"] in {tag1.tag_id, tag2.tag_id}
+
+    async def test_present_tag_not_duplicated_when_also_in_history(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """A still-present tag with both a tag_link and a tag_history 'a' row appears once."""
+        user = Users(
+            username="dupetaguser",
+            password="hashed",
+            password_type="bcrypt",
+            salt="",
+            email="dupetag@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        image = Images(
+            filename="dupetaghist",
+            ext="jpg",
+            md5_hash="dupetaghistmd500000000000000000",
+            user_id=user.user_id,
+            width=100,
+            height=100,
+            filesize=1000,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        tag = Tags(title="dupe tag", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        # Added later via add_tag_to_image: both a tag_link AND a tag_history 'a' exist.
+        db_session.add(TagLinks(tag_id=tag.tag_id, image_id=image.image_id, user_id=user.user_id))
+        db_session.add(
+            TagHistory(
+                image_id=image.image_id, tag_id=tag.tag_id, action="a", user_id=user.user_id
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{image.image_id}/tag-history")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total"] == 1
+        assert data["items"][0]["tag_id"] == tag.tag_id
+        assert data["items"][0]["action"] == "added"
+
+    async def test_removed_tag_shows_add_and_remove(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """A tag added then removed (no longer linked) keeps both events."""
+        user = Users(
+            username="removedtaguser",
+            password="hashed",
+            password_type="bcrypt",
+            salt="",
+            email="removedtag@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        image = Images(
+            filename="removedtaghist",
+            ext="jpg",
+            md5_hash="removedtaghistmd50000000000000",
+            user_id=user.user_id,
+            width=100,
+            height=100,
+            filesize=1000,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        tag = Tags(title="removed tag", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        # No tag_link (it was removed); tag_history carries the add then the remove.
+        db_session.add_all(
+            [
+                TagHistory(
+                    image_id=image.image_id, tag_id=tag.tag_id, action="a", user_id=user.user_id
+                ),
+                TagHistory(
+                    image_id=image.image_id, tag_id=tag.tag_id, action="r", user_id=user.user_id
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{image.image_id}/tag-history")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total"] == 2
+        assert sorted(item["action"] for item in data["items"]) == ["added", "removed"]
 
     async def test_includes_tag_info(
         self, client: AsyncClient, db_session: AsyncSession


### PR DESCRIPTION
## Summary

The image history page's **Tag History** read only `tag_history`. But upload (`link_tags_to_image`) writes `tag_links` and **never** `tag_history`, so an image whose tags were all set at upload showed a **blank** Tag History despite clearly having tags.

Rather than backfill ~14.5M `tag_history` rows (one per existing tag-link — duplicating data that already exists), this fixes the **read** side: `tag_links` already carries `user_id` + `date_linked` for every current tag, so the endpoint now derives **"added"** events from them.

`GET /images/{id}/tag-history` now merges:
- **Added** ← current `tag_links` (`date_linked` + `user_id`) — covers upload tags *and* later still-present tags, authoritatively.
- **Removed** ← `tag_history` `action='r'`.
- **Adds of no-longer-linked tags** ← `tag_history` `action='a'` where the tag isn't currently linked (so a removed tag keeps its add). Adds of currently-linked tags are skipped to avoid double-counting.

Merge + pagination happen in memory (event count is bounded by an image's tag count). `tag_history_id` on `ImageTagHistoryResponse` is nullable for the synthesized events.

**Benefits:** zero new rows, fixes all ~1.1M existing images immediately (no migration), and `date_linked` is the authoritative add time. (Caveat: ~5% of legacy `tag_links` carry the 2013 import date rather than the original — still far better than blank.)

## Test Plan

- [x] New tests: upload-only tags appear as `added`; a still-present tag with both a link and a history `a` row appears **once**; a removed tag keeps both `added`+`removed`. TDD: the upload test failed (blank) before the change.
- [x] Existing tag-history + pagination tests still pass.
- [x] Regression: `test_images.py` + image/user-history suites — **157 passed**. mypy + ruff clean.

Frontend (rendering the nullable `tag_history_id` / regenerated types) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)