### PR TITLE
fix(tags): stop logging no-op (empty) → (empty) description changes

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1409,8 +1409,10 @@ async def update_tag(
         )
         db.add(audit_entry)
 
-    # Check for description change
-    if tag.desc != original_desc:
+    # Check for description change. Legacy rows store "no description" as ''
+    # while new writes use NULL; treat the two as the same state so a no-op
+    # edit doesn't log a (empty) → (empty) entry.
+    if (tag.desc or "") != (original_desc or ""):
         audit_entry = TagAuditLog(
             tag_id=tag_id,
             action_type=TagAuditActionType.DESCRIPTION_CHANGE,

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -89,11 +89,12 @@ class TagCreate(TagBase):
         """
         Trim the description *before* the max_length constraint runs, so the limit
         applies to what actually lands in the DB — a value that fits after trimming
-        isn't rejected just for trailing whitespace. HTML escaping is handled by
-        Svelte's safe template interpolation on the frontend.
+        isn't rejected just for trailing whitespace. An empty result becomes None so
+        "no description" has a single representation (NULL, never ''). HTML escaping
+        is handled by Svelte's safe template interpolation on the frontend.
         """
         if isinstance(v, str):
-            return v.strip()
+            return v.strip() or None
         return v
 
 

--- a/tests/api/v1/test_tag_audit_log.py
+++ b/tests/api/v1/test_tag_audit_log.py
@@ -379,6 +379,127 @@ class TestTagAuditLogDescriptionChange:
         assert entries[0].old_desc is None
         assert entries[0].new_desc == "now it has one"
 
+    async def test_empty_string_to_none_creates_no_audit_log(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Legacy tags store desc='' while the edit form sends null; that is not a change."""
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        admin = Users(
+            username="descadmin4",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="descadmin4@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        user_perm = UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1)
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        # Legacy data: description is an empty string, not NULL.
+        tag = Tags(title="legacy empty desc", desc="", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "descadmin4", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        # Edit something else; the form normalizes an empty description to null.
+        update_data = {
+            "title": "legacy empty desc renamed",
+            "desc": None,
+            "type": TagType.THEME,
+        }
+        response = await client.put(
+            f"/api/v1/tags/{tag.tag_id}",
+            json=update_data,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+
+        audit_result = await db_session.execute(
+            select(TagAuditLog).where(
+                TagAuditLog.tag_id == tag.tag_id,
+                TagAuditLog.action_type == TagAuditActionType.DESCRIPTION_CHANGE,
+            )
+        )
+        audit_entries = audit_result.scalars().all()
+        assert len(audit_entries) == 0
+
+    async def test_clearing_description_stores_null_and_logs_new_desc_null(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Submitting desc='' clears the description to NULL, never storing ''."""
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        admin = Users(
+            username="descadmin5",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="descadmin5@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        user_perm = UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1)
+        db_session.add(user_perm)
+        await db_session.commit()
+
+        tag = Tags(title="clearable desc", desc="about to be cleared", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "descadmin5", "password": "AdminPassword123!"},
+        )
+        access_token = login_response.json()["access_token"]
+
+        update_data = {
+            "title": "clearable desc",
+            "desc": "",
+            "type": TagType.THEME,
+        }
+        response = await client.put(
+            f"/api/v1/tags/{tag.tag_id}",
+            json=update_data,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+        assert response.json()["desc"] is None
+
+        audit_result = await db_session.execute(
+            select(TagAuditLog).where(
+                TagAuditLog.tag_id == tag.tag_id,
+                TagAuditLog.action_type == TagAuditActionType.DESCRIPTION_CHANGE,
+            )
+        )
+        audit_entries = audit_result.scalars().all()
+        assert len(audit_entries) == 1
+        assert audit_entries[0].old_desc == "about to be cleared"
+        assert audit_entries[0].new_desc is None
+
 
 @pytest.mark.api
 class TestTagAuditLogTypeChange:


### PR DESCRIPTION
## Problem

Tag history shows entries like `Description: (empty) → (empty)` on edits that didn't touch the description.

84,762 legacy tags store "no description" as `''` (empty string) while only ~1,100 use `NULL`. The frontend edit form normalizes an untouched empty description to `null`, and the audit check in `update_tag` was a plain `tag.desc != original_desc` — `None != ''` is true in Python, so the first edit of any legacy tag wrote a meaningless `DESCRIPTION_CHANGE` audit row (and the history UI faithfully rendered both values as `(empty)`).

## Fix

- **`app/api/v1/tags.py`** — compare with `''` and `NULL` treated as the same "no description" state: `(tag.desc or "") != (original_desc or "")`
- **`app/schemas/tag.py`** — the existing `sanitize_desc` before-validator now coerces an empty/whitespace-only description to `None`, so new writes never reintroduce the `''` representation

No frontend change needed — it was rendering rows that genuinely existed in `tag_audit_log`.

## Tests (TDD)

Two new tests in `tests/api/v1/test_tag_audit_log.py`, both watched failing before the fix:

- `test_empty_string_to_none_creates_no_audit_log` — reproduces the bug: tag with `desc=''`, edit submits `desc=null` → no `DESCRIPTION_CHANGE` row (failed with `assert 1 == 0`)
- `test_clearing_description_stores_null_and_logs_new_desc_null` — clearing a real description with `desc=""` stores `NULL` and logs `new_desc=None` (failed with `assert '' is None`)

Full suite: **1765 passed, 9 skipped** (pre-existing documented skips).

## Not included (deliberately)

- Data migration converting the 84k legacy `desc=''` rows to `NULL` — no longer urgent since legacy tags now converge to `NULL` as they're edited; can be decided separately
- Cleanup of already-written junk audit rows, if any exist in production: `WHERE action_type='description_change' AND COALESCE(old_desc,'')='' AND COALESCE(new_desc,'')=''`
- Whitespace-only legacy descriptions (`desc='  '`) would still log one spurious entry since `'  '` is truthy — noted by review; the data has zero such rows (`SELECT COUNT(*) FROM tags WHERE desc <> '' AND TRIM(desc) = ''` → 0), so not handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
