### PR TITLE
fix(auth): SameSite=Lax on auth cookies (fixes recurring SSR logouts)

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -177,13 +177,24 @@ def _set_auth_cookies(response: Response, access_token: str, refresh_token: str)
         access_token: JWT access token
         refresh_token: Refresh token
     """
+    # SameSite=Lax (NOT Strict). This is a server-rendered app, so the SSR needs
+    # the auth cookie on the *top-level document request*. SameSite=Strict
+    # withholds cookies from top-level navigations the browser doesn't treat as
+    # same-site-initiated — reloads, links from other sites, or a tab first opened
+    # cross-site — so the server renders logged-out even though the session is
+    # valid (this caused the recurring "logged out after refresh" reports). Lax
+    # sends cookies on top-level GET navigations while still withholding them from
+    # cross-site POST/PUT/DELETE, so CSRF protection for state-changing requests is
+    # preserved (and the API has no state-changing GET endpoints). Do NOT change
+    # this back to Strict without first fixing SSR auth.
+
     # Set refresh token as HTTPOnly cookie
     response.set_cookie(
         key="refresh_token",
         value=refresh_token,
         httponly=True,  # Prevent JavaScript access (XSS protection)
         secure=settings.ENVIRONMENT != "development",  # HTTPS everywhere except development
-        samesite="strict",  # CSRF protection
+        samesite="lax",
         max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,  # seconds
     )
 
@@ -197,7 +208,7 @@ def _set_auth_cookies(response: Response, access_token: str, refresh_token: str)
         value=access_token,
         httponly=True,  # Prevent JavaScript access (XSS protection)
         secure=settings.ENVIRONMENT != "development",  # HTTPS everywhere except development
-        samesite="strict",  # CSRF protection
+        samesite="lax",
         max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
     )
 
@@ -209,22 +220,22 @@ def _clear_auth_cookies(response: Response) -> None:
     Args:
         response: FastAPI response object
     """
-    # Clear refresh token (match set_cookie params)
+    # Clear refresh token (match set_cookie params, incl. SameSite=Lax)
     response.delete_cookie(
         key="refresh_token",
         path="/",
         httponly=True,
         secure=settings.ENVIRONMENT != "development",
-        samesite="strict",
+        samesite="lax",
     )
 
-    # Clear access token (match set_cookie params)
+    # Clear access token (match set_cookie params, incl. SameSite=Lax)
     response.delete_cookie(
         key="access_token",
         path="/",
         httponly=True,
         secure=settings.ENVIRONMENT != "development",
-        samesite="strict",
+        samesite="lax",
     )
 
 

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -382,6 +382,45 @@ class TestLogin:
 class TestRefresh:
     """Tests for POST /api/v1/auth/refresh endpoint."""
 
+    async def test_refresh_cookies_are_samesite_lax(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Rotated cookies from /auth/refresh must also be SameSite=Lax.
+
+        _set_auth_cookies is shared with login, but refresh rotates both cookies
+        on every call, so guard the SameSite policy on this path too (see
+        test_login_cookies_are_samesite_lax for the rationale).
+        """
+        user = Users(
+            username="refreshsamesiteuser",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="refreshsamesite@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "refreshsamesiteuser", "password": "TestPassword123!"},
+        )
+        assert login_response.status_code == 200
+
+        refresh_response = await client.post("/api/v1/auth/refresh")
+        assert refresh_response.status_code == 200
+
+        set_cookies = refresh_response.headers.get_list("set-cookie")
+        auth_cookies = [
+            c for c in set_cookies if c.startswith(("refresh_token=", "access_token="))
+        ]
+        assert len(auth_cookies) == 2, f"expected both rotated cookies, got: {set_cookies}"
+        for cookie in auth_cookies:
+            lowered = cookie.lower()
+            assert "samesite=lax" in lowered, f"rotated cookie is not SameSite=Lax: {cookie}"
+            assert "samesite=strict" not in lowered
+
     async def test_refresh_token_success(self, client: AsyncClient, db_session: AsyncSession):
         """Test successful token refresh."""
         # Create user and login

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -82,6 +82,47 @@ class TestLogin:
         # Security: refresh token must NOT be in response body (HTTPOnly cookie only)
         assert "refresh_token" not in data
 
+    async def test_login_cookies_are_samesite_lax(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Auth cookies must be SameSite=Lax, never Strict.
+
+        This is a server-rendered app: the SSR needs the auth cookie on the
+        top-level document request. SameSite=Strict withholds cookies from
+        top-level navigations the browser doesn't treat as same-site-initiated
+        (reloads, links from other sites, a tab first opened cross-site), which
+        made the SSR render logged-out despite a valid session — the recurring
+        "logged out after refresh" bug. Lax sends the cookie on top-level GET
+        navigations while still blocking cross-site POST/PUT/DELETE, so CSRF
+        protection for state-changing requests is preserved.
+        """
+        user = Users(
+            username="samesiteuser",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="samesite@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+
+        response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": "samesiteuser", "password": "TestPassword123!"},
+        )
+        assert response.status_code == 200
+
+        set_cookies = response.headers.get_list("set-cookie")
+        auth_cookies = [
+            c for c in set_cookies if c.startswith(("refresh_token=", "access_token="))
+        ]
+        assert len(auth_cookies) == 2, f"expected both auth cookies, got: {set_cookies}"
+        for cookie in auth_cookies:
+            lowered = cookie.lower()
+            assert "samesite=lax" in lowered, f"auth cookie is not SameSite=Lax: {cookie}"
+            assert "samesite=strict" not in lowered
+
     async def test_login_wrong_password(self, client: AsyncClient, db_session: AsyncSession):
         """Test login with incorrect password."""
         user = Users(


### PR DESCRIPTION
## Root cause

The recurring **"logged out after refresh"** problem is `SameSite=Strict` on the auth cookies.

This is a server-rendered (SvelteKit) app: the SSR authenticates from the **top-level document request**. `SameSite=Strict` withholds cookies from top-level navigations the browser doesn't treat as same-site-*initiated* — page reloads, links from other sites, or a tab first opened cross-site. So the server renders logged-out even when the session is perfectly valid; the user re-logs-in, and it happens again.

**Confirmed by direct observation** in the browser: on a hard refresh, the `GET /` document request carried **no `Cookie` header**, while the same-site subresource requests in the same load (`/_app/immutable/chunks/*.js`, `/api/v1/...`) carried both cookies. It's also per-tab "sticky": a tab opened cross-site stays broken across reloads, while a new tab opened by typing the URL is fine — the exact signature of Strict's top-level-navigation rule.

## Fix

Switch both auth cookies to `SameSite=Lax` in `_set_auth_cookies` and `_clear_auth_cookies`. Lax sends the cookie on top-level **GET** navigations (so the SSR sees the session) while still withholding it from cross-site **POST/PUT/DELETE**.

## Why this is safe

- **No CSRF regression.** Verified there are **no state-changing GET endpoints** — every mutation is POST/PUT/PATCH/DELETE, and Lax still strips the cookie from cross-site versions of those. The only new thing Lax permits is the cookie on a cross-site top-level GET, and GETs don't change state.
- `Lax` is the **browser default** for cookies set without an explicit `SameSite`.
- SvelteKit form-action origin checks and the API CORS allowlist are unchanged.

## Tests

- New `test_login_cookies_are_samesite_lax` asserts both cookies are `Lax` (never `Strict`).
- Full `test_auth.py`: **43 passed**. `ruff` + `mypy` clean.

## Companion change

Frontend `getAuthCookieOptions` is aligned to `Lax` in a separate `shuushuu-frontend` PR (used for the logout cookie-delete; the SSR relay already propagates the backend's SameSite via `parseSetCookie`, so this API change is what actually flips the policy).

## Relation to #257

#257 instruments `/auth/refresh` 401s to measure the *separate* rotation-desync issue. This SameSite bug doesn't even reach `/auth/refresh` (the SSR has no cookie, so it never calls refresh), so the two are independent fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)