### PR TITLE
feat(search): exclude users from image search (exclude_user_id / exclude_favorited_by_user_id / exclude_commenter)

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -533,6 +533,7 @@ async def list_images(
     - `/images?hascomments=false` - Images with no comments
     - `/images?exclude_user_id=5,6` - Hide uploads by users 5 and 6
     - `/images?exclude_commenter=10` - Hide images user 10 commented on
+    - `/images?exclude_favorited_by_user_id=7` - Hide images user 7 favorited
     """
     # Build base query
     query = select(Images)
@@ -771,13 +772,17 @@ async def list_images(
         # Filter to images WITHOUT comments using posts counter
         query = query.where(Images.posts == 0)  # type: ignore[arg-type]
 
-    # Exclude commenter filter: anti-join to exclude images commented on by specified users
+    # Exclude commenter filter: anti-join to exclude images commented on by specified users.
+    # The legacy posts table's image_id is nullable, so the subquery must exclude NULL
+    # rows explicitly — SQL's NOT IN returns UNKNOWN (not TRUE) for every row when the
+    # subquery yields a NULL, which would silently empty the whole search.
     exclude_commenter_ids = _parse_user_id_list(exclude_commenter, "exclude_commenter")
     if exclude_commenter_ids:
         query = query.where(
             Images.image_id.notin_(  # type: ignore[union-attr]
                 select(Comments.image_id).where(  # type: ignore[call-overload]
-                    Comments.user_id.in_(exclude_commenter_ids)  # type: ignore[attr-defined]
+                    Comments.user_id.in_(exclude_commenter_ids),  # type: ignore[attr-defined]
+                    Comments.image_id.is_not(None),  # type: ignore[union-attr]
                 )
             )
         )

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -836,7 +836,16 @@ async def list_images(
     if is_bare_default_feed:
         total = await _default_feed_total(db, current_user, redis_client)
     else:
-        count_query = select(func.count()).select_from(query.subquery())
+        # When comment filters JOIN Comments, one image can match multiple
+        # comment rows — count distinct images to match the page subquery's
+        # distinct() below, or the pagination total is inflated.
+        if commenter is not None or commentsearch is not None:
+            distinct_ids = query.with_only_columns(
+                Images.image_id.label("image_id")  # type: ignore[union-attr]
+            ).distinct()
+            count_query = select(func.count()).select_from(distinct_ids.subquery())
+        else:
+            count_query = select(func.count()).select_from(query.subquery())
         total = (await db.execute(count_query)).scalar() or 0
 
     # Performance optimization: Two-stage query for fast filtering and sorting

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -310,6 +310,7 @@ class _FeedFilters:
     min_num_ratings: int | None = None
     commenter: int | None = None
     commentsearch: str | None = None
+    exclude_commenter: str | None = None
     hascomments: bool | None = None
     reported: bool | None = None
 
@@ -467,6 +468,10 @@ async def list_images(
     commenter: Annotated[
         int | None, Query(description="Filter by user who commented on the image")
     ] = None,
+    exclude_commenter: Annotated[
+        str | None,
+        Query(description="Comma-separated user IDs; exclude images any of them commented on"),
+    ] = None,
     commentsearch: Annotated[
         str | None, Query(description="Full-text search in comment text")
     ] = None,
@@ -526,6 +531,8 @@ async def list_images(
     - `/images?commentsearch=+great -bad&commentsearch_mode=boolean` - Boolean fulltext
     - `/images?hascomments=true` - Images that have comments
     - `/images?hascomments=false` - Images with no comments
+    - `/images?exclude_user_id=5,6` - Hide uploads by users 5 and 6
+    - `/images?exclude_commenter=10` - Hide images user 10 commented on
     """
     # Build base query
     query = select(Images)
@@ -764,6 +771,17 @@ async def list_images(
         # Filter to images WITHOUT comments using posts counter
         query = query.where(Images.posts == 0)  # type: ignore[arg-type]
 
+    # Exclude commenter filter: anti-join to exclude images commented on by specified users
+    exclude_commenter_ids = _parse_user_id_list(exclude_commenter, "exclude_commenter")
+    if exclude_commenter_ids:
+        query = query.where(
+            Images.image_id.notin_(  # type: ignore[union-attr]
+                select(Comments.image_id).where(  # type: ignore[call-overload]
+                    Comments.user_id.in_(exclude_commenter_ids)  # type: ignore[attr-defined]
+                )
+            )
+        )
+
     # Reported filtering: restrict to images that have a PENDING report. Mods only
     # (REPORT_VIEW) so it never leaks the triage queue — silently a no-op for everyone else.
     apply_reported = (
@@ -807,6 +825,7 @@ async def list_images(
         min_num_ratings=min_num_ratings,
         commenter=commenter,
         commentsearch=commentsearch,
+        exclude_commenter=exclude_commenter or None,
         hascomments=hascomments,
         reported=apply_reported or None,
     )

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -295,6 +295,7 @@ class _FeedFilters:
     user_id: int | None = None
     favorited_by_user_id: int | None = None
     exclude_user_id: str | None = None
+    exclude_favorited_by_user_id: str | None = None
     tags: str | None = None
     exclude_tags: str | None = None
     missing_tag_types: str | None = None
@@ -397,6 +398,10 @@ async def list_images(
     exclude_user_id: Annotated[
         str | None,
         Query(description="Comma-separated user IDs whose uploads to exclude (e.g., '5,6')"),
+    ] = None,
+    exclude_favorited_by_user_id: Annotated[
+        str | None,
+        Query(description="Comma-separated user IDs; exclude images any of them favorited"),
     ] = None,
     image_status: Annotated[
         list[int] | None,
@@ -534,6 +539,17 @@ async def list_images(
     if favorited_by_user_id is not None:
         # Join with Favorites table to filter by user who favorited
         query = query.join(Favorites).where(Favorites.user_id == favorited_by_user_id)  # type: ignore[arg-type]
+    exclude_favorited_ids = _parse_user_id_list(
+        exclude_favorited_by_user_id, "exclude_favorited_by_user_id"
+    )
+    if exclude_favorited_ids:
+        query = query.where(
+            Images.image_id.notin_(  # type: ignore[union-attr]
+                select(Favorites.image_id).where(  # type: ignore[call-overload]
+                    Favorites.user_id.in_(exclude_favorited_ids)  # type: ignore[attr-defined]
+                )
+            )
+        )
     # Status filtering: explicit param overrides, otherwise use user's show_all_images setting
     if image_status is not None:
         # Explicit status filter - always honor it (supports single or multiple values)
@@ -776,6 +792,7 @@ async def list_images(
         user_id=user_id,
         favorited_by_user_id=favorited_by_user_id,
         exclude_user_id=exclude_user_id or None,
+        exclude_favorited_by_user_id=exclude_favorited_by_user_id or None,
         tags=tags or None,
         exclude_tags=exclude_tags or None,
         missing_tag_types=missing_tag_types or None,

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -294,6 +294,7 @@ class _FeedFilters:
     image_status: list[int] | None = None
     user_id: int | None = None
     favorited_by_user_id: int | None = None
+    exclude_user_id: str | None = None
     tags: str | None = None
     exclude_tags: str | None = None
     missing_tag_types: str | None = None
@@ -310,6 +311,24 @@ class _FeedFilters:
     commentsearch: str | None = None
     hascomments: bool | None = None
     reported: bool | None = None
+
+
+def _parse_user_id_list(raw: str | None, param: str) -> list[int]:
+    """Parse a comma-separated user-id list param (``exclude_user_id`` etc.).
+
+    isdecimal() (not isdigit()): int() rejects chars like '²' that isdigit() matches.
+    Capped at MAX_SEARCH_USERS to bound the NOT IN list, mirroring the tags cap.
+    """
+    if not raw:
+        return []
+    ids = [int(tok.strip()) for tok in raw.split(",") if tok.strip().isdecimal()]
+    if len(ids) > settings.MAX_SEARCH_USERS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"You can only exclude up to {settings.MAX_SEARCH_USERS} users at a time"
+            f" ({param}).",
+        )
+    return ids
 
 
 async def _default_feed_total(
@@ -374,6 +393,10 @@ async def list_images(
     user_id: Annotated[int | None, Query(description="Filter by uploader user ID")] = None,
     favorited_by_user_id: Annotated[
         int | None, Query(description="Filter by user who favorited the image")
+    ] = None,
+    exclude_user_id: Annotated[
+        str | None,
+        Query(description="Comma-separated user IDs whose uploads to exclude (e.g., '5,6')"),
     ] = None,
     image_status: Annotated[
         list[int] | None,
@@ -505,6 +528,9 @@ async def list_images(
     # Apply basic filters
     if user_id is not None:
         query = query.where(Images.user_id == user_id)  # type: ignore[arg-type]
+    exclude_user_ids = _parse_user_id_list(exclude_user_id, "exclude_user_id")
+    if exclude_user_ids:
+        query = query.where(Images.user_id.notin_(exclude_user_ids))  # type: ignore[attr-defined]
     if favorited_by_user_id is not None:
         # Join with Favorites table to filter by user who favorited
         query = query.join(Favorites).where(Favorites.user_id == favorited_by_user_id)  # type: ignore[arg-type]
@@ -749,6 +775,7 @@ async def list_images(
         image_status=image_status,
         user_id=user_id,
         favorited_by_user_id=favorited_by_user_id,
+        exclude_user_id=exclude_user_id or None,
         tags=tags or None,
         exclude_tags=exclude_tags or None,
         missing_tag_types=missing_tag_types or None,

--- a/app/api/v1/meta.py
+++ b/app/api/v1/meta.py
@@ -14,6 +14,7 @@ class PublicConfig(BaseModel):
     """Public configuration exposed to frontend"""
 
     max_search_tags: int
+    max_search_users: int
     max_image_size: int
     max_avatar_size: int
     upload_delay_seconds: int
@@ -28,6 +29,7 @@ async def get_public_config() -> PublicConfig:
     """
     return PublicConfig(
         max_search_tags=settings.MAX_SEARCH_TAGS,
+        max_search_users=settings.MAX_SEARCH_USERS,
         max_image_size=settings.MAX_IMAGE_SIZE,
         max_avatar_size=settings.MAX_AVATAR_SIZE,
         upload_delay_seconds=settings.UPLOAD_DELAY_SECONDS,

--- a/app/config.py
+++ b/app/config.py
@@ -132,6 +132,7 @@ class Settings(BaseSettings):
     UPLOAD_DELAY_SECONDS: int = 30
     SEARCH_DELAY_SECONDS: int = 2
     MAX_SEARCH_TAGS: int = 5
+    MAX_SEARCH_USERS: int = 5
     SIMILARITY_CHECK_RATE_LIMIT: int = 5  # Max similarity checks per user per minute
     REGISTRATION_RATE_LIMIT: int = Field(
         default=5, description="Max registrations per IP per window"

--- a/tests/api/v1/test_feed_count.py
+++ b/tests/api/v1/test_feed_count.py
@@ -266,6 +266,7 @@ class TestFeedFilters:
             {"hascomments": False},
             {"exclude_user_id": "5"},
             {"exclude_favorited_by_user_id": "5"},
+            {"exclude_commenter": "5"},
         ]
         for kwargs in non_bare:
             assert _FeedFilters(**kwargs) != _FeedFilters(), kwargs
@@ -299,4 +300,5 @@ class TestFeedFilters:
             "reported",
             "exclude_user_id",
             "exclude_favorited_by_user_id",
+            "exclude_commenter",
         }

--- a/tests/api/v1/test_feed_count.py
+++ b/tests/api/v1/test_feed_count.py
@@ -265,6 +265,7 @@ class TestFeedFilters:
             {"commentsearch": "x"},
             {"hascomments": False},
             {"exclude_user_id": "5"},
+            {"exclude_favorited_by_user_id": "5"},
         ]
         for kwargs in non_bare:
             assert _FeedFilters(**kwargs) != _FeedFilters(), kwargs
@@ -297,4 +298,5 @@ class TestFeedFilters:
             "hascomments",
             "reported",
             "exclude_user_id",
+            "exclude_favorited_by_user_id",
         }

--- a/tests/api/v1/test_feed_count.py
+++ b/tests/api/v1/test_feed_count.py
@@ -264,6 +264,7 @@ class TestFeedFilters:
             {"commenter": 5},
             {"commentsearch": "x"},
             {"hascomments": False},
+            {"exclude_user_id": "5"},
         ]
         for kwargs in non_bare:
             assert _FeedFilters(**kwargs) != _FeedFilters(), kwargs
@@ -295,4 +296,5 @@ class TestFeedFilters:
             "commentsearch",
             "hascomments",
             "reported",
+            "exclude_user_id",
         }

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -3035,6 +3035,44 @@ class TestCommentFilters:
         filenames = {img["filename"] for img in data["images"]}
         assert filenames == {"no_comment", "also_no_comment"}
 
+    async def test_commenter_total_counts_distinct_images(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """An image with several comments by one user counts once in total.
+
+        The Comments JOIN produces one row per comment; the pagination total
+        must count distinct images (the page path already dedupes).
+        """
+        from app.models import Comments
+
+        user = Users(
+            username="multicommenter",
+            email="multi@test.com",
+            password="testpass1",
+            password_type="bcrypt",
+            salt="testsalt0000201",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        image_data = sample_image_data.copy()
+        image_data.update({"filename": "multi-comment", "md5_hash": "multicommenthash0001"})
+        image = Images(**image_data)
+        db_session.add(image)
+        await db_session.flush()
+
+        for text in ["First!", "Also this.", "And one more."]:
+            db_session.add(
+                Comments(image_id=image.image_id, user_id=user.id, post_text=text)
+            )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images?commenter={user.id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert len(data["images"]) == 1
+
 
 @pytest.mark.api
 class TestShowAllImagesFilter:

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -4303,3 +4303,74 @@ class TestHideReposts:
         # Control: reposts counted -> 3 before bm -> position 3 -> page ceil(4/2)=2.
         data = (await client.get("/api/v1/images/bookmark/page", headers=self._hdr(viewer))).json()
         assert data["page"] == 2
+
+
+@pytest.mark.api
+class TestExcludeUserId:
+    """Tests for the exclude_user_id parameter on image search."""
+
+    async def _create_images_for_users(self, db_session, sample_image_data, counts):
+        """counts: {user_id: n_images}. Users 1-3 pre-exist via conftest."""
+        for user_id, n in counts.items():
+            for i in range(n):
+                image_data = sample_image_data.copy()
+                image_data["filename"] = f"exclu{user_id}-{i}"
+                image_data["md5_hash"] = f"exclu{user_id}hash{i:018d}"
+                image_data["user_id"] = user_id
+                db_session.add(Images(**image_data))
+        await db_session.commit()
+
+    async def test_exclude_single_uploader(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """exclude_user_id drops that user's uploads and keeps everyone else's."""
+        await self._create_images_for_users(db_session, sample_image_data, {1: 2, 2: 3, 3: 1})
+
+        response = await client.get("/api/v1/images?exclude_user_id=2")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+        assert all(img["user_id"] != 2 for img in data["images"])
+
+    async def test_exclude_multiple_uploaders(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """A comma-separated list excludes every listed uploader."""
+        await self._create_images_for_users(db_session, sample_image_data, {1: 2, 2: 3, 3: 1})
+
+        response = await client.get("/api/v1/images?exclude_user_id=1,2")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["images"][0]["user_id"] == 3
+
+    async def test_exclude_user_id_composes_with_include(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Including and excluding the same uploader honestly returns nothing."""
+        await self._create_images_for_users(db_session, sample_image_data, {2: 3})
+
+        response = await client.get("/api/v1/images?user_id=2&exclude_user_id=2")
+        assert response.status_code == 200
+        assert response.json()["total"] == 0
+
+    async def test_exclude_user_id_garbage_tokens_ignored(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Non-decimal tokens (incl. unicode digits like ²) are dropped, not a 500."""
+        await self._create_images_for_users(db_session, sample_image_data, {1: 1, 2: 1})
+
+        response = await client.get("/api/v1/images?exclude_user_id=²,abc,,2")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["images"][0]["user_id"] == 1
+
+    async def test_exclude_user_id_over_cap_is_400(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """More than MAX_SEARCH_USERS ids is rejected with a 400."""
+        too_many = ",".join(str(i) for i in range(1, settings.MAX_SEARCH_USERS + 2))
+        response = await client.get(f"/api/v1/images?exclude_user_id={too_many}")
+        assert response.status_code == 400
+        assert str(settings.MAX_SEARCH_USERS) in response.json()["detail"]

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -4525,6 +4525,37 @@ class TestExcludeCommenter:
         assert response.status_code == 400
         assert str(settings.MAX_SEARCH_USERS) in response.json()["detail"]
 
+    async def test_exclude_commenter_ignores_null_image_comments(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """A NULL-image_id comment row must not poison the NOT IN subquery.
+
+        SQL's NOT IN returns UNKNOWN for every row if the subquery yields a
+        NULL, silently emptying the whole search.
+        """
+        from app.models import Comments
+
+        user = Users(
+            username="nullcommenter",
+            email="nullc@test.com",
+            password="testpass1",
+            password_type="bcrypt",
+            salt="testsalt0000301",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        image = Images(**{**sample_image_data, "filename": "null-safe", "md5_hash": "n" * 32})
+        db_session.add(image)
+        await db_session.flush()
+
+        db_session.add(Comments(image_id=None, user_id=user.id, post_text="orphaned"))
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images?exclude_commenter={user.id}")
+        assert response.status_code == 200
+        assert response.json()["total"] == 1
+
 
 @pytest.mark.api
 class TestExcludeUserId:

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -4306,6 +4306,104 @@ class TestHideReposts:
 
 
 @pytest.mark.api
+class TestExcludeFavoritedByUserId:
+    """Tests for the exclude_favorited_by_user_id parameter."""
+
+    async def _setup(self, db_session, sample_image_data):
+        """Two users; 4 images; user1 favorites 0,1; user2 favorites 1,2. Image 3 unfavorited.
+
+        Returns (user1, user2, images).
+        """
+        user1 = Users(
+            username="exclfav1",
+            password="testpass",
+            password_type="bcrypt",
+            salt="salt12345salt01",
+            email="exclfav1@example.com",
+        )
+        user2 = Users(
+            username="exclfav2",
+            password="testpass",
+            password_type="bcrypt",
+            salt="salt12345salt02",
+            email="exclfav2@example.com",
+        )
+        db_session.add_all([user1, user2])
+        await db_session.flush()
+
+        images = []
+        for i in range(4):
+            image_data = sample_image_data.copy()
+            image_data["filename"] = f"exclfav-{i}"
+            image_data["md5_hash"] = f"exclfavhash{i:018d}"
+            image = Images(**image_data)
+            db_session.add(image)
+            images.append(image)
+        await db_session.flush()
+
+        for i in [0, 1]:
+            db_session.add(Favorites(user_id=user1.user_id, image_id=images[i].image_id))
+        for i in [1, 2]:
+            db_session.add(Favorites(user_id=user2.user_id, image_id=images[i].image_id))
+        await db_session.commit()
+        return user1, user2, images
+
+    async def test_exclude_single_favoriter(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Excluding user1 drops images 0 and 1, keeps 2 and 3."""
+        user1, _user2, images = await self._setup(db_session, sample_image_data)
+
+        response = await client.get(
+            f"/api/v1/images?exclude_favorited_by_user_id={user1.user_id}"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        kept = {img["filename"] for img in data["images"]}
+        assert kept == {"exclfav-2", "exclfav-3"}
+
+    async def test_exclude_multiple_favoriters(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Excluding both users leaves only the unfavorited image."""
+        user1, user2, images = await self._setup(db_session, sample_image_data)
+
+        response = await client.get(
+            f"/api/v1/images?exclude_favorited_by_user_id={user1.user_id},{user2.user_id}"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["images"][0]["filename"] == "exclfav-3"
+
+    async def test_exclude_composes_with_favorited_by_include(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """favorited_by user1 minus favorited_by user2 = image 0 only."""
+        user1, user2, images = await self._setup(db_session, sample_image_data)
+
+        response = await client.get(
+            f"/api/v1/images?favorited_by_user_id={user1.user_id}"
+            f"&exclude_favorited_by_user_id={user2.user_id}"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["images"][0]["filename"] == "exclfav-0"
+
+    async def test_exclude_favorited_over_cap_is_400(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        too_many = ",".join(str(i) for i in range(1, settings.MAX_SEARCH_USERS + 2))
+        response = await client.get(
+            f"/api/v1/images?exclude_favorited_by_user_id={too_many}"
+        )
+        assert response.status_code == 400
+        assert str(settings.MAX_SEARCH_USERS) in response.json()["detail"]
+
+
+@pytest.mark.api
 class TestExcludeUserId:
     """Tests for the exclude_user_id parameter on image search."""
 

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -4404,6 +4404,91 @@ class TestExcludeFavoritedByUserId:
 
 
 @pytest.mark.api
+class TestExcludeCommenter:
+    """Tests for the exclude_commenter parameter."""
+
+    async def _setup(self, db_session, sample_image_data):
+        """Two users; 3 images; user1 comments on image 0, user2 on images 0 and 1.
+
+        Image 2 has no comments. Returns (user1, user2, images).
+        """
+        from app.models import Comments
+
+        user1 = Users(
+            username="exclcom1",
+            email="exclcom1@test.com",
+            password="testpass1",
+            password_type="bcrypt",
+            salt="testsalt0000101",
+        )
+        user2 = Users(
+            username="exclcom2",
+            email="exclcom2@test.com",
+            password="testpass2",
+            password_type="bcrypt",
+            salt="testsalt0000102",
+        )
+        db_session.add_all([user1, user2])
+        await db_session.flush()
+
+        images = []
+        for i in range(3):
+            image_data = sample_image_data.copy()
+            image_data["filename"] = f"exclcom-{i}"
+            image_data["md5_hash"] = f"exclcomhash{i:018d}"
+            image = Images(**image_data)
+            db_session.add(image)
+            images.append(image)
+        await db_session.flush()
+
+        db_session.add(
+            Comments(image_id=images[0].image_id, user_id=user1.id, post_text="First!")
+        )
+        db_session.add(
+            Comments(image_id=images[0].image_id, user_id=user2.id, post_text="Second!")
+        )
+        db_session.add(
+            Comments(image_id=images[1].image_id, user_id=user2.id, post_text="Nice!")
+        )
+        await db_session.commit()
+        return user1, user2, images
+
+    async def test_exclude_single_commenter(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Excluding user2 drops images 0 and 1, keeps the uncommented image 2."""
+        _user1, user2, images = await self._setup(db_session, sample_image_data)
+
+        response = await client.get(f"/api/v1/images?exclude_commenter={user2.id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["images"][0]["filename"] == "exclcom-2"
+
+    async def test_exclude_commenter_composes_with_commenter_include(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """Commented-by user2 minus commented-by user1 = image 1 only."""
+        user1, user2, images = await self._setup(db_session, sample_image_data)
+
+        response = await client.get(
+            f"/api/v1/images?commenter={user2.id}&exclude_commenter={user1.id}"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["images"][0]["filename"] == "exclcom-1"
+
+    async def test_exclude_commenter_over_cap_is_400(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        too_many = ",".join(str(i) for i in range(1, settings.MAX_SEARCH_USERS + 2))
+        response = await client.get(f"/api/v1/images?exclude_commenter={too_many}")
+        assert response.status_code == 400
+        assert str(settings.MAX_SEARCH_USERS) in response.json()["detail"]
+
+
+@pytest.mark.api
 class TestExcludeUserId:
     """Tests for the exclude_user_id parameter on image search."""
 

--- a/tests/api/v1/test_meta.py
+++ b/tests/api/v1/test_meta.py
@@ -24,6 +24,7 @@ class TestGetPublicConfig:
 
         # Verify all expected fields are present
         assert "max_search_tags" in data
+        assert "max_search_users" in data
         assert "max_image_size" in data
         assert "max_avatar_size" in data
         assert "upload_delay_seconds" in data
@@ -38,6 +39,7 @@ class TestGetPublicConfig:
 
         # Verify values match settings
         assert data["max_search_tags"] == settings.MAX_SEARCH_TAGS
+        assert data["max_search_users"] == settings.MAX_SEARCH_USERS
         assert data["max_image_size"] == settings.MAX_IMAGE_SIZE
         assert data["max_avatar_size"] == settings.MAX_AVATAR_SIZE
         assert data["upload_delay_seconds"] == settings.UPLOAD_DELAY_SECONDS
@@ -52,6 +54,7 @@ class TestGetPublicConfig:
 
         # Verify data types
         assert isinstance(data["max_search_tags"], int)
+        assert isinstance(data["max_search_users"], int)
         assert isinstance(data["max_image_size"], int)
         assert isinstance(data["max_avatar_size"], int)
         assert isinstance(data["upload_delay_seconds"], int)
@@ -59,6 +62,7 @@ class TestGetPublicConfig:
 
         # Verify positive values
         assert data["max_search_tags"] > 0
+        assert data["max_search_users"] > 0
         assert data["max_image_size"] > 0
         assert data["max_avatar_size"] > 0
         assert data["upload_delay_seconds"] >= 0


### PR DESCRIPTION
## Summary

Adds user exclusion to `GET /api/v1/images/` — the API side of "the minus doesn't work for users" (feedback from WhiteKitten). Three new optional query params, each a comma-separated user-id list, mirroring the `exclude_tags` idiom:

- `exclude_user_id` — hide images **uploaded** by any listed user (`user_id NOT IN`)
- `exclude_favorited_by_user_id` — hide images **favorited** by any listed user (anti-join `NOT IN` subquery on favorites)
- `exclude_commenter` — hide images **commented on** by any listed user (anti-join on comments, NULL-guarded: legacy `posts.image_id` is nullable and one NULL row would otherwise poison the whole `NOT IN`)

Supporting changes:
- New `MAX_SEARCH_USERS` setting (default 5) caps each list → HTTP 400, same wording as the tags cap; parsing uses the `isdecimal()` idiom (unicode-digit safe)
- All three params registered in `_FeedFilters` (+ both drift-guard tests) so the bare-feed fast count correctly falls back to exact counting
- **Bugfix (pre-existing, found by the e2e complement test):** pagination totals for `commenter`/`commentsearch` searches counted JOIN rows, not distinct images (e.g. 7586 vs 6013 for one user) — the count path now applies the same distinct-image-ids dedup the page path already used
- Endpoint docstring examples for the new params

Companion frontend PR: anonymousobject/shuushuu-frontend `feat/user-exclusion-search` (merge this one first or together — the frontend emits these params).

## Testing

- TDD throughout: 13 new endpoint tests (per-param exclusion, multi-id, include+exclude composition, garbage-token tolerance, over-cap 400, NULL-comment guard, distinct-count regression) + drift-guard updates
- Full suite: 1787 passed, 10 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqaSakrcWAgvqSjSFE5heV