### PR TITLE
fix(models): unsign the report_id/review_id family to match the legacy schema

### DIFF
--- a/app/models/admin_action.py
+++ b/app/models/admin_action.py
@@ -16,7 +16,7 @@ from sqlalchemy import ForeignKeyConstraint, Index, text
 from sqlalchemy.dialects.mysql import JSON
 from sqlmodel import Column, Field, SQLModel
 
-from app.models.types import UtcDateTime
+from app.models.types import UnsignedInt, UtcDateTime
 
 
 class AdminActions(SQLModel, table=True):
@@ -82,8 +82,9 @@ class AdminActions(SQLModel, table=True):
 
     action_type: int = Field(default=0)
 
-    report_id: int | None = Field(default=None)
-    review_id: int | None = Field(default=None)
+    # INT UNSIGNED to match the legacy-unsigned image_reports/image_reviews PKs
+    report_id: int | None = Field(default=None, sa_column=Column(UnsignedInt, nullable=True))
+    review_id: int | None = Field(default=None, sa_column=Column(UnsignedInt, nullable=True))
     image_id: int | None = Field(default=None)
 
     # JSON details with action context

--- a/app/models/image_report.py
+++ b/app/models/image_report.py
@@ -17,7 +17,7 @@ from sqlalchemy import Column, ForeignKey, Index, Integer, text
 from sqlmodel import Field, SQLModel
 
 from app.config import ReportStatus
-from app.models.types import UtcDateTime
+from app.models.types import UnsignedInt, UtcDateTime
 
 
 class ImageReportBase(SQLModel):
@@ -70,8 +70,11 @@ class ImageReports(ImageReportBase, table=True):
         Index("idx_image_reports_status", "status"),
     )
 
-    # Primary key
-    report_id: int | None = Field(default=None, primary_key=True)
+    # Primary key (INT UNSIGNED in the legacy schema, as are all FKs to it)
+    report_id: int | None = Field(
+        default=None,
+        sa_column=Column(UnsignedInt, primary_key=True, autoincrement=True),
+    )
 
     # Override to add foreign keys with CASCADE behavior
     # Note: We use sa_column to explicitly set ondelete="CASCADE" because Field(foreign_key=...)

--- a/app/models/image_report_tag_suggestion.py
+++ b/app/models/image_report_tag_suggestion.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from sqlalchemy import Column, ForeignKey, Index, Integer, UniqueConstraint, text
 from sqlmodel import Field, SQLModel
 
-from app.models.types import UtcDateTime
+from app.models.types import UnsignedInt, UtcDateTime
 
 
 class ImageReportTagSuggestionBase(SQLModel):
@@ -46,7 +46,7 @@ class ImageReportTagSuggestions(ImageReportTagSuggestionBase, table=True):
 
     report_id: int = Field(
         sa_column=Column(
-            Integer,
+            UnsignedInt,
             ForeignKey("image_reports.report_id", ondelete="CASCADE", onupdate="CASCADE"),
             nullable=False,
         )

--- a/app/models/image_review.py
+++ b/app/models/image_review.py
@@ -24,7 +24,7 @@ from sqlalchemy import Column, ForeignKey, Index, Integer, text
 from sqlmodel import Field, SQLModel
 
 from app.config import DeactivationReason, ReviewOutcome, ReviewStatus
-from app.models.types import UtcDateTime
+from app.models.types import UnsignedInt, UtcDateTime
 
 
 class ImageReviewBase(SQLModel):
@@ -87,8 +87,11 @@ class ImageReviews(ImageReviewBase, table=True):
         Index("idx_image_reviews_deadline", "deadline"),
     )
 
-    # Primary key
-    review_id: int | None = Field(default=None, primary_key=True)
+    # Primary key (INT UNSIGNED in the legacy schema, as are all FKs to it)
+    review_id: int | None = Field(
+        default=None,
+        sa_column=Column(UnsignedInt, primary_key=True, autoincrement=True),
+    )
 
     # Image under review - CASCADE delete when image is deleted
     image_id: int = Field(
@@ -103,7 +106,7 @@ class ImageReviews(ImageReviewBase, table=True):
     source_report_id: int | None = Field(
         default=None,
         sa_column=Column(
-            Integer,
+            UnsignedInt,
             ForeignKey("image_reports.report_id", ondelete="SET NULL", onupdate="CASCADE"),
             nullable=True,
         ),

--- a/app/models/image_status_history.py
+++ b/app/models/image_status_history.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
 
-from app.models.types import UtcDateTime
+from app.models.types import UnsignedInt, UtcDateTime
 
 
 class ImageStatusHistoryBase(SQLModel):
@@ -85,14 +85,9 @@ class ImageStatusHistory(ImageStatusHistoryBase, table=True):
 
     # Originating report/review for this transition (set on the triage/review-close
     # paths; NULL for direct mod changes and legacy rows). Exposed mods-only in the API.
-    #
-    # NOTE: the migration (1cdaf1ec0250) creates these as INT UNSIGNED to match the
-    # legacy-unsigned image_reports/image_reviews PKs. Those PKs are still declared
-    # *signed* in their models, so we keep these annotations signed too — otherwise
-    # create_all can't form the FK (signed PK <- unsigned FK). Unsigning the whole
-    # report_id/review_id family to match the DB is a separate schema-sync cleanup.
-    report_id: int | None = Field(default=None)
-    review_id: int | None = Field(default=None)
+    # INT UNSIGNED to match the legacy-unsigned image_reports/image_reviews PKs.
+    report_id: int | None = Field(default=None, sa_column=Column(UnsignedInt, nullable=True))
+    review_id: int | None = Field(default=None, sa_column=Column(UnsignedInt, nullable=True))
 
     # Timestamp
     created_at: datetime | None = Field(

--- a/app/models/review_vote.py
+++ b/app/models/review_vote.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from sqlalchemy import Column, ForeignKey, Index, Integer, text
 from sqlmodel import Field, SQLModel
 
-from app.models.types import UtcDateTime
+from app.models.types import UnsignedInt, UtcDateTime
 
 
 class ReviewVoteBase(SQLModel):
@@ -93,7 +93,7 @@ class ReviewVotes(ReviewVoteBase, table=True):
     review_id: int | None = Field(
         default=None,
         sa_column=Column(
-            Integer,
+            UnsignedInt,
             ForeignKey("image_reviews.review_id", ondelete="CASCADE", onupdate="CASCADE"),
             nullable=True,
         ),

--- a/app/models/types.py
+++ b/app/models/types.py
@@ -4,13 +4,20 @@ UtcDateTime: a DateTime variant that round-trips tz-aware datetimes through
 MariaDB's tz-naive DATETIME. Stores values as UTC (tzinfo stripped); attaches
 tzinfo=UTC on read. Naive datetimes are rejected on bind to avoid ambiguous
 "is this UTC or local?" assumptions.
+
+UnsignedInt: INT UNSIGNED, matching the legacy schema's ID columns. Models must
+declare the same signedness as the migrations, or create_all-built schemas
+(schema-sync tests) fail FK creation with errno 150 (signed PK <- unsigned FK).
 """
 
 from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy import DateTime
+from sqlalchemy.dialects.mysql import INTEGER
 from sqlalchemy.types import TypeDecorator
+
+UnsignedInt = INTEGER(unsigned=True)
 
 
 class UtcDateTime(TypeDecorator[datetime]):

--- a/app/models/types.py
+++ b/app/models/types.py
@@ -17,6 +17,7 @@ from sqlalchemy import DateTime
 from sqlalchemy.dialects.mysql import INTEGER
 from sqlalchemy.types import TypeDecorator
 
+# Shared type instance, not a class — use as Column(UnsignedInt, ...); don't call it.
 UnsignedInt = INTEGER(unsigned=True)
 
 

--- a/docs/plans/2026-06-10-schema-sync-signed-unsigned-drift.md
+++ b/docs/plans/2026-06-10-schema-sync-signed-unsigned-drift.md
@@ -1,0 +1,63 @@
+# Schema-sync: signed/unsigned drift in report_id/review_id family
+
+**Date:** 2026-06-10
+**Status:** IMPLEMENTED (2026-06-10) — family unsigned in models via `UnsignedInt`
+(`app/models/types.py`), `test_column_types_match` added to
+`tests/integration/test_schema_sync.py`. The broader full-schema type audit
+(see "Audit findings" below) remains open.
+
+## The drift
+
+Models declare the `report_id`/`review_id` family as signed `int`, but the DB has them as `int(10) unsigned`:
+
+- PKs: `image_reports.report_id` (`app/models/image_report.py:74`), `image_reviews.review_id` (`app/models/image_review.py:91`)
+- FKs to them:
+  - `image_status_history.report_id` / `review_id` (`app/models/image_status_history.py:94-95`)
+  - `image_reviews.source_report_id` (`app/models/image_review.py:103`)
+  - `image_report_tag_suggestions.report_id` (`app/models/image_report_tag_suggestion.py:47`)
+  - `admin_actions.report_id` / `review_id` (`app/models/admin_action.py:85-86`)
+  - `review_votes.review_id` (`app/models/review_vote.py:93`)
+
+Harmless at runtime (small positive auto-increment IDs, far below the signed 32-bit ceiling) and the migrations build the DB correctly — but it's real model↔DB drift.
+
+## How it was exposed
+
+The timeline FK work surfaced it: making one FK column unsigned broke `create_all` (errno 150 — signed PK ← unsigned FK type mismatch). Those 2 columns were reverted to signed for now so the family stays internally consistent.
+
+## Permanent fix
+
+1. **Unsign the whole family at once** — switch every column listed above to `mysql.INTEGER(unsigned=True)` in the models to match the DB. Partial changes break `create_all` (errno 150); it's all-or-nothing per FK family.
+2. **Extend `tests/integration/test_schema_sync.py`** — it currently only diffs FK CASCADE behavior (`get_foreign_keys`), NOT column types, which is why this drift was never caught. Add a `get_columns` diff covering type and signedness.
+
+## WARNING
+
+The `get_columns` diff will likely surface more pre-existing signed/unsigned (and possibly length/charset) mismatches across the legacy schema. Triage those as their own audit — don't block the report/review fix on them.
+
+## Audit findings (2026-06-10, from the whole-table diff of the 6 family tables)
+
+Confirmed: the drift extends well beyond the report/review family. The column
+test is therefore scoped to the 9 family columns; everything below is the open
+audit's work-list. Note fixing any unsigned FK column requires unsigning its
+parent PK first (errno 150), so `images.image_id` / `users.user_id` /
+`tags.tag_id` cascade schema-wide.
+
+**Signed in models, `INT UNSIGNED` in DB (beyond the fixed family):**
+- PKs: `image_status_history.id`, `review_votes.vote_id`, `admin_actions.action_id`, `image_report_tag_suggestions.suggestion_id`
+- FKs to parent tables: `image_id`, `user_id`, `tag_id`, `reviewed_by`, `initiated_by`, `closed_by` in all 6 tables — implies `images.image_id`, `users.user_id`, `tags.tag_id` PKs are unsigned in the DB too
+
+**`INTEGER` in models, `TINYINT` in DB:**
+- `image_reports.category` (unsigned), `image_reports.status`
+- `review_votes.vote`
+- `image_report_tag_suggestions.suggestion_type` (unsigned)
+
+**`VARCHAR(255)` in models, `MEDIUMTEXT` in DB:**
+- `image_reports.reason_text`, `image_reports.admin_notes`
+- `review_votes.comment`
+
+Tables outside the family (users, images, tags, posts, …) have not been
+diffed yet — extend `test_column_types_match`'s scope (or run a one-off
+whole-schema diff) as the audit proceeds.
+
+## Related
+
+- Postgres feasibility analysis (`docs/plans/2026-06-10-postgres-migration-feasibility.md`) notes Postgres has no unsigned ints; this family is among the columns that would need a signed-range check before any such migration.

--- a/tests/integration/test_schema_sync.py
+++ b/tests/integration/test_schema_sync.py
@@ -46,11 +46,111 @@ def get_foreign_keys(inspector, table_name: str) -> dict[str, dict]:
     return fks
 
 
+def get_column_types(inspector, table_name: str) -> dict[str, dict]:
+    """Get column types for a table, normalized for comparison.
+
+    Compares the reflected type class (INTEGER vs TINYINT, etc.), signedness,
+    and length. Display width is ignored (cosmetic in MariaDB); nullability and
+    defaults are out of scope here (this targets type drift specifically).
+    """
+    columns = {}
+    for column in inspector.get_columns(table_name):
+        column_type = column["type"]
+        columns[column["name"]] = {
+            "type": type(column_type).__name__,
+            "unsigned": getattr(column_type, "unsigned", False),
+            "length": getattr(column_type, "length", None),
+        }
+    return columns
+
+
 def normalize_fk_action(action: str | None) -> str | None:
     """Normalize FK action for comparison (handle NO ACTION vs None)."""
     if action is None or action == "NO ACTION":
         return None
     return action.upper()
+
+
+@pytest.fixture(scope="class")
+def schema_inspectors():
+    """Build one database from models (create_all) and one from migrations.
+
+    Yields (models_inspector, migrations_inspector) for schema comparison.
+    """
+    # Get credentials with defaults matching CI
+    db_user = os.getenv("TEST_DB_USER", DEFAULT_TEST_DB_USER)
+    db_password = os.getenv("TEST_DB_PASSWORD", DEFAULT_TEST_DB_PASSWORD)
+    db_host = os.getenv("TEST_DB_HOST", DEFAULT_TEST_DB_HOST)
+    db_port = os.getenv("TEST_DB_PORT", DEFAULT_TEST_DB_PORT)
+    root_password = os.getenv("MYSQL_ROOT_PASSWORD", DEFAULT_ROOT_PASSWORD)
+
+    admin_url = f"mysql+pymysql://root:{root_password}@{db_host}:{db_port}/mysql"
+
+    # Database names for comparison
+    db_models = "shuushuu_schema_models"
+    db_migrations = "shuushuu_schema_migrations"
+
+    admin_engine = create_engine(admin_url, isolation_level="AUTOCOMMIT")
+
+    try:
+        # Create fresh databases
+        with admin_engine.connect() as conn:
+            conn.execute(text(f"DROP DATABASE IF EXISTS `{db_models}`"))
+            conn.execute(text(f"DROP DATABASE IF EXISTS `{db_migrations}`"))
+            conn.execute(
+                text(
+                    f"CREATE DATABASE `{db_models}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                )
+            )
+            conn.execute(
+                text(
+                    f"CREATE DATABASE `{db_migrations}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                )
+            )
+            conn.execute(
+                text(f"GRANT ALL PRIVILEGES ON `{db_models}`.* TO :db_user@'%'"),
+                {"db_user": db_user},
+            )
+            conn.execute(
+                text(f"GRANT ALL PRIVILEGES ON `{db_migrations}`.* TO :db_user@'%'"),
+                {"db_user": db_user},
+            )
+            conn.execute(text("FLUSH PRIVILEGES"))
+
+        # Create schema from models
+        models_url = f"mysql+pymysql://{db_user}:{db_password}@{db_host}:{db_port}/{db_models}"
+        models_engine = create_engine(models_url)
+        SQLModel.metadata.create_all(models_engine)
+
+        # Create schema from migrations
+        # Run alembic via subprocess so it picks up the env var fresh
+        # (app.config.settings caches DATABASE_URL_SYNC at import time)
+        migrations_url = (
+            f"mysql+pymysql://{db_user}:{db_password}@{db_host}:{db_port}/{db_migrations}"
+        )
+
+        env = os.environ.copy()
+        env["DATABASE_URL_SYNC"] = migrations_url
+        result = subprocess.run(
+            ["uv", "run", "alembic", "upgrade", "head"],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(Path(__file__).parent.parent.parent),
+        )
+        if result.returncode != 0:
+            pytest.fail(f"Alembic migrations failed:\n{result.stderr}\n{result.stdout}")
+
+        migrations_engine = create_engine(migrations_url)
+
+        yield inspect(models_engine), inspect(migrations_engine)
+
+    finally:
+        # Cleanup
+        with admin_engine.connect() as conn:
+            conn.execute(text(f"DROP DATABASE IF EXISTS `{db_models}`"))
+            conn.execute(text(f"DROP DATABASE IF EXISTS `{db_migrations}`"))
+        admin_engine.dispose()
 
 
 @pytest.mark.integration
@@ -64,124 +164,107 @@ class TestSchemaSync:
     Run with: pytest tests/integration/test_schema_sync.py --schema-sync -v
     """
 
-    def test_foreign_key_cascade_behavior_matches(self):
+    def test_foreign_key_cascade_behavior_matches(self, schema_inspectors):
         """
         Verify that foreign key CASCADE behavior in models matches migrations.
-
-        This test:
-        1. Creates a database using SQLModel.metadata.create_all()
-        2. Creates a database using Alembic migrations
-        3. Compares foreign key constraints between them
 
         This catches issues where Field(foreign_key=...) doesn't include
         CASCADE behavior that ForeignKeyConstraint in migrations specifies.
         """
-        # Get credentials with defaults matching CI
-        db_user = os.getenv("TEST_DB_USER", DEFAULT_TEST_DB_USER)
-        db_password = os.getenv("TEST_DB_PASSWORD", DEFAULT_TEST_DB_PASSWORD)
-        db_host = os.getenv("TEST_DB_HOST", DEFAULT_TEST_DB_HOST)
-        db_port = os.getenv("TEST_DB_PORT", DEFAULT_TEST_DB_PORT)
-        root_password = os.getenv("MYSQL_ROOT_PASSWORD", DEFAULT_ROOT_PASSWORD)
+        models_inspector, migrations_inspector = schema_inspectors
 
-        admin_url = f"mysql+pymysql://root:{root_password}@{db_host}:{db_port}/mysql"
+        # Tables to check (the ones we fixed)
+        tables_to_check = ["image_reports", "image_reviews", "review_votes"]
 
-        # Database names for comparison
-        db_models = "shuushuu_schema_models"
-        db_migrations = "shuushuu_schema_migrations"
+        differences = []
+        for table in tables_to_check:
+            models_fks = get_foreign_keys(models_inspector, table)
+            migrations_fks = get_foreign_keys(migrations_inspector, table)
 
-        admin_engine = create_engine(admin_url, isolation_level="AUTOCOMMIT")
+            for col_key, model_fk in models_fks.items():
+                if col_key not in migrations_fks:
+                    differences.append(
+                        f"{table}: FK on {col_key} exists in models but not migrations"
+                    )
+                    continue
 
-        try:
-            # Create fresh databases
-            with admin_engine.connect() as conn:
-                conn.execute(text(f"DROP DATABASE IF EXISTS `{db_models}`"))
-                conn.execute(text(f"DROP DATABASE IF EXISTS `{db_migrations}`"))
-                conn.execute(
-                    text(f"CREATE DATABASE `{db_models}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
-                )
-                conn.execute(
-                    text(f"CREATE DATABASE `{db_migrations}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
-                )
-                conn.execute(
-                    text(f"GRANT ALL PRIVILEGES ON `{db_models}`.* TO :db_user@'%'"),
-                    {"db_user": db_user},
-                )
-                conn.execute(
-                    text(f"GRANT ALL PRIVILEGES ON `{db_migrations}`.* TO :db_user@'%'"),
-                    {"db_user": db_user},
-                )
-                conn.execute(text("FLUSH PRIVILEGES"))
+                migration_fk = migrations_fks[col_key]
 
-            # Create schema from models
-            models_url = f"mysql+pymysql://{db_user}:{db_password}@{db_host}:{db_port}/{db_models}"
-            models_engine = create_engine(models_url)
-            SQLModel.metadata.create_all(models_engine)
+                # Compare CASCADE behavior
+                model_ondelete = normalize_fk_action(model_fk["ondelete"])
+                migration_ondelete = normalize_fk_action(migration_fk["ondelete"])
 
-            # Create schema from migrations
-            # Run alembic via subprocess so it picks up the env var fresh
-            # (app.config.settings caches DATABASE_URL_SYNC at import time)
-            migrations_url = f"mysql+pymysql://{db_user}:{db_password}@{db_host}:{db_port}/{db_migrations}"
+                if model_ondelete != migration_ondelete:
+                    differences.append(
+                        f"{table}.{col_key}: ondelete mismatch - "
+                        f"models={model_ondelete}, migrations={migration_ondelete}"
+                    )
 
-            env = os.environ.copy()
-            env["DATABASE_URL_SYNC"] = migrations_url
-            result = subprocess.run(
-                ["uv", "run", "alembic", "upgrade", "head"],
-                capture_output=True,
-                text=True,
-                env=env,
-                cwd=str(Path(__file__).parent.parent.parent),
+                model_onupdate = normalize_fk_action(model_fk["onupdate"])
+                migration_onupdate = normalize_fk_action(migration_fk["onupdate"])
+
+                if model_onupdate != migration_onupdate:
+                    differences.append(
+                        f"{table}.{col_key}: onupdate mismatch - "
+                        f"models={model_onupdate}, migrations={migration_onupdate}"
+                    )
+
+        if differences:
+            pytest.fail(
+                "Schema differences between models and migrations:\n" + "\n".join(differences)
             )
-            if result.returncode != 0:
-                pytest.fail(f"Alembic migrations failed:\n{result.stderr}\n{result.stdout}")
 
-            migrations_engine = create_engine(migrations_url)
+    def test_column_types_match(self, schema_inspectors):
+        """
+        Verify that column types (including signedness) in models match migrations.
 
-            # Compare foreign keys
-            models_inspector = inspect(models_engine)
-            migrations_inspector = inspect(migrations_engine)
+        This catches drift like the report_id/review_id family: the DB has them
+        as INT UNSIGNED (legacy schema), but models declared them signed. The FK
+        CASCADE test never compared column types, so this went unnoticed.
 
-            # Tables to check (the ones we fixed)
-            tables_to_check = ["image_reports", "image_reviews", "review_votes"]
+        Scoped to the report_id/review_id column family. A whole-table diff also
+        flags image_id/user_id/tag_id signedness and TINYINT/MEDIUMTEXT drift,
+        but fixing those cascades into the images/users/tags parent PKs — that
+        full-schema type audit is tracked separately
+        (docs/plans/2026-06-10-schema-sync-signed-unsigned-drift.md).
+        """
+        models_inspector, migrations_inspector = schema_inspectors
 
-            differences = []
-            for table in tables_to_check:
-                models_fks = get_foreign_keys(models_inspector, table)
-                migrations_fks = get_foreign_keys(migrations_inspector, table)
+        # The report_id/review_id family: the PKs and every FK to them
+        columns_to_check = [
+            ("image_reports", "report_id"),
+            ("image_reviews", "review_id"),
+            ("image_reviews", "source_report_id"),
+            ("image_status_history", "report_id"),
+            ("image_status_history", "review_id"),
+            ("image_report_tag_suggestions", "report_id"),
+            ("admin_actions", "report_id"),
+            ("admin_actions", "review_id"),
+            ("review_votes", "review_id"),
+        ]
 
-                for col_key, model_fk in models_fks.items():
-                    if col_key not in migrations_fks:
-                        differences.append(f"{table}: FK on {col_key} exists in models but not migrations")
-                        continue
+        differences = []
+        for table in sorted({table for table, _ in columns_to_check}):
+            models_columns = get_column_types(models_inspector, table)
+            migrations_columns = get_column_types(migrations_inspector, table)
 
-                    migration_fk = migrations_fks[col_key]
+            for check_table, name in columns_to_check:
+                if check_table != table:
+                    continue
 
-                    # Compare CASCADE behavior
-                    model_ondelete = normalize_fk_action(model_fk["ondelete"])
-                    migration_ondelete = normalize_fk_action(migration_fk["ondelete"])
+                model_col = models_columns.get(name)
+                migration_col = migrations_columns.get(name)
+                if model_col is None or migration_col is None:
+                    differences.append(
+                        f"{table}.{name}: missing - models={model_col}, migrations={migration_col}"
+                    )
+                elif model_col != migration_col:
+                    differences.append(
+                        f"{table}.{name}: type mismatch - "
+                        f"models={model_col}, migrations={migration_col}"
+                    )
 
-                    if model_ondelete != migration_ondelete:
-                        differences.append(
-                            f"{table}.{col_key}: ondelete mismatch - "
-                            f"models={model_ondelete}, migrations={migration_ondelete}"
-                        )
-
-                    model_onupdate = normalize_fk_action(model_fk["onupdate"])
-                    migration_onupdate = normalize_fk_action(migration_fk["onupdate"])
-
-                    if model_onupdate != migration_onupdate:
-                        differences.append(
-                            f"{table}.{col_key}: onupdate mismatch - "
-                            f"models={model_onupdate}, migrations={migration_onupdate}"
-                        )
-
-            if differences:
-                pytest.fail(
-                    "Schema differences between models and migrations:\n" + "\n".join(differences)
-                )
-
-        finally:
-            # Cleanup
-            with admin_engine.connect() as conn:
-                conn.execute(text(f"DROP DATABASE IF EXISTS `{db_models}`"))
-                conn.execute(text(f"DROP DATABASE IF EXISTS `{db_migrations}`"))
-            admin_engine.dispose()
+        if differences:
+            pytest.fail(
+                "Column type differences between models and migrations:\n" + "\n".join(differences)
+            )


### PR DESCRIPTION
## Summary

The DB stores `image_reports.report_id` and `image_reviews.review_id` — and every FK referencing them — as `INT(10) UNSIGNED` (legacy schema), but the models declared them signed `int`. Harmless at runtime (small positive auto-increment IDs), but real model↔DB drift: it surfaced when unsigning a single FK column broke `create_all` with errno 150 (signed PK ← unsigned FK), since the family must be signedness-consistent end to end.

## Changes

- **`app/models/types.py`**: new shared `UnsignedInt` (`mysql.INTEGER(unsigned=True)`) with a comment documenting the errno 150 constraint
- **Models**: all 9 family columns unsigned — the `report_id`/`review_id` PKs plus the FKs in `image_status_history`, `image_reviews.source_report_id`, `image_report_tag_suggestions`, `admin_actions`, and `review_votes`; removed the now-stale deferral NOTE in `image_status_history.py`
- **`tests/integration/test_schema_sync.py`**: new `test_column_types_match` diffing reflected type class, signedness, and length via `get_columns` — the existing FK test only compared CASCADE behavior, which is why this drift was never caught. Also refactored the two-database setup into a shared class-scoped fixture so both tests reuse one models/migrations build (~25s instead of ~50s)
- **`docs/plans/2026-06-10-schema-sync-signed-unsigned-drift.md`**: the fix plan plus audit findings

## Scope note

A whole-table diff of these 6 tables surfaced much wider pre-existing drift: unsigned `image_id`/`user_id`/`tag_id` columns (implying the `images`/`users`/`tags` PKs are unsigned in the DB too), `TINYINT` vs `INTEGER` (`status`, `category`, `vote`, `suggestion_type`), and `MEDIUMTEXT` vs `VARCHAR(255)` (`reason_text`, `admin_notes`, `comment`). Fixing any unsigned FK cascades into its parent PK schema-wide, so the new test is scoped to the 9 family columns and the rest is recorded as a follow-up audit work-list in the plan doc.

## Runtime impact

None. Production DDL comes from migrations (which already create these columns unsigned); `mysql.INTEGER(unsigned=True)` has no bind/result processors, so queries are byte-identical; Pydantic-facing annotations remain `int | None`.

## Testing

- TDD: watched `test_column_types_match` fail with exactly the 9 expected signedness mismatches, then go green after the model fix
- `MYSQL_ROOT_PASSWORD=... pytest tests/integration/test_schema_sync.py --schema-sync` — 2 passed
- Full suite: 1763 passed, 10 skipped; mypy and ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)