### PR TITLE
feat(search): exclude_descendants — also exclude child tags

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -401,6 +401,13 @@ async def list_images(
     exclude_tags: Annotated[
         str | None, Query(description="Comma-separated tag IDs to exclude (e.g., '4,5,6')")
     ] = None,
+    exclude_descendants: Annotated[
+        bool,
+        Query(
+            description="When true, each excluded tag also excludes its child tags "
+            "(its full hierarchy). Default false (exact-match exclusion)."
+        ),
+    ] = False,
     missing_tag_types: Annotated[
         str | None,
         Query(
@@ -573,7 +580,8 @@ async def list_images(
                     )
                 )
 
-    # Exclude tag filtering (always exact match, no hierarchy expansion)
+    # Exclude tag filtering. Exact match by default; with exclude_descendants the
+    # excluded tag's whole subtree is removed too (mirrors the include-side hierarchy).
     if exclude_tags:
         # isdecimal() (not isdigit()): int() rejects chars like '²' that isdigit() matches.
         exclude_tag_ids = [
@@ -588,11 +596,14 @@ async def list_images(
                     detail=f"You can only search for up to {settings.MAX_SEARCH_TAGS} tags at a time.",
                 )
 
-            # Resolve aliases (no hierarchy expansion)
+            # Resolve aliases, then optionally expand each to its full subtree.
             resolved_exclude_ids: set[int] = set()
             for etid in exclude_tag_ids:
                 _, resolved_etid = await resolve_tag_alias(db, etid)
-                resolved_exclude_ids.add(resolved_etid)
+                if exclude_descendants:
+                    resolved_exclude_ids.update(await get_tag_hierarchy(db, resolved_etid))
+                else:
+                    resolved_exclude_ids.add(resolved_etid)
 
             # Apply NOT IN subquery
             query = query.where(

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -624,6 +624,7 @@ class TestExcludeTags:
         # Default (exact): only the parent-tagged image is excluded.
         resp = await client.get(f"/api/v1/images?exclude_tags={parent.tag_id}")
         assert resp.status_code == 200
+        assert resp.json()["total"] == 2
         assert {img["image_id"] for img in resp.json()["images"]} == {
             image2.image_id,
             image3.image_id,
@@ -634,6 +635,7 @@ class TestExcludeTags:
             f"/api/v1/images?exclude_tags={parent.tag_id}&exclude_descendants=true"
         )
         assert resp.status_code == 200
+        assert resp.json()["total"] == 1
         assert {img["image_id"] for img in resp.json()["images"]} == {image3.image_id}
 
     async def test_exclude_tags_resolves_aliases(

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -597,6 +597,45 @@ class TestExcludeTags:
         assert data["total"] == 1
         assert data["images"][0]["image_id"] == image2.image_id
 
+    async def test_exclude_tags_with_descendants(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """exclude_descendants=true also excludes images tagged with child tags."""
+        image1 = Images(**{**sample_image_data, "filename": "exdesc1", "md5_hash": "1" * 32})
+        image2 = Images(**{**sample_image_data, "filename": "exdesc2", "md5_hash": "2" * 32})
+        image3 = Images(**{**sample_image_data, "filename": "exdesc3", "md5_hash": "3" * 32})
+        db_session.add_all([image1, image2, image3])
+        await db_session.flush()
+
+        parent = Tags(title="swimsuit", desc="Swimsuit", type=1)
+        db_session.add(parent)
+        await db_session.flush()
+        child = Tags(title="bikini", desc="Bikini", type=1, inheritedfrom_id=parent.tag_id)
+        other = Tags(title="blonde hair", desc="Blonde", type=1)
+        db_session.add_all([child, other])
+        await db_session.flush()
+
+        # image1: swimsuit (parent), image2: bikini (child), image3: blonde hair
+        db_session.add(TagLinks(image_id=image1.image_id, tag_id=parent.tag_id, user_id=1))
+        db_session.add(TagLinks(image_id=image2.image_id, tag_id=child.tag_id, user_id=1))
+        db_session.add(TagLinks(image_id=image3.image_id, tag_id=other.tag_id, user_id=1))
+        await db_session.commit()
+
+        # Default (exact): only the parent-tagged image is excluded.
+        resp = await client.get(f"/api/v1/images?exclude_tags={parent.tag_id}")
+        assert resp.status_code == 200
+        assert {img["image_id"] for img in resp.json()["images"]} == {
+            image2.image_id,
+            image3.image_id,
+        }
+
+        # With descendants: the child-tagged image is excluded too.
+        resp = await client.get(
+            f"/api/v1/images?exclude_tags={parent.tag_id}&exclude_descendants=true"
+        )
+        assert resp.status_code == 200
+        assert {img["image_id"] for img in resp.json()["images"]} == {image3.image_id}
+
     async def test_exclude_tags_resolves_aliases(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
     ):


### PR DESCRIPTION
## Summary

`exclude_tags` was always exact-match: excluding a parent tag (e.g. `swimsuit`) still returned images tagged only with its children (`bikini`, `school swimsuit`, …). Add an **`exclude_descendants`** query flag that expands each excluded tag's full subtree using the same `get_tag_hierarchy` helper the include side already uses. Defaults to `false`, so existing behaviour is unchanged.

This is the API foundation for the upcoming advanced-search tag builder's "Also exclude child tags" option (the include side already has `tag_depth`).

## Test Plan

- [x] New `test_exclude_tags_with_descendants`: parent `swimsuit` + child `bikini`; without the flag only the parent-tagged image is excluded, with `exclude_descendants=true` the child-tagged image is excluded too. TDD: confirmed it failed before the change.
- [x] `TestExcludeTags` (9) + **full suite: 1759 passed, 9 skipped**. mypy + ruff clean.

Frontend (the tag builder that drives this + `tag_depth`) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)