### PR TITLE
perf(auth): embed user in token response, persist access_token cookie

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -14,6 +14,7 @@ import secrets
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
+import redis.asyncio as redis
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from sqlalchemy import delete, desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -27,6 +28,7 @@ from app.core.auth import (
 )
 from app.core.database import get_db
 from app.core.logging import get_logger
+from app.core.redis import get_redis
 from app.core.security import (
     RedactedStr,
     create_access_token,
@@ -44,6 +46,7 @@ from app.schemas.auth import (
     ResetPasswordRequest,
     TokenResponse,
 )
+from app.services.user import build_user_private_response
 from app.tasks.queue import enqueue_job
 
 logger = get_logger(__name__)
@@ -158,14 +161,18 @@ def _set_auth_cookies(response: Response, access_token: str, refresh_token: str)
         max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,  # seconds
     )
 
-    # Set access token as HTTPOnly cookie (for SSR and Swagger UI)
+    # Set access token as HTTPOnly cookie (for SSR and Swagger UI).
+    # Cookie Max-Age matches the refresh token, not the JWT expiry: the JWT's own
+    # `exp` claim is what's enforced server-side, and pinning the cookie to a
+    # 10-minute lifetime just creates a "cookie disappeared" branch in SSR auth
+    # that costs an extra round trip every page render after expiry.
     response.set_cookie(
         key="access_token",
         value=access_token,
         httponly=True,  # Prevent JavaScript access (XSS protection)
         secure=settings.ENVIRONMENT != "development",  # HTTPS everywhere except development
         samesite="strict",  # CSRF protection
-        max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # Match JWT expiration
+        max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
     )
 
 
@@ -250,6 +257,7 @@ async def login(
     request: Request,
     response: Response,
     db: Annotated[AsyncSession, Depends(get_db)],
+    redis_client: Annotated[redis.Redis, Depends(get_redis)],  # type: ignore[type-arg]
 ) -> TokenResponse:
     """
     Authenticate user and return JWT access token + refresh token.
@@ -405,10 +413,13 @@ async def login(
         migrated_to_bcrypt=migrate_to_bcrypt,
     )
 
+    user_response = await build_user_private_response(user.user_id, db, redis_client)
+
     return TokenResponse(
         access_token=access_token,
         token_type="bearer",
         expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        user=user_response,
     )
 
 
@@ -418,6 +429,7 @@ async def refresh_token(
     response: Response,
     refresh_token: Annotated[str, Depends(get_refresh_token_from_cookie)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    redis_client: Annotated[redis.Redis, Depends(get_redis)],  # type: ignore[type-arg]
 ) -> TokenResponse:
     """
     Refresh access token using refresh token.
@@ -560,10 +572,13 @@ async def refresh_token(
     # Set authentication cookies
     _set_auth_cookies(response, access_token, new_refresh_token)
 
+    user_response = await build_user_private_response(user.user_id, db, redis_client)
+
     return TokenResponse(
         access_token=access_token,
         token_type="bearer",
         expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        user=user_response,
     )
 
 

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -18,6 +18,7 @@ import redis.asyncio as redis
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from sqlalchemy import delete, desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.config import SuspensionAction, settings
 from app.core.auth import (
@@ -36,6 +37,7 @@ from app.core.security import (
     get_password_hash,
     verify_password,
 )
+from app.models.permissions import UserGroups
 from app.models.refresh_token import RefreshTokens
 from app.models.user import Users
 from app.schemas.auth import (
@@ -279,8 +281,15 @@ async def login(
     - Locks account after 5 failed attempts for 15 minutes
     - Resets lockout after successful login
     """
-    # Find user by username
-    result = await db.execute(select(Users).where(Users.username == credentials.username))  # type: ignore[arg-type]
+    # Find user by username. Eager-load groups so build_user_private_response
+    # below can reuse this row instead of issuing a second SELECT.
+    result = await db.execute(
+        select(Users)
+        .options(
+            selectinload(Users.user_groups).selectinload(UserGroups.group)  # type: ignore[arg-type]
+        )
+        .where(Users.username == credentials.username)  # type: ignore[arg-type]
+    )
     user = result.scalar_one_or_none()
 
     if not user:
@@ -413,11 +422,10 @@ async def login(
         migrated_to_bcrypt=migrate_to_bcrypt,
     )
 
-    # user.user_id is guaranteed non-None at this point (set on insert, and
-    # _create_tokens_for_user already validated it). The narrowing assert keeps
-    # mypy happy without adding a real-world failure mode.
-    assert user.user_id is not None
-    user_response = await build_user_private_response(user.user_id, db, redis_client)
+    # The just-authenticated `user` object already has user_groups eager-loaded
+    # (see the SELECT at the top of this function), so the helper skips its
+    # internal DB round trip and the None branch can't fire here.
+    user_response = await build_user_private_response(db, redis_client, user=user)
 
     return TokenResponse(
         access_token=access_token,
@@ -527,8 +535,15 @@ async def refresh_token(
                 detail="Refresh token reuse detected. All sessions revoked for security.",
             )
 
-    # Load user
-    result_user = await db.execute(select(Users).where(Users.user_id == db_token.user_id))  # type: ignore[arg-type]
+    # Load user. Eager-load groups so build_user_private_response below can
+    # reuse this row instead of issuing a second SELECT.
+    result_user = await db.execute(
+        select(Users)
+        .options(
+            selectinload(Users.user_groups).selectinload(UserGroups.group)  # type: ignore[arg-type]
+        )
+        .where(Users.user_id == db_token.user_id)  # type: ignore[arg-type]
+    )
     user = result_user.scalar_one_or_none()
 
     if not user:
@@ -576,7 +591,10 @@ async def refresh_token(
     # Set authentication cookies
     _set_auth_cookies(response, access_token, new_refresh_token)
 
-    user_response = await build_user_private_response(user.user_id, db, redis_client)
+    # `user` already has user_groups eager-loaded (see the SELECT earlier), so
+    # the helper skips its internal DB round trip and the None branch can't
+    # fire here.
+    user_response = await build_user_private_response(db, redis_client, user=user)
 
     return TokenResponse(
         access_token=access_token,

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -413,6 +413,10 @@ async def login(
         migrated_to_bcrypt=migrate_to_bcrypt,
     )
 
+    # user.user_id is guaranteed non-None at this point (set on insert, and
+    # _create_tokens_for_user already validated it). The narrowing assert keeps
+    # mypy happy without adding a real-world failure mode.
+    assert user.user_id is not None
     user_response = await build_user_private_response(user.user_id, db, redis_client)
 
     return TokenResponse(

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -67,6 +67,7 @@ from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 from app.services.rate_limit import check_registration_rate_limit
 from app.services.turnstile import verify_turnstile_token
 from app.services.upload import get_uploads_today
+from app.services.user import build_user_private_response
 from app.tasks.queue import enqueue_job
 
 logger = get_logger(__name__)
@@ -160,41 +161,9 @@ async def get_current_user_profile(
     This includes private settings like email, email_verified, email_pm_pref,
     and the user's permissions (cached for performance).
     """
-    user_result = await db.execute(
-        select(Users)
-        .options(
-            selectinload(Users.user_groups).selectinload(UserGroups.group)  # type: ignore[arg-type]
-        )
-        .where(Users.user_id == current_user_id)  # type: ignore[arg-type]
-    )
-    user = user_result.scalar_one_or_none()
-
-    if not user:
+    response = await build_user_private_response(current_user_id, db, redis_client)
+    if response is None:
         raise HTTPException(status_code=404, detail="User not found")
-
-    # Fetch user permissions (cached)
-    permissions = await get_cached_user_permissions(db, redis_client, current_user_id)
-
-    # Count unread PMs
-    unread_result = await db.execute(
-        select(func.count())
-        .select_from(Privmsgs)
-        .where(
-            Privmsgs.to_user_id == current_user_id,  # type: ignore[arg-type]
-            Privmsgs.viewed == 0,  # type: ignore[arg-type]
-            Privmsgs.to_del == 0,  # type: ignore[arg-type]
-        )
-    )
-    unread_pm_count = unread_result.scalar() or 0
-
-    # Count today's uploads for remaining calculation
-    uploads_today = await get_uploads_today(current_user_id, db)
-
-    # Convert to response model and add computed fields
-    response = UserPrivateResponse.model_validate(user)
-    response.permissions = sorted(permissions)
-    response.unread_pm_count = unread_pm_count
-    response.uploads_remaining_today = max(0, user.maximgperday - uploads_today)
     return response
 
 

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -36,12 +36,11 @@ from app.core.auth import (
 )
 from app.core.database import get_db
 from app.core.logging import get_logger
-from app.core.permission_cache import get_cached_user_permissions
 from app.core.permissions import Permission, has_permission
 from app.core.r2_client import get_r2_storage
 from app.core.redis import get_redis
 from app.core.security import RedactedStr, get_password_hash, validate_password_strength
-from app.models import Favorites, Images, Privmsgs, TagLinks, Users
+from app.models import Favorites, Images, TagLinks, Users
 from app.models.permissions import UserGroups
 from app.models.user_suspension import UserSuspensions
 from app.schemas.image import ImageDetailedListResponse, ImageDetailedResponse
@@ -66,7 +65,6 @@ from app.services.avatar import (
 from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 from app.services.rate_limit import check_registration_rate_limit
 from app.services.turnstile import verify_turnstile_token
-from app.services.upload import get_uploads_today
 from app.services.user import build_user_private_response
 from app.tasks.queue import enqueue_job
 

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -159,7 +159,7 @@ async def get_current_user_profile(
     This includes private settings like email, email_verified, email_pm_pref,
     and the user's permissions (cached for performance).
     """
-    response = await build_user_private_response(current_user_id, db, redis_client)
+    response = await build_user_private_response(db, redis_client, user_id=current_user_id)
     if response is None:
         raise HTTPException(status_code=404, detail="User not found")
     return response

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -10,6 +10,7 @@ This module defines Pydantic models for authentication-related API operations:
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from app.core.security import validate_password_strength
+from app.schemas.user import UserPrivateResponse
 
 
 class LoginRequest(BaseModel):
@@ -25,6 +26,13 @@ class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
     expires_in: int = Field(..., description="Access token expiration time in seconds from now")
+    user: UserPrivateResponse | None = Field(
+        default=None,
+        description=(
+            "Authenticated user profile. Populated on login/refresh so SSR clients "
+            "can skip a follow-up /users/me round trip."
+        ),
+    )
 
 
 class RefreshRequest(BaseModel):

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -1,0 +1,61 @@
+"""
+Shared user response builders used by auth + users endpoints.
+"""
+
+from __future__ import annotations
+
+import redis.asyncio as redis
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.permission_cache import get_cached_user_permissions
+from app.models import Privmsgs, Users
+from app.models.permissions import UserGroups
+from app.schemas.user import UserPrivateResponse
+from app.services.upload import get_uploads_today
+
+
+async def build_user_private_response(
+    user_id: int,
+    db: AsyncSession,
+    redis_client: redis.Redis,  # type: ignore[type-arg]
+) -> UserPrivateResponse | None:
+    """
+    Build the UserPrivateResponse for `user_id`, including cached permissions,
+    unread PM count, and uploads-remaining-today.
+
+    Returns None if the user doesn't exist. Callers that already know the user
+    exists (e.g. immediately after auth) can treat None as an internal error.
+    """
+    user_result = await db.execute(
+        select(Users)
+        .options(
+            selectinload(Users.user_groups).selectinload(UserGroups.group)  # type: ignore[arg-type]
+        )
+        .where(Users.user_id == user_id)  # type: ignore[arg-type]
+    )
+    user = user_result.scalar_one_or_none()
+    if not user:
+        return None
+
+    permissions = await get_cached_user_permissions(db, redis_client, user_id)
+
+    unread_result = await db.execute(
+        select(func.count())
+        .select_from(Privmsgs)
+        .where(
+            Privmsgs.to_user_id == user_id,  # type: ignore[arg-type]
+            Privmsgs.viewed == 0,  # type: ignore[arg-type]
+            Privmsgs.to_del == 0,  # type: ignore[arg-type]
+        )
+    )
+    unread_pm_count = unread_result.scalar() or 0
+
+    uploads_today = await get_uploads_today(user_id, db)
+
+    response = UserPrivateResponse.model_validate(user)
+    response.permissions = sorted(permissions)
+    response.unread_pm_count = unread_pm_count
+    response.uploads_remaining_today = max(0, user.maximgperday - uploads_today)
+    return response

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -17,42 +17,57 @@ from app.services.upload import get_uploads_today
 
 
 async def build_user_private_response(
-    user_id: int,
     db: AsyncSession,
     redis_client: redis.Redis,  # type: ignore[type-arg]
+    *,
+    user_id: int | None = None,
+    user: Users | None = None,
 ) -> UserPrivateResponse | None:
     """
-    Build the UserPrivateResponse for `user_id`, including cached permissions,
-    unread PM count, and uploads-remaining-today.
+    Build the UserPrivateResponse, including cached permissions, unread PM
+    count, and uploads-remaining-today.
 
-    Returns None if the user doesn't exist. Callers that already know the user
-    exists (e.g. immediately after auth) can treat None as an internal error.
+    Pass either:
+    - `user_id`: the helper fetches the row with `user_groups` eager-loaded
+      (used by /users/me where only the authenticated user_id is in scope).
+    - `user`: a pre-loaded ORM object with `user_groups` + groups already
+      selectinloaded (used by /auth/login and /auth/refresh, which already
+      hold the user from password verification — skipping the re-fetch saves
+      a round trip on every auth).
+
+    Returns None only when called with `user_id` and the row is missing.
     """
-    user_result = await db.execute(
-        select(Users)
-        .options(
-            selectinload(Users.user_groups).selectinload(UserGroups.group)  # type: ignore[arg-type]
+    if user is None:
+        if user_id is None:
+            raise ValueError("build_user_private_response requires user_id or user")
+        user_result = await db.execute(
+            select(Users)
+            .options(
+                selectinload(Users.user_groups).selectinload(UserGroups.group)  # type: ignore[arg-type]
+            )
+            .where(Users.user_id == user_id)  # type: ignore[arg-type]
         )
-        .where(Users.user_id == user_id)  # type: ignore[arg-type]
-    )
-    user = user_result.scalar_one_or_none()
-    if not user:
-        return None
+        user = user_result.scalar_one_or_none()
+        if not user:
+            return None
 
-    permissions = await get_cached_user_permissions(db, redis_client, user_id)
+    assert user.user_id is not None
+    uid = user.user_id
+
+    permissions = await get_cached_user_permissions(db, redis_client, uid)
 
     unread_result = await db.execute(
         select(func.count())
         .select_from(Privmsgs)
         .where(
-            Privmsgs.to_user_id == user_id,  # type: ignore[arg-type]
+            Privmsgs.to_user_id == uid,  # type: ignore[arg-type]
             Privmsgs.viewed == 0,  # type: ignore[arg-type]
             Privmsgs.to_del == 0,  # type: ignore[arg-type]
         )
     )
     unread_pm_count = unread_result.scalar() or 0
 
-    uploads_today = await get_uploads_today(user_id, db)
+    uploads_today = await get_uploads_today(uid, db)
 
     response = UserPrivateResponse.model_validate(user)
     response.permissions = sorted(permissions)

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -52,6 +52,15 @@ class TestLogin:
         assert data["token_type"] == "bearer"
         assert "expires_in" in data
 
+        # The login response embeds the authenticated user so SSR clients can
+        # skip a follow-up /users/me round trip. Asserting the shape here
+        # guards against a regression where `build_user_private_response`
+        # silently returns None.
+        assert data.get("user") is not None
+        assert data["user"]["username"] == "loginuser"
+        assert data["user"]["user_id"] == user.user_id
+        assert "permissions" in data["user"]
+
         # Check that refresh token cookie is set
         assert "refresh_token" in response.cookies
 
@@ -344,6 +353,15 @@ class TestRefresh:
         data = refresh_response.json()
         assert "access_token" in data
         assert data["token_type"] == "bearer"
+
+        # The refresh response embeds the authenticated user so SSR clients can
+        # skip a follow-up /users/me round trip. Asserting the shape here
+        # guards against a regression where `build_user_private_response`
+        # silently returns None.
+        assert data.get("user") is not None
+        assert data["user"]["username"] == "refreshuser"
+        assert data["user"]["user_id"] == user.user_id
+        assert "permissions" in data["user"]
 
         # Security: refresh token must NOT be in response body (HTTPOnly cookie only)
         assert "refresh_token" not in data


### PR DESCRIPTION
## Summary
- Cuts the SSR auth cold path from 3 round trips (futile `/users/me` → `/auth/refresh` → retry `/users/me`) to 1 by returning the user object on `/auth/refresh` and `/auth/login`.
- Extends the `access_token` cookie Max-Age to match the refresh token. The JWT's own `exp` still enforces the 10-minute access-token expiry — the cookie just stops getting purged early and forcing an extra round trip on every page render after expiry.
- Extracts the `/users/me` body-building logic into a shared `build_user_private_response()` so login/refresh/me all return identical shapes.

## Why
During a prod compose redeploy, a chunk of SSR refreshes rendered a logged-out page because one of the three SSR round trips threw into `hooks.server.ts`'s silent `try/catch`. Fewer round trips → smaller failure surface during cutovers, and the "cookie disappeared so go refresh" branch in SSR goes away entirely.

## Compatibility
- `TokenResponse.user` is optional; old frontends ignore it.
- The cookie Max-Age change is observable only on the next login/refresh — existing sessions keep their current cookies until they roll.
- Pairs with frontend PR: anonymousobject/shuushuu-frontend#TBD (`perf/auth-embed-user-in-token-response`). Safe to ship API first; frontend will start using the new field once deployed.

## Test plan
- [ ] `./run-tests.sh tests/api/v1/test_auth.py` — existing assertions on `access_token` / `expires_in` / `refresh_token` cookie still hold (the new `user` field is additive).
- [ ] Manual: log in, observe the API response includes a populated `user` object.
- [ ] Manual: log in, wait >10 min, refresh the page — verify SSR keeps you signed in via a single `/auth/refresh` (no preceding 401 `/users/me`) and that the response sets a new `access_token` cookie with Max-Age matching the refresh token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)