### PR TITLE
perf(tests): configurable bcrypt rounds — ~4x faster test suite

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,8 @@ class Settings(BaseSettings):
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 10
     REFRESH_TOKEN_EXPIRE_DAYS: int = 30
+    # bcrypt cost factor; tests override to 4 for speed (see tests/conftest.py)
+    BCRYPT_ROUNDS: int = 12
 
     # CORS
     # Allow str because it can be a comma-separated string in .env

--- a/app/config.py
+++ b/app/config.py
@@ -29,8 +29,9 @@ class Settings(BaseSettings):
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 10
     REFRESH_TOKEN_EXPIRE_DAYS: int = 30
-    # bcrypt cost factor; tests override to 4 for speed (see tests/conftest.py)
-    BCRYPT_ROUNDS: int = 12
+    # bcrypt cost factor (gensalt accepts 4-31); tests override to 4 for
+    # speed (see tests/conftest.py)
+    BCRYPT_ROUNDS: int = Field(default=12, ge=4, le=31)
 
     # CORS
     # Allow str because it can be a comma-separated string in .env

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -124,7 +124,7 @@ def get_password_hash(password: str) -> str:
     """
     prepared_password = _prepare_password_for_bcrypt(password)
     # Generate salt and hash password
-    salt = bcrypt.gensalt(rounds=12)
+    salt = bcrypt.gensalt(rounds=settings.BCRYPT_ROUNDS)
     hashed = bcrypt.hashpw(prepared_password.encode("utf-8"), salt)
     return hashed.decode("utf-8")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,11 @@ import os
 # this before any app imports ensures test cookies work over plain http://test.
 os.environ.setdefault("ENVIRONMENT", "development")
 
+# Use the bcrypt minimum cost factor in tests. Hashing at the production
+# 12 rounds takes ~200ms per call and dominated suite runtime (tests hash
+# and verify passwords constantly via fixtures and login flows).
+os.environ.setdefault("BCRYPT_ROUNDS", "4")
+
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/unit/test_daily_upload_limit.py
+++ b/tests/unit/test_daily_upload_limit.py
@@ -165,9 +165,11 @@ class TestGetUploadsToday:
 
 
 def _make_image(user_id: int, suffix: str) -> Images:
-    """Create an Images instance with today's date but far enough back to avoid rate limit."""
-    # Use start of today + 1 minute (UTC) so it's always "today" and always in the past
-    start_of_today = datetime.now(UTC).replace(hour=0, minute=1, second=0, microsecond=0)
+    """Create an Images instance dated start-of-today UTC (never in the future)."""
+    # Right after midnight UTC no timestamp is both "today" and older than the
+    # per-upload delay, so tests using this helper must disable the delay check
+    # (see _disable_upload_delay).
+    start_of_today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
     return Images(
         filename=f"limit-{suffix}",
         ext="jpg",
@@ -186,6 +188,13 @@ def _make_image(user_id: int, suffix: str) -> Images:
 @pytest.mark.unit
 class TestDailyLimitEnforcement:
     """Tests for daily limit enforcement in check_upload_rate_limit."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_upload_delay(self, monkeypatch):
+        """These tests cover the daily limit, not the per-upload delay."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "UPLOAD_DELAY_SECONDS", 0)
 
     async def test_allows_upload_under_limit(self, db_session: AsyncSession):
         """Should not raise when uploads are under the daily limit."""
@@ -206,6 +215,42 @@ class TestDailyLimitEnforcement:
         for i in range(2):
             db_session.add(_make_image(user.user_id, f"under-{i}"))
         await db_session.commit()
+
+        # Should not raise
+        await check_upload_rate_limit(user.user_id, db_session, maximgperday=5)
+
+    async def test_allows_upload_under_limit_just_after_midnight_utc(
+        self, db_session: AsyncSession, monkeypatch
+    ):
+        """Regression: just after midnight UTC, _make_image timestamps were in the
+        future, so the per-upload delay check raised an unexpected 429."""
+        user = Users(
+            username="midnightlimit",
+            password="hashed",
+            password_type="bcrypt",
+            salt="saltsalt12345678",
+            email="midnightlimit@example.com",
+            active=1,
+            maximgperday=5,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        for i in range(2):
+            db_session.add(_make_image(user.user_id, f"midnight-{i}"))
+        await db_session.commit()
+
+        just_after_midnight = datetime.now(UTC).replace(
+            hour=0, minute=0, second=15, microsecond=0
+        )
+
+        class FrozenDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return just_after_midnight
+
+        monkeypatch.setattr("app.services.upload.datetime", FrozenDatetime)
 
         # Should not raise
         await check_upload_rate_limit(user.user_id, db_session, maximgperday=5)

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,0 +1,22 @@
+"""Tests for password hashing in app/core/security.py."""
+
+from app.config import Settings, settings
+from app.core.security import get_password_hash, verify_password
+
+
+class TestBcryptRounds:
+    """Tests for the configurable bcrypt cost factor."""
+
+    def test_bcrypt_rounds_defaults_to_12(self) -> None:
+        """Production default stays at 12 rounds."""
+        # Check the field default (not a Settings() instance) so the test
+        # still passes when the test environment overrides BCRYPT_ROUNDS.
+        assert Settings.model_fields["BCRYPT_ROUNDS"].default == 12
+
+    def test_get_password_hash_uses_configured_rounds(self, monkeypatch) -> None:
+        """get_password_hash honors settings.BCRYPT_ROUNDS."""
+        monkeypatch.setattr(settings, "BCRYPT_ROUNDS", 4)
+        hashed = get_password_hash("TestPassword123!")
+        # bcrypt embeds the cost factor in the hash: $2b$<rounds>$...
+        assert hashed.startswith("$2b$04$")
+        assert verify_password("TestPassword123!", hashed)

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,5 +1,8 @@
 """Tests for password hashing in app/core/security.py."""
 
+import pytest
+from pydantic import ValidationError
+
 from app.config import Settings, settings
 from app.core.security import get_password_hash, verify_password
 
@@ -12,6 +15,14 @@ class TestBcryptRounds:
         # Check the field default (not a Settings() instance) so the test
         # still passes when the test environment overrides BCRYPT_ROUNDS.
         assert Settings.model_fields["BCRYPT_ROUNDS"].default == 12
+
+    def test_bcrypt_rounds_out_of_range_rejected_at_startup(self) -> None:
+        """bcrypt.gensalt only accepts 4-31; invalid values must fail at
+        settings load, not at first hash."""
+        with pytest.raises(ValidationError):
+            Settings(BCRYPT_ROUNDS=3)
+        with pytest.raises(ValidationError):
+            Settings(BCRYPT_ROUNDS=32)
 
     def test_get_password_hash_uses_configured_rounds(self, monkeypatch) -> None:
         """get_password_hash honors settings.BCRYPT_ROUNDS."""


### PR DESCRIPTION
## Summary

The pytest CI job had grown to ~8 minutes, almost all of it in test execution. Profiling showed bcrypt hashing at the production cost factor (12 rounds, ~200ms per call) dominated runtime: tests hash and verify passwords constantly via user fixtures and login flows (260 `get_password_hash` call sites, 178 login POSTs).

### Changes

- **Configurable bcrypt cost**: new `BCRYPT_ROUNDS` setting (default 12 — production behavior unchanged), used by `get_password_hash`. `tests/conftest.py` sets it to 4 (bcrypt's minimum) before app imports. New unit tests cover the default and the override.
- **Flaky test fix** (found while measuring): `test_daily_upload_limit::test_allows_upload_under_limit` failed when run in the ~90s window after midnight UTC — the test helper stamped images at 00:01 UTC "today", which is in the future (or <30s old) at that hour, tripping the per-upload delay check with an unexpected 429. The helper now stamps start-of-today, the enforcement tests disable `UPLOAD_DELAY_SECONDS` (they test the daily cap, not the delay), and a frozen-clock regression test pins the midnight case.

### Measurements (full suite, local)

| | bcrypt rounds | wall time |
|---|---|---|
| before | 12 | 335.9s (5:35) |
| after | 4 | 84.6s (1:27) |

~3.8x faster; CI should drop from ~8min to roughly 2.5–3min.

## Test plan

- [x] Full suite at 12 rounds (baseline) and 4 rounds — same pass/fail set, plus the new tests
- [x] New unit tests watched fail before implementation (TDD)
- [x] Midnight flake reproduced deterministically with a frozen clock before the fix
- [x] ruff, ruff format, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)