### PR TITLE
feat(auth): close server-side auth logging gaps (reset-password, access-log IP/UA, suspended login)

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -906,7 +906,24 @@ async def reset_password(
     )
     user = result.scalar_one_or_none()
 
-    if not user or not user.password_reset_token:
+    # The client always sees the same generic 400 to avoid leaking which step failed;
+    # server-side we log the specific outcome so reset failures aren't invisible.
+    if not user:
+        logger.info(
+            "reset_password_attempt",
+            outcome="user_not_found",
+            email=request_data.email,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired reset token",
+        )
+    if not user.password_reset_token:
+        logger.info(
+            "reset_password_attempt",
+            outcome="no_reset_token",
+            user_id=user.user_id,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired reset token",
@@ -915,6 +932,11 @@ async def reset_password(
     # Verify token matches (constant-time comparison to prevent timing side-channels)
     token_hash = hashlib.sha256(request_data.token.encode()).hexdigest()
     if not hmac.compare_digest(user.password_reset_token, token_hash):
+        logger.info(
+            "reset_password_attempt",
+            outcome="token_mismatch",
+            user_id=user.user_id,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired reset token",
@@ -922,12 +944,23 @@ async def reset_password(
 
     # Check expiration
     if not user.password_reset_expires_at:
+        logger.info(
+            "reset_password_attempt",
+            outcome="missing_expiry",
+            user_id=user.user_id,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired reset token",
         )
 
     if user.password_reset_expires_at < datetime.now(UTC):
+        logger.info(
+            "reset_password_attempt",
+            outcome="token_expired",
+            user_id=user.user_id,
+            expired_at=user.password_reset_expires_at.isoformat(),
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Reset token has expired. Please request a new one.",
@@ -949,7 +982,12 @@ async def reset_password(
 
     await db.commit()
 
-    logger.info("password_reset_complete", user_id=user.user_id, username=user.username)
+    logger.info(
+        "reset_password_attempt",
+        outcome="success",
+        user_id=user.user_id,
+        username=user.username,
+    )
 
     return MessageResponse(
         message="Password reset successfully. Please login with your new password."

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -59,6 +59,8 @@ router = APIRouter(prefix="/auth", tags=["Authentication"])
 async def _check_and_handle_suspension(
     user: Users,
     db: AsyncSession,
+    *,
+    log_event: str | None = None,
 ) -> None:
     """
     Check if a user is suspended and handle auto-reactivation if expired.
@@ -68,6 +70,9 @@ async def _check_and_handle_suspension(
     Args:
         user: User object to check
         db: Database session
+        log_event: When set, emit a structured log under this event name (e.g.
+            "login_attempt") for the blocked-access outcomes (account_suspended /
+            account_inactive). Left None by callers that have their own logging.
 
     Raises:
         HTTPException: 403 if user is suspended, 401 if inactive for other reasons
@@ -129,12 +134,31 @@ async def _check_and_handle_suspension(
                 if suspension.reason:
                     message += f" Reason: {suspension.reason}"
 
+                if log_event:
+                    logger.info(
+                        log_event,
+                        outcome="account_suspended",
+                        username=user.username,
+                        user_id=user.user_id,
+                        suspended_until=(
+                            suspension.suspended_until.isoformat()
+                            if suspension.suspended_until
+                            else None
+                        ),
+                    )
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail=message,
                 )
         else:
             # Inactive but not suspended
+            if log_event:
+                logger.info(
+                    log_event,
+                    outcome="account_inactive",
+                    username=user.username,
+                    user_id=user.user_id,
+                )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="User account is inactive",
@@ -389,7 +413,7 @@ async def login(
         )
 
     # Check if user is active and handle suspension
-    await _check_and_handle_suspension(user, db)
+    await _check_and_handle_suspension(user, db, log_event="login_attempt")
 
     # Reset failed login attempts and lockout on successful login
     user.failed_login_attempts = 0

--- a/app/main.py
+++ b/app/main.py
@@ -78,6 +78,11 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
                 + ("?" + _redact_query(str(request.url.query)) if request.url.query else ""),
                 status_code=response.status_code,
                 elapsed_ms=elapsed_ms,
+                # client_host + user_agent let anonymous 401s be clustered by source
+                # (one user fat-fingering vs. credential stuffing). request.client is
+                # None when the ASGI server reports no client (e.g. some test harnesses).
+                client_host=request.client.host if request.client else None,
+                user_agent=request.headers.get("user-agent"),
             )
             return response
         finally:

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -9,6 +9,7 @@ These tests cover the /api/v1/auth endpoints including:
 - Suspension checks during login and refresh
 """
 
+import logging
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -21,6 +22,20 @@ from app.core.security import get_password_hash
 from app.models.refresh_token import RefreshTokens
 from app.models.user import Users
 from app.models.user_suspension import UserSuspensions
+
+
+def assert_outcome_logged(caplog: pytest.LogCaptureFixture, event: str, outcome: str) -> None:
+    """Assert a structured log record carrying both `event` and `outcome=<outcome>` was emitted.
+
+    Matches on contiguous substrings rather than the whole `event=... outcome=...`
+    string because the dev ConsoleRenderer interleaves ANSI color codes between the
+    key, `=`, and value. The event name and outcome value are each emitted as one
+    uninterrupted token, so substring matching on them is stable.
+    """
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        event in message and outcome in message for message in messages
+    ), f"expected log event={event!r} with outcome={outcome!r}; got {messages!r}"
 
 
 @pytest.mark.api
@@ -219,7 +234,7 @@ class TestLogin:
         """Test that accounts with real MD5 passwords return a reset prompt, not a generic auth error."""
         import hashlib
 
-        md5_hash = hashlib.md5("oldpassword".encode()).hexdigest()  # 32-char unsalted MD5
+        md5_hash = hashlib.md5(b"oldpassword").hexdigest()  # 32-char unsalted MD5
 
         user = Users(
             username="md5user",
@@ -246,7 +261,7 @@ class TestLogin:
         """Test that MD5 login attempts count toward the failed attempt lockout threshold."""
         import hashlib
 
-        md5_hash = hashlib.md5("oldpassword".encode()).hexdigest()
+        md5_hash = hashlib.md5(b"oldpassword").hexdigest()
 
         user = Users(
             username="md5lockuser",
@@ -1117,20 +1132,22 @@ class TestResetPassword:
         return user, raw_token
 
     async def test_reset_password_success(
-        self, client: AsyncClient, db_session: AsyncSession
+        self, client: AsyncClient, db_session: AsyncSession, caplog: pytest.LogCaptureFixture
     ):
-        """Test successful password reset."""
+        """Test successful password reset logs a reset_password_attempt success outcome."""
         user, raw_token = await self._create_user_with_reset_token(db_session)
 
-        response = await client.post(
-            "/api/v1/auth/reset-password",
-            json={
-                "email": "reset@example.com",
-                "token": raw_token,
-                "new_password": "NewPassword456!",
-            },
-        )
+        with caplog.at_level(logging.INFO):
+            response = await client.post(
+                "/api/v1/auth/reset-password",
+                json={
+                    "email": "reset@example.com",
+                    "token": raw_token,
+                    "new_password": "NewPassword456!",
+                },
+            )
         assert response.status_code == 200
+        assert_outcome_logged(caplog, "reset_password_attempt", "success")
 
         # Verify token fields are cleared
         await db_session.refresh(user)
@@ -1153,25 +1170,27 @@ class TestResetPassword:
         assert old_login.status_code == 401
 
     async def test_reset_password_invalid_token(
-        self, client: AsyncClient, db_session: AsyncSession
+        self, client: AsyncClient, db_session: AsyncSession, caplog: pytest.LogCaptureFixture
     ):
-        """Test reset with wrong token returns 400."""
+        """Test reset with wrong token returns 400 and logs a token_mismatch outcome."""
         await self._create_user_with_reset_token(db_session)
 
-        response = await client.post(
-            "/api/v1/auth/reset-password",
-            json={
-                "email": "reset@example.com",
-                "token": "wrong_token",
-                "new_password": "NewPassword456!",
-            },
-        )
+        with caplog.at_level(logging.INFO):
+            response = await client.post(
+                "/api/v1/auth/reset-password",
+                json={
+                    "email": "reset@example.com",
+                    "token": "wrong_token",
+                    "new_password": "NewPassword456!",
+                },
+            )
         assert response.status_code == 400
+        assert_outcome_logged(caplog, "reset_password_attempt", "token_mismatch")
 
     async def test_reset_password_expired_token(
-        self, client: AsyncClient, db_session: AsyncSession
+        self, client: AsyncClient, db_session: AsyncSession, caplog: pytest.LogCaptureFixture
     ):
-        """Test reset with expired token returns 400."""
+        """Test reset with expired token returns 400 and logs a token_expired outcome."""
         import hashlib
         import secrets
         from datetime import UTC, datetime, timedelta
@@ -1193,32 +1212,99 @@ class TestResetPassword:
         db_session.add(user)
         await db_session.commit()
 
-        response = await client.post(
-            "/api/v1/auth/reset-password",
-            json={
-                "email": "expired@example.com",
-                "token": raw_token,
-                "new_password": "NewPassword456!",
-            },
-        )
+        with caplog.at_level(logging.INFO):
+            response = await client.post(
+                "/api/v1/auth/reset-password",
+                json={
+                    "email": "expired@example.com",
+                    "token": raw_token,
+                    "new_password": "NewPassword456!",
+                },
+            )
         assert response.status_code == 400
         assert "expired" in response.json()["detail"].lower()
+        assert_outcome_logged(caplog, "reset_password_attempt", "token_expired")
 
     async def test_reset_password_wrong_email(
-        self, client: AsyncClient, db_session: AsyncSession
+        self, client: AsyncClient, db_session: AsyncSession, caplog: pytest.LogCaptureFixture
     ):
-        """Test reset with wrong email returns 400."""
+        """Test reset with wrong email returns 400 and logs a user_not_found outcome."""
         _user, raw_token = await self._create_user_with_reset_token(db_session)
 
-        response = await client.post(
-            "/api/v1/auth/reset-password",
-            json={
-                "email": "wrong@example.com",
-                "token": raw_token,
-                "new_password": "NewPassword456!",
-            },
-        )
+        with caplog.at_level(logging.INFO):
+            response = await client.post(
+                "/api/v1/auth/reset-password",
+                json={
+                    "email": "wrong@example.com",
+                    "token": raw_token,
+                    "new_password": "NewPassword456!",
+                },
+            )
         assert response.status_code == 400
+        assert_outcome_logged(caplog, "reset_password_attempt", "user_not_found")
+
+    async def test_reset_password_no_pending_token(
+        self, client: AsyncClient, db_session: AsyncSession, caplog: pytest.LogCaptureFixture
+    ):
+        """Test reset for a user with no pending token returns 400 and logs no_reset_token."""
+        user = Users(
+            username="notokenuser",
+            password=get_password_hash("OldPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="notoken@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+
+        with caplog.at_level(logging.INFO):
+            response = await client.post(
+                "/api/v1/auth/reset-password",
+                json={
+                    "email": "notoken@example.com",
+                    "token": "anytoken",
+                    "new_password": "NewPassword456!",
+                },
+            )
+        assert response.status_code == 400
+        assert_outcome_logged(caplog, "reset_password_attempt", "no_reset_token")
+
+    async def test_reset_password_missing_expiry(
+        self, client: AsyncClient, db_session: AsyncSession, caplog: pytest.LogCaptureFixture
+    ):
+        """Test reset for a token row with no expiry returns 400 and logs missing_expiry."""
+        import hashlib
+        import secrets
+
+        raw_token = secrets.token_urlsafe(32)
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+
+        user = Users(
+            username="noexpiryuser",
+            password=get_password_hash("OldPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="noexpiry@example.com",
+            active=1,
+            password_reset_token=token_hash,
+            password_reset_sent_at=datetime.now(UTC),
+            password_reset_expires_at=None,
+        )
+        db_session.add(user)
+        await db_session.commit()
+
+        with caplog.at_level(logging.INFO):
+            response = await client.post(
+                "/api/v1/auth/reset-password",
+                json={
+                    "email": "noexpiry@example.com",
+                    "token": raw_token,
+                    "new_password": "NewPassword456!",
+                },
+            )
+        assert response.status_code == 400
+        assert_outcome_logged(caplog, "reset_password_attempt", "missing_expiry")
 
     async def test_reset_password_weak_password(
         self, client: AsyncClient, db_session: AsyncSession

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -714,7 +714,7 @@ class TestLoginSuspensionCheck:
     """Tests for suspension checking during login."""
 
     async def test_login_blocked_by_active_suspension(
-        self, client: AsyncClient, db_session: AsyncSession
+        self, client: AsyncClient, db_session: AsyncSession, caplog: pytest.LogCaptureFixture
     ):
         """Test that login is blocked when user has an active suspension."""
         # Create suspended user
@@ -743,16 +743,18 @@ class TestLoginSuspensionCheck:
         await db_session.commit()
 
         # Attempt login
-        response = await client.post(
-            "/api/v1/auth/login",
-            json={"username": "suspendedlogin", "password": "TestPassword123!"},
-        )
+        with caplog.at_level(logging.INFO):
+            response = await client.post(
+                "/api/v1/auth/login",
+                json={"username": "suspendedlogin", "password": "TestPassword123!"},
+            )
 
         assert response.status_code == 403
         assert "violated our terms" in response.json()["detail"].lower()
+        assert_outcome_logged(caplog, "login_attempt", "account_suspended")
 
     async def test_login_blocked_by_permanent_suspension(
-        self, client: AsyncClient, db_session: AsyncSession
+        self, client: AsyncClient, db_session: AsyncSession, caplog: pytest.LogCaptureFixture
     ):
         """Test that login is blocked when user has a permanent suspension."""
         user = Users(
@@ -778,13 +780,15 @@ class TestLoginSuspensionCheck:
         db_session.add(suspension)
         await db_session.commit()
 
-        response = await client.post(
-            "/api/v1/auth/login",
-            json={"username": "permaban", "password": "TestPassword123!"},
-        )
+        with caplog.at_level(logging.INFO):
+            response = await client.post(
+                "/api/v1/auth/login",
+                json={"username": "permaban", "password": "TestPassword123!"},
+            )
 
         assert response.status_code == 403
         assert "permanent" in response.json()["detail"].lower()
+        assert_outcome_logged(caplog, "login_attempt", "account_suspended")
 
     async def test_login_auto_reactivates_expired_suspension(
         self, client: AsyncClient, db_session: AsyncSession
@@ -837,7 +841,7 @@ class TestLoginSuspensionCheck:
         assert reactivation.actioned_by is None  # Auto-reactivated
 
     async def test_login_inactive_user_without_suspension(
-        self, client: AsyncClient, db_session: AsyncSession
+        self, client: AsyncClient, db_session: AsyncSession, caplog: pytest.LogCaptureFixture
     ):
         """Test that inactive users without suspension records get appropriate error."""
         user = Users(
@@ -852,13 +856,15 @@ class TestLoginSuspensionCheck:
         await db_session.commit()
         # No suspension record created
 
-        response = await client.post(
-            "/api/v1/auth/login",
-            json={"username": "inactivenosuspension", "password": "TestPassword123!"},
-        )
+        with caplog.at_level(logging.INFO):
+            response = await client.post(
+                "/api/v1/auth/login",
+                json={"username": "inactivenosuspension", "password": "TestPassword123!"},
+            )
 
         assert response.status_code == 401
         assert "inactive" in response.json()["detail"].lower()
+        assert_outcome_logged(caplog, "login_attempt", "account_inactive")
 
 
 @pytest.mark.api

--- a/tests/test_request_logging.py
+++ b/tests/test_request_logging.py
@@ -1,0 +1,38 @@
+"""Tests for the RequestLoggingMiddleware access log in app/main.py."""
+
+import logging
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.api
+async def test_request_complete_logs_client_host_and_user_agent(
+    client: AsyncClient, caplog: pytest.LogCaptureFixture
+):
+    """The request_complete access log records the client host and user agent.
+
+    Without these, anonymous 401s can't be clustered by source — you can't tell
+    one user fat-fingering a password from credential stuffing across many IPs.
+    """
+    with caplog.at_level(logging.INFO):
+        response = await client.get("/health", headers={"user-agent": "test-agent/9.9"})
+    assert response.status_code == 200
+
+    # The dev ConsoleRenderer interleaves ANSI color codes between a field's key,
+    # `=`, and value, so match on the contiguous value tokens rather than `key=value`.
+    request_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if "request_complete" in record.getMessage()
+    ]
+    assert request_logs, (
+        "no request_complete log emitted; "
+        f"got {[record.getMessage() for record in caplog.records]}"
+    )
+    assert any("test-agent/9.9" in message for message in request_logs), (
+        f"user agent missing from access log; got {request_logs!r}"
+    )
+    assert any("127.0.0.1" in message for message in request_logs), (
+        f"client host missing from access log; got {request_logs!r}"
+    )

--- a/tests/test_request_logging.py
+++ b/tests/test_request_logging.py
@@ -33,6 +33,9 @@ async def test_request_complete_logs_client_host_and_user_agent(
     assert any("test-agent/9.9" in message for message in request_logs), (
         f"user agent missing from access log; got {request_logs!r}"
     )
+    # The httpx ASGITransport reports the loopback address as request.client, so a
+    # wired-up client_host shows up as 127.0.0.1. If the test transport ever changes
+    # (e.g. a Unix-socket transport with no client), update this expected host.
     assert any("127.0.0.1" in message for message in request_logs), (
         f"client host missing from access log; got {request_logs!r}"
     )


### PR DESCRIPTION
## Summary

Closes server-side observability gaps in the auth path (todo items #1 account_suspended, #2 reset-password half, #3 access log).

### 1. reset-password failure logging (`app/api/v1/auth.py`)
Previously only success was logged (`password_reset_complete`); every failure branch was silent. Each branch now emits `reset_password_attempt` with a distinct `outcome`:

| Outcome | Branch | Fields |
|---------|--------|--------|
| `user_not_found` | no user for that email | `email` |
| `no_reset_token` | user has no pending token | `user_id` |
| `token_mismatch` | token hash doesn't match | `user_id` |
| `missing_expiry` | token row has null expiry (defensive) | `user_id` |
| `token_expired` | past expiry | `user_id`, `expired_at` |
| `success` | reset completed | `user_id`, `username` |

The combined `not user or not token` guard is split so the two causes are distinguishable; the client still receives the same generic 400. Success renamed `password_reset_complete` → `reset_password_attempt outcome=success` to match the `login_attempt` / `forgot_password_attempt` convention.

### 2. IP / user-agent on the access log (`app/main.py`)
`request_complete` now records `client_host` (`request.client.host`, `None`-guarded) and `user_agent`, so anonymous 401s can be clustered by source.

### 3. suspended / inactive login outcomes (`app/api/v1/auth.py`)
`_check_and_handle_suspension` ran after a correct password but emitted no log — a suspended account with the right password was the one login outcome with no trace. The helper now takes an optional `log_event`; `login` passes `"login_attempt"` so blocked access logs `outcome=account_suspended` (with `suspended_until`) or `outcome=account_inactive`. `refresh_token` keeps its existing behavior. This completes the `login_attempt` outcome taxonomy.

## Tests
- `tests/api/v1/test_auth.py`: log assertions added to the existing reset-failure/success and login-suspension tests, plus new tests for the split reset branches (`no_reset_token`, `missing_expiry`). Shared `assert_outcome_logged` helper (matches contiguous tokens — the dev ConsoleRenderer interleaves ANSI codes between key/`=`/value).
- `tests/test_request_logging.py`: new test asserting the access log carries client host + user agent.
- Every new assertion watched fail (RED) before implementing (GREEN).
- Fixed two pre-existing `UP012` lint nits in `test_auth.py` surfaced while editing.

**Full suite: 1769 passed, 10 skipped. ruff + mypy clean.**

## Review feedback (PR #254 bot review)
- **`127.0.0.1` hardcode in the access-log test** — added a clarifying comment about the ASGITransport loopback-client assumption.
- **Raw `email` in `user_not_found` log (newline log-injection)** — left as-is: our renderer is JSON (newlines escaped, Alloy parses JSON downstream), the same pattern already exists in `forgot_password_attempt`, and it's a codebase-wide concern better handled as a dedicated sanitise-on-log pass than piecemeal here. Flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)