### PR TITLE
fix(db): retry MariaDB snapshot conflicts (err 1020) — upload + user-profile writes

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -28,6 +28,7 @@ from fastapi import (
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy import and_, asc, delete, desc, func, or_, select
 from sqlalchemy import text as sql_text
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
@@ -2628,6 +2629,26 @@ async def unfavorite_image(
     }
 
 
+# MariaDB with innodb_snapshot_isolation=ON aborts a locking operation that
+# meets index entries committed after the transaction's snapshot (ER_CHECKREAD,
+# errno 1020) instead of returning stale data. Concurrent uploads collide this
+# way on the temp-row INSERT below: every in-flight upload writes identical
+# placeholder values ("temp", status=1, zeroes) into the same index positions,
+# and the request's snapshot is pinned by the auth query well before the INSERT
+# runs. The conflict is transient — a rollback starts a fresh transaction whose
+# snapshot sees the other upload's committed rows — so a bounded retry resolves
+# it. Observed in practice when parallel e2e suites upload concurrently.
+_SNAPSHOT_CONFLICT_ERRNO = 1020
+_SNAPSHOT_CONFLICT_ATTEMPTS = 3
+
+
+def _is_snapshot_conflict(exc: OperationalError) -> bool:
+    args = getattr(exc.orig, "args", None)
+    if not args:
+        return False
+    return bool(args[0] == _SNAPSHOT_CONFLICT_ERRNO)
+
+
 @router.post(
     "/upload",
     response_model=ImageUploadResponse,
@@ -2699,22 +2720,42 @@ async def upload_image(
     # Get client IP address for logging
     client_ip = _get_client_ip(request)
 
-    # Create temporary image record to get image_id for filename
-    temp_image = Images(
-        filename="temp",  # Will be updated after save
-        ext="tmp",
-        original_filename=file.filename or "unknown",
-        md5_hash="",  # Will be calculated during save
-        filesize=0,
-        width=0,
-        height=0,
-        user_id=current_user.id,
-        ip=client_ip,  # Log IP address
-        status=1,
-        locked=0,
-    )
-    db.add(temp_image)
-    await db.flush()  # Get image_id
+    # Capture as a primitive: a snapshot-conflict retry below rolls back the
+    # transaction, which expires ORM instances (including current_user) — and
+    # touching an expired attribute on an async session raises.
+    uploader_id: int = current_user.id
+
+    # Create temporary image record to get image_id for filename. Retried on
+    # ER_CHECKREAD — see _is_snapshot_conflict above.
+    for attempt in range(1, _SNAPSHOT_CONFLICT_ATTEMPTS + 1):
+        temp_image = Images(
+            filename="temp",  # Will be updated after save
+            ext="tmp",
+            original_filename=file.filename or "unknown",
+            md5_hash="",  # Will be calculated during save
+            filesize=0,
+            width=0,
+            height=0,
+            user_id=uploader_id,
+            ip=client_ip,  # Log IP address
+            status=1,
+            locked=0,
+        )
+        db.add(temp_image)
+        try:
+            await db.flush()  # Get image_id
+            break
+        except OperationalError as e:
+            if not _is_snapshot_conflict(e) or attempt == _SNAPSHOT_CONFLICT_ATTEMPTS:
+                raise
+            # Fresh transaction -> fresh snapshot. The rolled-back auto-inc id
+            # is simply burned; id gaps are normal.
+            await db.rollback()
+            logger.warning(
+                "upload_snapshot_conflict_retry",
+                attempt=attempt,
+                user_id=uploader_id,
+            )
     image_id: int = temp_image.image_id  # type: ignore[assignment]
 
     logger.info("image_record_created", image_id=image_id)
@@ -2829,7 +2870,7 @@ async def upload_image(
         if tag_ids.strip():
             try:
                 tag_id_list = [int(tid.strip()) for tid in tag_ids.split(",") if tid.strip()]
-                await link_tags_to_image(image_id, tag_id_list, current_user.id, db)
+                await link_tags_to_image(image_id, tag_id_list, uploader_id, db)
             except ValueError as e:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -28,7 +28,6 @@ from fastapi import (
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy import and_, asc, delete, desc, func, or_, select
 from sqlalchemy import text as sql_text
-from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
@@ -51,6 +50,7 @@ from app.config import (
 )
 from app.core.auth import CurrentUser, VerifiedUser, get_current_user, get_optional_current_user
 from app.core.database import get_db
+from app.core.db_retry import retry_on_snapshot_conflict
 from app.core.logging import get_logger
 from app.core.permission_deps import require_permission
 from app.core.permissions import Permission, has_any_permission, has_permission
@@ -2629,26 +2629,6 @@ async def unfavorite_image(
     }
 
 
-# MariaDB with innodb_snapshot_isolation=ON aborts a locking operation that
-# meets index entries committed after the transaction's snapshot (ER_CHECKREAD,
-# errno 1020) instead of returning stale data. Concurrent uploads collide this
-# way on the temp-row INSERT below: every in-flight upload writes identical
-# placeholder values ("temp", status=1, zeroes) into the same index positions,
-# and the request's snapshot is pinned by the auth query well before the INSERT
-# runs. The conflict is transient — a rollback starts a fresh transaction whose
-# snapshot sees the other upload's committed rows — so a bounded retry resolves
-# it. Observed in practice when parallel e2e suites upload concurrently.
-_SNAPSHOT_CONFLICT_ERRNO = 1020
-_SNAPSHOT_CONFLICT_ATTEMPTS = 3
-
-
-def _is_snapshot_conflict(exc: OperationalError) -> bool:
-    args = getattr(exc.orig, "args", None)
-    if not args:
-        return False
-    return bool(args[0] == _SNAPSHOT_CONFLICT_ERRNO)
-
-
 @router.post(
     "/upload",
     response_model=ImageUploadResponse,
@@ -2725,10 +2705,11 @@ async def upload_image(
     # touching an expired attribute on an async session raises.
     uploader_id: int = current_user.id
 
-    # Create temporary image record to get image_id for filename. Retried on
-    # ER_CHECKREAD — see _is_snapshot_conflict above.
-    for attempt in range(1, _SNAPSHOT_CONFLICT_ATTEMPTS + 1):
-        temp_image = Images(
+    # Concurrent uploads write identical placeholder values into the same
+    # index positions, so this INSERT can hit a snapshot conflict (see
+    # app/core/db_retry.py). A rolled-back attempt just burns an auto-inc id.
+    async def _insert_temp_image() -> Images:
+        temp = Images(
             filename="temp",  # Will be updated after save
             ext="tmp",
             original_filename=file.filename or "unknown",
@@ -2741,21 +2722,11 @@ async def upload_image(
             status=1,
             locked=0,
         )
-        db.add(temp_image)
-        try:
-            await db.flush()  # Get image_id
-            break
-        except OperationalError as e:
-            if not _is_snapshot_conflict(e) or attempt == _SNAPSHOT_CONFLICT_ATTEMPTS:
-                raise
-            # Fresh transaction -> fresh snapshot. The rolled-back auto-inc id
-            # is simply burned; id gaps are normal.
-            await db.rollback()
-            logger.warning(
-                "upload_snapshot_conflict_retry",
-                attempt=attempt,
-                user_id=uploader_id,
-            )
+        db.add(temp)
+        await db.flush()  # Get image_id
+        return temp
+
+    temp_image = await retry_on_snapshot_conflict(db, _insert_temp_image, what="upload_temp_image")
     image_id: int = temp_image.image_id  # type: ignore[assignment]
 
     logger.info("image_record_created", image_id=image_id)

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -35,6 +35,7 @@ from app.core.auth import (
     get_optional_current_user,
 )
 from app.core.database import get_db
+from app.core.db_retry import retry_on_snapshot_conflict
 from app.core.logging import get_logger
 from app.core.permissions import Permission, has_permission
 from app.core.r2_client import get_r2_storage
@@ -547,79 +548,88 @@ async def _update_user_profile(
     Returns:
         Updated user response (as UserResponse; caller may wrap as UserPrivateResponse)
     """
-    user_result = await db.execute(
-        select(Users)
-        .options(
-            selectinload(Users.user_groups).selectinload(UserGroups.group)  # type: ignore[arg-type]
+
+    # Concurrent PATCHes of the same users row can hit a snapshot conflict at
+    # commit (see app/core/db_retry.py), so the whole fetch-apply-commit unit
+    # is retried. Everything below re-derives its state per attempt — notably
+    # update_data, which the password branch pops from and must not be shared
+    # across attempts.
+    async def _apply() -> Users:
+        user_result = await db.execute(
+            select(Users)
+            .options(
+                selectinload(Users.user_groups).selectinload(UserGroups.group)  # type: ignore[arg-type]
+            )
+            .where(Users.user_id == user_id)  # type: ignore[arg-type]
         )
-        .where(Users.user_id == user_id)  # type: ignore[arg-type]
-    )
-    user = user_result.scalar_one_or_none()
+        user = user_result.scalar_one_or_none()
 
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
 
-    # Update only provided fields
-    update_data = user_data.model_dump(exclude_unset=True)
+        # Update only provided fields
+        update_data = user_data.model_dump(exclude_unset=True)
 
-    # user_title can only be updated by users with USER_EDIT_PROFILE permission
-    if "user_title" in update_data and not has_edit_permission:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only moderators can update user titles",
-        )
-
-    # maximgperday can only be updated by users with USER_EDIT_PROFILE permission
-    if "maximgperday" in update_data and not has_edit_permission:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only moderators can update user upload limits",
-        )
-
-    # Handle password separately with validation and hashing.
-    # Self-service password changes must go through POST /auth/change-password,
-    # which verifies the current password and revokes existing sessions; PATCH
-    # would silently bypass both. Moderators may still set passwords here.
-    if "password" in update_data:
-        if not has_edit_permission:
+        # user_title can only be updated by users with USER_EDIT_PROFILE permission
+        if "user_title" in update_data and not has_edit_permission:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail="Use /api/v1/auth/change-password to change your own password",
+                detail="Only moderators can update user titles",
             )
-        password = update_data.pop("password")
-        is_valid, error_message = validate_password_strength(password)
-        if not is_valid:
-            raise HTTPException(status_code=400, detail=error_message)
-        user.password = get_password_hash(password)
-        user.password_type = "bcrypt"
-        # A forced reset usually responds to a compromised account: revoke the
-        # target's sessions so holders of the old credentials are logged out.
-        await db.execute(
-            delete(RefreshTokens).where(RefreshTokens.user_id == user.user_id)  # type: ignore[arg-type]
-        )
 
-    # Handle email validation
-    if "email" in update_data:
-        email = update_data["email"]
-        # Check if email is already taken by another user
-        existing_email = await db.execute(
-            select(Users).where(Users.email == email, Users.user_id != user_id)  # type: ignore[arg-type]
-        )
-        if existing_email.scalar_one_or_none():
-            raise HTTPException(status_code=409, detail="Email already in use")
+        # maximgperday can only be updated by users with USER_EDIT_PROFILE permission
+        if "maximgperday" in update_data and not has_edit_permission:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only moderators can update user upload limits",
+            )
 
-    # Update user fields
-    # NOTE: Input sanitization is now handled by schema validators (UserUpdate)
-    # which escape HTML to prevent XSS attacks. We no longer normalize here.
-    for field, value in update_data.items():
-        setattr(user, field, value)
+        # Handle password separately with validation and hashing.
+        # Self-service password changes must go through POST /auth/change-password,
+        # which verifies the current password and revokes existing sessions; PATCH
+        # would silently bypass both. Moderators may still set passwords here.
+        if "password" in update_data:
+            if not has_edit_permission:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Use /api/v1/auth/change-password to change your own password",
+                )
+            password = update_data.pop("password")
+            is_valid, error_message = validate_password_strength(password)
+            if not is_valid:
+                raise HTTPException(status_code=400, detail=error_message)
+            user.password = get_password_hash(password)
+            user.password_type = "bcrypt"
+            # A forced reset usually responds to a compromised account: revoke the
+            # target's sessions so holders of the old credentials are logged out.
+            await db.execute(
+                delete(RefreshTokens).where(RefreshTokens.user_id == user.user_id)  # type: ignore[arg-type]
+            )
 
-    await db.commit()
-    await db.refresh(user)
+        # Handle email validation
+        if "email" in update_data:
+            email = update_data["email"]
+            # Check if email is already taken by another user
+            existing_email = await db.execute(
+                select(Users).where(Users.email == email, Users.user_id != user_id)  # type: ignore[arg-type]
+            )
+            if existing_email.scalar_one_or_none():
+                raise HTTPException(status_code=409, detail="Email already in use")
 
-    # Return the DB model instance so callers can serialize to either
-    # public or private response schemas depending on the endpoint.
-    return user
+        # Update user fields
+        # NOTE: Input sanitization is now handled by schema validators (UserUpdate)
+        # which escape HTML to prevent XSS attacks. We no longer normalize here.
+        for field, value in update_data.items():
+            setattr(user, field, value)
+
+        await db.commit()
+        await db.refresh(user)
+
+        # Return the DB model instance so callers can serialize to either
+        # public or private response schemas depending on the endpoint.
+        return user
+
+    return await retry_on_snapshot_conflict(db, _apply, what="user_profile_update")
 
 
 @router.get("/{user_id}/images", response_model=ImageDetailedListResponse)

--- a/app/core/db_retry.py
+++ b/app/core/db_retry.py
@@ -1,0 +1,81 @@
+"""Retry helper for MariaDB snapshot-isolation conflicts (ER_CHECKREAD, errno 1020).
+
+With ``innodb_snapshot_isolation=ON`` (prod 11.8.6, dev mariadb:12), a locking
+statement that meets row/index versions committed *after* the transaction's
+snapshot aborts with error 1020 instead of returning stale data. The snapshot
+is pinned by the request's first read — the auth query — so the conflict
+window spans nearly the whole request, and any two requests writing the same
+rows (or inserting into the same index positions) concurrently can collide.
+Confirmed sites: the upload temp-row INSERT into ``images``; concurrent
+``PATCH /users/me`` UPDATEs of one ``users`` row.
+
+The conflict is transient: a rollback ends the transaction, and the retry's
+new transaction gets a fresh snapshot that sees the other writer's rows. A
+savepoint is NOT sufficient — rolling back to a savepoint keeps the
+transaction (and its snapshot) alive, so the conflict would recur.
+
+Usage — wrap a *self-contained transactional unit* and retry it:
+
+    async def _apply() -> Thing:
+        row = await db.get(Thing, thing_id)   # (re)fetch INSIDE the unit
+        ...mutate/insert...
+        await db.commit()                     # or flush
+        return row
+
+    thing = await retry_on_snapshot_conflict(db, _apply, what="thing_update")
+
+Rules for the callable:
+- Re-fetch rows inside it. The rollback between attempts expires every ORM
+  instance in the session, and touching an expired attribute on an async
+  session raises; closures over previously-loaded instances are bugs.
+- DB work only. Non-DB side effects (file writes, redis/arq enqueues, email)
+  would be repeated on retry; keep them outside the callable.
+- Non-conflict errors (HTTPException, other DB errors) propagate unchanged.
+
+This is deliberately opt-in per write path rather than request-replay
+middleware: replaying a whole request would re-run its non-DB side effects.
+"""
+
+from collections.abc import Awaitable, Callable
+
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+SNAPSHOT_CONFLICT_ERRNO = 1020
+SNAPSHOT_CONFLICT_ATTEMPTS = 3
+
+
+def is_snapshot_conflict(exc: OperationalError) -> bool:
+    """True when `exc` wraps MariaDB ER_CHECKREAD (errno 1020)."""
+    args = getattr(exc.orig, "args", None)
+    if not args:
+        return False
+    return bool(args[0] == SNAPSHOT_CONFLICT_ERRNO)
+
+
+async def retry_on_snapshot_conflict[T](
+    db: AsyncSession,
+    fn: Callable[[], Awaitable[T]],
+    *,
+    what: str,
+    attempts: int = SNAPSHOT_CONFLICT_ATTEMPTS,
+) -> T:
+    """Run `fn`, retrying up to `attempts` times on snapshot conflicts.
+
+    Rolls back between attempts so each retry runs in a fresh transaction
+    (fresh snapshot). Exhausted retries and non-conflict errors re-raise.
+    `what` names the call site in the retry log line.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            return await fn()
+        except OperationalError as e:
+            if not is_snapshot_conflict(e) or attempt == attempts:
+                raise
+            await db.rollback()
+            logger.warning("snapshot_conflict_retry", what=what, attempt=attempt)
+    raise AssertionError("unreachable")  # pragma: no cover

--- a/tests/api/v1/test_upload.py
+++ b/tests/api/v1/test_upload.py
@@ -6,8 +6,10 @@ from io import BytesIO
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import pymysql
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import create_access_token
@@ -314,7 +316,9 @@ class TestUploadMLTagSuggestions:
             for call in enqueue_mock.call_args_list
             if call.args and call.args[0] == "generate_ml_tag_suggestions"
         ]
-        assert len(ml_calls) == 1, f"Expected 1 ml job call, got {len(ml_calls)}: {enqueue_mock.call_args_list}"
+        assert len(ml_calls) == 1, (
+            f"Expected 1 ml job call, got {len(ml_calls)}: {enqueue_mock.call_args_list}"
+        )
         image_id = response.json()["image"]["image_id"]
         assert ml_calls[0].kwargs.get("image_id") == image_id
         assert ml_calls[0].kwargs.get("_defer_by") is None  # runs immediately, no defer
@@ -388,7 +392,8 @@ class TestUploadMLTagSuggestions:
 
         assert response.status_code == 201
         non_ml_calls = [
-            c for c in enqueue_mock.call_args_list
+            c
+            for c in enqueue_mock.call_args_list
             if not (c.args and c.args[0] == "generate_ml_tag_suggestions")
         ]
         assert non_ml_calls, "other enqueue jobs should still have been called"
@@ -478,3 +483,115 @@ async def test_images_source_url_roundtrip(db_session: AsyncSession):
     await db_session.commit()
     await db_session.refresh(image)
     assert image.source_url == "https://www.pixiv.net/artworks/138823691"
+
+
+def _db_error(errno: int, message: str) -> OperationalError:
+    """Build the sqlalchemy error the aiomysql/pymysql driver raises for `errno`."""
+    return OperationalError(
+        "INSERT INTO images ...", None, pymysql.err.OperationalError(errno, message)
+    )
+
+
+def _snapshot_conflict_error() -> OperationalError:
+    """The error MariaDB raises under innodb_snapshot_isolation (ER_CHECKREAD)."""
+    return _db_error(1020, "Record has changed since last read in table 'images'")
+
+
+def _flaky_flush(fail_times: int, error: OperationalError):
+    """Patch AsyncSession.flush to raise `error` for the first `fail_times`
+    calls, then delegate to the real flush. Only the route's explicit
+    `await db.flush()` goes through AsyncSession.flush (autoflush runs inside
+    the sync Session), so the first intercepted call is the temp-row INSERT.
+    Returns (patch_ctx, calls) where calls records each intercepted flush."""
+    real_flush = AsyncSession.flush
+    calls: list[int] = []
+
+    async def flush(self, *args, **kwargs):
+        calls.append(1)
+        if len(calls) <= fail_times:
+            raise error
+        await real_flush(self, *args, **kwargs)
+
+    return patch.object(AsyncSession, "flush", flush), calls
+
+
+class TestUploadSnapshotConflictRetry:
+    """Concurrent uploads trip MariaDB ER_CHECKREAD (errno 1020) on the temp-row
+    INSERT: with innodb_snapshot_isolation=ON, a locking insert that meets index
+    entries committed after this transaction's snapshot aborts instead of
+    proceeding, and every in-flight upload writes identical placeholder values
+    into the same index positions. The upload route must retry on a fresh
+    snapshot instead of surfacing a 500."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.needs_commit
+    async def test_upload_retries_snapshot_conflict_and_succeeds(
+        self, upload_client: AsyncClient, verified_user: Users
+    ):
+        """A transient 1020 on the temp-row INSERT is retried and the upload succeeds.
+
+        needs_commit: the retry performs a real session rollback to obtain a
+        fresh snapshot; under the default SAVEPOINT isolation that rollback
+        would unwind the fixture's user row too (FK 1452 on the retried
+        INSERT), which can't happen in production where the user is durably
+        committed.
+        """
+        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error())
+        with (
+            _mock_save_uploaded_image("snapshotretry1"),
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("app.api.v1.images.get_image_dimensions", return_value=(100, 100)),
+            patch("app.api.v1.images.enqueue_job", new_callable=AsyncMock),
+            flush_patch,
+        ):
+            response = await upload_client.post(
+                "/api/v1/images/upload",
+                files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+                data={"tag_ids": "", "caption": ""},
+            )
+
+        assert response.status_code == 201, response.text
+        assert response.json()["image"]["image_id"] > 0
+        assert len(calls) >= 2  # failed attempt + successful retry
+
+    @pytest.mark.asyncio
+    async def test_upload_gives_up_after_bounded_retries(
+        self, upload_client: AsyncClient, verified_user: Users
+    ):
+        """A persistent 1020 propagates after a bounded number of attempts."""
+        flush_patch, calls = _flaky_flush(100, _snapshot_conflict_error())
+        with (
+            _mock_save_uploaded_image("snapshotretry2"),
+            flush_patch,
+            pytest.raises(OperationalError),
+        ):
+            await upload_client.post(
+                "/api/v1/images/upload",
+                files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+                data={"tag_ids": "", "caption": ""},
+            )
+
+        assert len(calls) == 3  # bounded: no infinite retry loop
+
+    @pytest.mark.asyncio
+    async def test_upload_does_not_retry_other_db_errors(
+        self, upload_client: AsyncClient, verified_user: Users
+    ):
+        """Non-1020 database errors propagate immediately with no retry."""
+        flush_patch, calls = _flaky_flush(100, _db_error(1213, "Deadlock found"))
+        with (
+            _mock_save_uploaded_image("snapshotretry3"),
+            flush_patch,
+            pytest.raises(OperationalError),
+        ):
+            await upload_client.post(
+                "/api/v1/images/upload",
+                files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+                data={"tag_ids": "", "caption": ""},
+            )
+
+        assert len(calls) == 1  # not retried

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -127,7 +127,9 @@ class TestListUsers:
         assert data["total"] == 0
         assert data["users"] == []
 
-    async def test_update_user_freeform_fields_normalized(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_update_user_freeform_fields_normalized(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Updating user free-form fields (location/interests) stores plain text (no normalization).
 
         Note: user_title is restricted to users with USER_EDIT_PROFILE permission.
@@ -167,7 +169,9 @@ class TestListUsers:
         assert response.status_code == 200
 
         # Fetch profile and verify fields are stored as plain text
-        response = await client.get("/api/v1/users/me", headers={"Authorization": f"Bearer {access_token}"})
+        response = await client.get(
+            "/api/v1/users/me", headers={"Authorization": f"Bearer {access_token}"}
+        )
         assert response.status_code == 200
         data = response.json()
         # Plain text storage: what goes in comes out (no HTML escaping/normalization)
@@ -237,7 +241,9 @@ class TestListUsers:
         assert "user.name" in usernames
         assert "user-name" in usernames
 
-    async def test_list_users_search_exact_match_priority(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_list_users_search_exact_match_priority(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Exact username match should be prioritized for search results."""
         # Create a user with exact name 'Ran'
         ran = Users(
@@ -461,10 +467,42 @@ class TestGetCurrentUserProfile:
         await db_session.refresh(sender)
 
         # Add 2 unread + 1 read + 1 deleted PM
-        db_session.add(Privmsgs(from_user_id=sender.user_id, to_user_id=user.user_id, subject="Unread 1", viewed=0, to_del=0))
-        db_session.add(Privmsgs(from_user_id=sender.user_id, to_user_id=user.user_id, subject="Unread 2", viewed=0, to_del=0))
-        db_session.add(Privmsgs(from_user_id=sender.user_id, to_user_id=user.user_id, subject="Read", viewed=1, to_del=0))
-        db_session.add(Privmsgs(from_user_id=sender.user_id, to_user_id=user.user_id, subject="Deleted", viewed=0, to_del=1))
+        db_session.add(
+            Privmsgs(
+                from_user_id=sender.user_id,
+                to_user_id=user.user_id,
+                subject="Unread 1",
+                viewed=0,
+                to_del=0,
+            )
+        )
+        db_session.add(
+            Privmsgs(
+                from_user_id=sender.user_id,
+                to_user_id=user.user_id,
+                subject="Unread 2",
+                viewed=0,
+                to_del=0,
+            )
+        )
+        db_session.add(
+            Privmsgs(
+                from_user_id=sender.user_id,
+                to_user_id=user.user_id,
+                subject="Read",
+                viewed=1,
+                to_del=0,
+            )
+        )
+        db_session.add(
+            Privmsgs(
+                from_user_id=sender.user_id,
+                to_user_id=user.user_id,
+                subject="Deleted",
+                viewed=0,
+                to_del=1,
+            )
+        )
         await db_session.commit()
 
         login_response = await client.post(
@@ -666,8 +704,7 @@ class TestUpdateUserProfile:
             headers={"Authorization": f"Bearer {access_token}"},
         )
         assert response.status_code == 200
-        data = response.json()
-        # assert data["email"] == "newemail@example.com"  # Email may not be returned in response
+        # response.json()["email"] not asserted: email may not be returned in the response
 
     async def test_self_password_change_via_patch_rejected(
         self, client: AsyncClient, db_session: AsyncSession
@@ -824,9 +861,7 @@ class TestUpdateUserProfile:
         await db_session.refresh(user)
         assert user.email_pm_pref == 1
 
-    async def test_update_user_settings_via_me(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_update_user_settings_via_me(self, client: AsyncClient, db_session: AsyncSession):
         """Test that PATCH /api/v1/users/me accepts and returns user settings."""
         # Create user with default settings
         user = Users(
@@ -1125,9 +1160,7 @@ class TestUpdateUserProfile:
         assert user.theme_preset is None
         assert user.dark_mode is None
 
-    async def test_theme_preset_allowlist(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_theme_preset_allowlist(self, client: AsyncClient, db_session: AsyncSession):
         """PATCH /api/v1/users/me rejects unknown theme_preset values."""
         user = Users(
             username="themeallowlist",
@@ -1171,9 +1204,7 @@ class TestUpdateUserProfile:
         )
         assert response.status_code == 422
 
-    async def test_dark_mode_type_validation(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_dark_mode_type_validation(self, client: AsyncClient, db_session: AsyncSession):
         """PATCH /api/v1/users/me requires dark_mode to be a boolean or null."""
         user = Users(
             username="darkmodevalidation",
@@ -1200,9 +1231,7 @@ class TestUpdateUserProfile:
                 json={"dark_mode": bad_value},
                 headers={"Authorization": f"Bearer {access_token}"},
             )
-            assert response.status_code == 422, (
-                f"dark_mode={bad_value!r} should be rejected"
-            )
+            assert response.status_code == 422, f"dark_mode={bad_value!r} should be rejected"
 
 
 @pytest.mark.api
@@ -1252,12 +1281,12 @@ class TestGetUserImages:
 
         # Create images with various statuses
         statuses = {
-            "active": 1,       # public
-            "repost": -1,      # public
-            "spoiler": 2,      # public
-            "review": -4,      # non-public
+            "active": 1,  # public
+            "repost": -1,  # public
+            "spoiler": 2,  # public
+            "review": -4,  # non-public
             "inappropriate": -2,  # non-public
-            "other": 0,        # non-public
+            "other": 0,  # non-public
         }
         for name, status_val in statuses.items():
             data = sample_image_data.copy()
@@ -1324,11 +1353,23 @@ class TestGetUserImages:
         """A hide_reposts viewer doesn't see another user's reposts in their gallery."""
         from app.core.security import create_access_token
 
-        subject = Users(username="hrg_subject", password=get_password_hash("TestPassword123!"),
-                        password_type="bcrypt", salt="", email="hrg_subject@test.com", active=1)
-        viewer = Users(username="hrg_viewer", password=get_password_hash("TestPassword123!"),
-                       password_type="bcrypt", salt="", email="hrg_viewer@test.com", active=1,
-                       hide_reposts=1)
+        subject = Users(
+            username="hrg_subject",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="hrg_subject@test.com",
+            active=1,
+        )
+        viewer = Users(
+            username="hrg_viewer",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="hrg_viewer@test.com",
+            active=1,
+            hide_reposts=1,
+        )
         db_session.add(subject)
         db_session.add(viewer)
         await db_session.commit()
@@ -1345,8 +1386,9 @@ class TestGetUserImages:
         await db_session.commit()
 
         token = create_access_token(viewer.user_id)
-        response = await client.get(f"/api/v1/users/{subject.user_id}/images",
-                                    headers={"Authorization": f"Bearer {token}"})
+        response = await client.get(
+            f"/api/v1/users/{subject.user_id}/images", headers={"Authorization": f"Bearer {token}"}
+        )
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 2
@@ -1358,9 +1400,15 @@ class TestGetUserImages:
         """hide_reposts hides the viewer's OWN reposts but keeps own non-repost non-public images."""
         from app.core.security import create_access_token
 
-        viewer = Users(username="hrg_own", password=get_password_hash("TestPassword123!"),
-                       password_type="bcrypt", salt="", email="hrg_own@test.com", active=1,
-                       hide_reposts=1)
+        viewer = Users(
+            username="hrg_own",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="hrg_own@test.com",
+            active=1,
+            hide_reposts=1,
+        )
         db_session.add(viewer)
         await db_session.commit()
         await db_session.refresh(viewer)
@@ -1375,8 +1423,9 @@ class TestGetUserImages:
         await db_session.commit()
 
         token = create_access_token(viewer.user_id)
-        response = await client.get(f"/api/v1/users/{viewer.user_id}/images",
-                                    headers={"Authorization": f"Bearer {token}"})
+        response = await client.get(
+            f"/api/v1/users/{viewer.user_id}/images", headers={"Authorization": f"Bearer {token}"}
+        )
         assert response.status_code == 200
         data = response.json()
         # own active (public) + own review (own non-public) visible; own repost hidden.
@@ -1478,11 +1527,23 @@ class TestGetUserFavorites:
         """A hide_reposts viewer doesn't see reposts in another user's favorites."""
         from app.core.security import create_access_token
 
-        subject = Users(username="hrf_subject", password=get_password_hash("TestPassword123!"),
-                        password_type="bcrypt", salt="", email="hrf_subject@test.com", active=1)
-        viewer = Users(username="hrf_viewer", password=get_password_hash("TestPassword123!"),
-                       password_type="bcrypt", salt="", email="hrf_viewer@test.com", active=1,
-                       hide_reposts=1)
+        subject = Users(
+            username="hrf_subject",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="hrf_subject@test.com",
+            active=1,
+        )
+        viewer = Users(
+            username="hrf_viewer",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="hrf_viewer@test.com",
+            active=1,
+            hide_reposts=1,
+        )
         db_session.add(subject)
         db_session.add(viewer)
         await db_session.commit()
@@ -1490,12 +1551,24 @@ class TestGetUserFavorites:
         await db_session.refresh(viewer)
 
         active_data = sample_image_data.copy()
-        active_data.update({"filename": "hrf-active", "md5_hash": "hrfactive" + "0" * 15,
-                            "status": 1, "user_id": subject.user_id})
+        active_data.update(
+            {
+                "filename": "hrf-active",
+                "md5_hash": "hrfactive" + "0" * 15,
+                "status": 1,
+                "user_id": subject.user_id,
+            }
+        )
         active_img = Images(**active_data)
         repost_data = sample_image_data.copy()
-        repost_data.update({"filename": "hrf-repost", "md5_hash": "hrfrepost" + "0" * 15,
-                            "status": -1, "user_id": subject.user_id})
+        repost_data.update(
+            {
+                "filename": "hrf-repost",
+                "md5_hash": "hrfrepost" + "0" * 15,
+                "status": -1,
+                "user_id": subject.user_id,
+            }
+        )
         repost_img = Images(**repost_data)
         db_session.add(active_img)
         db_session.add(repost_img)
@@ -1508,8 +1581,10 @@ class TestGetUserFavorites:
         await db_session.commit()
 
         token = create_access_token(viewer.user_id)
-        response = await client.get(f"/api/v1/users/{subject.user_id}/favorites",
-                                    headers={"Authorization": f"Bearer {token}"})
+        response = await client.get(
+            f"/api/v1/users/{subject.user_id}/favorites",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
@@ -1856,7 +1931,9 @@ class TestUserSorting:
         for user in users:
             await db_session.refresh(user)
 
-        response = await client.get("/api/v1/users?sort_by=username&sort_order=DESC&search=sortuser")
+        response = await client.get(
+            "/api/v1/users?sort_by=username&sort_order=DESC&search=sortuser"
+        )
         assert response.status_code == 200
         data = response.json()
         returned_usernames = [u["username"] for u in data["users"]]
@@ -1885,7 +1962,9 @@ class TestUserSorting:
             db_session.add(user)
         await db_session.commit()
 
-        response = await client.get("/api/v1/users?sort_by=date_joined&sort_order=ASC&search=datejoinuser")
+        response = await client.get(
+            "/api/v1/users?sort_by=date_joined&sort_order=ASC&search=datejoinuser"
+        )
         assert response.status_code == 200
         data = response.json()
         assert len(data["users"]) == 5
@@ -1915,7 +1994,9 @@ class TestUserSorting:
             db_session.add(user)
         await db_session.commit()
 
-        response = await client.get("/api/v1/users?sort_by=date_joined&sort_order=DESC&search=datejoinuser_desc")
+        response = await client.get(
+            "/api/v1/users?sort_by=date_joined&sort_order=DESC&search=datejoinuser_desc"
+        )
         assert response.status_code == 200
         data = response.json()
         assert len(data["users"]) == 5
@@ -1945,7 +2026,9 @@ class TestUserSorting:
             db_session.add(user)
         await db_session.commit()
 
-        response = await client.get("/api/v1/users?sort_by=last_login&sort_order=ASC&search=loginuser")
+        response = await client.get(
+            "/api/v1/users?sort_by=last_login&sort_order=ASC&search=loginuser"
+        )
         assert response.status_code == 200
         data = response.json()
         assert len(data["users"]) == 5
@@ -1976,7 +2059,9 @@ class TestUserSorting:
             db_session.add(user)
         await db_session.commit()
 
-        response = await client.get("/api/v1/users?sort_by=last_login&sort_order=DESC&search=loginuser_desc")
+        response = await client.get(
+            "/api/v1/users?sort_by=last_login&sort_order=DESC&search=loginuser_desc"
+        )
         assert response.status_code == 200
         data = response.json()
         assert len(data["users"]) == 5
@@ -2013,7 +2098,9 @@ class TestUserSorting:
             db_session.add(user)
         await db_session.commit()
 
-        response = await client.get("/api/v1/users?sort_by=last_active&sort_order=ASC&search=activeuser_asc")
+        response = await client.get(
+            "/api/v1/users?sort_by=last_active&sort_order=ASC&search=activeuser_asc"
+        )
         assert response.status_code == 200
         data = response.json()
         assert len(data["users"]) == 5
@@ -2041,7 +2128,9 @@ class TestUserSorting:
             db_session.add(user)
         await db_session.commit()
 
-        response = await client.get("/api/v1/users?sort_by=last_active&sort_order=DESC&search=activeuser_desc")
+        response = await client.get(
+            "/api/v1/users?sort_by=last_active&sort_order=DESC&search=activeuser_desc"
+        )
         assert response.status_code == 200
         data = response.json()
         assert len(data["users"]) == 5
@@ -2074,7 +2163,9 @@ class TestUserSorting:
             db_session.add(user)
         await db_session.commit()
 
-        response = await client.get("/api/v1/users?sort_by=image_posts&sort_order=ASC&search=imgpostuser")
+        response = await client.get(
+            "/api/v1/users?sort_by=image_posts&sort_order=ASC&search=imgpostuser"
+        )
         assert response.status_code == 200
         data = response.json()
         assert len(data["users"]) == 5
@@ -2102,7 +2193,9 @@ class TestUserSorting:
             db_session.add(user)
         await db_session.commit()
 
-        response = await client.get("/api/v1/users?sort_by=image_posts&sort_order=DESC&search=imgpostuser_desc")
+        response = await client.get(
+            "/api/v1/users?sort_by=image_posts&sort_order=DESC&search=imgpostuser_desc"
+        )
         assert response.status_code == 200
         data = response.json()
         assert len(data["users"]) == 5
@@ -2158,7 +2251,9 @@ class TestUserSorting:
             db_session.add(user)
         await db_session.commit()
 
-        response = await client.get("/api/v1/users?sort_by=posts&sort_order=DESC&search=postsuser_desc")
+        response = await client.get(
+            "/api/v1/users?sort_by=posts&sort_order=DESC&search=postsuser_desc"
+        )
         assert response.status_code == 200
         data = response.json()
         assert len(data["users"]) == 5
@@ -2214,7 +2309,9 @@ class TestUserSorting:
             db_session.add(user)
         await db_session.commit()
 
-        response = await client.get("/api/v1/users?sort_by=favorites&sort_order=DESC&search=favuser_desc")
+        response = await client.get(
+            "/api/v1/users?sort_by=favorites&sort_order=DESC&search=favuser_desc"
+        )
         assert response.status_code == 200
         data = response.json()
         assert len(data["users"]) == 5
@@ -2258,12 +2355,16 @@ class TestUserSorting:
         await db_session.commit()
 
         # Test ASC order - filter to only our test users
-        response_asc = await client.get("/api/v1/users?sort_by=last_login&sort_order=ASC&search=nullloginuser")
+        response_asc = await client.get(
+            "/api/v1/users?sort_by=last_login&sort_order=ASC&search=nullloginuser"
+        )
         assert response_asc.status_code == 200
         data_asc = response_asc.json()
 
         # Test DESC order - filter to only our test users
-        response_desc = await client.get("/api/v1/users?sort_by=last_login&sort_order=DESC&search=nullloginuser")
+        response_desc = await client.get(
+            "/api/v1/users?sort_by=last_login&sort_order=DESC&search=nullloginuser"
+        )
         assert response_desc.status_code == 200
         data_desc = response_desc.json()
 
@@ -2272,8 +2373,12 @@ class TestUserSorting:
         assert len(data_desc["users"]) == 6
 
         # Verify that users with non-null last_login are properly ordered
-        last_logins_asc = [u["last_login"] for u in data_asc["users"] if u["last_login"] is not None]
-        last_logins_desc = [u["last_login"] for u in data_desc["users"] if u["last_login"] is not None]
+        last_logins_asc = [
+            u["last_login"] for u in data_asc["users"] if u["last_login"] is not None
+        ]
+        last_logins_desc = [
+            u["last_login"] for u in data_desc["users"] if u["last_login"] is not None
+        ]
 
         # Check ordering by comparing adjacent elements
         for i in range(len(last_logins_asc) - 1):
@@ -2547,9 +2652,7 @@ async def grant_user_permission(db_session: AsyncSession, user_id: int, perm_tit
         db_session.add(perm)
         await db_session.flush()
 
-    result = await db_session.execute(
-        select(Groups).where(Groups.title == "user_edit_test_group")
-    )
+    result = await db_session.execute(select(Groups).where(Groups.title == "user_edit_test_group"))
     group = result.scalar_one_or_none()
     if not group:
         group = Groups(title="user_edit_test_group", desc="User edit test group")
@@ -2862,9 +2965,7 @@ class TestMaxImgPerDayRestriction:
 class TestUserProfileEditAuthorization:
     """Tests for user profile edit authorization using permission system."""
 
-    async def test_user_can_edit_own_profile(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_user_can_edit_own_profile(self, client: AsyncClient, db_session: AsyncSession):
         """Test that a user can edit their own profile."""
         user, password = await create_test_user_with_password(
             db_session, "selfeditor", "selfeditor@example.com"
@@ -2889,9 +2990,7 @@ class TestUserProfileEditAuthorization:
         )
         await grant_user_permission(db_session, editor.user_id, "user_edit_profile")
 
-        target, _ = await create_test_user_with_password(
-            db_session, "editme", "editme@example.com"
-        )
+        target, _ = await create_test_user_with_password(db_session, "editme", "editme@example.com")
 
         token = await login_test_user(client, editor.username, editor_password)
 
@@ -2930,9 +3029,7 @@ class TestUserProfileEditAuthorization:
 class TestGenderField:
     """Tests for free-form gender field."""
 
-    async def test_update_gender_freeform_text(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_update_gender_freeform_text(self, client: AsyncClient, db_session: AsyncSession):
         """Test that gender field accepts free-form text input."""
         user, password = await create_test_user_with_password(
             db_session, "genderuser", "genderuser@example.com"
@@ -2949,9 +3046,7 @@ class TestGenderField:
         assert response.status_code == 200
         assert response.json()["gender"] == "Non-binary"
 
-    async def test_update_gender_longer_text(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_update_gender_longer_text(self, client: AsyncClient, db_session: AsyncSession):
         """Test that gender field accepts longer descriptive text."""
         user, password = await create_test_user_with_password(
             db_session, "genderuser2", "genderuser2@example.com"
@@ -2969,9 +3064,7 @@ class TestGenderField:
         assert response.status_code == 200
         assert response.json()["gender"] == gender_value
 
-    async def test_update_gender_empty_string(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_update_gender_empty_string(self, client: AsyncClient, db_session: AsyncSession):
         """Test that gender field accepts empty string."""
         user, password = await create_test_user_with_password(
             db_session, "genderuser3", "genderuser3@example.com"
@@ -2987,9 +3080,7 @@ class TestGenderField:
         assert response.status_code == 200
         assert response.json()["gender"] == ""
 
-    async def test_gender_max_length(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_gender_max_length(self, client: AsyncClient, db_session: AsyncSession):
         """Test that gender field has reasonable max length (50 chars)."""
         user, password = await create_test_user_with_password(
             db_session, "genderuser4", "genderuser4@example.com"
@@ -3020,9 +3111,7 @@ class TestGenderField:
 class TestUserGroups:
     """Tests for groups field in user responses."""
 
-    async def test_get_user_includes_groups(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_user_includes_groups(self, client: AsyncClient, db_session: AsyncSession):
         """Test that GET /users/{id} returns user's groups."""
         # Create user
         user = Users(
@@ -3057,9 +3146,7 @@ class TestUserGroups:
         assert isinstance(data["groups"], list)
         assert "Moderators" in data["groups"]
 
-    async def test_list_users_includes_groups(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_list_users_includes_groups(self, client: AsyncClient, db_session: AsyncSession):
         """Test that GET /users returns groups for each user."""
         # Create user with a group
         user = Users(
@@ -3130,8 +3217,12 @@ class TestHideRepostsSetting:
 
     async def test_patch_persists_hide_reposts(self, client: AsyncClient, db_session: AsyncSession):
         user = Users(
-            username="hr_persist", password=get_password_hash("TestPassword123!"),
-            password_type="bcrypt", salt="", email="hr_persist@test.com", active=1,
+            username="hr_persist",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="hr_persist@test.com",
+            active=1,
         )
         db_session.add(user)
         await db_session.commit()
@@ -3152,10 +3243,16 @@ class TestHideRepostsSetting:
         await db_session.refresh(user)
         assert user.hide_reposts == 1
 
-    async def test_hide_reposts_rejects_non_boolean(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_hide_reposts_rejects_non_boolean(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         user = Users(
-            username="hr_valid", password=get_password_hash("TestPassword123!"),
-            password_type="bcrypt", salt="", email="hr_valid@test.com", active=1,
+            username="hr_valid",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="hr_valid@test.com",
+            active=1,
         )
         db_session.add(user)
         await db_session.commit()
@@ -3163,7 +3260,118 @@ class TestHideRepostsSetting:
         token = create_access_token(user.user_id)
 
         resp = await client.patch(
-            "/api/v1/users/me", json={"hide_reposts": 2},
+            "/api/v1/users/me",
+            json={"hide_reposts": 2},
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 422
+
+
+class TestUserUpdateSnapshotConflictRetry:
+    """Concurrent PATCHes of one users row trip MariaDB ER_CHECKREAD (errno
+    1020) under innodb_snapshot_isolation — the losing transaction's UPDATE
+    meets a row version committed after its snapshot. The update must retry on
+    a fresh snapshot instead of surfacing a 500. (Observed in practice when
+    the frontend's settings auto-save fires several PATCHes back-to-back.)"""
+
+    async def _make_user_and_token(self, db_session: AsyncSession) -> tuple[Users, str]:
+        user = Users(
+            username="snapshotpatch",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="snapshotpatch@example.com",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        return user, create_access_token(user.id)
+
+    @pytest.mark.asyncio
+    @pytest.mark.needs_commit
+    async def test_patch_me_retries_snapshot_conflict_and_succeeds(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A transient 1020 on the users UPDATE is retried and the PATCH succeeds.
+
+        needs_commit: the retry performs a real session rollback for a fresh
+        snapshot; under SAVEPOINT isolation that rollback would unwind the
+        fixture's user row too, which can't happen in production.
+        """
+        from unittest.mock import patch
+
+        import pymysql
+        from sqlalchemy.exc import OperationalError
+
+        _, token = await self._make_user_and_token(db_session)
+
+        real_commit = AsyncSession.commit
+        calls: list[int] = []
+
+        async def flaky_commit(self, *args, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                raise OperationalError(
+                    "UPDATE users ...",
+                    None,
+                    pymysql.err.OperationalError(
+                        1020, "Record has changed since last read in table 'users'"
+                    ),
+                )
+            await real_commit(self, *args, **kwargs)
+
+        with patch.object(AsyncSession, "commit", flaky_commit):
+            resp = await client.patch(
+                "/api/v1/users/me",
+                json={"location": "Retry City"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["location"] == "Retry City"
+        assert len(calls) >= 2  # failed attempt + successful retry
+
+    @pytest.mark.asyncio
+    @pytest.mark.needs_commit
+    async def test_patch_me_gives_up_after_bounded_retries(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A persistent 1020 propagates after a bounded number of attempts.
+
+        needs_commit: each retry re-SELECTs the user after a real rollback;
+        under SAVEPOINT isolation that rollback unwinds the fixture's user row
+        and the retry would 404 instead of exercising the conflict path.
+        """
+        from unittest.mock import patch
+
+        import pymysql
+        from sqlalchemy.exc import OperationalError
+
+        _, token = await self._make_user_and_token(db_session)
+
+        calls: list[int] = []
+
+        async def always_conflict(self, *args, **kwargs):
+            calls.append(1)
+            raise OperationalError(
+                "UPDATE users ...",
+                None,
+                pymysql.err.OperationalError(
+                    1020, "Record has changed since last read in table 'users'"
+                ),
+            )
+
+        with (
+            patch.object(AsyncSession, "commit", always_conflict),
+            pytest.raises(OperationalError),
+        ):
+            await client.patch(
+                "/api/v1/users/me",
+                json={"location": "Never Land"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert len(calls) == 3  # bounded: no infinite retry loop
+
+        assert len(calls) == 3  # bounded: no infinite retry loop

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -3373,5 +3373,3 @@ class TestUserUpdateSnapshotConflictRetry:
             )
 
         assert len(calls) == 3  # bounded: no infinite retry loop
-
-        assert len(calls) == 3  # bounded: no infinite retry loop

--- a/tests/unit/test_db_retry.py
+++ b/tests/unit/test_db_retry.py
@@ -1,0 +1,120 @@
+"""Tests for the snapshot-conflict retry helper (app/core/db_retry.py)."""
+
+import pymysql
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from app.core.db_retry import is_snapshot_conflict, retry_on_snapshot_conflict
+
+
+def _db_error(errno: int, message: str) -> OperationalError:
+    return OperationalError("STATEMENT", None, pymysql.err.OperationalError(errno, message))
+
+
+def _conflict() -> OperationalError:
+    return _db_error(1020, "Record has changed since last read in table 'images'")
+
+
+class _StubSession:
+    """Records rollback calls; the helper must roll back between attempts."""
+
+    def __init__(self) -> None:
+        self.rollbacks = 0
+
+    async def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class TestIsSnapshotConflict:
+    def test_matches_errno_1020(self):
+        assert is_snapshot_conflict(_conflict()) is True
+
+    def test_rejects_other_errnos(self):
+        assert is_snapshot_conflict(_db_error(1213, "Deadlock found")) is False
+
+    def test_rejects_error_without_args(self):
+        assert is_snapshot_conflict(OperationalError("STATEMENT", None, Exception())) is False
+
+
+class TestRetryOnSnapshotConflict:
+    @pytest.mark.asyncio
+    async def test_returns_value_on_first_success_without_rollback(self):
+        db = _StubSession()
+
+        async def fn() -> str:
+            return "ok"
+
+        assert await retry_on_snapshot_conflict(db, fn, what="test") == "ok"
+        assert db.rollbacks == 0
+
+    @pytest.mark.asyncio
+    async def test_retries_conflict_with_rollback_between_attempts(self):
+        db = _StubSession()
+        calls = 0
+
+        async def fn() -> str:
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise _conflict()
+            return "ok"
+
+        assert await retry_on_snapshot_conflict(db, fn, what="test") == "ok"
+        assert calls == 3
+        assert db.rollbacks == 2  # one per failed attempt
+
+    @pytest.mark.asyncio
+    async def test_reraises_after_attempts_exhausted(self):
+        db = _StubSession()
+        calls = 0
+
+        async def fn() -> None:
+            nonlocal calls
+            calls += 1
+            raise _conflict()
+
+        with pytest.raises(OperationalError):
+            await retry_on_snapshot_conflict(db, fn, what="test")
+        assert calls == 3  # default bound
+        assert db.rollbacks == 2  # no rollback after the final, re-raised failure
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_other_operational_errors(self):
+        db = _StubSession()
+        calls = 0
+
+        async def fn() -> None:
+            nonlocal calls
+            calls += 1
+            raise _db_error(1213, "Deadlock found")
+
+        with pytest.raises(OperationalError):
+            await retry_on_snapshot_conflict(db, fn, what="test")
+        assert calls == 1
+        assert db.rollbacks == 0
+
+    @pytest.mark.asyncio
+    async def test_does_not_swallow_non_db_errors(self):
+        db = _StubSession()
+
+        async def fn() -> None:
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError):
+            await retry_on_snapshot_conflict(db, fn, what="test")
+        assert db.rollbacks == 0
+
+    @pytest.mark.asyncio
+    async def test_attempts_override(self):
+        db = _StubSession()
+        calls = 0
+
+        async def fn() -> None:
+            nonlocal calls
+            calls += 1
+            raise _conflict()
+
+        with pytest.raises(OperationalError):
+            await retry_on_snapshot_conflict(db, fn, what="test", attempts=5)
+        assert calls == 5
+        assert db.rollbacks == 4


### PR DESCRIPTION
## The bug class

With `innodb_snapshot_isolation=ON` (prod 11.8.6; dev `mariadb:12`), a locking statement that meets row/index versions committed **after** the transaction's snapshot aborts with **ER_CHECKREAD (errno 1020)** instead of returning stale data. The snapshot is pinned by the request's first read (the auth query), so the conflict window spans nearly the whole request. Nothing caught the error → the losing request surfaced a raw **500**.

**Two sites confirmed live** (both via the frontend e2e suite at 7–8 workers; see frontend PR #284):
1. the upload temp-row `INSERT INTO images` — every in-flight upload writes identical placeholder values into the same index positions (reproducible)
2. concurrent `PATCH /users/me` UPDATEs of one `users` row — the settings auto-save firing back-to-back (observed in logs during verification of fix 1)

## The fix (commit 1: upload; commit 2: generalized helper + users path)

**`app/core/db_retry.py`** — `retry_on_snapshot_conflict(db, fn, what=...)`: runs a self-contained transactional unit, **rolling back between attempts** so each retry gets a fresh snapshot. A savepoint would be functionally wrong (the snapshot stays pinned; the conflict recurs). Bounded (3 attempts); non-conflict errors and exhaustion propagate unchanged; each retry logs `snapshot_conflict_retry`.

Deliberately **opt-in per write path, not request-replay middleware** — replaying a whole request would re-run its non-DB side effects (file writes, redis/arq enqueues, email). The module docstring spells out the callable's rules (re-fetch rows inside the unit — rollback expires ORM instances; DB work only).

Converted sites:
- `upload_image` → helper wraps the temp-row INSERT (endpoint tests unchanged & green = behavioral equivalence with commit 1's inline loop)
- `_update_user_profile` → helper wraps the whole fetch-apply-commit unit, covering both `PATCH /users/me` and `PATCH /users/{id}`. Subtle catch handled: `update_data` is derived *inside* the retried unit because the password branch `pop`s from it — sharing it across attempts would silently drop the password on retry.

## Tests (all TDD, red first)

- **9 unit tests** for the helper: attempt/rollback counts, non-1020 passthrough, non-DB exceptions untouched, attempts override.
- **Upload endpoint** (3): transient 1020 → retried → 201; persistent → exactly 3 attempts then propagates; non-1020 not retried.
- **Users endpoint** (2): transient 1020 at commit → retried → 200 with the update applied; persistent → bounded then propagates.
- Retry-success/persistent tests are `@needs_commit`: the real rollback unwinds SAVEPOINT fixture isolation (the retried re-SELECT would 404) — a harness artifact impossible in production.

## Verification

- Full API suite: **2,241 passed / 0 failed**; ruff + mypy clean.
- Frontend e2e at 8 workers (previously reproducibly failing): **343/0 green**, twice — including one run where `upload_snapshot_conflict_retry` fired mid-run and absorbed a real collision; zero 1020s escaping as 500s since.

## Follow-ups
- Other write paths can adopt the helper as sites surface (the forum concurrent-reply path on `feat/forum` is a natural candidate post-merge).
- Frontend: bump local Playwright workers to `'75%'` (~1.6m suite, −12%) once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjX1n6o5UrzPz92oWZ8mw3