### PR TITLE
fix(test): eliminate xdist connection-death flakiness — pytest OOM-kills the shared dev MariaDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Ensure bash is used for all commands (required for read -p in clean target)
 SHELL := /bin/bash
 
-.PHONY: help dev dev-up dev-down dev-logs dev-ps test test-up test-down test-logs test-ps test-build-frontend prod prod-up prod-down prod-logs prod-ps prod-build prod-build-frontend prod-migrate prod-restart prod-deploy clean
+.PHONY: help dev dev-up dev-down dev-logs dev-ps test test-up test-down test-logs test-ps test-build-frontend pytest pytest-db-up pytest-db-down prod prod-up prod-down prod-logs prod-ps prod-build prod-build-frontend prod-migrate prod-restart prod-deploy clean
 
 # Capture extra arguments for logs commands (e.g., `make dev-logs api`)
 ARGS = $(filter-out $@,$(MAKECMDGOALS))
@@ -27,6 +27,11 @@ help:
 	@echo "  test-logs    Follow all logs"
 	@echo "  test-ps      Show running containers"
 	@echo "  test-build-frontend     Rebuild frontend image"
+	@echo ""
+	@echo "Python test suite (isolated DB on :3316):"
+	@echo "  pytest       Run the pytest suite (-n auto) against an isolated MariaDB"
+	@echo "  pytest-db-up   Start the isolated pytest MariaDB"
+	@echo "  pytest-db-down Stop the isolated pytest MariaDB"
 	@echo ""
 	@echo "Production (HTTPS on e-shuushuu.net):"
 	@echo "  prod         Start production environment (foreground)"
@@ -105,6 +110,35 @@ test-ps:
 
 test-build-frontend:
 	$(COMPOSE_TEST) build --no-cache frontend
+
+# pytest targets — run the Python unit/integration suite against an isolated,
+# right-sized MariaDB (docker-compose.pytest.yml) instead of the shared,
+# memory-saturated dev container. See that file's header for the OOM root cause
+# this avoids. This is the supported way to run `pytest -n auto` locally.
+COMPOSE_PYTEST = docker compose -f docker-compose.pytest.yml
+# Pin the suite at the isolated DB (port 3316) regardless of what .env holds.
+# DATABASE_URL is what the app engine builds from at import; the TEST_DB_*
+# components are what conftest builds the test engine AND the root admin engine
+# (which creates the per-worker databases) from -- the root path reads
+# TEST_DB_HOST/TEST_DB_PORT, not TEST_DATABASE_URL, so set the components.
+PYTEST_DB_ENV = \
+	DATABASE_URL="mysql+aiomysql://shuushuu:shuushuu_password@127.0.0.1:3316/shuushuu_pytest?charset=utf8mb4" \
+	DATABASE_URL_SYNC="mysql+pymysql://shuushuu:shuushuu_password@127.0.0.1:3316/shuushuu_pytest?charset=utf8mb4" \
+	TEST_DB_HOST=127.0.0.1 \
+	TEST_DB_PORT=3316 \
+	TEST_DB_USER=shuushuu \
+	TEST_DB_PASSWORD=shuushuu_password \
+	TEST_DB_NAME=shuushuu_pytest \
+	MARIADB_ROOT_PASSWORD=root_password
+
+pytest-db-up:
+	$(COMPOSE_PYTEST) up -d --wait
+
+pytest-db-down:
+	$(COMPOSE_PYTEST) down
+
+pytest: pytest-db-up
+	$(PYTEST_DB_ENV) uv run pytest -n auto --dist loadgroup $(ARGS)
 
 # Production targets
 prod:

--- a/docker-compose.pytest.yml
+++ b/docker-compose.pytest.yml
@@ -64,8 +64,9 @@ services:
     # Hard ceiling well above the ~0.8 GiB this container actually peaks at
     # under `-n auto`, but far below the dev container's 3 GiB — so it can
     # never repeat the OOM, and uses less host memory than sharing the dev DB.
+    # memswap_limit equal to mem_limit disables swap entirely (cgroup v2).
     mem_limit: 1g
-    mem_swappiness: 0
+    memswap_limit: 1g
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s

--- a/docker-compose.pytest.yml
+++ b/docker-compose.pytest.yml
@@ -55,7 +55,9 @@ services:
       --max_connections=400
       --innodb_buffer_pool_size=256M
     ports:
-      - "3316:3306"
+      # localhost-only bind: credentials are hardcoded throwaway values and must
+      # never be network-reachable from off-host
+      - "127.0.0.1:3316:3306"
     # RAM-backed datadir: the pytest databases are ephemeral and rebuilt each
     # session, so there is nothing to persist. Also makes migrations/truncates
     # dramatically faster than fsync-ing to disk.

--- a/docker-compose.pytest.yml
+++ b/docker-compose.pytest.yml
@@ -65,6 +65,7 @@ services:
     # under `-n auto`, but far below the dev container's 3 GiB — so it can
     # never repeat the OOM, and uses less host memory than sharing the dev DB.
     mem_limit: 1g
+    mem_swappiness: 0
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s

--- a/docker-compose.pytest.yml
+++ b/docker-compose.pytest.yml
@@ -1,0 +1,73 @@
+# Dedicated, resource-isolated MariaDB for the pytest unit/integration suite.
+#
+# Why this file exists — root cause of the xdist "connection death" flakiness
+# ---------------------------------------------------------------------------
+# Running `uv run pytest -n auto` against the shared dev MariaDB
+# (docker-compose.yml) intermittently produced mass carnage: hundreds of
+# setup/teardown ERRORs, all pymysql (2013 "Lost connection during query") /
+# aiomysql IncompleteReadError signatures, while every test passes serially.
+#
+# It was never a connection-limit problem (Max_used_connections peaked at ~10,
+# limit is 400). mariadbd was being OOM-killed mid-run. The arithmetic:
+#
+#   dev container cap ................ 3.0 GiB   (docker-compose.yml)
+#   --innodb_buffer_pool_size ........ 2.0 GiB   (tuned for the live dev feed;
+#                                                 stays ~2.36 GiB resident while
+#                                                 serving the dev site)
+#   headroom under the cap ........... ~0.6 GiB
+#   `pytest -n auto` adds ............ ~0.5 GiB   (one xdist worker per core;
+#                                                 concurrent migration/DDL +
+#                                                 connections + temp tables)
+#
+# Combined peak sits right at the 3 GiB cap. Because the dev container also
+# allows swap (memory-swap 6 GiB) on a host whose swap is already ~93% full,
+# the overflow drives the host out of memory and the host OOM-killer reaps
+# mariadbd (unclean SIGKILL -> InnoDB crash recovery on restart). All in-flight
+# test connections die at once -> the ERROR storm. It is intermittent because
+# it only tips over when the test load, a filled buffer pool, and concurrent
+# dev-site activity align.
+#
+# The fix: give the suite its own database instead of borrowing the
+# memory-saturated dev container — exactly what CI already does. The pytest
+# databases are tiny, so a 256 MiB buffer pool is ample and a RAM-backed
+# (tmpfs) datadir with its own 1 GiB budget leaves enormous headroom. Verified:
+# `pytest -n auto` runs clean 3x in a row with zero connection-death errors,
+# and ~8x faster (~172 s -> ~21 s) thanks to the small pool + tmpfs.
+#
+# Isolated from the dev/test/prod stacks: own container name, own port (3316),
+# ephemeral tmpfs data. Use it via the Makefile:
+#
+#   make pytest            # start this DB (if needed) and run the suite on it
+#   make pytest-db-up      # just start the DB
+#   make pytest-db-down    # stop and remove it
+services:
+  mariadb-pytest:
+    image: mariadb:12
+    container_name: shuushuu-mariadb-pytest
+    environment:
+      MARIADB_ROOT_PASSWORD: root_password
+      MARIADB_DATABASE: shuushuu_pytest
+      MARIADB_USER: shuushuu
+      MARIADB_PASSWORD: shuushuu_password
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+      --max_connections=400
+      --innodb_buffer_pool_size=256M
+    ports:
+      - "3316:3306"
+    # RAM-backed datadir: the pytest databases are ephemeral and rebuilt each
+    # session, so there is nothing to persist. Also makes migrations/truncates
+    # dramatically faster than fsync-ing to disk.
+    tmpfs:
+      - /var/lib/mysql
+    # Hard ceiling well above the ~0.8 GiB this container actually peaks at
+    # under `-n auto`, but far below the dev container's 3 GiB — so it can
+    # never repeat the OOM, and uses less host memory than sharing the dev DB.
+    mem_limit: 1g
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: "no"

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,6 +55,11 @@ Each worker gets its own database (`shuushuu_pytest_gw0`, ...) and Redis DB,
 created automatically. `--dist loadgroup` keeps the schema-sync tests (which
 rebuild fixed-name databases) on a single worker.
 
+**Note on Redis fixtures:** Tests using real-Redis fixtures (not mocked) still
+target the local Redis at `localhost:6379`. They skip gracefully if Redis is not
+available (pre-existing behavior). Only the database is fully isolated; Redis
+fixtures are shared across workers.
+
 **Do not run `-n auto` against the dev database.** The dev MariaDB runs a 2 GiB
 InnoDB buffer pool inside a 3 GiB container cap; serving the live dev site keeps
 that pool resident, so a parallel run has almost no headroom. The added

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,16 +44,33 @@ uv run pytest tests/unit/test_schemas.py
 ```
 
 ### Run in parallel (pytest-xdist)
+
+Use the Makefile target. It starts a dedicated, right-sized MariaDB and runs the
+suite against it:
 ```bash
-uv run pytest -n 4 --dist loadgroup
+make pytest                 # full suite, -n auto --dist loadgroup
+make pytest ARGS="-m unit"  # forward extra args to pytest
 ```
 Each worker gets its own database (`shuushuu_pytest_gw0`, ...) and Redis DB,
 created automatically. `--dist loadgroup` keeps the schema-sync tests (which
-rebuild fixed-name databases) on a single worker. 4 workers is the sweet spot
-locally; more just contend on MariaDB, and Redis DB numbering caps runs at
-13 workers. CI runs with `-n auto --dist loadgroup`.
+rebuild fixed-name databases) on a single worker.
 
-If root DB access is unavailable, worker databases require a one-time grant:
+**Do not run `-n auto` against the dev database.** The dev MariaDB runs a 2 GiB
+InnoDB buffer pool inside a 3 GiB container cap; serving the live dev site keeps
+that pool resident, so a parallel run has almost no headroom. The added
+migration/connection/temp memory tips mariadbd over the cap and it is OOM-killed
+mid-run, dropping every in-flight connection at once — hundreds of pymysql
+`(2013, 'Lost connection during query')` / aiomysql `IncompleteReadError` setup
+and teardown ERRORs that all pass when re-run serially. `make pytest` sidesteps
+this by pointing the suite at the isolated `docker-compose.pytest.yml` database
+(256 MiB pool, RAM-backed, port 3316); see that file's header for the full
+arithmetic. CI runs `-n auto --dist loadgroup` against its own dedicated DB for
+the same reason.
+
+Redis DB numbering caps runs at 13 workers (see `_test_redis_db` in conftest).
+
+If you instead point the suite at a server where root DB access is unavailable,
+worker databases require a one-time grant:
 ```sql
 GRANT ALL PRIVILEGES ON `shuushuu\_pytest\_%`.* TO `shuushuu`@`%`;
 ```


### PR DESCRIPTION
## Symptom

Running the full suite in parallel (`pytest -n auto`, ~2270 tests) intermittently produces mass carnage: a recent run logged **141 ERRORs + 3 FAILED**, every one a MySQL connection-death signature (`pymysql (2013, 'Lost connection during query')`, aiomysql `IncompleteReadError`, occasional `(2003) Can't connect`). All of it passes when re-run serially. Documented as known/pre-existing.

## Root cause

**mariadbd is being OOM-killed mid-run.** It was never a connection-limit problem (`Max_used_connections` peaked at ~10 against a 400 limit; `Connection_errors_max_connections = 0`). The evidence log shows **693× `(2013)` + 462× `IncompleteReadError` + 20× `(2003)` and zero `(1040) Too many connections`** — the signature of the server dying, not the pool exhausting. The dev container's logs confirm an unclean death: `InnoDB: Starting crash recovery` on restart, with no internal crash backtrace anywhere (i.e. an external SIGKILL, not a MariaDB bug).

The arithmetic, measured on this box:

| | |
|---|---|
| dev container memory cap | **3.0 GiB** |
| `--innodb_buffer_pool_size` | **2.0 GiB** (tuned for the live dev feed) |
| dev container RSS at idle | **2.36 GiB** (pool filled with live dev data) |
| headroom under the cap | **~0.6 GiB** |
| peak RSS `pytest -n auto` adds (measured, isolated) | **~0.42 GiB** (10-worker migration/DDL storm + connections + temp) |

The combined peak sits right at the 3 GiB cap. Because the dev container also permits swap (`memory-swap` 6 GiB) on a host whose swap is already ~93% full, the overflow drives the **host** out of memory and the host OOM-killer reaps mariadbd (hence `OOMKilled=false` — it's host-level, not the cgroup wall). Every in-flight test connection dies at once → the ERROR storm. It's intermittent because it only tips over when the test load, a filled buffer pool, and concurrent dev-site activity align.

CI never sees this: its dedicated `mariadb:12` service uses the **default** buffer pool (~128 MiB) with a tmpfs datadir, so it has gigabytes of headroom. The flakiness is specific to local runs borrowing the memory-saturated dev container.

### Reproduced deterministically

Against an isolated throwaway on the **exact dev command** (`--innodb_buffer_pool_size=2G`) but a tightened cap that forces the same squeeze, `pytest -n auto` reproduced it: **116 ERRORs + 6 FAILED**, `OOMKilled=true`, identical `(2013)` / `IncompleteReadError` / `(2003)` profile.

## The fix

Give the suite its own database instead of the shared dev container — the same thing CI already does. The pytest databases are tiny, so a 256 MiB buffer pool is ample; a RAM-backed (tmpfs) datadir with its own 1 GiB budget leaves enormous headroom and can never repeat the OOM.

- **`docker-compose.pytest.yml`** — isolated `mariadb:12` (256 MiB pool, tmpfs, 1 GiB cap, port 3316). Header documents the full arithmetic.
- **Makefile** — `make pytest` (starts the DB, runs `-n auto --dist loadgroup` against it), `pytest-db-up`, `pytest-db-down`.
- **tests/README.md** — replaces the "-n 4 is the sweet spot, more contend on MariaDB" guidance with `make pytest`, and explains why not to run `-n auto` against the dev DB.

No change to the dev/test/prod stacks or the dev container.

## Verification

3× `make pytest` (`-n auto --dist loadgroup`) against the shipped `docker-compose.pytest.yml`, exactly as a developer would run it:

| run | result | 2013 / IncompleteRead / 2003 | OOMKilled | wall |
|-----|--------|------------------------------|-----------|------|
| 1 | 2235 passed, 15 skipped | 0 / 0 / 0 | false | 26.5s |
| 2 | 2235 passed, 15 skipped | 0 / 0 / 0 | false | 21.6s |
| 3 | 2235 passed, 15 skipped | 0 / 0 / 0 | false | 21.5s |

Zero connection-death errors across all runs, server never died. **Not slower — ~7-8× faster** (a passing run against a dev-config DB is ~172 s; the lean tmpfs DB is ~22 s).

### Follow-up (not in this PR)
`tests/conftest.py`'s root admin engine reads `TEST_DB_HOST`/`TEST_DB_PORT` (default `localhost:3306`) rather than parsing them from `TEST_DATABASE_URL`, so the README's "set `TEST_DATABASE_URL`" instruction silently points per-worker DB creation at the wrong server for any non-default host/port. Worth reconciling separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThKKr7X94FCpf7qQ4BfGV2