### PR TITLE
fix(tags): sort count column by effective count, stabilize ties

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -648,12 +648,48 @@ async def list_tags(
         "tag_id": Tags.tag_id,
         "type": Tags.type,
     }
+    sort_func = desc if sorting.sort_order == "DESC" else asc
 
-    if sorting.sort_by is not None:
-        # Explicit sort_by: always honor it, even during search
+    # A count sort with aliases visible orders by the *effective* count —
+    # COALESCE(target's count, own count), the value the UI displays — so the
+    # sorted column orders by what the user sees. With exclude_aliases the two
+    # counts are identical (every alias row is filtered out), so the plain
+    # indexed column in the map covers it.
+    sorts_by_count = sorting.sort_by == "usage_count" or (sorting.sort_by is None and not search)
+    deferred_count_sort = sorts_by_count and not exclude_aliases
+
+    if deferred_count_sort:
+        # COALESCE over the self-join can't use the usage_count index, and
+        # ordering the full SELECT materializes 230k+ wide rows (desc TEXT)
+        # into a temp table (~210ms vs 0.3ms indexed). Deferred join: sort
+        # narrow (tag_id, count) tuples, paginate down to one page of ids,
+        # then fetch the wide rows for just those ids (~85ms).
+        effective_count = func.coalesce(AliasedTag.usage_count, Tags.usage_count)
+        page_ids = (
+            query.with_only_columns(Tags.tag_id, effective_count.label("effective_count"))  # type: ignore[call-overload]
+            .order_by(sort_func(effective_count), sort_func(Tags.tag_id))  # type: ignore[arg-type]
+            .offset(pagination.offset)
+            .limit(pagination.per_page)
+            .subquery()
+        )
+        query = (
+            select(
+                Tags,
+                AliasedTag.title.label("alias_of_name"),  # type: ignore[union-attr]
+                AliasedTag.usage_count.label("alias_of_usage_count"),  # type: ignore[attr-defined]
+            )
+            .join(page_ids, Tags.tag_id == page_ids.c.tag_id)
+            .outerjoin(
+                AliasedTag,
+                Tags.alias_of == AliasedTag.tag_id,  # type: ignore[arg-type]
+            )
+            .order_by(sort_func(page_ids.c.effective_count), sort_func(Tags.tag_id))  # type: ignore[arg-type]
+        )
+    elif sorting.sort_by is not None:
+        # Explicit sort_by: always honor it, even during search.
+        # tag_id tie-breaker keeps pagination stable when counts/types tie.
         sort_column = sort_column_map[sorting.sort_by]
-        sort_func = desc if sorting.sort_order == "DESC" else asc
-        query = query.order_by(sort_func(sort_column))
+        query = query.order_by(sort_func(sort_column), sort_func(Tags.tag_id))  # type: ignore[arg-type]
     elif search:
         # No explicit sort_by + search: use relevance ranking
         if len(search) < 3 or not fulltext_query_str:
@@ -681,12 +717,18 @@ async def list_tags(
                 func.lower(Tags.title),  # Tertiary sort: alphabetical (case-insensitive)
             ).params(search=fulltext_query_str)
     else:
-        # No search, no explicit sort_by: default to usage_count, honoring sort_order
-        sort_func = desc if sorting.sort_order == "DESC" else asc
-        query = query.order_by(sort_func(sort_column_map["usage_count"]))
+        # No search, no explicit sort_by: default to usage_count, honoring
+        # sort_order. Only reachable with exclude_aliases (aliases-visible
+        # count sorts take the deferred branch), so the plain column is the
+        # effective count here.
+        query = query.order_by(
+            sort_func(sort_column_map["usage_count"]),
+            sort_func(Tags.tag_id),  # type: ignore[arg-type]
+        )
 
-    # Paginate
-    query = query.offset(pagination.offset).limit(pagination.per_page)
+    # Paginate (the deferred branch already paginated inside its subquery)
+    if not deferred_count_sort:
+        query = query.offset(pagination.offset).limit(pagination.per_page)
 
     # Execute
     result = await db.execute(query)

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -559,6 +559,65 @@ class TestTagListSorting:
         titles = [t["title"] for t in data["tags"] if "sort" in t["title"]]
         assert titles == ["unpopular sort", "medium sort", "popular sort"]
 
+    async def test_sort_by_usage_count_uses_effective_count_for_aliases(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Aliases sort by their target's count — the value the UI displays."""
+        target = Tags(title="effective target", type=TagType.CHARACTER, usage_count=100)
+        zero = Tags(title="effective zero", type=TagType.CHARACTER, usage_count=0)
+        mid = Tags(title="effective mid", type=TagType.CHARACTER, usage_count=50)
+        for tag in (target, zero, mid):
+            db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(target)
+
+        # Own count 0, but effective count 100 via the target.
+        alias = Tags(
+            title="effective alias",
+            type=TagType.CHARACTER,
+            usage_count=0,
+            alias_of=target.tag_id,
+        )
+        db_session.add(alias)
+        await db_session.commit()
+
+        response = await client.get("/api/v1/tags?type=4&sort_by=usage_count&sort_order=ASC")
+        assert response.status_code == 200
+        titles = [t["title"] for t in response.json()["tags"] if "effective" in t["title"]]
+        # Alias ties with its target at 100; tag_id tie-breaker puts the
+        # older target row first when ascending.
+        assert titles == ["effective zero", "effective mid", "effective target", "effective alias"]
+
+        response = await client.get("/api/v1/tags?type=4&sort_by=usage_count&sort_order=DESC")
+        assert response.status_code == 200
+        titles = [t["title"] for t in response.json()["tags"] if "effective" in t["title"]]
+        assert titles == ["effective alias", "effective target", "effective mid", "effective zero"]
+
+    async def test_sort_by_usage_count_ties_break_by_tag_id(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Equal counts order by tag_id so pagination is stable across pages."""
+        tags = [
+            Tags(title=f"tiebreak {i}", type=TagType.CHARACTER, usage_count=7)
+            for i in range(3)
+        ]
+        for tag in tags:
+            db_session.add(tag)
+        await db_session.commit()
+        for tag in tags:
+            await db_session.refresh(tag)
+        ids_in_creation_order = [t.tag_id for t in tags]
+
+        response = await client.get("/api/v1/tags?type=4&sort_by=usage_count&sort_order=ASC")
+        assert response.status_code == 200
+        ids = [t["tag_id"] for t in response.json()["tags"] if t["title"].startswith("tiebreak")]
+        assert ids == ids_in_creation_order
+
+        response = await client.get("/api/v1/tags?type=4&sort_by=usage_count&sort_order=DESC")
+        assert response.status_code == 200
+        ids = [t["tag_id"] for t in response.json()["tags"] if t["title"].startswith("tiebreak")]
+        assert ids == list(reversed(ids_in_creation_order))
+
     async def test_sort_order_case_insensitive(
         self, client: AsyncClient, db_session: AsyncSession
     ):

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -618,6 +618,29 @@ class TestTagListSorting:
         ids = [t["tag_id"] for t in response.json()["tags"] if t["title"].startswith("tiebreak")]
         assert ids == list(reversed(ids_in_creation_order))
 
+        # exclude_aliases routes count sorts down the plain indexed branch
+        # (no deferred join) — the tie-breaker must hold there independently.
+        response = await client.get(
+            "/api/v1/tags?type=4&sort_by=usage_count&sort_order=ASC&exclude_aliases=true"
+        )
+        assert response.status_code == 200
+        ids = [t["tag_id"] for t in response.json()["tags"] if t["title"].startswith("tiebreak")]
+        assert ids == ids_in_creation_order
+
+        response = await client.get(
+            "/api/v1/tags?type=4&sort_by=usage_count&sort_order=DESC&exclude_aliases=true"
+        )
+        assert response.status_code == 200
+        ids = [t["tag_id"] for t in response.json()["tags"] if t["title"].startswith("tiebreak")]
+        assert ids == list(reversed(ids_in_creation_order))
+
+        # No sort_by at all hits the default-listing branch (DESC default),
+        # which is only reachable with exclude_aliases.
+        response = await client.get("/api/v1/tags?type=4&exclude_aliases=true")
+        assert response.status_code == 200
+        ids = [t["tag_id"] for t in response.json()["tags"] if t["title"].startswith("tiebreak")]
+        assert ids == list(reversed(ids_in_creation_order))
+
     async def test_sort_order_case_insensitive(
         self, client: AsyncClient, db_session: AsyncSession
     ):


### PR DESCRIPTION
## Problem

On /tags, sorting by count ASC with "Hide aliases" off mixes tags showing 0 with alias tags showing their target's non-zero count. The API sorted on each tag's *own* `usage_count` (0 for aliases) while the UI displays aliases with `alias_of_usage_count` — two different definitions of "count", so the sorted column appears scrambled.

## Fix

`usage_count` sorting now orders by the **effective count** — `COALESCE(target's count, own count)` — the value the UI displays. Plus a `tag_id` tie-breaker on explicit and default sorts so pagination is stable across the thousands of equal-count tags.

## Performance

Benchmarked on the dev DB (233k tags, 56k aliases) because the naive version is a trap: ordering the joined SELECT by `COALESCE` forfeits `idx_tags_usage_count` and filesorts 230k+ wide rows (`desc` TEXT) through a temp table — ~210ms warm / 1s cold versus 0.3ms today. Two measures keep it fast:

- **`exclude_aliases=true` (the UI default) keeps the plain indexed sort** — provably identical ordering since every alias row is filtered out. Default path: unchanged (~0.3ms in DB, ~20-35ms end-to-end).
- **Aliases-visible count sorts use a deferred join**: sort narrow `(tag_id, effective_count)` tuples, paginate down to one page of ids, then fetch the wide rows for just those ids. ~85ms in DB (~110ms end-to-end) — the only path that pays, and it's the one that was producing wrong output.

The tie-breaker is free on indexed paths: InnoDB secondary index entries end in the PK, so `ORDER BY usage_count, tag_id` is still an index walk (verified via EXPLAIN, 50 rows read).

## Testing

- New: `test_sort_by_usage_count_uses_effective_count_for_aliases` (ASC + DESC, alias ties with its target broken by tag_id) — failed before the fix.
- New: `test_sort_by_usage_count_ties_break_by_tag_id` (stable pagination both directions).
- Full `test_tags.py` suite: 152 passed. mypy + ruff clean on the changed app file.
- Verified live against the dev DB: count-ASC page 1 with aliases visible now shows only effective-zero rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)