### PR TITLE
fix(forum): security review fixes — lock bypass, existence oracle, snapshot 500s, rate limit

### DIFF
--- a/app/api/v1/forum.py
+++ b/app/api/v1/forum.py
@@ -37,6 +37,7 @@ from app.schemas.forum import (
     ForumThreadUpdate,
 )
 from app.services.forum import can_access, recompute_thread_stats, upsert_thread_read
+from app.services.rate_limit import check_forum_create_rate_limit
 
 router = APIRouter(prefix="/forum", tags=["forum"])
 
@@ -413,9 +414,12 @@ async def create_thread(
     """Create a thread with its opening post in one transaction."""
     assert current_user.user_id is not None
     perms = await _effective_perms(db, redis_client, current_user)
+    is_moderator = Permission.FORUM_MODERATE.value in perms
     category = await _visible_category(db, category_id, perms)
     if not can_access(perms, category.thread_create_perm):
         raise HTTPException(status_code=403, detail="You cannot create threads in this category")
+    if not is_moderator:
+        await check_forum_create_rate_limit(current_user.user_id, redis_client)
 
     thread = ForumThreads(
         category_id=category.category_id, title=body.title, user_id=current_user.user_id
@@ -624,6 +628,11 @@ async def create_post(
     # transaction, expiring ORM instances (including current_user).
     user_id = current_user.user_id
     client_ip = request.client.host if request.client else ""
+
+    # Anti-spam rate limit (moderators exempt). Kept outside the retried unit
+    # below so a snapshot-conflict retry does not double-count the attempt.
+    if not is_moderator:
+        await check_forum_create_rate_limit(user_id, redis_client)
 
     # Lock the thread row and recompute its stats as one retryable unit: under
     # innodb_snapshot_isolation the locking read can abort with ER_CHECKREAD

--- a/app/api/v1/forum.py
+++ b/app/api/v1/forum.py
@@ -13,6 +13,7 @@ from app.api.dependencies import PaginationParams
 from app.core.archived_user import get_archived_user_id
 from app.core.auth import CurrentUser, OptionalCurrentUser
 from app.core.database import get_db
+from app.core.db_retry import retry_on_snapshot_conflict
 from app.core.permission_cache import get_cached_user_permissions
 from app.core.permission_deps import require_permission
 from app.core.permissions import Permission
@@ -619,46 +620,56 @@ async def create_post(
     assert current_user.user_id is not None
     perms = await _effective_perms(db, redis_client, current_user)
     is_moderator = Permission.FORUM_MODERATE.value in perms
+    # Capture as primitives: a snapshot-conflict retry rolls back the
+    # transaction, expiring ORM instances (including current_user).
+    user_id = current_user.user_id
+    client_ip = request.client.host if request.client else ""
 
-    # Lock the thread row: the denormalized stats recompute below must not
-    # race a concurrent reply/delete.
-    result = await db.execute(
-        select(ForumThreads)
-        .where(ForumThreads.thread_id == thread_id)  # type: ignore[arg-type]
-        .with_for_update()
-    )
-    thread = result.scalar_one_or_none()
-    if thread is None or (thread.deleted and not is_moderator):
-        # Non-moderators can't distinguish a deleted thread from a missing one,
-        # matching get_thread/update_thread/delete_thread — no existence leak.
-        raise HTTPException(status_code=404, detail="Thread not found")
-    category = await _visible_category(
-        db, thread.category_id, perms, not_found_detail="Thread not found"
-    )
-    if thread.deleted:
-        # Moderator path: the thread exists but must be restored before posting.
-        raise HTTPException(status_code=403, detail="Thread is deleted")
-    if thread.locked:
-        raise HTTPException(status_code=403, detail="Thread is locked")
-    if not can_access(perms, category.reply_perm):
-        raise HTTPException(status_code=403, detail="You cannot reply in this category")
+    # Lock the thread row and recompute its stats as one retryable unit: under
+    # innodb_snapshot_isolation the locking read can abort with ER_CHECKREAD
+    # (1020) when a concurrent request commits to the same thread/post rows, so
+    # re-fetch on a fresh snapshot instead of 500ing (see app/core/db_retry.py).
+    async def _apply() -> ForumPosts:
+        result = await db.execute(
+            select(ForumThreads)
+            .where(ForumThreads.thread_id == thread_id)  # type: ignore[arg-type]
+            .with_for_update()
+        )
+        thread = result.scalar_one_or_none()
+        if thread is None or (thread.deleted and not is_moderator):
+            # Non-moderators can't distinguish a deleted thread from a missing
+            # one, matching get_thread/update_thread/delete_thread — no leak.
+            raise HTTPException(status_code=404, detail="Thread not found")
+        category = await _visible_category(
+            db, thread.category_id, perms, not_found_detail="Thread not found"
+        )
+        if thread.deleted:
+            # Moderator path: the thread exists but must be restored first.
+            raise HTTPException(status_code=403, detail="Thread is deleted")
+        if thread.locked:
+            raise HTTPException(status_code=403, detail="Thread is locked")
+        if not can_access(perms, category.reply_perm):
+            raise HTTPException(status_code=403, detail="You cannot reply in this category")
 
-    post = ForumPosts(
-        thread_id=thread_id,
-        user_id=current_user.user_id,
-        post_text=body.post_text,
-        ip=request.client.host if request.client else "",
-    )
-    db.add(post)
-    await db.flush()
-    await db.refresh(post)
-    await recompute_thread_stats(db, thread)
-    # The author has read their own reply
-    await upsert_thread_read(db, current_user.user_id, thread_id, post.date)
-    await db.commit()
+        post = ForumPosts(
+            thread_id=thread_id,
+            user_id=user_id,
+            post_text=body.post_text,
+            ip=client_ip,
+        )
+        db.add(post)
+        await db.flush()
+        await db.refresh(post)
+        await recompute_thread_stats(db, thread)
+        # The author has read their own reply
+        await upsert_thread_read(db, user_id, thread_id, post.date)
+        await db.commit()
+        return post
 
-    summaries = await build_user_summaries(db, {current_user.user_id})
-    return _post_response(post, summaries[current_user.user_id], is_moderator)
+    post = await retry_on_snapshot_conflict(db, _apply, what="forum_create_post")
+
+    summaries = await build_user_summaries(db, {user_id})
+    return _post_response(post, summaries[user_id], is_moderator)
 
 
 @router.patch("/posts/{post_id}", response_model=ForumPostResponse)
@@ -674,48 +685,58 @@ async def update_post(
     assert current_user.user_id is not None
     perms = await _effective_perms(db, redis_client, current_user)
     is_moderator = Permission.FORUM_MODERATE.value in perms
-
-    post = await db.get(ForumPosts, post_id)
-    if post is None:
-        raise HTTPException(status_code=404, detail="Post not found")
-    result = await db.execute(
-        select(ForumThreads)
-        .where(ForumThreads.thread_id == post.thread_id)  # type: ignore[arg-type]
-        .with_for_update()
-    )
-    thread = result.scalar_one()
-    if thread.deleted and not is_moderator:
-        raise HTTPException(status_code=404, detail="Thread not found")
-    await _visible_category(db, thread.category_id, perms)
-    if thread.locked and not is_moderator:
-        # A locked thread blocks the owner's own edit/soft-delete too, matching
-        # create_post; moderators may still act (they unlock first).
-        raise HTTPException(status_code=403, detail="Thread is locked")
-
+    user_id = current_user.user_id
     updates = body.model_dump(exclude_unset=True)
-    if "deleted" in updates and not is_moderator:
-        raise HTTPException(status_code=403, detail="FORUM_MODERATE permission required")
-    if "post_text" in updates:
-        if not (is_moderator or post.user_id == current_user.user_id):
-            raise HTTPException(
-                status_code=403, detail="Only the author or a moderator can edit this post"
-            )
-        will_be_deleted = updates.get("deleted", post.deleted)
-        if will_be_deleted:
-            raise HTTPException(status_code=400, detail="Restore the post before editing it")
-        post.post_text = updates["post_text"]
-        post.update_count += 1
-        post.last_updated = datetime.now(UTC)
-        post.last_updated_user_id = current_user.user_id
-    if "deleted" in updates:
-        if updates["deleted"] and post.post_id == await _first_post_id(db, thread.thread_id or 0):
-            raise HTTPException(
-                status_code=400,
-                detail="The opening post cannot be deleted; delete the thread instead",
-            )
-        post.deleted = updates["deleted"]
-        await recompute_thread_stats(db, thread)
-    await db.commit()
+
+    # Lock the thread row and recompute its stats as one retryable unit; the
+    # locking read can abort with a snapshot conflict (1020) under concurrency,
+    # so re-fetch post + thread on a fresh snapshot (see app/core/db_retry.py).
+    async def _apply() -> ForumPosts:
+        post = await db.get(ForumPosts, post_id)
+        if post is None:
+            raise HTTPException(status_code=404, detail="Post not found")
+        result = await db.execute(
+            select(ForumThreads)
+            .where(ForumThreads.thread_id == post.thread_id)  # type: ignore[arg-type]
+            .with_for_update()
+        )
+        thread = result.scalar_one()
+        if thread.deleted and not is_moderator:
+            raise HTTPException(status_code=404, detail="Thread not found")
+        await _visible_category(db, thread.category_id, perms)
+        if thread.locked and not is_moderator:
+            # A locked thread blocks the owner's own edit/soft-delete too,
+            # matching create_post; moderators may still act (they unlock first).
+            raise HTTPException(status_code=403, detail="Thread is locked")
+
+        if "deleted" in updates and not is_moderator:
+            raise HTTPException(status_code=403, detail="FORUM_MODERATE permission required")
+        if "post_text" in updates:
+            if not (is_moderator or post.user_id == user_id):
+                raise HTTPException(
+                    status_code=403, detail="Only the author or a moderator can edit this post"
+                )
+            will_be_deleted = updates.get("deleted", post.deleted)
+            if will_be_deleted:
+                raise HTTPException(status_code=400, detail="Restore the post before editing it")
+            post.post_text = updates["post_text"]
+            post.update_count += 1
+            post.last_updated = datetime.now(UTC)
+            post.last_updated_user_id = user_id
+        if "deleted" in updates:
+            if updates["deleted"] and post.post_id == await _first_post_id(
+                db, thread.thread_id or 0
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail="The opening post cannot be deleted; delete the thread instead",
+                )
+            post.deleted = updates["deleted"]
+            await recompute_thread_stats(db, thread)
+        await db.commit()
+        return post
+
+    post = await retry_on_snapshot_conflict(db, _apply, what="forum_update_post")
 
     summaries = await build_user_summaries(db, {post.user_id})
     return _post_response(post, summaries[post.user_id], is_moderator)
@@ -733,36 +754,43 @@ async def delete_post(
     assert current_user.user_id is not None
     perms = await _effective_perms(db, redis_client, current_user)
     is_moderator = Permission.FORUM_MODERATE.value in perms
+    user_id = current_user.user_id
 
-    post = await db.get(ForumPosts, post_id)
-    if post is None or (post.deleted and not is_moderator):
-        raise HTTPException(status_code=404, detail="Post not found")
-    result = await db.execute(
-        select(ForumThreads)
-        .where(ForumThreads.thread_id == post.thread_id)  # type: ignore[arg-type]
-        .with_for_update()
-    )
-    thread = result.scalar_one()
-    if thread.deleted and not is_moderator:
-        raise HTTPException(status_code=404, detail="Thread not found")
-    await _visible_category(db, thread.category_id, perms)
-    if thread.locked and not is_moderator:
-        # A locked thread blocks the owner's own soft-delete too, matching
-        # create_post; moderators may still act (they unlock first).
-        raise HTTPException(status_code=403, detail="Thread is locked")
+    # Lock the thread row and recompute its stats as one retryable unit; the
+    # locking read can abort with a snapshot conflict (1020) under concurrency,
+    # so re-fetch post + thread on a fresh snapshot (see app/core/db_retry.py).
+    async def _apply() -> None:
+        post = await db.get(ForumPosts, post_id)
+        if post is None or (post.deleted and not is_moderator):
+            raise HTTPException(status_code=404, detail="Post not found")
+        result = await db.execute(
+            select(ForumThreads)
+            .where(ForumThreads.thread_id == post.thread_id)  # type: ignore[arg-type]
+            .with_for_update()
+        )
+        thread = result.scalar_one()
+        if thread.deleted and not is_moderator:
+            raise HTTPException(status_code=404, detail="Thread not found")
+        await _visible_category(db, thread.category_id, perms)
+        if thread.locked and not is_moderator:
+            # A locked thread blocks the owner's own soft-delete too, matching
+            # create_post; moderators may still act (they unlock first).
+            raise HTTPException(status_code=403, detail="Thread is locked")
 
-    if not (is_moderator or post.user_id == current_user.user_id):
-        raise HTTPException(
-            status_code=403, detail="Only the author or a moderator can delete this post"
-        )
-    if post.post_id == await _first_post_id(db, thread.thread_id or 0):
-        raise HTTPException(
-            status_code=400,
-            detail="The opening post cannot be deleted; delete the thread instead",
-        )
-    post.deleted = True
-    await recompute_thread_stats(db, thread)
-    await db.commit()
+        if not (is_moderator or post.user_id == user_id):
+            raise HTTPException(
+                status_code=403, detail="Only the author or a moderator can delete this post"
+            )
+        if post.post_id == await _first_post_id(db, thread.thread_id or 0):
+            raise HTTPException(
+                status_code=400,
+                detail="The opening post cannot be deleted; delete the thread instead",
+            )
+        post.deleted = True
+        await recompute_thread_stats(db, thread)
+        await db.commit()
+
+    await retry_on_snapshot_conflict(db, _apply, what="forum_delete_post")
 
 
 # ===== Legacy phpBB URL redirects & post permalinks =====

--- a/app/api/v1/forum.py
+++ b/app/api/v1/forum.py
@@ -533,6 +533,10 @@ async def update_thread(
             status_code=403,
             detail="Only the thread author or a moderator can edit the title",
         )
+    if "title" in updates and thread.locked and not is_moderator:
+        # A locked thread blocks the author's rename too (moderators unlock
+        # first); mod-only fields above are already gated by FORUM_MODERATE.
+        raise HTTPException(status_code=403, detail="Thread is locked")
     if "category_id" in updates:
         target = await db.get(ForumCategories, updates["category_id"])
         if target is None:
@@ -668,6 +672,10 @@ async def update_post(
     if thread.deleted and not is_moderator:
         raise HTTPException(status_code=404, detail="Thread not found")
     await _visible_category(db, thread.category_id, perms)
+    if thread.locked and not is_moderator:
+        # A locked thread blocks the owner's own edit/soft-delete too, matching
+        # create_post; moderators may still act (they unlock first).
+        raise HTTPException(status_code=403, detail="Thread is locked")
 
     updates = body.model_dump(exclude_unset=True)
     if "deleted" in updates and not is_moderator:
@@ -723,6 +731,10 @@ async def delete_post(
     if thread.deleted and not is_moderator:
         raise HTTPException(status_code=404, detail="Thread not found")
     await _visible_category(db, thread.category_id, perms)
+    if thread.locked and not is_moderator:
+        # A locked thread blocks the owner's own soft-delete too, matching
+        # create_post; moderators may still act (they unlock first).
+        raise HTTPException(status_code=403, detail="Thread is locked")
 
     if not (is_moderator or post.user_id == current_user.user_id):
         raise HTTPException(

--- a/app/api/v1/forum.py
+++ b/app/api/v1/forum.py
@@ -63,12 +63,23 @@ async def _effective_perms(
     return await get_cached_user_permissions(db, redis_client, user.user_id)
 
 
-async def _visible_category(db: AsyncSession, category_id: int, perms: set[str]) -> ForumCategories:
+async def _visible_category(
+    db: AsyncSession,
+    category_id: int,
+    perms: set[str],
+    *,
+    not_found_detail: str = "Not found",
+) -> ForumCategories:
     """Load a category the caller may view; 404 (not 403) otherwise so gated
-    categories don't leak existence."""
+    categories don't leak existence.
+
+    Callers that reach this after resolving a thread/post pass their own
+    missing-object detail as ``not_found_detail`` so a gated-but-existing
+    object and a missing one return a byte-identical 404 — otherwise the
+    differing detail string is itself an existence oracle for gated ids."""
     category = await db.get(ForumCategories, category_id)
     if category is None or not can_access(perms, category.view_perm):
-        raise HTTPException(status_code=404, detail="Category not found")
+        raise HTTPException(status_code=404, detail=not_found_detail)
     return category
 
 
@@ -447,7 +458,9 @@ async def get_thread(
     thread = await db.get(ForumThreads, thread_id)
     if thread is None or (thread.deleted and not is_moderator):
         raise HTTPException(status_code=404, detail="Thread not found")
-    category = await _visible_category(db, thread.category_id, perms)
+    category = await _visible_category(
+        db, thread.category_id, perms, not_found_detail="Thread not found"
+    )
 
     total = (
         await db.execute(
@@ -619,7 +632,9 @@ async def create_post(
         # Non-moderators can't distinguish a deleted thread from a missing one,
         # matching get_thread/update_thread/delete_thread — no existence leak.
         raise HTTPException(status_code=404, detail="Thread not found")
-    category = await _visible_category(db, thread.category_id, perms)
+    category = await _visible_category(
+        db, thread.category_id, perms, not_found_detail="Thread not found"
+    )
     if thread.deleted:
         # Moderator path: the thread exists but must be restored before posting.
         raise HTTPException(status_code=403, detail="Thread is deleted")
@@ -795,8 +810,10 @@ async def legacy_viewtopic(
     thread = result.scalars().first()
     if thread is None:
         raise HTTPException(status_code=404, detail="Topic not found")
-    # 404 if the destination category is gated and not visible to the caller.
-    await _visible_category(db, thread.category_id, perms)
+    # 404 (identical to the missing-topic 404 above) if the destination category
+    # is gated and not visible to the caller, so gated topic ids can't be
+    # enumerated by the differing detail string.
+    await _visible_category(db, thread.category_id, perms, not_found_detail="Topic not found")
     return RedirectResponse(
         url=f"/forum/threads/{thread.thread_id}",
         status_code=status.HTTP_301_MOVED_PERMANENTLY,
@@ -821,8 +838,10 @@ async def post_permalink(
     thread = await db.get(ForumThreads, post.thread_id)
     if thread is None:  # FK guarantees a parent thread; guard defensively anyway.
         raise HTTPException(status_code=404, detail="Post not found")
-    # 404 if the destination category is gated and not visible to the caller.
-    await _visible_category(db, thread.category_id, perms)
+    # 404 (identical to the missing-post 404 above) if the destination category
+    # is gated and not visible to the caller, so gated post ids can't be
+    # enumerated by the differing detail string.
+    await _visible_category(db, thread.category_id, perms, not_found_detail="Post not found")
     rank = (
         await db.execute(
             select(func.count())

--- a/app/api/v1/forum.py
+++ b/app/api/v1/forum.py
@@ -540,7 +540,7 @@ async def update_thread(
     thread = await db.get(ForumThreads, thread_id)
     if thread is None or (thread.deleted and not is_moderator):
         raise HTTPException(status_code=404, detail="Thread not found")
-    await _visible_category(db, thread.category_id, perms)
+    await _visible_category(db, thread.category_id, perms, not_found_detail="Thread not found")
 
     updates = body.model_dump(exclude_unset=True)
     mod_fields = {"pinned", "locked", "category_id", "deleted"} & updates.keys()
@@ -588,7 +588,7 @@ async def delete_thread(
     thread = await db.get(ForumThreads, thread_id)
     if thread is None or (thread.deleted and not is_moderator):
         raise HTTPException(status_code=404, detail="Thread not found")
-    await _visible_category(db, thread.category_id, perms)
+    await _visible_category(db, thread.category_id, perms, not_found_detail="Thread not found")
 
     if not is_moderator:
         if thread.user_id != current_user.user_id:
@@ -712,7 +712,7 @@ async def update_post(
         thread = result.scalar_one()
         if thread.deleted and not is_moderator:
             raise HTTPException(status_code=404, detail="Thread not found")
-        await _visible_category(db, thread.category_id, perms)
+        await _visible_category(db, thread.category_id, perms, not_found_detail="Post not found")
         if thread.locked and not is_moderator:
             # A locked thread blocks the owner's own edit/soft-delete too,
             # matching create_post; moderators may still act (they unlock first).
@@ -780,7 +780,7 @@ async def delete_post(
         thread = result.scalar_one()
         if thread.deleted and not is_moderator:
             raise HTTPException(status_code=404, detail="Thread not found")
-        await _visible_category(db, thread.category_id, perms)
+        await _visible_category(db, thread.category_id, perms, not_found_detail="Post not found")
         if thread.locked and not is_moderator:
             # A locked thread blocks the owner's own soft-delete too, matching
             # create_post; moderators may still act (they unlock first).

--- a/app/config.py
+++ b/app/config.py
@@ -235,6 +235,10 @@ class Settings(BaseSettings):
     MAX_SEARCH_TAGS: int = 5
     MAX_SEARCH_USERS: int = 5
     SIMILARITY_CHECK_RATE_LIMIT: int = 5  # Max similarity checks per user per minute
+    FORUM_CREATE_RATE_LIMIT: int = Field(
+        default=10,
+        description="Max forum threads + posts a user may create per minute (moderators exempt)",
+    )
     REGISTRATION_RATE_LIMIT: int = Field(
         default=5, description="Max registrations per IP per window"
     )

--- a/app/services/rate_limit.py
+++ b/app/services/rate_limit.py
@@ -162,6 +162,37 @@ async def check_similarity_rate_limit(user_id: int, redis_client: redis.Redis) -
     )
 
 
+async def check_forum_create_rate_limit(user_id: int, redis_client: redis.Redis) -> None:  # type: ignore[type-arg]
+    """
+    Enforce the anti-spam rate limit on forum content creation per user.
+
+    Thread and post creation share one per-user budget (a spammer must not be
+    able to bypass the cap by alternating the two endpoints).
+
+    Limit: FORUM_CREATE_RATE_LIMIT per user per 60 seconds. Moderators are
+    exempt (the caller skips this check), mirroring how the upload path exempts
+    admins.
+
+    Uses Redis for fast lookups and automatic expiration.
+    Gracefully degrades if Redis is unavailable (allows the request).
+
+    Args:
+        user_id: ID of the user making the request
+        redis_client: Redis client instance
+
+    Raises:
+        HTTPException: 429 if rate limit exceeded
+    """
+    await _check_user_rate_limit(
+        redis_client,
+        user_id,
+        key_prefix="forum_create_rate",
+        limit=settings.FORUM_CREATE_RATE_LIMIT,
+        window_seconds=60,
+        detail="You are posting too fast. Please wait a minute and try again.",
+    )
+
+
 async def check_analyze_rate_limit(user_id: int, redis_client: redis.Redis) -> None:  # type: ignore[type-arg]
     """
     Enforce tag-analysis rate limit per user.

--- a/tests/api/v1/test_forum_legacy_redirects.py
+++ b/tests/api/v1/test_forum_legacy_redirects.py
@@ -77,3 +77,16 @@ class TestViewtopicRedirect:
         await db_session.commit()
         r = await client.get("/api/v1/forum/legacy/viewtopic?t=42")
         assert r.status_code == 404
+
+    async def test_missing_and_gated_topic_return_identical_404(
+        self, client: AsyncClient, db_session: AsyncSession, staff_category
+    ):
+        # A gated-but-existing legacy topic and a missing one must be
+        # indistinguishable to an anonymous caller (no existence oracle).
+        thread = await make_thread(db_session, staff_category, title="Secret")
+        thread.legacy_topic_id = 4242
+        await db_session.commit()
+        missing_resp = await client.get("/api/v1/forum/legacy/viewtopic?t=999999")
+        gated_resp = await client.get("/api/v1/forum/legacy/viewtopic?t=4242")
+        assert missing_resp.status_code == gated_resp.status_code == 404
+        assert missing_resp.json() == gated_resp.json()

--- a/tests/api/v1/test_forum_permalink.py
+++ b/tests/api/v1/test_forum_permalink.py
@@ -73,3 +73,15 @@ class TestPostPermalink:
         opening = await _opening_post(db_session, thread)
         r = await client.get(f"/api/v1/forum/posts/{opening.post_id}/redirect")
         assert r.status_code == 404
+
+    async def test_missing_and_gated_post_return_identical_404(
+        self, client: AsyncClient, db_session: AsyncSession, staff_category
+    ):
+        # A gated-but-existing post and a missing one must be indistinguishable
+        # to an anonymous caller (no existence oracle for gated post ids).
+        thread = await make_thread(db_session, staff_category, title="Secret")
+        opening = await _opening_post(db_session, thread)
+        missing_resp = await client.get("/api/v1/forum/posts/999999/redirect")
+        gated_resp = await client.get(f"/api/v1/forum/posts/{opening.post_id}/redirect")
+        assert missing_resp.status_code == gated_resp.status_code == 404
+        assert missing_resp.json() == gated_resp.json()

--- a/tests/api/v1/test_forum_posts.py
+++ b/tests/api/v1/test_forum_posts.py
@@ -127,6 +127,25 @@ class TestCreatePost:
         )
         assert response.status_code == 404
 
+    async def test_missing_and_gated_thread_reply_return_identical_404(
+        self, client: AsyncClient, db_session: AsyncSession, staff_category, user_token
+    ):
+        # Replying to a gated-but-existing thread and to a missing one must be
+        # indistinguishable (no existence oracle), matching get_thread.
+        thread = await make_thread(db_session, staff_category)
+        missing_resp = await client.post(
+            "/api/v1/forum/threads/999999/posts",
+            json={"post_text": "hi"},
+            headers=_auth(user_token),
+        )
+        gated_resp = await client.post(
+            f"/api/v1/forum/threads/{thread.thread_id}/posts",
+            json={"post_text": "hi"},
+            headers=_auth(user_token),
+        )
+        assert missing_resp.status_code == gated_resp.status_code == 404
+        assert missing_resp.json() == gated_resp.json()
+
     async def test_reply_gated_403(self, client: AsyncClient, db_session: AsyncSession, user_token):
         # Public view, staff-only replies (a read-only announcements pattern)
         cat = ForumCategories(

--- a/tests/api/v1/test_forum_posts.py
+++ b/tests/api/v1/test_forum_posts.py
@@ -1,6 +1,11 @@
 """Tests for forum post endpoints."""
 
+from unittest.mock import patch
+
+import pymysql
+import pytest
 from httpx import AsyncClient
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.permissions import Permission
@@ -10,6 +15,38 @@ from tests.api.v1.conftest import make_thread
 
 def _auth(token: str) -> dict:
     return {"Authorization": f"Bearer {token}"}
+
+
+def _db_error(errno: int, message: str) -> OperationalError:
+    """Build the sqlalchemy error the aiomysql/pymysql driver raises for `errno`."""
+    return OperationalError(
+        "SELECT ... FOR UPDATE", None, pymysql.err.OperationalError(errno, message)
+    )
+
+
+def _snapshot_conflict_error() -> OperationalError:
+    """The error MariaDB raises under innodb_snapshot_isolation (ER_CHECKREAD)."""
+    return _db_error(1020, "Record has changed since last read in table 'forum_threads'")
+
+
+def _flaky_locking_read(fail_times: int, error: OperationalError):
+    """Patch AsyncSession.execute to raise `error` the first `fail_times` times
+    it runs a locking (FOR UPDATE) statement — the exact site MariaDB aborts
+    with ER_CHECKREAD (1020) under innodb_snapshot_isolation. Non-locking
+    statements (and db.get, which does not go through AsyncSession.execute) pass
+    through untouched. Returns (patch_ctx, calls) where calls records each
+    intercepted locking read."""
+    real_execute = AsyncSession.execute
+    calls: list[int] = []
+
+    async def execute(self, statement, *args, **kwargs):
+        if getattr(statement, "_for_update_arg", None) is not None:
+            calls.append(1)
+            if len(calls) <= fail_times:
+                raise error
+        return await real_execute(self, statement, *args, **kwargs)
+
+    return patch.object(AsyncSession, "execute", execute), calls
 
 
 async def _get_thread(db_session: AsyncSession, thread_id: int) -> ForumThreads:
@@ -357,3 +394,105 @@ class TestDeletePost:
             f"/api/v1/forum/posts/{post['post_id']}", headers=_auth(staff_token)
         )
         assert mod_resp.status_code == 204
+
+
+class TestForumSnapshotConflictRetry:
+    """create_post/update_post/delete_post lock the thread row (FOR UPDATE) and
+    recompute denormalized stats. Under innodb_snapshot_isolation a concurrent
+    commit to the same thread/post rows aborts that locking read with
+    ER_CHECKREAD (errno 1020). Each write path must retry on a fresh snapshot
+    instead of surfacing a 500. The 1020 is injected into the locking read
+    itself — the real conflict site — via _flaky_locking_read, exercising the
+    real retry helper (app/core/db_retry.py).
+
+    needs_commit: the retry performs a real session rollback to obtain a fresh
+    snapshot; under the default SAVEPOINT test isolation that rollback would
+    unwind the committed thread/user fixtures too, which cannot happen in
+    production where they are durably committed."""
+
+    async def _create_reply(self, client: AsyncClient, thread_id: int, token: str) -> dict:
+        r = await client.post(
+            f"/api/v1/forum/threads/{thread_id}/posts",
+            json={"post_text": "original"},
+            headers=_auth(token),
+        )
+        assert r.status_code == 201
+        return r.json()
+
+    @pytest.mark.needs_commit
+    async def test_reply_retries_snapshot_conflict_and_succeeds(
+        self, client: AsyncClient, public_thread, user_token
+    ):
+        read_patch, calls = _flaky_locking_read(1, _snapshot_conflict_error())
+        with read_patch:
+            response = await client.post(
+                f"/api/v1/forum/threads/{public_thread.thread_id}/posts",
+                json={"post_text": "hi"},
+                headers=_auth(user_token),
+            )
+        assert response.status_code == 201, response.text
+        assert len(calls) >= 2  # failed attempt + successful retry
+
+        # The reply landed exactly once despite the retry.
+        detail = (
+            await client.get(f"/api/v1/forum/threads/{public_thread.thread_id}")
+        ).json()
+        assert detail["total"] == 2  # opening + the single retried reply
+
+    @pytest.mark.needs_commit
+    async def test_reply_gives_up_after_bounded_retries(
+        self, client: AsyncClient, public_thread, user_token
+    ):
+        read_patch, calls = _flaky_locking_read(100, _snapshot_conflict_error())
+        with read_patch, pytest.raises(OperationalError):
+            await client.post(
+                f"/api/v1/forum/threads/{public_thread.thread_id}/posts",
+                json={"post_text": "hi"},
+                headers=_auth(user_token),
+            )
+        assert len(calls) == 3  # bounded: no infinite retry loop
+
+    async def test_reply_does_not_retry_other_db_errors(
+        self, client: AsyncClient, public_thread, user_token
+    ):
+        read_patch, calls = _flaky_locking_read(100, _db_error(1213, "Deadlock found"))
+        with read_patch, pytest.raises(OperationalError):
+            await client.post(
+                f"/api/v1/forum/threads/{public_thread.thread_id}/posts",
+                json={"post_text": "hi"},
+                headers=_auth(user_token),
+            )
+        assert len(calls) == 1  # non-1020 error is not retried
+
+    @pytest.mark.needs_commit
+    async def test_edit_post_retries_snapshot_conflict_and_succeeds(
+        self, client: AsyncClient, public_thread, user_token
+    ):
+        post = await self._create_reply(client, public_thread.thread_id, user_token)
+        read_patch, calls = _flaky_locking_read(1, _snapshot_conflict_error())
+        with read_patch:
+            response = await client.patch(
+                f"/api/v1/forum/posts/{post['post_id']}",
+                json={"post_text": "edited"},
+                headers=_auth(user_token),
+            )
+        assert response.status_code == 200, response.text
+        assert response.json()["post_text"] == "edited"
+        assert len(calls) >= 2
+
+    @pytest.mark.needs_commit
+    async def test_delete_post_retries_snapshot_conflict_and_succeeds(
+        self, client: AsyncClient, db_session: AsyncSession, public_thread, user_token
+    ):
+        post = await self._create_reply(client, public_thread.thread_id, user_token)
+        read_patch, calls = _flaky_locking_read(1, _snapshot_conflict_error())
+        with read_patch:
+            response = await client.delete(
+                f"/api/v1/forum/posts/{post['post_id']}",
+                headers=_auth(user_token),
+            )
+        assert response.status_code == 204, response.text
+        assert len(calls) >= 2
+
+        thread = await _get_thread(db_session, public_thread.thread_id)
+        assert thread.post_count == 1  # stats recomputed exactly once

--- a/tests/api/v1/test_forum_posts.py
+++ b/tests/api/v1/test_forum_posts.py
@@ -234,6 +234,32 @@ class TestUpdatePost:
         assert thread.post_count == 2
         assert thread.last_post_user_id == 3
 
+    async def test_locked_thread_blocks_owner_edit_but_not_moderator(
+        self, client: AsyncClient, db_session: AsyncSession, public_thread, user_token, staff_token
+    ):
+        # The lock must block the post owner's own edit (parity with create_post),
+        # but a moderator may still act (they unlock first in the normal flow).
+        post = await self._create_reply(client, public_thread.thread_id, user_token)
+        thread = await _get_thread(db_session, public_thread.thread_id)
+        thread.locked = True
+        await db_session.commit()
+
+        owner_resp = await client.patch(
+            f"/api/v1/forum/posts/{post['post_id']}",
+            json={"post_text": "sneaky edit"},
+            headers=_auth(user_token),
+        )
+        assert owner_resp.status_code == 403
+        assert "locked" in owner_resp.json()["detail"].lower()
+
+        mod_resp = await client.patch(
+            f"/api/v1/forum/posts/{post['post_id']}",
+            json={"post_text": "mod edit"},
+            headers=_auth(staff_token),
+        )
+        assert mod_resp.status_code == 200
+        assert mod_resp.json()["post_text"] == "mod edit"
+
 
 class TestDeletePost:
     """DELETE /api/v1/forum/posts/{post_id}"""
@@ -291,3 +317,24 @@ class TestDeletePost:
             f"/api/v1/forum/posts/{post['post_id']}", headers=_auth(staff_token)
         )
         assert response.status_code == 204
+
+    async def test_locked_thread_blocks_owner_delete_but_not_moderator(
+        self, client: AsyncClient, db_session: AsyncSession, public_thread, user_token, staff_token
+    ):
+        # A locked thread must block the owner's soft-delete of their own post,
+        # but a moderator may still remove it.
+        post = await self._create_reply(client, public_thread.thread_id, user_token)
+        thread = await _get_thread(db_session, public_thread.thread_id)
+        thread.locked = True
+        await db_session.commit()
+
+        owner_resp = await client.delete(
+            f"/api/v1/forum/posts/{post['post_id']}", headers=_auth(user_token)
+        )
+        assert owner_resp.status_code == 403
+        assert "locked" in owner_resp.json()["detail"].lower()
+
+        mod_resp = await client.delete(
+            f"/api/v1/forum/posts/{post['post_id']}", headers=_auth(staff_token)
+        )
+        assert mod_resp.status_code == 204

--- a/tests/api/v1/test_forum_posts.py
+++ b/tests/api/v1/test_forum_posts.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.permissions import Permission
-from app.models.forum import ForumCategories, ForumThreads
+from app.models.forum import ForumCategories, ForumPosts, ForumThreads
 from tests.api.v1.conftest import make_thread
 
 
@@ -182,6 +182,25 @@ class TestCreatePost:
         )
         assert missing_resp.status_code == gated_resp.status_code == 404
         assert missing_resp.json() == gated_resp.json()
+
+    async def test_missing_and_gated_post_mutation_return_identical_404(
+        self, client: AsyncClient, db_session: AsyncSession, staff_category, user_token
+    ):
+        # PATCH/DELETE of a gated-but-existing post must be byte-identical to a
+        # missing post, so the mutation endpoints don't leak gated post ids.
+        gated_thread = await make_thread(db_session, staff_category)
+        post = ForumPosts(thread_id=gated_thread.thread_id, user_id=1, post_text="secret")
+        db_session.add(post)
+        await db_session.commit()
+        await db_session.refresh(post)
+        for method, kwargs in (("patch", {"json": {"post_text": "x"}}), ("delete", {})):
+            req = getattr(client, method)
+            missing = await req("/api/v1/forum/posts/999999", headers=_auth(user_token), **kwargs)
+            gated = await req(
+                f"/api/v1/forum/posts/{post.post_id}", headers=_auth(user_token), **kwargs
+            )
+            assert missing.status_code == gated.status_code == 404
+            assert missing.json() == gated.json()
 
     async def test_reply_gated_403(self, client: AsyncClient, db_session: AsyncSession, user_token):
         # Public view, staff-only replies (a read-only announcements pattern)
@@ -434,9 +453,7 @@ class TestForumSnapshotConflictRetry:
         assert len(calls) >= 2  # failed attempt + successful retry
 
         # The reply landed exactly once despite the retry.
-        detail = (
-            await client.get(f"/api/v1/forum/threads/{public_thread.thread_id}")
-        ).json()
+        detail = (await client.get(f"/api/v1/forum/threads/{public_thread.thread_id}")).json()
         assert detail["total"] == 2  # opening + the single retried reply
 
     @pytest.mark.needs_commit

--- a/tests/api/v1/test_forum_rate_limit.py
+++ b/tests/api/v1/test_forum_rate_limit.py
@@ -1,0 +1,97 @@
+"""Endpoint-level tests for the forum thread/post creation rate limit.
+
+These use the real Redis client (client_real_redis) so the per-user counter
+actually accumulates across requests; the default mock_redis reports every
+lookup as a cache miss and so can never trip the limit.
+"""
+
+from httpx import AsyncClient
+
+from app.config import settings
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestForumCreateRateLimit:
+    """Anti-spam per-user rate limit shared by thread and post creation."""
+
+    async def test_thread_creation_rate_limited(
+        self, client_real_redis: AsyncClient, public_category, user_token, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "FORUM_CREATE_RATE_LIMIT", 2)
+        url = f"/api/v1/forum/categories/{public_category.category_id}/threads"
+        body = {"title": "T", "post_text": "body"}
+        assert (
+            await client_real_redis.post(url, json=body, headers=_auth(user_token))
+        ).status_code == 201
+        assert (
+            await client_real_redis.post(url, json=body, headers=_auth(user_token))
+        ).status_code == 201
+        third = await client_real_redis.post(url, json=body, headers=_auth(user_token))
+        assert third.status_code == 429
+
+    async def test_post_creation_rate_limited(
+        self, client_real_redis: AsyncClient, public_thread, user_token, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "FORUM_CREATE_RATE_LIMIT", 2)
+        url = f"/api/v1/forum/threads/{public_thread.thread_id}/posts"
+        body = {"post_text": "reply"}
+        assert (
+            await client_real_redis.post(url, json=body, headers=_auth(user_token))
+        ).status_code == 201
+        assert (
+            await client_real_redis.post(url, json=body, headers=_auth(user_token))
+        ).status_code == 201
+        third = await client_real_redis.post(url, json=body, headers=_auth(user_token))
+        assert third.status_code == 429
+
+    async def test_thread_and_post_share_one_budget(
+        self, client_real_redis: AsyncClient, public_thread, public_category, user_token, monkeypatch
+    ):
+        # A spammer must not bypass the cap by alternating thread and post
+        # creation: both draw from the same per-user budget.
+        monkeypatch.setattr(settings, "FORUM_CREATE_RATE_LIMIT", 2)
+        thread_url = f"/api/v1/forum/categories/{public_category.category_id}/threads"
+        post_url = f"/api/v1/forum/threads/{public_thread.thread_id}/posts"
+        assert (
+            await client_real_redis.post(
+                thread_url, json={"title": "T", "post_text": "b"}, headers=_auth(user_token)
+            )
+        ).status_code == 201
+        assert (
+            await client_real_redis.post(
+                post_url, json={"post_text": "reply"}, headers=_auth(user_token)
+            )
+        ).status_code == 201
+        # Budget (2) is now spent across the two endpoints.
+        blocked = await client_real_redis.post(
+            post_url, json={"post_text": "reply"}, headers=_auth(user_token)
+        )
+        assert blocked.status_code == 429
+
+    async def test_normal_paced_request_succeeds(
+        self, client_real_redis: AsyncClient, public_category, user_token, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "FORUM_CREATE_RATE_LIMIT", 10)
+        url = f"/api/v1/forum/categories/{public_category.category_id}/threads"
+        r = await client_real_redis.post(
+            url, json={"title": "T", "post_text": "body"}, headers=_auth(user_token)
+        )
+        assert r.status_code == 201
+
+    async def test_moderator_exempt_from_rate_limit(
+        self, client_real_redis: AsyncClient, public_category, staff_token, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "FORUM_CREATE_RATE_LIMIT", 1)
+        url = f"/api/v1/forum/categories/{public_category.category_id}/threads"
+        body = {"title": "T", "post_text": "body"}
+        assert (
+            await client_real_redis.post(url, json=body, headers=_auth(staff_token))
+        ).status_code == 201
+        # A second creation would exceed the cap for a normal user; moderators
+        # are exempt (they need to be able to post freely while moderating).
+        assert (
+            await client_real_redis.post(url, json=body, headers=_auth(staff_token))
+        ).status_code == 201

--- a/tests/api/v1/test_forum_rate_limit.py
+++ b/tests/api/v1/test_forum_rate_limit.py
@@ -48,7 +48,12 @@ class TestForumCreateRateLimit:
         assert third.status_code == 429
 
     async def test_thread_and_post_share_one_budget(
-        self, client_real_redis: AsyncClient, public_thread, public_category, user_token, monkeypatch
+        self,
+        client_real_redis: AsyncClient,
+        public_thread,
+        public_category,
+        user_token,
+        monkeypatch,
     ):
         # A spammer must not bypass the cap by alternating thread and post
         # creation: both draw from the same per-user budget.

--- a/tests/api/v1/test_forum_threads.py
+++ b/tests/api/v1/test_forum_threads.py
@@ -198,6 +198,24 @@ class TestGetThread:
         assert missing_resp.status_code == gated_resp.status_code == 404
         assert missing_resp.json() == gated_resp.json()
 
+    async def test_missing_and_gated_thread_mutation_return_identical_404(
+        self, client: AsyncClient, db_session: AsyncSession, staff_category, user_token
+    ):
+        # The same non-existence-oracle guarantee must hold on the authenticated
+        # mutation endpoints: PATCH/DELETE of a gated-but-existing thread must be
+        # byte-identical to that of a missing thread (no enumeration of gated ids).
+        gated = await make_thread(db_session, staff_category, title="Secret")
+        for method, kwargs in (("patch", {"json": {"title": "x"}}), ("delete", {})):
+            req = getattr(client, method)
+            missing = await req(
+                "/api/v1/forum/threads/999999", headers=_auth(user_token), **kwargs
+            )
+            gated_resp = await req(
+                f"/api/v1/forum/threads/{gated.thread_id}", headers=_auth(user_token), **kwargs
+            )
+            assert missing.status_code == gated_resp.status_code == 404
+            assert missing.json() == gated_resp.json()
+
     async def test_deleted_thread_404_for_users_200_for_mods(
         self, client: AsyncClient, db_session: AsyncSession, public_thread, user_token, staff_token
     ):

--- a/tests/api/v1/test_forum_threads.py
+++ b/tests/api/v1/test_forum_threads.py
@@ -207,9 +207,7 @@ class TestGetThread:
         gated = await make_thread(db_session, staff_category, title="Secret")
         for method, kwargs in (("patch", {"json": {"title": "x"}}), ("delete", {})):
             req = getattr(client, method)
-            missing = await req(
-                "/api/v1/forum/threads/999999", headers=_auth(user_token), **kwargs
-            )
+            missing = await req("/api/v1/forum/threads/999999", headers=_auth(user_token), **kwargs)
             gated_resp = await req(
                 f"/api/v1/forum/threads/{gated.thread_id}", headers=_auth(user_token), **kwargs
             )
@@ -306,7 +304,12 @@ class TestUpdateThread:
         assert data["locked"] is True
 
     async def test_locked_thread_blocks_author_title_edit_but_not_moderator(
-        self, client: AsyncClient, db_session: AsyncSession, public_thread, author_token, staff_token
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        public_thread,
+        author_token,
+        staff_token,
     ):
         # A lock must block the author's title rename too — otherwise the thread
         # author could still mutate a locked thread. Moderators may still rename.

--- a/tests/api/v1/test_forum_threads.py
+++ b/tests/api/v1/test_forum_threads.py
@@ -275,17 +275,29 @@ class TestUpdateThread:
         assert data["pinned"] is True
         assert data["locked"] is True
 
-    async def test_locked_thread_title_still_editable(
-        self, client: AsyncClient, db_session: AsyncSession, public_thread, author_token
+    async def test_locked_thread_blocks_author_title_edit_but_not_moderator(
+        self, client: AsyncClient, db_session: AsyncSession, public_thread, author_token, staff_token
     ):
+        # A lock must block the author's title rename too — otherwise the thread
+        # author could still mutate a locked thread. Moderators may still rename.
         public_thread.locked = True
         await db_session.commit()
-        response = await client.patch(
+
+        author_resp = await client.patch(
             f"/api/v1/forum/threads/{public_thread.thread_id}",
-            json={"title": "Still editable"},
+            json={"title": "Sneaky rename"},
             headers=_auth(author_token),
         )
-        assert response.status_code == 200
+        assert author_resp.status_code == 403
+        assert "locked" in author_resp.json()["detail"].lower()
+
+        mod_resp = await client.patch(
+            f"/api/v1/forum/threads/{public_thread.thread_id}",
+            json={"title": "Mod rename"},
+            headers=_auth(staff_token),
+        )
+        assert mod_resp.status_code == 200
+        assert mod_resp.json()["title"] == "Mod rename"
 
     async def test_moderator_moves_thread(
         self, client: AsyncClient, public_thread, announce_category, staff_token

--- a/tests/api/v1/test_forum_threads.py
+++ b/tests/api/v1/test_forum_threads.py
@@ -186,6 +186,18 @@ class TestGetThread:
         )
         assert response.status_code == 404
 
+    async def test_missing_and_gated_thread_return_identical_404(
+        self, client: AsyncClient, db_session: AsyncSession, staff_category
+    ):
+        # An anonymous caller must not distinguish a gated-but-existing thread
+        # from a missing one: both 404s must be byte-identical (no existence
+        # oracle for enumerating gated thread ids).
+        gated = await make_thread(db_session, staff_category, title="Secret")
+        missing_resp = await client.get("/api/v1/forum/threads/999999")
+        gated_resp = await client.get(f"/api/v1/forum/threads/{gated.thread_id}")
+        assert missing_resp.status_code == gated_resp.status_code == 404
+        assert missing_resp.json() == gated_resp.json()
+
     async def test_deleted_thread_404_for_users_200_for_mods(
         self, client: AsyncClient, db_session: AsyncSession, public_thread, user_token, staff_token
     ):

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -6,7 +6,11 @@ import pytest
 from fastapi import HTTPException
 from redis.exceptions import ConnectionError as RedisConnectionError
 
-from app.services.rate_limit import check_analyze_rate_limit, check_similarity_rate_limit
+from app.services.rate_limit import (
+    check_analyze_rate_limit,
+    check_forum_create_rate_limit,
+    check_similarity_rate_limit,
+)
 
 
 @pytest.fixture
@@ -208,3 +212,81 @@ class TestCheckAnalyzeRateLimit:
 
         # Should not raise - graceful degradation
         await check_analyze_rate_limit(user_id=1, redis_client=mock_redis)
+
+
+@pytest.mark.unit
+class TestCheckForumCreateRateLimit:
+    """Tests for check_forum_create_rate_limit (shared thread + post budget)."""
+
+    async def test_allows_request_under_limit(self, mock_redis, monkeypatch):
+        """First request (count=None) should be allowed."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "FORUM_CREATE_RATE_LIMIT", 2)
+        mock_redis.get.return_value = None
+
+        # Should not raise
+        await check_forum_create_rate_limit(user_id=1, redis_client=mock_redis)
+
+    async def test_allows_request_at_limit_minus_one(self, mock_redis, monkeypatch):
+        """Request at count=1 (limit-1) should be allowed when limit=2."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "FORUM_CREATE_RATE_LIMIT", 2)
+        mock_redis.get.return_value = b"1"
+
+        # Should not raise
+        await check_forum_create_rate_limit(user_id=1, redis_client=mock_redis)
+
+    async def test_rejects_request_at_limit(self, mock_redis, monkeypatch):
+        """Request at count=2 (limit) should raise 429 with Retry-After header."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "FORUM_CREATE_RATE_LIMIT", 2)
+        mock_redis.get.return_value = b"2"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check_forum_create_rate_limit(user_id=1, redis_client=mock_redis)
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.headers["Retry-After"] == "60"
+
+    async def test_rejects_request_over_limit(self, mock_redis, monkeypatch):
+        """Request at count=10 (over limit) should raise 429."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "FORUM_CREATE_RATE_LIMIT", 2)
+        mock_redis.get.return_value = b"10"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check_forum_create_rate_limit(user_id=1, redis_client=mock_redis)
+
+        assert exc_info.value.status_code == 429
+
+    async def test_uses_correct_redis_key(self, mock_redis, monkeypatch):
+        """Should read the count from key 'forum_create_rate:{user_id}'.
+
+        A count stored under any other key must be invisible to the check, so
+        if the implementation used the wrong key the request would incorrectly
+        be allowed instead of raising 429.
+        """
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "FORUM_CREATE_RATE_LIMIT", 2)
+        redis_state = {"forum_create_rate:42": b"2"}
+        mock_redis.get.side_effect = lambda key: redis_state.get(key)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check_forum_create_rate_limit(user_id=42, redis_client=mock_redis)
+
+        assert exc_info.value.status_code == 429
+
+    async def test_allows_request_when_redis_unavailable(self, mock_redis, monkeypatch):
+        """Should allow request (not raise) when Redis is down."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "FORUM_CREATE_RATE_LIMIT", 2)
+        mock_redis.get.side_effect = RedisConnectionError("Connection refused")
+
+        # Should not raise - graceful degradation
+        await check_forum_create_rate_limit(user_id=1, redis_client=mock_redis)


### PR DESCRIPTION
Security/robustness fixes from the forum-branch review, stacked on `feat/forum-urls`. Each is TDD (failing test → fix → pass); all forum + rate-limit + db_retry test files pass.

## Fixes

**#1 — Locked-thread mutation bypass.** The lock was enforced only on new replies (`create_post`). `update_post`, `delete_post`, and `update_thread`'s title path now also reject `thread.locked and not is_moderator` with 403 — a post owner could otherwise rewrite/soft-delete their post or rename the title in a locked thread. (Reverses the old `test_locked_thread_title_still_editable`, rewritten to assert the new behavior.)

**#2 — Existence oracle via 404 detail strings.** Missing objects returned `"Thread/Post/Topic not found"` while a gated-but-existing object returned `"Category not found"` — letting a caller enumerate gated ids. `_visible_category` now takes `not_found_detail`; every read path **and** the 4 authenticated mutation endpoints (update/delete thread, update/delete post) return byte-identical 404s for missing vs gated.

**#3 — Concurrency 500s under snapshot isolation.** `create_post`/`update_post`/`delete_post` do `SELECT … FOR UPDATE` + `recompute_thread_stats`; under prod `innodb_snapshot_isolation=ON` a concurrent commit raises err 1020 → unhandled 500. Each write unit is now wrapped in `retry_on_snapshot_conflict` (re-fetch inside, commit inside, response outside). Tests inject a real 1020 into the locking read and assert retry-then-success, bounded retries, and that non-1020 errors are not retried.

**#5 — No rate limit on thread/post creation.** New `check_forum_create_rate_limit` (10/min, shared thread+post budget, moderators exempt), placed outside the retry unit so a snapshot retry can't double-count.

## ⚠️ Note on `db_retry.py`
This branch predates #266 (which added `app/core/db_retry.py` on `main`), so the helper (and its unit test) are **brought over verbatim** here to make #3 implementable and testable. The forum stack is ~21 commits behind `main` and must be rebased onto it before merge — at which point `db_retry.py` already exists on `main` identically and dedups trivially. Nothing else here conflicts.

## Open item for the maintainer
`create_post` checks the rate limit (429) before the visibility/lock checks now inside the retry unit, so a rate-limited reply to a gated/locked thread returns 429 before 404/403. Acceptable for anti-spam (a prober burns their own budget); flag if you'd prefer 404/403 to win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCNg31vd8RtgwXexr52g8F
