### PR TITLE
chore(auth): log /auth/refresh 401 reasons to diagnose recurring logouts

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -616,10 +616,12 @@ async def refresh_token(
     if user.active:
         await db.commit()
 
-    # Create new access token
+    # Create new access token. Named distinctly from the `access_token` cookie
+    # parameter above (which feeds the had_access_cookie diagnostic) so the two
+    # can never be confused.
     if user.user_id is None:
         raise ValueError("User ID cannot be None")
-    access_token = create_access_token(user.user_id)
+    new_access_token = create_access_token(user.user_id)
 
     # Create new refresh token (rotation)
     new_refresh_token = create_refresh_token()
@@ -647,7 +649,7 @@ async def refresh_token(
     await db.commit()
 
     # Set authentication cookies
-    _set_auth_cookies(response, access_token, new_refresh_token)
+    _set_auth_cookies(response, new_access_token, new_refresh_token)
 
     # `user` already has user_groups eager-loaded (see the SELECT earlier), so
     # the helper skips its internal DB round trip and the None branch can't
@@ -655,7 +657,7 @@ async def refresh_token(
     user_response = await build_user_private_response(db, redis_client, user=user)
 
     return TokenResponse(
-        access_token=access_token,
+        access_token=new_access_token,
         token_type="bearer",
         expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
         user=user_response,

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
 import redis.asyncio as redis
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, Request, Response, status
 from sqlalchemy import delete, desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -463,9 +463,10 @@ async def login(
 async def refresh_token(
     request: Request,
     response: Response,
-    refresh_token: Annotated[str, Depends(get_refresh_token_from_cookie)],
     db: Annotated[AsyncSession, Depends(get_db)],
     redis_client: Annotated[redis.Redis, Depends(get_redis)],  # type: ignore[type-arg]
+    refresh_token: Annotated[str | None, Cookie()] = None,
+    access_token: Annotated[str | None, Cookie()] = None,
 ) -> TokenResponse:
     """
     Refresh access token using refresh token.
@@ -481,6 +482,24 @@ async def refresh_token(
     If an already-used (revoked) refresh token is presented, this indicates
     potential token theft, and all tokens in the family are revoked.
     """
+    # TEMP INSTRUMENTATION (remove after capturing the prod 401-reason split):
+    # classify every refresh failure so we can confirm the dominant cause before
+    # reworking rotation/cookies. `had_access_cookie` distinguishes "cookies
+    # diverged" (access cookie present, refresh cookie gone) from a benign
+    # unauthenticated poke; `user_agent` exposes any browser-specific skew.
+    if not refresh_token:
+        logger.info(
+            "refresh_failed",
+            reason="cookie_missing",
+            had_access_cookie=bool(access_token),
+            user_agent=get_user_agent(request),
+            ip_address=get_client_ip(request),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Refresh token missing",
+        )
+
     # Hash the provided token to look up in database
     token_hash = hashlib.sha256(refresh_token.encode()).hexdigest()
 
@@ -489,6 +508,13 @@ async def refresh_token(
     db_token = result.scalar_one_or_none()
 
     if not db_token:
+        logger.info(
+            "refresh_failed",
+            reason="token_not_found",
+            had_access_cookie=bool(access_token),
+            user_agent=get_user_agent(request),
+            ip_address=get_client_ip(request),
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid refresh token",
@@ -496,6 +522,14 @@ async def refresh_token(
 
     # Check if token is expired
     if db_token.expires_at < datetime.now(UTC):
+        logger.info(
+            "refresh_failed",
+            reason="expired",
+            user_id=db_token.user_id,
+            had_access_cookie=bool(access_token),
+            user_agent=get_user_agent(request),
+            ip_address=get_client_ip(request),
+        )
         # Clean up expired token
         await db.delete(db_token)
         await db.commit()


### PR DESCRIPTION
## Why

The new site has a **site-wide forced-logout problem**: ~32% of `/auth/refresh` calls return 401 (380 of 1196 over 7 days), and many users re-login repeatedly. Before reworking token rotation / cookie policy, we want to **confirm the dominant cause from prod data** rather than guess (prior fixes in this area haven't fully resolved it).

The two revoked-token branches already emit events (`refresh_race_condition_detected` / `refresh_token_reuse_detected`), but the three other 401 paths were silent — so we can't currently tell whether failures are cookie-delivery, rotation desync, or genuinely expired sessions.

## What this does

Adds structured `refresh_failed` logging to the three silent 401 branches in `app/api/v1/auth.py`:

| `reason` | meaning |
|---|---|
| `cookie_missing` | no `refresh_token` cookie was sent |
| `token_not_found` | token not in DB (already rotated away) |
| `expired` | past the 30-day refresh lifetime |

Each log also carries:
- **`had_access_cookie`** — distinguishes "cookies diverged" (access cookie present, refresh cookie gone) from a benign unauthenticated poke
- **`user_agent` / `ip_address`** — separates SSR-side refreshes (`node`, frontend IP) from client-side ones (real browser/IP), exposing any browser-specific skew

To log the missing-cookie case in one place, the endpoint now reads the `refresh_token` + `access_token` cookies directly instead of via the raising `get_refresh_token_from_cookie` dependency (still used by `/auth/logout`).

## Not a behavior change

Status codes and error details are **unchanged**. This is logging-only and reversible.

## Validation

- `tests/api/v1/test_auth.py`: **42 passed** (run against disposable MariaDB 12 + Redis)
- `ruff check` + `mypy` clean

## After merge / deploy

1. Deploy and let it run ~1 day.
2. Read the breakdown: `{service_name="api"} |= "refresh_failed"` grouped by `reason` / `had_access_cookie` / `user_agent`.
3. That decides where the real fix lands (self-healing rotation + 30-min access token + `SameSite=Lax` + single-refresher frontend).

> Temporary diagnostic — **remove once the prod 401-reason split is captured.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)