### PR TITLE
chore(admin-actions): drop the unscheduled 2-year prune job

### DIFF
--- a/app/models/admin_action.py
+++ b/app/models/admin_action.py
@@ -6,7 +6,10 @@ moderation actions. This provides an audit trail for:
 - Report triage (dismiss, action, escalate)
 - Review management (start, vote, close, extend)
 
-The table is pruned after 2 years to maintain manageable size.
+Rows are retained indefinitely: growth is a few thousand rows a year on this
+site, all read paths are indexed point lookups, and an audit trail loses its
+value if history expires. (A 2-year prune job existed but was never scheduled;
+see git history for `prune_admin_actions`.)
 """
 
 from datetime import datetime
@@ -30,8 +33,9 @@ class AdminActions(SQLModel, table=True):
     - References to related entities (report, review, image)
     - JSON details with context (previous/new status, vote value, etc.)
 
-    Note: This table should be pruned periodically (after 2 years) to
-    maintain reasonable size. See background job `prune_admin_actions`.
+    Rows are retained indefinitely (see module docstring). Report-linked rows
+    in particular must never be deleted: report resolutions are derived from
+    them (_populate_report_resolutions).
     """
 
     __tablename__ = "admin_actions"

--- a/app/models/admin_action.py
+++ b/app/models/admin_action.py
@@ -99,7 +99,7 @@ class AdminActions(SQLModel, table=True):
     # - review_close: {"outcome": 1, "vote_count": 5, "keep_votes": 3, "remove_votes": 2}
     details: dict[str, Any] | None = Field(default=None, sa_column=Column(JSON))
 
-    # Timestamp (indexed for pruning queries)
+    # Timestamp (indexed for time-ordered lookups)
     created_at: datetime | None = Field(
         default=None,
         sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),

--- a/app/services/review_jobs.py
+++ b/app/services/review_jobs.py
@@ -1,14 +1,14 @@
 """
 Background jobs for the review system.
 
-Provides scheduled tasks for processing review deadlines and pruning old audit logs.
+Provides scheduled tasks for processing review deadlines.
 """
 
 import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import (
@@ -309,44 +309,3 @@ async def check_early_close(db: AsyncSession, review: ImageReviews) -> tuple[int
 
     outcome = ReviewOutcome.KEEP if keep_votes > remove_votes else ReviewOutcome.REMOVE
     return await _close_review(db, review, outcome, "early_close_margin")
-
-
-async def prune_admin_actions(
-    db: AsyncSession,
-    retention_years: int = 2,
-) -> int:
-    """
-    Delete admin_actions older than retention period.
-
-    Runs monthly to maintain audit log size.
-
-    Args:
-        db: Database session
-        retention_years: How many years of history to keep (default 2)
-
-    Returns:
-        Number of rows deleted
-    """
-    cutoff_date = datetime.now(UTC) - timedelta(days=retention_years * 365)
-
-    stmt = (
-        delete(AdminActions)
-        .where(
-            AdminActions.created_at < cutoff_date,  # type: ignore[arg-type, operator]
-            # Keep report-linked rows: report resolutions are derived from them
-            # (_populate_report_resolutions), so pruning would erase that data.
-            AdminActions.report_id.is_(None),  # type: ignore[union-attr]
-        )
-        .execution_options(synchronize_session=False)
-    )
-    result = await db.execute(stmt)
-    await db.commit()
-
-    deleted_count = result.rowcount or 0  # type: ignore[attr-defined]
-
-    logger.info(
-        f"Pruned {deleted_count} admin_actions older than "
-        f"{cutoff_date.date()} ({retention_years} years)"
-    )
-
-    return deleted_count

--- a/tests/unit/test_review_deadline_job.py
+++ b/tests/unit/test_review_deadline_job.py
@@ -7,7 +7,6 @@ Tests cover all quorum, majority, tie, and edge case scenarios.
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import (
@@ -19,17 +18,15 @@ from app.config import (
 )
 from app.models.admin_action import AdminActions
 from app.models.image import Images
-from app.models.image_report import ImageReports
 from app.models.image_review import ImageReviews
+from app.models.image_status_history import ImageStatusHistory
 from app.models.review_vote import ReviewVotes
 from app.models.user import Users
-from app.models.image_status_history import ImageStatusHistory
 from app.services.review_jobs import (
     _close_review,
     _get_vote_counts,
     check_early_close,
     check_review_deadlines,
-    prune_admin_actions,
 )
 
 
@@ -471,86 +468,6 @@ class TestAuditLogging:
         assert action.user_id is None
         assert action.details["automatic"] is True
         assert action.details["reason"] == "deadline_expired_auto_extend"
-
-
-@pytest.mark.asyncio
-class TestPruneAdminActions:
-    """Tests for admin_actions pruning."""
-
-    async def test_prune_old_actions(self, db_session: AsyncSession):
-        """Old admin_actions are deleted."""
-        now = datetime.now(UTC)
-
-        # Create old action (3 years ago)
-        old_action = AdminActions(
-            user_id=1,
-            action_type=AdminActionType.REPORT_DISMISS,
-            created_at=now - timedelta(days=3 * 365),
-        )
-        db_session.add(old_action)
-
-        # Create recent action (1 month ago)
-        recent_action = AdminActions(
-            user_id=1,
-            action_type=AdminActionType.REPORT_DISMISS,
-            created_at=now - timedelta(days=30),
-        )
-        db_session.add(recent_action)
-        await db_session.commit()
-        await db_session.refresh(recent_action)
-
-        deleted = await prune_admin_actions(db_session, retention_years=2)
-
-        assert deleted == 1
-
-        # Verify recent action still exists
-        from sqlalchemy import select
-        stmt = select(AdminActions).where(AdminActions.action_id == recent_action.action_id)
-        result = await db_session.execute(stmt)
-        assert result.scalar_one_or_none() is not None
-
-    async def test_prune_no_old_actions(self, db_session: AsyncSession):
-        """No actions deleted when all are within retention period."""
-        now = datetime.now(UTC)
-        action = AdminActions(
-            user_id=1,
-            action_type=AdminActionType.REPORT_DISMISS,
-            created_at=now - timedelta(days=30),
-        )
-        db_session.add(action)
-        await db_session.commit()
-
-        deleted = await prune_admin_actions(db_session, retention_years=2)
-
-        assert deleted == 0
-
-    async def test_prune_keeps_report_linked_actions(self, db_session: AsyncSession):
-        """Report-linked audit rows survive past retention: report resolutions are
-        derived from them, so pruning would silently erase resolution data."""
-        now = datetime.now(UTC)
-        img = await create_test_image(db_session, status=ImageStatus.DEACTIVATED)
-        report = ImageReports(image_id=img.image_id, user_id=1, category=2, status=1)
-        db_session.add(report)
-        await db_session.commit()
-        await db_session.refresh(report)
-
-        # Old (3y) report-linked action — must be kept.
-        db_session.add(AdminActions(
-            user_id=1, action_type=AdminActionType.REPORT_ACTION,
-            report_id=report.report_id, image_id=img.image_id,
-            created_at=now - timedelta(days=3 * 365)))
-        # Old (3y) non-report action — should be deleted.
-        db_session.add(AdminActions(
-            user_id=1, action_type=AdminActionType.IMAGE_STATUS_CHANGE,
-            created_at=now - timedelta(days=3 * 365)))
-        await db_session.commit()
-
-        deleted = await prune_admin_actions(db_session, retention_years=2)
-
-        assert deleted == 1  # only the non-report row
-        kept = (await db_session.execute(
-            select(AdminActions).where(AdminActions.report_id == report.report_id))).scalars().all()
-        assert len(kept) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Context

`todo.md` asked whether to keep the 2-year prune on admin actions, pending growth and performance analysis. The analysis came back firmly against — and revealed the prune **was never actually running**: `prune_admin_actions` existed in `review_jobs.py` with unit tests, but was absent from the arq `cron_jobs` list in `app/tasks/worker.py`. The "pruned after 2 years" notes in the model docs described a policy that never executed.

## Growth analysis

Measured from the production-snapshot dev DB:

- `admin_actions` today: 577 rows, ~340 B/row fully indexed (96 KB data + 96 KB index)
- Write drivers at real rates: reports 235–986/yr over the last five years, ~4,900 image uploads/yr, ~310 comments/yr, reviews in the tens
- Generous estimate: **~10–20k rows (~3–7 MB) per year** — ~200k rows after a decade, against an images table of 1.1M rows

## Performance analysis

- The only read path is `_populate_report_resolutions`, an indexed `report_id IN (...)` lookup; `created_at` and `action_type` are also indexed. No table-scan endpoint exists.
- The prune exempted report-linked rows (resolutions are derived from them) — 45% of rows today, and the only rows ever queried. It would have shrunk the unqueried half of an already-tiny table: performance benefit ≈ zero by design.
- An audit log loses its accountability value when history expires; at single-digit MB/year, retention costs nothing.

## Changes

- Remove `prune_admin_actions` from `app/services/review_jobs.py` (and the now-unused `delete` import + docstring mention)
- Remove `TestPruneAdminActions` and its orphaned imports from `tests/unit/test_review_deadline_job.py` (ruff also re-sorted the import block, fixing a pre-existing I001)
- Replace the model's "pruned after 2 years" notes with the actual policy: indefinite retention, with an explicit warning that report-linked rows must never be deleted

Full suite: **1764 passed, 10 skipped**. The function stays recoverable in git history if the math ever changes (revisit around ~1M rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)