### PR TITLE
perf(tests): parallel test runs with pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
+          --tmpfs /var/lib/mysql:rw
 
       redis:
         image: redis:7-alpine
@@ -129,7 +130,7 @@ jobs:
           DEBUG: "True"
           REDIS_URL: redis://localhost:6379/0
         run: |
-          uv run pytest tests/ -v --tb=short --maxfail=5 --schema-sync
+          uv run pytest tests/ -v --tb=short --maxfail=5 --schema-sync -n auto --dist loadgroup
 
       - name: Upload test results
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
     "pip-audit>=2.10.0",
     "moto[s3,server]>=5.0.0",  # Mock S3 for R2 adapter tests
     "types-aioboto3>=13.0.0",  # Type stubs
+    "pytest-xdist>=3.8.0",
 ]
 
 [build-system]

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Test runner script for shuushuu-api
 # Usage: ./run-tests.sh [pytest args]
+# With no args, runs the full suite in parallel (-n 4 --dist loadgroup).
+# Pass any args (e.g. a test path) for a plain serial pytest run.
 
 set -e
 
@@ -25,5 +27,10 @@ echo "  Test user: $TEST_DB_USER"
 echo "  Test password: ${TEST_DB_PASSWORD:+***set***}"
 echo ""
 
-# Run pytest with all arguments passed through
-uv run pytest "$@"
+# Run pytest with all arguments passed through; default to the parallel
+# sweet spot (see tests/README.md) when none are given
+if [ $# -eq 0 ]; then
+    uv run pytest -n 4 --dist loadgroup
+else
+    uv run pytest "$@"
+fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,6 +43,20 @@ uv run pytest tests/api/v1/test_images.py
 uv run pytest tests/unit/test_schemas.py
 ```
 
+### Run in parallel (pytest-xdist)
+```bash
+uv run pytest -n 4 --dist loadgroup
+```
+Each worker gets its own database (`shuushuu_pytest_gw0`, ...) and Redis DB,
+created automatically. `--dist loadgroup` keeps the schema-sync tests (which
+rebuild fixed-name databases) on a single worker. 4 workers is the sweet spot
+locally; more just contend on MariaDB. CI runs with `-n auto --dist loadgroup`.
+
+If root DB access is unavailable, worker databases require a one-time grant:
+```sql
+GRANT ALL PRIVILEGES ON `shuushuu\_pytest\_%`.* TO `shuushuu`@`%`;
+```
+
 ### Run with coverage
 ```bash
 # Enable coverage in pyproject.toml first, then:

--- a/tests/README.md
+++ b/tests/README.md
@@ -50,7 +50,8 @@ uv run pytest -n 4 --dist loadgroup
 Each worker gets its own database (`shuushuu_pytest_gw0`, ...) and Redis DB,
 created automatically. `--dist loadgroup` keeps the schema-sync tests (which
 rebuild fixed-name databases) on a single worker. 4 workers is the sweet spot
-locally; more just contend on MariaDB. CI runs with `-n auto --dist loadgroup`.
+locally; more just contend on MariaDB, and Redis DB numbering caps runs at
+13 workers. CI runs with `-n auto --dist loadgroup`.
 
 If root DB access is unavailable, worker databases require a one-time grant:
 ```sql

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -1157,8 +1157,12 @@ class TestFuzzyTagSearch:
         # Create test tags with different types
         tag1 = Tags(title="kinomoto sakura", type=TagType.CHARACTER)
         tag2 = Tags(title="sakura kinomoto", type=TagType.THEME)
-        tag3 = Tags(title="sakura leaf", type=TagType.CHARACTER, alias_of=1)
-        db_session.add_all([tag1, tag2, tag3])
+        db_session.add_all([tag1, tag2])
+        await db_session.commit()
+        # alias_of must use tag1's real id; auto-increment doesn't reliably
+        # start at 1 (e.g. under pytest-xdist test distribution)
+        tag3 = Tags(title="sakura leaf", type=TagType.CHARACTER, alias_of=tag1.tag_id)
+        db_session.add(tag3)
         await db_session.commit()
 
         # Search for "sakura" with type filter (CHARACTER only)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,7 +192,7 @@ def setup_test_database():
         with admin_engine.connect() as conn:
             conn.execute(
                 text(
-                    f"CREATE DATABASE IF NOT EXISTS {test_db_name} "
+                    f"CREATE DATABASE IF NOT EXISTS `{test_db_name}` "
                     "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
                 )
             )
@@ -201,7 +201,7 @@ def setup_test_database():
                 {"username": test_user, "password": test_password},
             )
             conn.execute(
-                text(f"GRANT ALL PRIVILEGES ON {test_db_name}.* TO :username@'%'"),
+                text(f"GRANT ALL PRIVILEGES ON `{test_db_name}`.* TO :username@'%'"),
                 {"username": test_user},
             )
             conn.execute(text("FLUSH PRIVILEGES"))
@@ -223,7 +223,7 @@ def setup_test_database():
             with server_engine.connect() as conn:
                 conn.execute(
                     text(
-                        f"CREATE DATABASE IF NOT EXISTS {test_db_name} "
+                        f"CREATE DATABASE IF NOT EXISTS `{test_db_name}` "
                         "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
                     )
                 )
@@ -253,7 +253,6 @@ def setup_test_database():
     alembic_cfg.set_main_option("script_location", "alembic")
     head_revision = ScriptDirectory.from_config(alembic_cfg).get_current_head()
 
-    db_name = make_url(TEST_DATABASE_URL_SYNC).database
     with sync_engine.begin() as conn:
         tables = [
             tbl
@@ -262,7 +261,7 @@ def setup_test_database():
                     "SELECT table_name FROM information_schema.tables "
                     "WHERE table_schema = :db_name AND table_type = 'BASE TABLE'"
                 ),
-                {"db_name": db_name},
+                {"db_name": test_db_name},
             )
         ]
         current_revision = None
@@ -525,6 +524,8 @@ def _test_redis_db() -> int:
     base = int(os.getenv("TEST_REDIS_DB", "15"))
     if not _XDIST_WORKER:
         return base
+    # With base=15 and DBs 0-1 reserved, this supports up to 13 workers
+    # (gw0..gw12); gw13+ raises below.
     db = base - 1 - int(_XDIST_WORKER.removeprefix("gw"))
     if db < 2:
         raise RuntimeError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,11 @@ DEFAULT_TEST_DB_PORT = "3306"
 DEFAULT_TEST_DB_NAME = "shuushuu_pytest"  # Separate from staging environment (shuushuu_test in .env.test)
 DEFAULT_ROOT_PASSWORD = "root_password"
 
+# Under pytest-xdist each worker process gets its own database (and Redis DB)
+# so workers can't deadlock on each other's fixture rows or truncate each
+# other's tables. Empty string = not running under xdist.
+_XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER", "")
+
 
 # Load .env file if present (optional - defaults work without it)
 env_path = Path(__file__).parent.parent / ".env"
@@ -123,7 +128,19 @@ def _get_test_database_url() -> tuple[str, str]:
     # Allow sync URL to be derived from async URL if not explicitly set
     test_url_sync = os.getenv("TEST_DATABASE_URL_SYNC", test_url.replace("+aiomysql", "+pymysql"))
 
+    if _XDIST_WORKER:
+        test_url = _with_worker_suffix(test_url)
+        test_url_sync = _with_worker_suffix(test_url_sync)
+
     return test_url, test_url_sync
+
+
+def _with_worker_suffix(url: str) -> str:
+    """Append the xdist worker id to the database name (e.g. shuushuu_pytest_gw0)."""
+    parsed = make_url(url)
+    return parsed.set(database=f"{parsed.database}_{_XDIST_WORKER}").render_as_string(
+        hide_password=False
+    )
 
 
 # Get test database URLs (uses defaults if env vars not set)
@@ -139,16 +156,15 @@ def anyio_backend():
 @pytest.fixture(scope="session", autouse=True)
 def setup_test_database():
     """
-    Recreate test database and run migrations before ALL tests.
+    Reset the test database and ensure schema is at head before ALL tests.
 
-    This runs once per test session (autouse=True) and ensures:
-    1. Test database is dropped and recreated (clean slate)
-    2. Latest Alembic migrations are applied
+    This runs once per test session (autouse=True; per worker under xdist)
+    and ensures:
+    1. Test database exists (created via root when available, else test user)
+    2. Schema is at the latest Alembic head (truncate when already current,
+       full drop + migrate otherwise)
     3. Schema matches production exactly
-    4. Test user is created with proper permissions
-
-    Note: Uses root credentials to create database and user, then runs migrations
-    with the test user credentials.
+    4. Test user is created with proper permissions (root path only)
     """
     import os
 
@@ -162,20 +178,22 @@ def setup_test_database():
     test_host = os.getenv("TEST_DB_HOST", DEFAULT_TEST_DB_HOST)
     test_port = os.getenv("TEST_DB_PORT", DEFAULT_TEST_DB_PORT)
 
-    # When root credentials are available (local dev / CI), drop and recreate the database
-    # for a completely clean slate. On servers where root is unavailable, this is skipped
-    # and drop_all/create_all below handles schema reset instead.
-    test_db_name = os.getenv("TEST_DB_NAME", DEFAULT_TEST_DB_NAME)
+    # When root credentials are available (local dev / CI), make sure the database
+    # and test user exist. On servers where root is unavailable, this is skipped
+    # and the test user creates the database itself below.
+    # Use the URL's database (not TEST_DB_NAME) so xdist worker suffixes are included.
+    test_db_name = make_url(TEST_DATABASE_URL_SYNC).database
+    root_available = True
     try:
         admin_engine = create_engine(
             f"mysql+pymysql://root:{root_password}@{test_host}:{test_port}/mysql",
             isolation_level="AUTOCOMMIT",
         )
         with admin_engine.connect() as conn:
-            conn.execute(text(f"DROP DATABASE IF EXISTS {test_db_name}"))
             conn.execute(
                 text(
-                    f"CREATE DATABASE {test_db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                    f"CREATE DATABASE IF NOT EXISTS {test_db_name} "
+                    "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
                 )
             )
             conn.execute(
@@ -191,52 +209,101 @@ def setup_test_database():
     except OperationalError as e:
         # Root access not available on this server (access denied or connection refused).
         # The table-by-table drop below handles schema reset instead.
+        root_available = False
         print(f"\n[conftest] Root DB setup skipped (root not available): {e}")
+
+    if not root_available:
+        # Without root the database may not exist yet (xdist worker databases like
+        # shuushuu_pytest_gw0 are created on demand). Create it as the test user;
+        # this needs a one-time wildcard grant:
+        #   GRANT ALL PRIVILEGES ON `shuushuu\_pytest\_%`.* TO `shuushuu`@`%`;
+        server_url = make_url(TEST_DATABASE_URL_SYNC).set(database=None)
+        server_engine = create_engine(server_url, isolation_level="AUTOCOMMIT")
+        try:
+            with server_engine.connect() as conn:
+                conn.execute(
+                    text(
+                        f"CREATE DATABASE IF NOT EXISTS {test_db_name} "
+                        "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                    )
+                )
+        except OperationalError as e:
+            raise RuntimeError(
+                f"Cannot create test database {test_db_name} as the test user and "
+                "root is unavailable. Grant the test user wildcard privileges once:\n"
+                "  GRANT ALL PRIVILEGES ON `shuushuu\\_pytest\\_%`.* TO `shuushuu`@`%`;"
+            ) from e
+        finally:
+            server_engine.dispose()
 
     sync_engine = create_engine(TEST_DATABASE_URL_SYNC, echo=False)
 
-    # When root credentials are available the DROP/CREATE DATABASE above already
-    # left an empty schema; otherwise drop every table here so the migration
-    # chain runs from a clean slate. Either way alembic_version must be gone.
+    # Reuse the schema when it's already at the alembic head: truncating
+    # tables is far cheaper than replaying the migration chain, which matters
+    # under xdist where every worker pays this cost on every run. A freshly
+    # migrated test DB contains no rows besides alembic_version and perms
+    # (the group_perms seed migrations are no-ops on an empty groups table),
+    # and perms is re-synced below, so truncate + sync reproduces the
+    # post-migration state exactly. Any schema change adds a new head
+    # revision, which forces the full rebuild path.
+    from alembic.config import Config as AlembicConfig
+    from alembic.script import ScriptDirectory
+
+    alembic_cfg = AlembicConfig()
+    alembic_cfg.set_main_option("script_location", "alembic")
+    head_revision = ScriptDirectory.from_config(alembic_cfg).get_current_head()
+
     db_name = make_url(TEST_DATABASE_URL_SYNC).database
     with sync_engine.begin() as conn:
+        tables = [
+            tbl
+            for (tbl,) in conn.execute(
+                text(
+                    "SELECT table_name FROM information_schema.tables "
+                    "WHERE table_schema = :db_name AND table_type = 'BASE TABLE'"
+                ),
+                {"db_name": db_name},
+            )
+        ]
+        current_revision = None
+        if "alembic_version" in tables:
+            current_revision = conn.execute(
+                text("SELECT version_num FROM alembic_version")
+            ).scalar()
+
+        schema_current = current_revision == head_revision
         conn.execute(text("SET FOREIGN_KEY_CHECKS = 0"))
-        result = conn.execute(
-            text(
-                "SELECT table_name FROM information_schema.tables "
-                "WHERE table_schema = :db_name AND table_type = 'BASE TABLE'"
-            ),
-            {"db_name": db_name},
-        )
-        for (tbl,) in result:
-            conn.execute(text(f"DROP TABLE IF EXISTS `{tbl}`"))
+        for tbl in tables:
+            if schema_current:
+                if tbl != "alembic_version":
+                    conn.execute(text(f"TRUNCATE TABLE `{tbl}`"))
+            else:
+                conn.execute(text(f"DROP TABLE IF EXISTS `{tbl}`"))
         conn.execute(text("SET FOREIGN_KEY_CHECKS = 1"))
 
     sync_engine.dispose()
 
-    # Apply the full migration chain so the test DB matches production schema
-    # exactly -- column widths, FULLTEXT indexes, triggers, everything. This
-    # also catches broken migrations in CI instead of letting create_all paper
-    # over them.
-    #
-    # alembic/env.py picks up ALEMBIC_DB_URL from the environment when no
-    # `-x dbUrl=...` argument is supplied; that's how we steer programmatic
-    # alembic invocations (like this one) at the test DB instead of the
-    # production DATABASE_URL_SYNC fallback.
-    from alembic import command as alembic_command
-    from alembic.config import Config as AlembicConfig
+    if not schema_current:
+        # Apply the full migration chain so the test DB matches production schema
+        # exactly -- column widths, FULLTEXT indexes, triggers, everything. This
+        # also catches broken migrations in CI instead of letting create_all paper
+        # over them.
+        #
+        # alembic/env.py picks up ALEMBIC_DB_URL from the environment when no
+        # `-x dbUrl=...` argument is supplied; that's how we steer programmatic
+        # alembic invocations (like this one) at the test DB instead of the
+        # production DATABASE_URL_SYNC fallback.
+        from alembic import command as alembic_command
 
-    prev_alembic_url = os.environ.get("ALEMBIC_DB_URL")
-    os.environ["ALEMBIC_DB_URL"] = TEST_DATABASE_URL_SYNC
-    try:
-        alembic_cfg = AlembicConfig()
-        alembic_cfg.set_main_option("script_location", "alembic")
-        alembic_command.upgrade(alembic_cfg, "head")
-    finally:
-        if prev_alembic_url is None:
-            del os.environ["ALEMBIC_DB_URL"]
-        else:
-            os.environ["ALEMBIC_DB_URL"] = prev_alembic_url
+        prev_alembic_url = os.environ.get("ALEMBIC_DB_URL")
+        os.environ["ALEMBIC_DB_URL"] = TEST_DATABASE_URL_SYNC
+        try:
+            alembic_command.upgrade(alembic_cfg, "head")
+        finally:
+            if prev_alembic_url is None:
+                del os.environ["ALEMBIC_DB_URL"]
+            else:
+                os.environ["ALEMBIC_DB_URL"] = prev_alembic_url
 
     # Mirror application startup: sync the Permission enum into the perms
     # table. The seed migration uses UPDATE statements that assume a
@@ -447,11 +514,32 @@ async def mock_redis():
     return mock
 
 
+def _test_redis_db() -> int:
+    """Pick the Redis DB for this process.
+
+    Serial runs use TEST_REDIS_DB (default 15). Under xdist each worker counts
+    down from there (gw0 -> 14, gw1 -> 13, ...) because the redis_client
+    fixture flushes its DB after each test. DBs 0 and 1 are reserved for the
+    dev app and arq.
+    """
+    base = int(os.getenv("TEST_REDIS_DB", "15"))
+    if not _XDIST_WORKER:
+        return base
+    db = base - 1 - int(_XDIST_WORKER.removeprefix("gw"))
+    if db < 2:
+        raise RuntimeError(
+            f"xdist worker {_XDIST_WORKER} has no free Redis DB "
+            f"(base {base}, DBs 0-1 reserved); run with fewer workers"
+        )
+    return db
+
+
 @pytest.fixture
 async def redis_client():
     """Real Redis client for tests that require Redis functionality.
 
-    Defaults to localhost:6379 DB 15 (dedicated to tests).
+    Defaults to localhost:6379 DB 15 (dedicated to tests; per-worker under
+    xdist, see _test_redis_db).
 
     Set env vars to customize:
     - TEST_REDIS_HOST (default: localhost)
@@ -462,7 +550,7 @@ async def redis_client():
 
     host = os.getenv("TEST_REDIS_HOST", "localhost")
     port = int(os.getenv("TEST_REDIS_PORT", "6379"))
-    db = int(os.getenv("TEST_REDIS_DB", "15"))
+    db = _test_redis_db()
 
     client = redis.Redis(host=host, port=port, db=db, decode_responses=True)
 

--- a/tests/integration/test_schema_sync.py
+++ b/tests/integration/test_schema_sync.py
@@ -55,6 +55,9 @@ def normalize_fk_action(action: str | None) -> str | None:
 
 @pytest.mark.integration
 @pytest.mark.schema_sync
+# These tests rebuild fixed-name databases (shuushuu_schema_models/_migrations),
+# so under xdist they must all run on the same worker (--dist loadgroup).
+@pytest.mark.xdist_group("schema_sync")
 class TestSchemaSync:
     """Tests to verify models match migrations.
 

--- a/tests/integration/test_schema_sync.py
+++ b/tests/integration/test_schema_sync.py
@@ -94,16 +94,22 @@ class TestSchemaSync:
         try:
             # Create fresh databases
             with admin_engine.connect() as conn:
-                conn.execute(text(f"DROP DATABASE IF EXISTS {db_models}"))
-                conn.execute(text(f"DROP DATABASE IF EXISTS {db_migrations}"))
+                conn.execute(text(f"DROP DATABASE IF EXISTS `{db_models}`"))
+                conn.execute(text(f"DROP DATABASE IF EXISTS `{db_migrations}`"))
                 conn.execute(
-                    text(f"CREATE DATABASE {db_models} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
+                    text(f"CREATE DATABASE `{db_models}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
                 )
                 conn.execute(
-                    text(f"CREATE DATABASE {db_migrations} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
+                    text(f"CREATE DATABASE `{db_migrations}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
                 )
-                conn.execute(text(f"GRANT ALL PRIVILEGES ON {db_models}.* TO '{db_user}'@'%'"))
-                conn.execute(text(f"GRANT ALL PRIVILEGES ON {db_migrations}.* TO '{db_user}'@'%'"))
+                conn.execute(
+                    text(f"GRANT ALL PRIVILEGES ON `{db_models}`.* TO :db_user@'%'"),
+                    {"db_user": db_user},
+                )
+                conn.execute(
+                    text(f"GRANT ALL PRIVILEGES ON `{db_migrations}`.* TO :db_user@'%'"),
+                    {"db_user": db_user},
+                )
                 conn.execute(text("FLUSH PRIVILEGES"))
 
             # Create schema from models
@@ -176,6 +182,6 @@ class TestSchemaSync:
         finally:
             # Cleanup
             with admin_engine.connect() as conn:
-                conn.execute(text(f"DROP DATABASE IF EXISTS {db_models}"))
-                conn.execute(text(f"DROP DATABASE IF EXISTS {db_migrations}"))
+                conn.execute(text(f"DROP DATABASE IF EXISTS `{db_models}`"))
+                conn.execute(text(f"DROP DATABASE IF EXISTS `{db_migrations}`"))
             admin_engine.dispose()

--- a/tests/integration/test_search_integration.py
+++ b/tests/integration/test_search_integration.py
@@ -18,8 +18,10 @@ from app.services.search import SearchService, configure_tags_index
 MEILISEARCH_URL = os.getenv("MEILISEARCH_URL", "http://localhost:7700")
 MEILISEARCH_KEY = os.getenv("MEILISEARCH_API_KEY") or os.getenv("MEILI_MASTER_KEY", "dev_master_key")
 
-# Use a test-specific index prefix to avoid colliding with dev data
-TEST_INDEX_NAME = "tags_test"
+# Use a test-specific index prefix to avoid colliding with dev data.
+# Suffix with the xdist worker id so parallel workers don't share an index.
+_WORKER = os.getenv("PYTEST_XDIST_WORKER", "")
+TEST_INDEX_NAME = f"tags_test_{_WORKER}" if _WORKER else "tags_test"
 
 
 @pytest.fixture

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,34 +4,13 @@ import time
 
 import aioboto3
 import pytest
-import redis.asyncio as redis
 from moto.server import ThreadedMotoServer
 
 from app.services.r2_storage import R2Storage
 
-
-@pytest.fixture
-async def redis_client():
-    """
-    Real Redis client for unit tests requiring Redis functionality.
-
-    Connects to test Redis instance (same as integration tests).
-    """
-    # Use a dedicated Redis DB for tests to avoid interfering with dev services
-    client = redis.Redis(host="localhost", port=6379, db=15, decode_responses=True)
-
-    # Verify connection - skip test if Redis is unavailable
-    try:
-        await client.ping()
-    except Exception as exc:
-        await client.aclose()
-        pytest.skip(f"Redis not available at localhost:6379/15: {exc}")
-
-    yield client
-
-    # Cleanup - flush test database
-    await client.flushdb()
-    await client.aclose()
+# Note: redis_client comes from tests/conftest.py (it previously had a
+# near-identical copy here that hardcoded Redis DB 15, which would break
+# per-worker isolation under pytest-xdist).
 
 
 # =============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -673,6 +673,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1905,6 +1914,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2299,6 +2321,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-aioboto3" },
     { name = "types-redis" },
@@ -2339,6 +2362,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.5.0" },
     { name = "types-aioboto3", specifier = ">=13.0.0" },
     { name = "types-redis", specifier = ">=4.6.0" },


### PR DESCRIPTION
## Summary

Follow-up to #246. Runs the suite in parallel with pytest-xdist, with per-worker isolation for every shared resource:

- **Per-worker MariaDB databases** — `PYTEST_XDIST_WORKER` suffixes the DB name (`shuushuu_pytest_gw0`, ...). Without this, workers deadlock on fixture rows with fixed PKs and the `needs_commit` tests truncate tables out from under each other.
- **Per-worker Redis DBs** — the `redis_client` fixture flushes its DB after each test; workers count down from DB 15 (0–1 reserved for dev/arq). The duplicate fixture in `tests/unit/conftest.py` that hardcoded DB 15 is removed in favor of the worker-aware top-level one.
- **Per-worker Meilisearch index** for the search integration tests.
- **Schema-sync tests pinned to one worker** (`xdist_group` + `--dist loadgroup`) — they rebuild fixed-name databases.

### Schema reuse (the key to making parallelism pay)

Initial parallel runs were *slower* than serial: every worker replayed the 56-migration chain on every run (~43s of setup at 4 workers, vs ~15s serial). Session setup now truncates and reuses the schema when `alembic_version` already matches the alembic script head, and only drops + migrates when it doesn't (any schema change adds a new head, forcing the rebuild). A freshly migrated test DB has no rows besides `alembic_version` and perms — the `group_perms` seed migrations are documented no-ops on an empty `groups` table — and perms is re-synced after truncation, so reused state matches a fresh migration exactly.

### Also fixed

`test_hybrid_search_with_filters` hardcoded `alias_of=1`, assuming tag1 gets `tag_id=1` from a fresh auto-increment — broke under xdist distribution; now references `tag1.tag_id`.

### Measurements (full suite, local, 10-core machine)

| | wall time |
|---|---|
| serial, before this PR | 84.6s |
| serial, with schema reuse | 68.1s |
| `-n 10 --dist loadgroup` | 56.8s |
| `-n 4 --dist loadgroup` | **51.4s** |

4 workers is the local sweet spot — beyond that, workers contend on the single MariaDB instance. CI uses `-n auto` (4 vCPUs) plus a tmpfs-backed MariaDB to take fsync out of the picture.

### Local requirement

Worker databases are created on demand. With root available (CI), this is automatic; without it, a one-time grant is needed (documented in tests/README.md):
```sql
GRANT ALL PRIVILEGES ON `shuushuu\_pytest\_%`.* TO `shuushuu`@`%`;
```
Already applied to the local dev container.

## Test plan

- [x] Full suite serial: same results as before (1763 passed + known local-only schema_sync root-credential failure), 29 warnings unchanged
- [x] Full suite `-n 4` and `-n 10`: same pass/fail set
- [x] Setup-cost measurements before/after schema reuse (43s → 12s at 4 workers)
- [x] CI validates the fresh-database path (worker DBs created via root, full migration chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)