### PR TITLE
feat(ml): suggestion rows follow the image-status lifecycle

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,19 @@
+# Shuushuu
+
+An anime image board: users upload, tag, rate, favorite, and discuss images; moderators curate via reports, reviews, statuses, and an ML-assisted tagging queue. This API defines the core domain; the SvelteKit frontend (shuushuu-frontend) consumes it.
+
+## Language
+
+### ML tag suggestions
+
+**Suggestion-eligible**:
+An image status in which ML tag suggestion rows may exist and appear in review surfaces. Exactly `ACTIVE` and `SPOILER`; every other status (REPOST, DEACTIVATED, REVIEW, legacy hidden statuses) is ineligible.
+_Avoid_: taggable (any image can be tagged regardless of status), visible/hidden (REPOST pages are publicly visible yet ineligible)
+
+**Implicit approval**:
+A pending suggestion resolved to approved because a person applied its tag outside the ML review flow (manual add, batch tagging, report resolution). The tagger is recorded as reviewer.
+_Avoid_: auto-approval (implies no human involvement)
+
+**System resolution**:
+A pending suggestion resolved to approved by data movement rather than any person's tagging action — the stale-row backfill, or tag migration during repost-marking. Reviewer is empty and displays as "—".
+_Avoid_: auto-approval, implicit approval (both imply a human actor)

--- a/alembic/versions/7d98087eabcb_backfill_delete_suggestions_for_.py
+++ b/alembic/versions/7d98087eabcb_backfill_delete_suggestions_for_.py
@@ -1,0 +1,42 @@
+"""backfill delete suggestions for ineligible images
+
+Data migration (ADR-0002): suggestion rows may exist only on
+suggestion-eligible images (status ACTIVE=1, SPOILER=2). Reposts (-1) leave
+review scope permanently and lose ALL rows (matching the favorites/ratings/
+tags wipe at repost-marking); other ineligible statuses (DEACTIVATED=0,
+legacy -2/-3, REVIEW=-4) lose only pending rows — reviewed rows keep
+provenance for tags still applied to those images.
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '7d98087eabcb'
+down_revision: str | Sequence[str] | None = 'a61c09c0f331'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DELETE s FROM ml_tag_suggestions s
+        JOIN images i ON i.image_id = s.image_id
+        WHERE i.status = -1
+        """
+    )
+    op.execute(
+        """
+        DELETE s FROM ml_tag_suggestions s
+        JOIN images i ON i.image_id = s.image_id
+        WHERE i.status NOT IN (1, 2) AND i.status <> -1
+          AND s.status = 'pending'
+        """
+    )
+
+
+def downgrade() -> None:
+    # Irreversible data migration: deleted rows are re-seedable from the
+    # raw-prediction store on restore (ADR-0002). Intentionally a no-op.
+    pass

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -127,6 +127,7 @@ from app.services.image_processing import (
 from app.services.image_status import enqueue_r2_sync_on_status_change
 from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 from app.services.iqdb import check_iqdb_similarity, check_iqdb_similarity_by_hash, remove_from_iqdb
+from app.services.ml_suggestion_lifecycle import sync_suggestions_for_status_transition
 from app.services.ml_suggestion_review import approve_pending_suggestions_for_links
 from app.services.rate_limit import check_similarity_rate_limit
 from app.services.rating import RatingStats, recalculate_image_ratings
@@ -1459,6 +1460,10 @@ async def update_image(
         image.status = new_status
         image.status_user_id = current_user.id
         image.status_updated = datetime.now(UTC)
+
+        # Keep ML suggestion rows consistent with the new status (ADR-0002).
+        if new_status != previous_status:
+            await sync_suggestions_for_status_transition(db, image_id, previous_status, new_status)
 
         # Log to status history
         history = ImageStatusHistory(

--- a/app/config.py
+++ b/app/config.py
@@ -414,6 +414,11 @@ class ImageStatus:
     # Hide for: REVIEW (-4), LOW_QUALITY (-3), INAPPROPRIATE (-2), DEACTIVATED (0)
     VISIBLE_USER_STATUSES: set[int] = {REPOST, SPOILER, ACTIVE}
 
+    # Statuses where ML tag suggestion rows may exist and appear in review
+    # surfaces (see CONTEXT.md "suggestion-eligible" and ADR-0002). Everything
+    # else — REPOST, DEACTIVATED, REVIEW, legacy hidden — is ineligible.
+    SUGGESTION_ELIGIBLE_STATUSES: set[int] = {ACTIVE, SPOILER}
+
     LABELS: dict[int, str] = {
         REVIEW: "review",
         LOW_QUALITY: "low_quality",  # legacy label for historical rows

--- a/app/services/image_status.py
+++ b/app/services/image_status.py
@@ -19,6 +19,7 @@ from app.models.admin_action import AdminActions
 from app.models.image import Images
 from app.models.image_status_history import ImageStatusHistory
 from app.models.user import Users
+from app.services.ml_suggestion_lifecycle import sync_suggestions_for_status_transition
 from app.services.repost import migrate_repost_data
 from app.tasks.queue import enqueue_job
 
@@ -134,6 +135,12 @@ async def change_image_status(
         image.status = new_status
         image.status_user_id = actor_id
         image.status_updated = datetime.now(UTC)
+
+        # Keep ML suggestion rows consistent with the new status (ADR-0002).
+        if new_status != previous_status:
+            await sync_suggestions_for_status_transition(
+                db, image.image_id, previous_status, new_status
+            )
 
     if locked is not None:
         image.locked = 1 if locked else 0

--- a/app/services/ml_remap.py
+++ b/app/services/ml_remap.py
@@ -39,6 +39,8 @@ async def remap_image(
     UNIQUE(image_id, tag_id) constraint, re-map scopes its reconcile to its own
     model_version so it never deletes pending rows produced by a different model
     (e.g. swinv2 live path rows are safe during a caformer re-map).
+
+    Flush-only; the caller owns the transaction and commit.
     """
     implied, _applied = await compute_implied_suggestions(db, image_id, predictions)
     implied_by_tag = {p["tag_id"]: p for p in implied}
@@ -83,7 +85,7 @@ async def remap_image(
         )
         added += 1
 
-    await db.commit()
+    await db.flush()
     logger.info(
         "ml_remap_image_reconciled",
         image_id=image_id,
@@ -178,5 +180,6 @@ async def remap_images_for_tag(db: AsyncSession, internal_tag_id: int, model_nam
     # Step 3: remap each image using the existing per-image entry point
     for image_id in image_ids:
         await remap_image_from_store(db, image_id, model_name)
+        await db.commit()
 
     return len(image_ids)

--- a/app/services/ml_remap.py
+++ b/app/services/ml_remap.py
@@ -19,7 +19,9 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import ImageStatus
 from app.core.logging import get_logger
+from app.models.image import Images
 from app.models.ml_raw_prediction import MlExternalTags, MlModels, MlRawPredictions
 from app.models.ml_tag_suggestion import MlTagSuggestions
 from app.models.tag_mapping import TagMappings
@@ -42,6 +44,15 @@ async def remap_image(
 
     Flush-only; the caller owns the transaction and commit.
     """
+    image = await db.get(Images, image_id)
+    if image is None or image.status not in ImageStatus.SUGGESTION_ELIGIBLE_STATUSES:
+        logger.info(
+            "ml_remap_skipped_ineligible",
+            image_id=image_id,
+            status=None if image is None else image.status,
+        )
+        return 0
+
     implied, _applied = await compute_implied_suggestions(db, image_id, predictions)
     implied_by_tag = {p["tag_id"]: p for p in implied}
 

--- a/app/services/ml_remap.py
+++ b/app/services/ml_remap.py
@@ -35,7 +35,8 @@ async def remap_image(
 ) -> int:
     """Re-map raw predictions into ml_tag_suggestions: regenerate the pending set
     from current mappings, preserve approved/rejected, never re-suggest a
-    dismissed tag. Returns the number of pending rows added.
+    dismissed tag. Returns the number of pending rows added. Missing or
+    ineligible-status images (ADR-0002) short-circuit to 0.
 
     The delete step is scoped to ``model_name``: because ml_tag_suggestions has a
     UNIQUE(image_id, tag_id) constraint, re-map scopes its reconcile to its own

--- a/app/services/ml_suggestion_lifecycle.py
+++ b/app/services/ml_suggestion_lifecycle.py
@@ -1,0 +1,47 @@
+"""Couple ML suggestion rows to the image-status lifecycle.
+
+Pending suggestions exist only on suggestion-eligible images (ACTIVE, SPOILER —
+see CONTEXT.md and ADR-0002). This module owns the transition hook called by
+both status-write sites (change_image_status and the owner-facing image-update
+endpoint). Repost-specific cleanup lives in app/services/repost.py.
+"""
+
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, settings
+from app.models.ml_tag_suggestion import MlTagSuggestions
+from app.services.ml_remap import remap_image_from_store
+
+
+async def sync_suggestions_for_status_transition(
+    db: AsyncSession,
+    image_id: int,
+    old_status: int,
+    new_status: int,
+) -> None:
+    """Keep suggestion rows consistent with an image-status change.
+
+    eligible -> ineligible: delete the image's pending rows. (Marking as REPOST
+    additionally wipes reviewed rows — that lives in migrate_repost_data, which
+    both repost paths share.)
+    ineligible -> eligible: re-seed pending rows from the raw-prediction store
+    (no inference; seeds nothing if the image has no raw predictions).
+
+    Must be called AFTER the caller has assigned the new status to the
+    in-session Images row. Flush-only; the caller owns the transaction.
+    """
+    was_eligible = old_status in ImageStatus.SUGGESTION_ELIGIBLE_STATUSES
+    is_eligible = new_status in ImageStatus.SUGGESTION_ELIGIBLE_STATUSES
+    if was_eligible == is_eligible:
+        return
+
+    if was_eligible:
+        await db.execute(
+            delete(MlTagSuggestions).where(
+                MlTagSuggestions.image_id == image_id,  # type: ignore[arg-type]
+                MlTagSuggestions.status == "pending",  # type: ignore[arg-type]
+            )
+        )
+    else:
+        await remap_image_from_store(db, image_id, settings.ML_MODEL_NAME)

--- a/app/services/ml_suggestion_pipeline.py
+++ b/app/services/ml_suggestion_pipeline.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from app.services.ml_service import MLTagSuggestionService
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import TagType, settings
+from app.config import ImageStatus, TagType, settings
 from app.core.logging import get_logger
 from app.models.image import Images
 from app.models.ml_tag_suggestion import MlTagSuggestions
@@ -242,6 +242,16 @@ async def generate_and_store_suggestions(
     """
     assert image.image_id is not None  # a persisted image always has an id
     image_id = image.image_id
+
+    # Ineligible images (repost/deactivated/etc.) never get suggestion rows
+    # (ADR-0002) — return before touching the filesystem or the model.
+    if image.status not in ImageStatus.SUGGESTION_ELIGIBLE_STATUSES:
+        logger.info(
+            "ml_suggestion_pipeline_skipped_ineligible",
+            image_id=image_id,
+            status=image.status,
+        )
+        return 0
 
     # Resolve the local image path. Images are stored as:
     #   {STORAGE_PATH}/fullsize/{filename}.{ext}

--- a/app/services/ml_suggestion_pipeline.py
+++ b/app/services/ml_suggestion_pipeline.py
@@ -236,6 +236,7 @@ async def generate_and_store_suggestions(
     aliases/hierarchy → drop redundant vs existing tags → upsert suggestions.
     Existing suggestions are kept (idempotent regeneration); approved
     suggestions whose tag was since removed from the image reset to pending.
+    Ineligible-status images (ADR-0002) short-circuit to 0 before inference.
 
     Returns the number of new suggestions created.
     Raises FileNotFoundError if the local image file is missing.
@@ -395,7 +396,22 @@ async def store_predictions(
     Existing suggestions are kept (idempotent regeneration); approved
     suggestions whose tag was since removed from the image reset to pending.
     Commits the session. Returns the number of new suggestions created.
+
+    This is the single creation funnel — reached from the live job's md5
+    analyze-cache hit path (persist_predictions) and from the offline backfill
+    ingest, neither of which checks eligibility first — so it guards itself:
+    missing or ineligible-status images (ADR-0002) short-circuit to 0 before
+    any row is created or reset.
     """
+    image = await db.get(Images, image_id)
+    if image is None or image.status not in ImageStatus.SUGGESTION_ELIGIBLE_STATUSES:
+        logger.info(
+            "ml_suggestion_store_skipped_ineligible",
+            image_id=image_id,
+            status=None if image is None else image.status,
+        )
+        return 0
+
     implied, applied = await compute_implied_suggestions(db, image_id, predictions)
 
     # 5. Get existing suggestions for this image (to avoid duplicate key errors on regenerate).

--- a/app/services/repost.py
+++ b/app/services/repost.py
@@ -11,7 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.favorite import Favorites
 from app.models.image import Images
 from app.models.image_rating import ImageRatings
+from app.models.ml_tag_suggestion import MlTagSuggestions
 from app.models.tag_link import TagLinks
+from app.services.ml_suggestion_review import approve_pending_suggestions_for_links
 from app.services.tag_type_flags import refresh_images_tag_type_flags
 
 
@@ -149,6 +151,33 @@ async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession
     await db.execute(
         delete(TagLinks).where(
             TagLinks.image_id == repost_id  # type: ignore[arg-type]
+        )
+    )
+
+    # --- ML suggestions ---
+    # The migrated tags are now applied to the original: resolve its matching
+    # pending suggestions. Reviewer stays NULL — this is data movement, not a
+    # human review (system resolution; see CONTEXT.md and ADR-0001).
+    original_tag_ids = (
+        (
+            await db.execute(
+                select(TagLinks.tag_id).where(  # type: ignore[call-overload]
+                    TagLinks.image_id == original_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    await approve_pending_suggestions_for_links(
+        db, [(original_id, tag_id) for tag_id in original_tag_ids], None
+    )
+
+    # A repost is permanently out of review scope: wipe ALL its suggestion rows,
+    # matching the favorites/ratings/tags wipe above (ADR-0002).
+    await db.execute(
+        delete(MlTagSuggestions).where(
+            MlTagSuggestions.image_id == repost_id  # type: ignore[arg-type]
         )
     )
 

--- a/docs/adr/0001-ml-queue-write-time-invalidation.md
+++ b/docs/adr/0001-ml-queue-write-time-invalidation.md
@@ -1,0 +1,13 @@
+# ML suggestion queue consistency via write-time invalidation, not read-time filtering
+
+A pending ML suggestion whose tag is already applied to its image is stale and must not surface for review. We keep the data honest at write time — every path that applies a tag outside the ML review flow (manual add, batch tagging, report resolution, repost tag migration) resolves the matching pending suggestion via `approve_pending_suggestions_for_links()` — instead of filtering stale rows out of queries.
+
+## Considered Options
+
+Read-time filtering (`NOT EXISTS` anti-join against `tag_links`) was measured on production-sized data (2.06M pending suggestions, 14.7M tag links): **43ms** on the per-tag grid, but **7–11s vs 0.9s** on the worklist aggregate, which probes every pending row. The worklist therefore must never gain that anti-join; its counts are correct because writes keep them correct.
+
+## Consequences
+
+- The per-tag grid keeps its cheap anti-join as a safety net, so a future tag-write path that forgets the helper degrades worklist counts but never shows a mod an already-applied tag.
+- Any new code path that creates `tag_links` must call `approve_pending_suggestions_for_links()` in the same transaction.
+- Matching is by exact `tag_id` everywhere (generation, invalidation, grid filter); a suggestion whose tag later becomes an alias of the applied tag is deliberately not matched.

--- a/docs/adr/0002-suggestion-rows-follow-image-status.md
+++ b/docs/adr/0002-suggestion-rows-follow-image-status.md
@@ -1,0 +1,13 @@
+# ML suggestion rows follow the image-status lifecycle
+
+Suggestion rows exist only on suggestion-eligible images (`ACTIVE`, `SPOILER` — see CONTEXT.md). On any eligible→ineligible transition in `change_image_status()`, the image's pending rows are deleted (marking as REPOST deletes all its rows, matching how repost-marking already wipes favorites/ratings/tags); on any ineligible→eligible transition, pending rows are re-seeded from the raw-prediction store via `remap_image_from_store()` — no inference or image file needed. Both hooks run atomically with the status change. Suggestion creation (pipeline and remap) skips ineligible images so nothing resurrects between transitions.
+
+## Considered Options
+
+- **Auto-rejecting instead of deleting** would be remap-proof without creation guards, but "rejected" would be a lie (the tag wasn't judged wrong — the image left review scope) and would fill the per-image suggestion history with junk attributed to whichever mod changed the status.
+- **Hiding at query time** hits the measured worklist-aggregate wall recorded in ADR-0001.
+
+## Consequences
+
+- Deletion looks like data loss but isn't: raw predictions are retained, so re-seed on restore is free and complete. An un-reposted image (tagless today by existing design) immediately regains a full pending set.
+- `ml_remap` and the generation pipeline must check eligibility; widening eligibility later (e.g. to `REVIEW`) is a one-set change.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,40 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## Cross-repo note
+
+This repo's `CONTEXT.md` is the **system of record** for core domain terms (image statuses, tagging, ML suggestions, moderation). The SvelteKit frontend (`../shuushuu-frontend` locally) defers to it; its own `CONTEXT.md` holds frontend-specific vocabulary only.
+
+## File structure
+
+Single-context repo (this repo):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-ml-queue-write-time-invalidation.md
+│   └── 0002-suggestion-rows-follow-image-status.md
+└── app/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0001 (write-time invalidation) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/plans/2026-07-16-ml-suggestion-lifecycle-impl.md
+++ b/docs/plans/2026-07-16-ml-suggestion-lifecycle-impl.md
@@ -1,0 +1,1035 @@
+# ML Suggestion Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ML suggestion rows follow the image-status lifecycle — deleted when an image leaves suggestion-eligible status (reposts lose everything), re-seeded from the raw-prediction store on restore — fixing issue #274.
+
+**Architecture:** A shared hook `sync_suggestions_for_status_transition()` (new module `app/services/ml_suggestion_lifecycle.py`) is called from both status-write sites (`change_image_status()` and the owner-facing `PATCH /images/{image_id}` path). Repost-specific cleanup (wipe-all + resolving the original's pending suggestions) lives inside `migrate_repost_data()`, which both repost paths share. `remap_image()` becomes flush-only so the restore re-seed runs inside the caller's transaction. Creation guards keep ineligible images row-free.
+
+**Tech Stack:** FastAPI, SQLModel/SQLAlchemy async, Alembic, pytest (`make pytest`, isolated MariaDB).
+
+## Global Constraints
+
+- Spec of record: `../shuushuu-frontend/docs/plans/2026-07-16-ml-suggestion-lifecycle-and-history-design.md` (Part 1); decisions: `docs/adr/0001-ml-queue-write-time-invalidation.md`, `docs/adr/0002-suggestion-rows-follow-image-status.md`; vocabulary: `CONTEXT.md` (suggestion-eligible, system resolution).
+- Suggestion-eligible statuses are exactly `{ImageStatus.ACTIVE, ImageStatus.SPOILER}` = `{1, 2}`. Real constants: `REVIEW=-4, LOW_QUALITY=-3, INAPPROPRIATE=-2, REPOST=-1, DEACTIVATED=0, ACTIVE=1, SPOILER=2` (`app/config.py:400-410`). Never invent status values.
+- Feature branch `feat/ml-suggestion-lifecycle` off `main`. This repo has unrelated uncommitted WIP (`scripts/db_utils.py`, `scripts/prune_inactive_users.py`, `scripts/restore_prod_db.py`, old `docs/plans/*.md`) — **never `git add -A`**; stage only the files you touched.
+- Lifecycle hooks are atomic with the status change: no try/except around them; flush-only, caller owns commit.
+- Reviewer for repost-migration resolution is **NULL** (system resolution) — do not thread an actor into `migrate_repost_data`.
+- Tests: `make pytest ARGS="<paths>"` from the repo root (starts the isolated DB on port 3316). If `pytest-db-up` fails with a container-name conflict but `docker ps` shows `shuushuu-mariadb-pytest` healthy, run pytest directly with the same env the Makefile sets (see `Makefile:124-132`).
+- Run `uv run ruff check <files>` and `uv run mypy <files>` on every file you touch before committing; pre-commit runs ruff + ruff-format on staged files.
+- Match the codebase's `# type: ignore[...]` idiom when mypy complains about SQLModel column comparisons — copy the style of neighboring queries; if mypy passes without one, leave it off.
+
+---
+
+### Task 1: Make `remap_image()` flush-only (callers own commits)
+
+`remap_image()` currently commits (`app/services/ml_remap.py:86`). The restore hook (Task 3) must run inside the caller's transaction, so the commit moves out to the existing entry points.
+
+**Files:**
+- Modify: `app/services/ml_remap.py` (remap_image commit → flush; `remap_images_for_tag` loop commits per image)
+- Modify: `scripts/ml_remap.py:79` area (commit after each `remap_image_from_store` call)
+- Test: `tests/services/test_ml_remap.py` (existing suite is the safety net)
+
+**Interfaces:**
+- Produces: `remap_image(db, image_id, predictions, model_name) -> int` — unchanged signature, now flush-only.
+- Later tasks rely on: calling `remap_image_from_store(db, image_id, model_name)` mid-transaction without a commit being issued.
+
+- [ ] **Step 1: Change the commit to a flush**
+
+In `app/services/ml_remap.py`, inside `remap_image()`, replace:
+
+```python
+    await db.commit()
+```
+
+with:
+
+```python
+    await db.flush()
+```
+
+Update the `remap_image` docstring: append the line `Flush-only; the caller owns the transaction and commit.`
+
+- [ ] **Step 2: Make the two existing entry points commit**
+
+In `app/services/ml_remap.py`, in `remap_images_for_tag()`, the per-image loop currently reads:
+
+```python
+    for image_id in image_ids:
+        await remap_image_from_store(db, image_id, model_name)
+```
+
+Change to:
+
+```python
+    for image_id in image_ids:
+        await remap_image_from_store(db, image_id, model_name)
+        await db.commit()
+```
+
+In `scripts/ml_remap.py`, after `added = await remap_image_from_store(db, image_id, model_name)` (line 79), add on the next line at the same indentation:
+
+```python
+            await db.commit()
+```
+
+(Confirm indentation from the surrounding loop when editing.)
+
+- [ ] **Step 3: Run the remap suite to prove behavior is preserved**
+
+Run: `make pytest ARGS="tests/services/test_ml_remap.py"`
+Expected: all tests PASS. The tests run inside the `db_session` SAVEPOINT fixture, so rows written by `remap_image` are visible via flush; if any test asserted on commit-specific behavior, fix the test's expectation, not the service.
+
+- [ ] **Step 4: Lint, typecheck, commit**
+
+Run: `uv run ruff check app/services/ml_remap.py scripts/ml_remap.py && uv run mypy app/services/ml_remap.py`
+Expected: clean.
+
+```bash
+git add app/services/ml_remap.py scripts/ml_remap.py
+git commit -m "refactor(ml): make remap_image flush-only; callers own commits"
+```
+
+---
+
+### Task 2: `SUGGESTION_ELIGIBLE_STATUSES` + eligibility guard in `remap_image()`
+
+**Files:**
+- Modify: `app/config.py` (ImageStatus class, after line 415)
+- Modify: `app/services/ml_remap.py` (guard at top of `remap_image`)
+- Test: `tests/services/test_ml_remap.py`
+
+**Interfaces:**
+- Produces: `ImageStatus.SUGGESTION_ELIGIBLE_STATUSES: set[int]` — used by Tasks 3, 6.
+- Produces: `remap_image()` returns 0 and creates nothing for ineligible or missing images.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/services/test_ml_remap.py` (reuse the file's existing `_make_user`, `_make_image`, `_make_tags`, `_preds`, `_resolver_to_tag_ids`, `_resolver_passthrough`, `PIPELINE`, `CAFORMER` helpers):
+
+```python
+# ---------------------------------------------------------------------------
+# Eligibility guard: ineligible images never get suggestion rows (ADR-0002)
+# ---------------------------------------------------------------------------
+
+
+async def test_remap_skips_suggestion_ineligible_image(db_session, monkeypatch):
+    """remap_image returns 0 and writes nothing for an image outside
+    SUGGESTION_ELIGIBLE_STATUSES (e.g. a repost)."""
+    monkeypatch.setattr(settings, "ML_MIN_CONFIDENCE", 0.35)
+
+    user = await _make_user(db_session, "inelig")
+    image = await _make_image(db_session, user, "inelig")
+    image.status = ImageStatus.REPOST
+    await _make_tags(db_session, 301)
+    await db_session.commit()
+
+    predictions = _preds(301, model=CAFORMER)
+
+    with (
+        patch(f"{PIPELINE}.resolve_external_tags", _resolver_to_tag_ids(predictions)),
+        patch(f"{PIPELINE}.resolve_tag_relationships", _resolver_passthrough),
+    ):
+        added = await remap_image(db_session, image.image_id, predictions, CAFORMER)
+
+    assert added == 0
+    rows = (
+        await db_session.execute(
+            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+        )
+    ).scalars().all()
+    assert rows == []
+```
+
+Add `ImageStatus` to the file's existing `from app.config import settings` import: `from app.config import ImageStatus, settings`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make pytest ARGS="tests/services/test_ml_remap.py::test_remap_skips_suggestion_ineligible_image"`
+Expected: FAIL — `added == 1` (row created for the repost).
+
+- [ ] **Step 3: Add the constant**
+
+In `app/config.py`, inside `class ImageStatus`, directly after `VISIBLE_USER_STATUSES` (line 415) and before `LABELS`, add:
+
+```python
+    # Statuses where ML tag suggestion rows may exist and appear in review
+    # surfaces (see CONTEXT.md "suggestion-eligible" and ADR-0002). Everything
+    # else — REPOST, DEACTIVATED, REVIEW, legacy hidden — is ineligible.
+    SUGGESTION_ELIGIBLE_STATUSES: set[int] = {ACTIVE, SPOILER}
+```
+
+- [ ] **Step 4: Add the guard**
+
+In `app/services/ml_remap.py`, at the very top of `remap_image()` (before the `compute_implied_suggestions` call), add:
+
+```python
+    image = await db.get(Images, image_id)
+    if image is None or image.status not in ImageStatus.SUGGESTION_ELIGIBLE_STATUSES:
+        logger.info(
+            "ml_remap_skipped_ineligible",
+            image_id=image_id,
+            status=None if image is None else image.status,
+        )
+        return 0
+```
+
+Add imports to `app/services/ml_remap.py`: `from app.config import ImageStatus` and `from app.models.image import Images` (merge into existing import blocks in sorted order).
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `make pytest ARGS="tests/services/test_ml_remap.py"`
+Expected: all PASS (the guard's `db.get` reads the in-session image, so existing eligible-image tests are unaffected).
+
+- [ ] **Step 6: Lint, typecheck, commit**
+
+Run: `uv run ruff check app/config.py app/services/ml_remap.py tests/services/test_ml_remap.py && uv run mypy app/config.py app/services/ml_remap.py`
+
+```bash
+git add app/config.py app/services/ml_remap.py tests/services/test_ml_remap.py
+git commit -m "feat(ml): suggestion-eligibility guard in remap_image + SUGGESTION_ELIGIBLE_STATUSES"
+```
+
+---
+
+### Task 3: Lifecycle service `sync_suggestions_for_status_transition()`
+
+**Files:**
+- Create: `app/services/ml_suggestion_lifecycle.py`
+- Create: `tests/services/test_ml_suggestion_lifecycle.py`
+
+**Interfaces:**
+- Consumes: `remap_image_from_store(db, image_id, model_name)` (Task 1, flush-only), `ImageStatus.SUGGESTION_ELIGIBLE_STATUSES` (Task 2).
+- Produces: `async def sync_suggestions_for_status_transition(db: AsyncSession, image_id: int, old_status: int, new_status: int) -> None` — Tasks 4 and 5 call this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/services/test_ml_suggestion_lifecycle.py`:
+
+```python
+"""Tests for the suggestion-lifecycle hook (ADR-0002).
+
+Pending rows are deleted when an image leaves suggestion-eligible status;
+pending rows are re-seeded from the raw store when it returns. Reviewed rows
+survive non-repost transitions. All against the real test DB.
+"""
+
+from unittest.mock import patch
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, settings
+from app.models.image import Images
+from app.models.ml_raw_prediction import MlExternalTags, MlModels, MlRawPredictions
+from app.models.ml_tag_suggestion import MlTagSuggestions
+from app.models.tag import Tags
+from app.models.user import Users
+from app.services.ml_suggestion_lifecycle import sync_suggestions_for_status_transition
+
+PIPELINE = "app.services.ml_suggestion_pipeline"
+MODEL = "caformer_b36.dbv4-full"
+
+
+async def _make_user(db: AsyncSession, suffix: str) -> Users:
+    user = Users(
+        username=f"lifecycle_{suffix}",
+        email=f"lifecycle_{suffix}@example.com",
+        password="hashed",
+        password_type="bcrypt",
+        salt="testsalt12345678",
+        active=1,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_image(db: AsyncSession, user: Users, suffix: str, status: int) -> Images:
+    image = Images(
+        filename=f"2024-01-01-lifecycle-{suffix}",
+        ext="jpg",
+        user_id=user.user_id,
+        md5_hash=f"lifecycle_hash_{suffix}",
+        filesize=1024,
+        width=800,
+        height=600,
+        status=status,
+    )
+    db.add(image)
+    await db.flush()
+    return image
+
+
+async def _make_tag(db: AsyncSession, user: Users, suffix: str) -> Tags:
+    tag = Tags(title=f"lifecycle tag {suffix}", type=1, user_id=user.user_id)
+    db.add(tag)
+    await db.flush()
+    return tag
+
+
+async def _make_suggestion(
+    db: AsyncSession, image: Images, tag: Tags, status: str = "pending"
+) -> MlTagSuggestions:
+    suggestion = MlTagSuggestions(
+        image_id=image.image_id,
+        tag_id=tag.tag_id,
+        confidence=0.9,
+        model_version=MODEL,
+        status=status,
+    )
+    db.add(suggestion)
+    await db.flush()
+    return suggestion
+
+
+async def _suggestion_rows(db: AsyncSession, image_id: int) -> list[MlTagSuggestions]:
+    return list(
+        (
+            await db.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def _resolver_passthrough(db, suggestions):
+    return suggestions
+
+
+class TestEligibleToIneligible:
+    async def test_deletes_pending_keeps_reviewed(self, db_session: AsyncSession):
+        """ACTIVE -> DEACTIVATED deletes pending rows but keeps approved/rejected."""
+        user = await _make_user(db_session, "e2i")
+        image = await _make_image(db_session, user, "e2i", ImageStatus.ACTIVE)
+        t1 = await _make_tag(db_session, user, "e2i_p")
+        t2 = await _make_tag(db_session, user, "e2i_a")
+        t3 = await _make_tag(db_session, user, "e2i_r")
+        await _make_suggestion(db_session, image, t1, status="pending")
+        await _make_suggestion(db_session, image, t2, status="approved")
+        await _make_suggestion(db_session, image, t3, status="rejected")
+        await db_session.commit()
+
+        await sync_suggestions_for_status_transition(
+            db_session, image.image_id, ImageStatus.ACTIVE, ImageStatus.DEACTIVATED
+        )
+        await db_session.commit()
+
+        rows = await _suggestion_rows(db_session, image.image_id)
+        statuses = sorted(r.status for r in rows)
+        assert statuses == ["approved", "rejected"]
+
+
+class TestNoOpTransitions:
+    async def test_eligible_to_eligible_is_noop(self, db_session: AsyncSession):
+        """ACTIVE -> SPOILER leaves pending rows alone."""
+        user = await _make_user(db_session, "e2e")
+        image = await _make_image(db_session, user, "e2e", ImageStatus.ACTIVE)
+        tag = await _make_tag(db_session, user, "e2e")
+        await _make_suggestion(db_session, image, tag, status="pending")
+        await db_session.commit()
+
+        await sync_suggestions_for_status_transition(
+            db_session, image.image_id, ImageStatus.ACTIVE, ImageStatus.SPOILER
+        )
+        await db_session.commit()
+
+        rows = await _suggestion_rows(db_session, image.image_id)
+        assert len(rows) == 1
+        assert rows[0].status == "pending"
+
+    async def test_ineligible_to_ineligible_is_noop(self, db_session: AsyncSession):
+        """DEACTIVATED -> REVIEW does not touch rows and does not re-seed."""
+        user = await _make_user(db_session, "i2i")
+        image = await _make_image(db_session, user, "i2i", ImageStatus.DEACTIVATED)
+        tag = await _make_tag(db_session, user, "i2i")
+        await _make_suggestion(db_session, image, tag, status="approved")
+        await db_session.commit()
+
+        await sync_suggestions_for_status_transition(
+            db_session, image.image_id, ImageStatus.DEACTIVATED, ImageStatus.REVIEW
+        )
+        await db_session.commit()
+
+        rows = await _suggestion_rows(db_session, image.image_id)
+        assert len(rows) == 1
+        assert rows[0].status == "approved"
+
+
+class TestIneligibleToEligible:
+    async def test_reseeds_pending_from_raw_store(
+        self, db_session: AsyncSession, monkeypatch
+    ):
+        """DEACTIVATED -> ACTIVE re-seeds pending rows from ml_raw_predictions."""
+        monkeypatch.setattr(settings, "ML_MODEL_NAME", MODEL)
+        monkeypatch.setattr(settings, "ML_MIN_CONFIDENCE", 0.35)
+
+        user = await _make_user(db_session, "i2e")
+        image = await _make_image(db_session, user, "i2e", ImageStatus.ACTIVE)
+        tag = await _make_tag(db_session, user, "i2e")
+
+        # Seed the raw store: model -> external tag -> raw prediction.
+        model_row = MlModels(name=MODEL)
+        db_session.add(model_row)
+        await db_session.flush()
+        ext_tag = MlExternalTags(name="lifecycle_ext", category=0)
+        db_session.add(ext_tag)
+        await db_session.flush()
+        db_session.add(
+            MlRawPredictions(
+                image_id=image.image_id,
+                external_tag_id=ext_tag.id,
+                model_id=model_row.id,
+                confidence=0.9,
+            )
+        )
+        await db_session.commit()
+
+        # Patch resolvers so the external tag maps straight to our internal tag
+        # (established pattern from tests/services/test_ml_remap.py).
+        resolved = [{"tag_id": tag.tag_id, "confidence": 0.9, "model_version": MODEL}]
+
+        async def _resolve_to_internal(db, suggestions):
+            return [dict(r) for r in resolved]
+
+        with (
+            patch(f"{PIPELINE}.resolve_external_tags", _resolve_to_internal),
+            patch(f"{PIPELINE}.resolve_tag_relationships", _resolver_passthrough),
+        ):
+            await sync_suggestions_for_status_transition(
+                db_session, image.image_id, ImageStatus.DEACTIVATED, ImageStatus.ACTIVE
+            )
+        await db_session.commit()
+
+        rows = await _suggestion_rows(db_session, image.image_id)
+        assert len(rows) == 1
+        assert rows[0].status == "pending"
+        assert rows[0].tag_id == tag.tag_id
+```
+
+Note: the re-seed test creates the image already in ACTIVE status because the lifecycle hook is always called *after* the caller has set the new status (the `remap_image` guard reads the in-session row).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make pytest ARGS="tests/services/test_ml_suggestion_lifecycle.py"`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.services.ml_suggestion_lifecycle'`.
+
+- [ ] **Step 3: Write the service**
+
+Create `app/services/ml_suggestion_lifecycle.py`:
+
+```python
+"""Couple ML suggestion rows to the image-status lifecycle.
+
+Pending suggestions exist only on suggestion-eligible images (ACTIVE, SPOILER —
+see CONTEXT.md and ADR-0002). This module owns the transition hook called by
+both status-write sites (change_image_status and the owner-facing image-update
+endpoint). Repost-specific cleanup lives in app/services/repost.py.
+"""
+
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, settings
+from app.models.ml_tag_suggestion import MlTagSuggestions
+from app.services.ml_remap import remap_image_from_store
+
+
+async def sync_suggestions_for_status_transition(
+    db: AsyncSession,
+    image_id: int,
+    old_status: int,
+    new_status: int,
+) -> None:
+    """Keep suggestion rows consistent with an image-status change.
+
+    eligible -> ineligible: delete the image's pending rows. (Marking as REPOST
+    additionally wipes reviewed rows — that lives in migrate_repost_data, which
+    both repost paths share.)
+    ineligible -> eligible: re-seed pending rows from the raw-prediction store
+    (no inference; seeds nothing if the image has no raw predictions).
+
+    Must be called AFTER the caller has assigned the new status to the
+    in-session Images row. Flush-only; the caller owns the transaction.
+    """
+    was_eligible = old_status in ImageStatus.SUGGESTION_ELIGIBLE_STATUSES
+    is_eligible = new_status in ImageStatus.SUGGESTION_ELIGIBLE_STATUSES
+    if was_eligible == is_eligible:
+        return
+
+    if was_eligible:
+        await db.execute(
+            delete(MlTagSuggestions).where(
+                MlTagSuggestions.image_id == image_id,  # type: ignore[arg-type]
+                MlTagSuggestions.status == "pending",  # type: ignore[arg-type]
+            )
+        )
+    else:
+        await remap_image_from_store(db, image_id, settings.ML_MODEL_NAME)
+```
+
+(If mypy reports the `# type: ignore` comments as unused, remove them.)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `make pytest ARGS="tests/services/test_ml_suggestion_lifecycle.py"`
+Expected: 4 PASS.
+
+- [ ] **Step 5: Lint, typecheck, commit**
+
+Run: `uv run ruff check app/services/ml_suggestion_lifecycle.py tests/services/test_ml_suggestion_lifecycle.py && uv run mypy app/services/ml_suggestion_lifecycle.py`
+
+```bash
+git add app/services/ml_suggestion_lifecycle.py tests/services/test_ml_suggestion_lifecycle.py
+git commit -m "feat(ml): suggestion lifecycle hook — delete pending on ineligible, re-seed on restore"
+```
+
+---
+
+### Task 4: Wire the hook into both status-write sites
+
+**Files:**
+- Modify: `app/services/image_status.py` (`change_image_status`, after the status assignment ~line 140)
+- Modify: `app/api/v1/images.py` (owner-facing update endpoint, after its status assignment ~line 1460)
+- Test: `tests/services/test_image_status_service.py` (extend), `tests/api/v1/test_images.py` (extend)
+
+**Interfaces:**
+- Consumes: `sync_suggestions_for_status_transition(db, image_id, old_status, new_status)` (Task 3).
+
+- [ ] **Step 1: Write the failing service-level test**
+
+Append to `tests/services/test_image_status_service.py` (the file already has `_mk_image` and fetches the seeded actor via `select(Users).where(Users.user_id == 1)`; it already imports `ImageStatus` and `select`):
+
+```python
+async def test_status_change_syncs_ml_suggestions(db_session: AsyncSession):
+    """Deactivating an image deletes its pending ML suggestions (ADR-0002)."""
+    from app.models.ml_tag_suggestion import MlTagSuggestions
+    from app.models.tag import Tags
+
+    actor = (await db_session.execute(select(Users).where(Users.user_id == 1))).scalar_one()
+    img = await _mk_image(db_session, actor.user_id)
+    tag = Tags(title="lifecycle-hook-tag", type=1)
+    db_session.add(tag)
+    await db_session.flush()
+    db_session.add(
+        MlTagSuggestions(
+            image_id=img.image_id,
+            tag_id=tag.tag_id,
+            confidence=0.9,
+            model_version="test-model",
+            status="pending",
+        )
+    )
+    await db_session.commit()
+
+    await change_image_status(
+        db_session,
+        img,
+        actor,
+        new_status=ImageStatus.DEACTIVATED,
+        reason_category=DeactivationReason.OTHER,
+        reason="lifecycle test",
+    )
+    await db_session.commit()
+
+    remaining = (
+        await db_session.execute(
+            select(MlTagSuggestions).where(MlTagSuggestions.image_id == img.image_id)
+        )
+    ).scalars().all()
+    assert remaining == []
+```
+
+Check the file's existing deactivation tests for the exact `reason_category` value they pass (`DeactivationReason.OTHER` is the pattern; copy whatever the neighboring test uses if it differs).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make pytest ARGS="tests/services/test_image_status_service.py::test_status_change_syncs_ml_suggestions"`
+Expected: FAIL — `remaining` has 1 pending row.
+
+- [ ] **Step 3: Wire `change_image_status`**
+
+In `app/services/image_status.py`, add the import (sorted into the existing block):
+
+```python
+from app.services.ml_suggestion_lifecycle import sync_suggestions_for_status_transition
+```
+
+Inside `change_image_status()`, directly after the block that assigns the new status:
+
+```python
+        image.status = new_status
+        image.status_user_id = actor_id
+        image.status_updated = datetime.now(UTC)
+```
+
+add:
+
+```python
+        # Keep ML suggestion rows consistent with the new status (ADR-0002).
+        if new_status != previous_status:
+            await sync_suggestions_for_status_transition(
+                db, image.image_id, previous_status, new_status
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `make pytest ARGS="tests/services/test_image_status_service.py"`
+Expected: all PASS (new test plus the pre-existing suite).
+
+- [ ] **Step 5: Write the failing endpoint test for the owner path**
+
+Append to `tests/api/v1/test_images.py` a new class next to `TestAddTagApprovesMlSuggestion` (same fixture style):
+
+```python
+@pytest.mark.api
+class TestOwnerStatusChangeSyncsMlSuggestions:
+    """The owner-facing PATCH /images/{id} status path runs the lifecycle hook."""
+
+    async def test_owner_spoiler_marking_keeps_pending(
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
+        sample_user: Users,
+        sample_image_data: dict,
+    ):
+        """ACTIVE -> SPOILER is eligible -> eligible: pending rows survive."""
+        image_data = sample_image_data.copy()
+        image_data["user_id"] = sample_user.user_id
+        image = Images(**image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        tag = Tags(title="owner_spoiler_ml_tag", type=1)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        suggestion = MlTagSuggestions(
+            image_id=image.image_id,
+            tag_id=tag.tag_id,
+            confidence=0.9,
+            model_version="test-model",
+            status="pending",
+        )
+        db_session.add(suggestion)
+        await db_session.commit()
+        await db_session.refresh(suggestion)
+
+        response = await authenticated_client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"status": 2},
+        )
+        assert response.status_code == 200
+
+        await db_session.refresh(suggestion)
+        assert suggestion.status == "pending"
+```
+
+(The repost variant of the owner path is covered in Task 5, which owns the repost cleanup.)
+
+- [ ] **Step 6: Run it before wiring**
+
+Run: `make pytest ARGS="tests/api/v1/test_images.py::TestOwnerStatusChangeSyncsMlSuggestions"`
+Expected: PASS even before Step 7 (eligible→eligible is a no-op with or without the hook). This test exists to pin the no-op contract so the Step 7 wiring can't over-delete; it must STILL pass after Step 7.
+
+- [ ] **Step 7: Wire the owner path**
+
+In `app/api/v1/images.py`, add the module-level import (sorted into the existing `app.services` block):
+
+```python
+from app.services.ml_suggestion_lifecycle import sync_suggestions_for_status_transition
+```
+
+In the owner-facing update endpoint, the status block currently ends with:
+
+```python
+        previous_status = image.status
+        image.status = new_status
+        image.status_user_id = current_user.id
+        image.status_updated = datetime.now(UTC)
+```
+
+Add directly after:
+
+```python
+        # Keep ML suggestion rows consistent with the new status (ADR-0002).
+        if new_status != previous_status:
+            await sync_suggestions_for_status_transition(
+                db, image_id, previous_status, new_status
+            )
+```
+
+- [ ] **Step 8: Run both test files**
+
+Run: `make pytest ARGS="tests/services/test_image_status_service.py tests/api/v1/test_images.py"`
+Expected: all PASS.
+
+- [ ] **Step 9: Lint, typecheck, commit**
+
+Run: `uv run ruff check app/services/image_status.py app/api/v1/images.py tests/services/test_image_status_service.py tests/api/v1/test_images.py && uv run mypy app/services/image_status.py app/api/v1/images.py`
+
+```bash
+git add app/services/image_status.py app/api/v1/images.py tests/services/test_image_status_service.py tests/api/v1/test_images.py
+git commit -m "feat(ml): run suggestion lifecycle hook at both image-status write sites"
+```
+
+---
+
+### Task 5: Repost cleanup in `migrate_repost_data()`
+
+**Files:**
+- Modify: `app/services/repost.py`
+- Test: `tests/services/test_ml_suggestion_lifecycle.py` (extend), `tests/api/v1/test_admin_images.py` (extend)
+
+**Interfaces:**
+- Consumes: `approve_pending_suggestions_for_links(db, links, user_id)` from `app/services/ml_suggestion_review.py` (exists on main).
+- Produces: `migrate_repost_data(repost_id, original_id, db)` — unchanged signature; now also resolves the original's pending suggestions (reviewer NULL) and deletes ALL of the repost's suggestion rows.
+
+- [ ] **Step 1: Write the failing service tests**
+
+Append to `tests/services/test_ml_suggestion_lifecycle.py`:
+
+```python
+class TestMigrateRepostData:
+    async def test_wipes_repost_rows_and_resolves_original(
+        self, db_session: AsyncSession
+    ):
+        """Repost-marking wipes ALL the repost's suggestion rows and resolves the
+        original's matching pending suggestion with a NULL reviewer."""
+        from app.models.tag_link import TagLinks
+        from app.services.repost import migrate_repost_data
+
+        user = await _make_user(db_session, "repost")
+        repost = await _make_image(db_session, user, "repost_r", ImageStatus.ACTIVE)
+        original = await _make_image(db_session, user, "repost_o", ImageStatus.ACTIVE)
+        shared_tag = await _make_tag(db_session, user, "repost_shared")
+
+        # The repost carries the tag; the original has a pending suggestion for it.
+        db_session.add(
+            TagLinks(image_id=repost.image_id, tag_id=shared_tag.tag_id, user_id=user.user_id)
+        )
+        await _make_suggestion(db_session, repost, shared_tag, status="approved")
+        original_pending = await _make_suggestion(
+            db_session, original, shared_tag, status="pending"
+        )
+        await db_session.commit()
+
+        await migrate_repost_data(repost.image_id, original.image_id, db_session)
+        await db_session.commit()
+
+        # Repost: every suggestion row gone.
+        assert await _suggestion_rows(db_session, repost.image_id) == []
+
+        # Original: pending resolved as a system resolution (NULL reviewer).
+        await db_session.refresh(original_pending)
+        assert original_pending.status == "approved"
+        assert original_pending.reviewed_by_user_id is None
+        assert original_pending.reviewed_at is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make pytest ARGS="tests/services/test_ml_suggestion_lifecycle.py::TestMigrateRepostData"`
+Expected: FAIL — repost rows still present / original still pending.
+
+- [ ] **Step 3: Implement in `migrate_repost_data`**
+
+In `app/services/repost.py`, add imports (sorted into the existing blocks):
+
+```python
+from app.models.ml_tag_suggestion import MlTagSuggestions
+from app.services.ml_suggestion_review import approve_pending_suggestions_for_links
+```
+
+Inside `migrate_repost_data()`, after the tag-migration section's final statement (the `delete(TagLinks).where(TagLinks.image_id == repost_id)` execute) and before `refresh_images_tag_type_flags(...)`, add:
+
+```python
+    # --- ML suggestions ---
+    # The migrated tags are now applied to the original: resolve its matching
+    # pending suggestions. Reviewer stays NULL — this is data movement, not a
+    # human review (system resolution; see CONTEXT.md and ADR-0001).
+    original_tag_ids = (
+        (
+            await db.execute(
+                select(TagLinks.tag_id).where(  # type: ignore[call-overload]
+                    TagLinks.image_id == original_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    await approve_pending_suggestions_for_links(
+        db, [(original_id, tag_id) for tag_id in original_tag_ids], None
+    )
+
+    # A repost is permanently out of review scope: wipe ALL its suggestion rows,
+    # matching the favorites/ratings/tags wipe above (ADR-0002).
+    await db.execute(
+        delete(MlTagSuggestions).where(
+            MlTagSuggestions.image_id == repost_id  # type: ignore[arg-type]
+        )
+    )
+```
+
+(Resolving against ALL of the original's tag_links — not only the just-migrated ones — is deliberate: any pending suggestion matching an applied tag is stale by definition, so this also self-heals older drift on the original.)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `make pytest ARGS="tests/services/test_ml_suggestion_lifecycle.py"`
+Expected: all PASS.
+
+- [ ] **Step 5: Endpoint-level test through the admin repost route**
+
+Append to `tests/api/v1/test_admin_images.py` (reuse its `create_admin_user`, `grant_permission`, `create_test_image`, `login_user` helpers; check the file's existing repost test for the exact JSON shape — it PATCHes `/api/v1/admin/images/{id}` with `{"status": ImageStatus.REPOST, "replacement_id": ...}`):
+
+```python
+    async def test_repost_marking_cleans_ml_suggestions(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Marking a repost via the admin endpoint wipes its suggestion rows."""
+        from app.models.ml_tag_suggestion import MlTagSuggestions
+        from app.models.tag import Tags
+
+        admin, admin_password = await create_admin_user(db_session)
+        await grant_permission(db_session, admin.user_id, "image_edit")
+        original = await create_test_image(db_session, admin.user_id)
+        repost = await create_test_image(db_session, admin.user_id)
+
+        tag = Tags(title="admin_repost_ml_tag", type=1)
+        db_session.add(tag)
+        await db_session.flush()
+        suggestion = MlTagSuggestions(
+            image_id=repost.image_id,
+            tag_id=tag.tag_id,
+            confidence=0.9,
+            model_version="test-model",
+            status="pending",
+        )
+        db_session.add(suggestion)
+        await db_session.commit()
+
+        token = await login_user(client, admin.username, admin_password)
+        response = await client.patch(
+            f"/api/v1/admin/images/{repost.image_id}",
+            json={"status": ImageStatus.REPOST, "replacement_id": original.image_id},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+
+        rows = (
+            await db_session.execute(
+                select(MlTagSuggestions).where(
+                    MlTagSuggestions.image_id == repost.image_id
+                )
+            )
+        ).scalars().all()
+        assert rows == []
+```
+
+Place it inside the existing test class covering the PATCH endpoint; match its indentation and any fixture idioms (e.g. if `create_test_image` requires extra kwargs, copy from the neighboring repost test). Add `from sqlalchemy import select` to the file's imports if not already present.
+
+- [ ] **Step 6: Run, then lint, typecheck, commit**
+
+Run: `make pytest ARGS="tests/api/v1/test_admin_images.py tests/services/test_ml_suggestion_lifecycle.py"`
+Expected: all PASS.
+
+Run: `uv run ruff check app/services/repost.py tests/services/test_ml_suggestion_lifecycle.py tests/api/v1/test_admin_images.py && uv run mypy app/services/repost.py`
+
+```bash
+git add app/services/repost.py tests/services/test_ml_suggestion_lifecycle.py tests/api/v1/test_admin_images.py
+git commit -m "feat(ml): repost marking wipes suggestion rows and resolves the original's pending"
+```
+
+---
+
+### Task 6: Eligibility guard in the generation pipeline
+
+**Files:**
+- Modify: `app/services/ml_suggestion_pipeline.py` (`generate_and_store_suggestions`)
+- Test: `tests/services/test_ml_suggestion_pipeline.py` (extend)
+
+**Interfaces:**
+- Consumes: `ImageStatus.SUGGESTION_ELIGIBLE_STATUSES` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/services/test_ml_suggestion_pipeline.py` (reuse the file's existing image/user creation helpers — read its header first and copy the idiom; the test below assumes helpers equivalent to the lifecycle file's, adapt names accordingly):
+
+```python
+async def test_generate_skips_suggestion_ineligible_image(db_session):
+    """generate_and_store_suggestions returns 0 for an ineligible image without
+    touching the filesystem or the model (guard runs before file resolution)."""
+    from app.config import ImageStatus
+    from app.services.ml_suggestion_pipeline import generate_and_store_suggestions
+
+    # Create a minimal image row in REPOST status using this file's helpers.
+    user = await _make_user(db_session, "inelig")
+    image = await _make_image(db_session, user, "inelig")
+    image.status = ImageStatus.REPOST
+    await db_session.commit()
+
+    # ml_service is never reached: the guard returns before any use.
+    created = await generate_and_store_suggestions(db_session, image, None)  # type: ignore[arg-type]
+
+    assert created == 0
+```
+
+If the file's helper names differ (`_make_user`/`_make_image` are the convention in sibling ML test files), use the file's own.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make pytest ARGS="tests/services/test_ml_suggestion_pipeline.py::test_generate_skips_suggestion_ineligible_image"`
+Expected: FAIL with `FileNotFoundError` (pipeline reaches the file check) or `AttributeError` on the `None` service.
+
+- [ ] **Step 3: Add the guard**
+
+In `app/services/ml_suggestion_pipeline.py`, in `generate_and_store_suggestions()`, directly after:
+
+```python
+    assert image.image_id is not None  # a persisted image always has an id
+    image_id = image.image_id
+```
+
+add:
+
+```python
+    # Ineligible images (repost/deactivated/etc.) never get suggestion rows
+    # (ADR-0002) — return before touching the filesystem or the model.
+    if image.status not in ImageStatus.SUGGESTION_ELIGIBLE_STATUSES:
+        logger.info(
+            "ml_suggestion_pipeline_skipped_ineligible",
+            image_id=image_id,
+            status=image.status,
+        )
+        return 0
+```
+
+Add `ImageStatus` to the module's `from app.config import ...` line.
+
+- [ ] **Step 4: Run the pipeline suite**
+
+Run: `make pytest ARGS="tests/services/test_ml_suggestion_pipeline.py"`
+Expected: all PASS (existing tests create ACTIVE-status images by default).
+
+- [ ] **Step 5: Lint, typecheck, commit**
+
+Run: `uv run ruff check app/services/ml_suggestion_pipeline.py tests/services/test_ml_suggestion_pipeline.py && uv run mypy app/services/ml_suggestion_pipeline.py`
+
+```bash
+git add app/services/ml_suggestion_pipeline.py tests/services/test_ml_suggestion_pipeline.py
+git commit -m "feat(ml): skip suggestion generation for ineligible images"
+```
+
+---
+
+### Task 7: Backfill migration
+
+**Files:**
+- Create: `alembic/versions/<generated>_backfill_delete_suggestions_for_ineligible_images.py`
+
+**Interfaces:**
+- Chains from current head `a61c09c0f331`.
+
+- [ ] **Step 1: Generate the revision**
+
+Run: `uv run alembic revision -m "backfill delete suggestions for ineligible images"`
+Expected: new file under `alembic/versions/` with `down_revision = 'a61c09c0f331'` (verify; if another migration landed meanwhile, alembic fills the actual head).
+
+- [ ] **Step 2: Write the migration**
+
+Replace the generated stubs (keep the generated `revision`/`down_revision` identifiers):
+
+```python
+"""backfill delete suggestions for ineligible images
+
+Data migration (ADR-0002): suggestion rows may exist only on
+suggestion-eligible images (status ACTIVE=1, SPOILER=2). Reposts (-1) leave
+review scope permanently and lose ALL rows (matching the favorites/ratings/
+tags wipe at repost-marking); other ineligible statuses (DEACTIVATED=0,
+legacy -2/-3, REVIEW=-4) lose only pending rows — reviewed rows keep
+provenance for tags still applied to those images.
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '<keep generated>'
+down_revision: str | Sequence[str] | None = '<keep generated>'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DELETE s FROM ml_tag_suggestions s
+        JOIN images i ON i.image_id = s.image_id
+        WHERE i.status = -1
+        """
+    )
+    op.execute(
+        """
+        DELETE s FROM ml_tag_suggestions s
+        JOIN images i ON i.image_id = s.image_id
+        WHERE i.status NOT IN (1, 2) AND i.status <> -1
+          AND s.status = 'pending'
+        """
+    )
+
+
+def downgrade() -> None:
+    # Irreversible data migration: deleted rows are re-seedable from the
+    # raw-prediction store on restore (ADR-0002). Intentionally a no-op.
+    pass
+```
+
+- [ ] **Step 3: Verify migration linearity and syntax**
+
+Run: `uv run alembic heads && uv run python -c "import ast,glob; [ast.parse(open(f).read()) for f in glob.glob('alembic/versions/*.py')]; print('ok')"`
+Expected: exactly one head (the new revision), then `ok`.
+
+(The migration executes against dev/test/prod via the normal `alembic upgrade head` in each deploy; dev application happens at rollout, not in this task.)
+
+- [ ] **Step 4: Lint and commit**
+
+Run: `uv run ruff check alembic/versions/`
+
+```bash
+git add alembic/versions/
+git commit -m "feat(ml): backfill — delete suggestion rows stranded on ineligible images"
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Full suite**
+
+Run: `make pytest`
+Expected: 0 failures (baseline was 2288 passed, 10 skipped).
+
+- [ ] **Step 2: Repo-wide checks on touched files**
+
+Run: `uv run ruff check app/ tests/services/test_ml_suggestion_lifecycle.py && uv run mypy app/services/ml_suggestion_lifecycle.py app/services/ml_remap.py app/services/repost.py app/services/image_status.py app/services/ml_suggestion_pipeline.py app/api/v1/images.py`
+Expected: clean.
+
+- [ ] **Step 3: App imports cleanly (no circular imports)**
+
+Run: `uv run python -c "import app.main; print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push origin HEAD
+gh pr create --base main --head feat/ml-suggestion-lifecycle \
+  --title "feat(ml): suggestion rows follow the image-status lifecycle" \
+  --body "Closes #274. See docs/adr/0002-suggestion-rows-follow-image-status.md and the design doc in shuushuu-frontend/docs/plans/2026-07-16-ml-suggestion-lifecycle-and-history-design.md."
+```

--- a/scripts/ml_remap.py
+++ b/scripts/ml_remap.py
@@ -77,6 +77,7 @@ async def run(args: argparse.Namespace) -> None:
 
             try:
                 added = await remap_image_from_store(db, image_id, model_name)
+                await db.commit()
                 added_total += added
                 processed += 1
                 write_results(checkpoint, [{"image_id": image_id}])

--- a/tests/api/v1/test_admin_images.py
+++ b/tests/api/v1/test_admin_images.py
@@ -587,6 +587,48 @@ class TestImageStatusChangeAuditLog:
         assert action.details["ratings_moved"] == 1
         assert action.details["tags_moved"] == 1
 
+    async def test_repost_marking_cleans_ml_suggestions(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Marking a repost via the admin endpoint wipes its suggestion rows."""
+        from app.models.ml_tag_suggestion import MlTagSuggestions
+        from app.models.tag import Tags
+
+        admin, admin_password = await create_admin_user(db_session)
+        await grant_permission(db_session, admin.user_id, "image_edit")
+        original = await create_test_image(db_session, admin.user_id)
+        repost = await create_test_image(db_session, admin.user_id)
+
+        tag = Tags(title="admin_repost_ml_tag", type=1)
+        db_session.add(tag)
+        await db_session.flush()
+        suggestion = MlTagSuggestions(
+            image_id=repost.image_id,
+            tag_id=tag.tag_id,
+            confidence=0.9,
+            model_version="test-model",
+            status="pending",
+        )
+        db_session.add(suggestion)
+        await db_session.commit()
+
+        token = await login_user(client, admin.username, admin_password)
+        response = await client.patch(
+            f"/api/v1/admin/images/{repost.image_id}",
+            json={"status": ImageStatus.REPOST, "replacement_id": original.image_id},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+
+        rows = (
+            await db_session.execute(
+                select(MlTagSuggestions).where(
+                    MlTagSuggestions.image_id == repost.image_id
+                )
+            )
+        ).scalars().all()
+        assert rows == []
+
 
 @pytest.mark.api
 class TestImageLocked:

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -2494,6 +2494,51 @@ class TestAddTagApprovesMlSuggestion:
 
 
 @pytest.mark.api
+class TestOwnerStatusChangeSyncsMlSuggestions:
+    """The owner-facing PATCH /images/{id} status path runs the lifecycle hook."""
+
+    async def test_owner_spoiler_marking_keeps_pending(
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
+        sample_user: Users,
+        sample_image_data: dict,
+    ):
+        """ACTIVE -> SPOILER is eligible -> eligible: pending rows survive."""
+        image_data = sample_image_data.copy()
+        image_data["user_id"] = sample_user.user_id
+        image = Images(**image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        tag = Tags(title="owner_spoiler_ml_tag", type=1)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        suggestion = MlTagSuggestions(
+            image_id=image.image_id,
+            tag_id=tag.tag_id,
+            confidence=0.9,
+            model_version="test-model",
+            status="pending",
+        )
+        db_session.add(suggestion)
+        await db_session.commit()
+        await db_session.refresh(suggestion)
+
+        response = await authenticated_client.patch(
+            f"/api/v1/images/{image.image_id}",
+            json={"status": 2},
+        )
+        assert response.status_code == 200
+
+        await db_session.refresh(suggestion)
+        assert suggestion.status == "pending"
+
+
+@pytest.mark.api
 class TestTagUsageCount:
     """Tests for automatic tag usage_count updates via database triggers."""
 

--- a/tests/services/test_image_status_service.py
+++ b/tests/services/test_image_status_service.py
@@ -186,3 +186,42 @@ async def test_status_history_row_records_report_id(db_session: AsyncSession):
     )).scalars().all()
     assert hist[0].report_id == report.report_id
     assert hist[0].review_id is None
+
+
+async def test_status_change_syncs_ml_suggestions(db_session: AsyncSession):
+    """Deactivating an image deletes its pending ML suggestions (ADR-0002)."""
+    from app.models.ml_tag_suggestion import MlTagSuggestions
+    from app.models.tag import Tags
+
+    actor = (await db_session.execute(select(Users).where(Users.user_id == 1))).scalar_one()
+    img = await _mk_image(db_session, actor.user_id)
+    tag = Tags(title="lifecycle-hook-tag", type=1)
+    db_session.add(tag)
+    await db_session.flush()
+    db_session.add(
+        MlTagSuggestions(
+            image_id=img.image_id,
+            tag_id=tag.tag_id,
+            confidence=0.9,
+            model_version="test-model",
+            status="pending",
+        )
+    )
+    await db_session.commit()
+
+    await change_image_status(
+        db_session,
+        img,
+        actor,
+        new_status=ImageStatus.DEACTIVATED,
+        reason_category=DeactivationReason.OTHER,
+        reason="lifecycle test",
+    )
+    await db_session.commit()
+
+    remaining = (
+        await db_session.execute(
+            select(MlTagSuggestions).where(MlTagSuggestions.image_id == img.image_id)
+        )
+    ).scalars().all()
+    assert remaining == []

--- a/tests/services/test_ml_backfill.py
+++ b/tests/services/test_ml_backfill.py
@@ -360,8 +360,17 @@ async def test_ingest_results_skips_given_ids(db_session):
 
 
 @pytest.mark.needs_commit
-async def test_ingest_results_records_errors_and_continues(db_session):
-    """A bad image_id (FK violation) is recorded; remaining images still ingest."""
+async def test_ingest_results_skips_missing_image_and_continues(db_session):
+    """A manifest entry for an image_id that no longer exists (e.g. deleted since
+    the manifest was built) is gracefully skipped by store_predictions'
+    eligibility guard (db.get returns None -> 0 created, no exception) rather
+    than tripping an images FK violation; remaining images still ingest.
+
+    This test previously asserted the FK-violation path was caught and recorded
+    in stats.errors. store_predictions now fetches the image via db.get before
+    any insert, so a missing image_id never reaches the FK constraint -- it is
+    absorbed as a normal 0-created result and counted as processed, not errored.
+    """
     user = await _make_user(db_session, "err")
     good = await _make_image(db_session, user, "good")
     db_session.add(Tags(tag_id=46, title="long hair"))
@@ -380,8 +389,8 @@ async def test_ingest_results_records_errors_and_continues(db_session):
     ):
         stats = await ingest_results(db_session, results)
 
-    assert stats.processed == 1
+    assert stats.processed == 2
     assert stats.created == 1
-    assert len(stats.errors) == 1
+    assert stats.errors == []
     rows = await db_session.execute(select(MlTagSuggestions))
     assert {s.image_id for s in rows.scalars().all()} == {good_id}

--- a/tests/services/test_ml_backfill.py
+++ b/tests/services/test_ml_backfill.py
@@ -394,3 +394,67 @@ async def test_ingest_results_skips_missing_image_and_continues(db_session):
     assert stats.errors == []
     rows = await db_session.execute(select(MlTagSuggestions))
     assert {s.image_id for s in rows.scalars().all()} == {good_id}
+
+
+@pytest.mark.needs_commit
+async def test_ingest_results_records_exception_and_continues(db_session):
+    """A genuine error partway through ingest is recorded in stats.errors and
+    rolled back; a later valid manifest item still processes and creates a row.
+
+    Restores coverage of ingest_results' except/rollback/append/continue branch.
+    test_ingest_results_skips_missing_image_and_continues no longer exercises this
+    branch: its "missing image_id" trigger is now intercepted earlier by
+    store_predictions' own eligibility guard (db.get returns None) before any
+    insert is attempted, so nothing raises there anymore.
+
+    This test instead targets an ELIGIBLE image whose predicted external tag
+    resolves to a tag_id with no row in `tags`. store_predictions' guard passes
+    (the image itself is fine), so its insert-then-commit reaches the database,
+    where the dangling FK trips a real IntegrityError -- NOT the
+    unique_ml_suggestion_image_tag case store_predictions swallows -- so it
+    re-raises and ingest_results' try/except catches it.
+    """
+    user = await _make_user(db_session, "err2")
+    bad_img = await _make_image(db_session, user, "bad_tag")
+    good_img = await _make_image(db_session, user, "good2")
+    db_session.add(Tags(tag_id=46, title="long hair"))
+    await db_session.commit()
+    # capture before ingest: the rollback below expires `bad_img`/`good_img`
+    bad_id = bad_img.image_id
+    good_id = good_img.image_id
+
+    results = [
+        {
+            "image_id": bad_id,
+            "predictions": [{"external_tag": "ghost_tag", "confidence": 0.9, "model_version": "v3"}],
+        },
+        {
+            "image_id": good_id,
+            "predictions": [{"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}],
+        },
+    ]
+
+    async def _resolver_by_external_tag(db, suggestions):
+        # "ghost_tag" maps to a tag_id absent from `tags` (dangling FK);
+        # "long_hair" maps to the real tag_id 46.
+        return [
+            {
+                "tag_id": 999999 if s["external_tag"] == "ghost_tag" else 46,
+                "confidence": s["confidence"],
+                "model_version": s["model_version"],
+            }
+            for s in suggestions
+        ]
+
+    with (
+        patch(f"{PIPELINE}.resolve_external_tags", _resolver_by_external_tag),
+        patch(f"{PIPELINE}.resolve_tag_relationships", _passthrough),
+    ):
+        stats = await ingest_results(db_session, results)
+
+    assert stats.processed == 1
+    assert stats.created == 1
+    assert len(stats.errors) == 1
+    assert stats.errors[0].startswith(f"{bad_id}:")
+    rows = await db_session.execute(select(MlTagSuggestions))
+    assert {s.image_id for s in rows.scalars().all()} == {good_id}

--- a/tests/services/test_ml_remap.py
+++ b/tests/services/test_ml_remap.py
@@ -25,7 +25,7 @@ import pytest
 from sqlalchemy import select
 
 import scripts.ml_remap as ml_remap_script
-from app.config import settings
+from app.config import ImageStatus, settings
 from app.models.image import Images
 from app.models.ml_raw_prediction import MlExternalTags, MlModels, MlRawPredictions
 from app.models.ml_tag_suggestion import MlTagSuggestions
@@ -708,3 +708,36 @@ async def test_remap_image_from_store_ignores_other_model(db_session, monkeypatc
         )
     ).scalars().all()
     assert rows == [], "swinv2 raw predictions must not be picked up by caformer remap"
+
+
+# ---------------------------------------------------------------------------
+# Eligibility guard: ineligible images never get suggestion rows (ADR-0002)
+# ---------------------------------------------------------------------------
+
+
+async def test_remap_skips_suggestion_ineligible_image(db_session, monkeypatch):
+    """remap_image returns 0 and writes nothing for an image outside
+    SUGGESTION_ELIGIBLE_STATUSES (e.g. a repost)."""
+    monkeypatch.setattr(settings, "ML_MIN_CONFIDENCE", 0.35)
+
+    user = await _make_user(db_session, "inelig")
+    image = await _make_image(db_session, user, "inelig")
+    image.status = ImageStatus.REPOST
+    await _make_tags(db_session, 301)
+    await db_session.commit()
+
+    predictions = _preds(301, model=CAFORMER)
+
+    with (
+        patch(f"{PIPELINE}.resolve_external_tags", _resolver_to_tag_ids(predictions)),
+        patch(f"{PIPELINE}.resolve_tag_relationships", _resolver_passthrough),
+    ):
+        added = await remap_image(db_session, image.image_id, predictions, CAFORMER)
+
+    assert added == 0
+    rows = (
+        await db_session.execute(
+            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+        )
+    ).scalars().all()
+    assert rows == []

--- a/tests/services/test_ml_suggestion_lifecycle.py
+++ b/tests/services/test_ml_suggestion_lifecycle.py
@@ -198,3 +198,40 @@ class TestIneligibleToEligible:
         assert len(rows) == 1
         assert rows[0].status == "pending"
         assert rows[0].tag_id == tag.tag_id
+
+
+class TestMigrateRepostData:
+    async def test_wipes_repost_rows_and_resolves_original(
+        self, db_session: AsyncSession
+    ):
+        """Repost-marking wipes ALL the repost's suggestion rows and resolves the
+        original's matching pending suggestion with a NULL reviewer."""
+        from app.models.tag_link import TagLinks
+        from app.services.repost import migrate_repost_data
+
+        user = await _make_user(db_session, "repost")
+        repost = await _make_image(db_session, user, "repost_r", ImageStatus.ACTIVE)
+        original = await _make_image(db_session, user, "repost_o", ImageStatus.ACTIVE)
+        shared_tag = await _make_tag(db_session, user, "repost_shared")
+
+        # The repost carries the tag; the original has a pending suggestion for it.
+        db_session.add(
+            TagLinks(image_id=repost.image_id, tag_id=shared_tag.tag_id, user_id=user.user_id)
+        )
+        await _make_suggestion(db_session, repost, shared_tag, status="approved")
+        original_pending = await _make_suggestion(
+            db_session, original, shared_tag, status="pending"
+        )
+        await db_session.commit()
+
+        await migrate_repost_data(repost.image_id, original.image_id, db_session)
+        await db_session.commit()
+
+        # Repost: every suggestion row gone.
+        assert await _suggestion_rows(db_session, repost.image_id) == []
+
+        # Original: pending resolved as a system resolution (NULL reviewer).
+        await db_session.refresh(original_pending)
+        assert original_pending.status == "approved"
+        assert original_pending.reviewed_by_user_id is None
+        assert original_pending.reviewed_at is not None

--- a/tests/services/test_ml_suggestion_lifecycle.py
+++ b/tests/services/test_ml_suggestion_lifecycle.py
@@ -1,0 +1,200 @@
+"""Tests for the suggestion-lifecycle hook (ADR-0002).
+
+Pending rows are deleted when an image leaves suggestion-eligible status;
+pending rows are re-seeded from the raw store when it returns. Reviewed rows
+survive non-repost transitions. All against the real test DB.
+"""
+
+from unittest.mock import patch
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, settings
+from app.models.image import Images
+from app.models.ml_raw_prediction import MlExternalTags, MlModels, MlRawPredictions
+from app.models.ml_tag_suggestion import MlTagSuggestions
+from app.models.tag import Tags
+from app.models.user import Users
+from app.services.ml_suggestion_lifecycle import sync_suggestions_for_status_transition
+
+PIPELINE = "app.services.ml_suggestion_pipeline"
+MODEL = "caformer_b36.dbv4-full"
+
+
+async def _make_user(db: AsyncSession, suffix: str) -> Users:
+    user = Users(
+        username=f"lifecycle_{suffix}",
+        email=f"lifecycle_{suffix}@example.com",
+        password="hashed",
+        password_type="bcrypt",
+        salt="testsalt12345678",
+        active=1,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_image(db: AsyncSession, user: Users, suffix: str, status: int) -> Images:
+    image = Images(
+        filename=f"2024-01-01-lifecycle-{suffix}",
+        ext="jpg",
+        user_id=user.user_id,
+        md5_hash=f"lifecycle_hash_{suffix}",
+        filesize=1024,
+        width=800,
+        height=600,
+        status=status,
+    )
+    db.add(image)
+    await db.flush()
+    return image
+
+
+async def _make_tag(db: AsyncSession, user: Users, suffix: str) -> Tags:
+    tag = Tags(title=f"lifecycle tag {suffix}", type=1, user_id=user.user_id)
+    db.add(tag)
+    await db.flush()
+    return tag
+
+
+async def _make_suggestion(
+    db: AsyncSession, image: Images, tag: Tags, status: str = "pending"
+) -> MlTagSuggestions:
+    suggestion = MlTagSuggestions(
+        image_id=image.image_id,
+        tag_id=tag.tag_id,
+        confidence=0.9,
+        model_version=MODEL,
+        status=status,
+    )
+    db.add(suggestion)
+    await db.flush()
+    return suggestion
+
+
+async def _suggestion_rows(db: AsyncSession, image_id: int) -> list[MlTagSuggestions]:
+    return list(
+        (
+            await db.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def _resolver_passthrough(db, suggestions):
+    return suggestions
+
+
+class TestEligibleToIneligible:
+    async def test_deletes_pending_keeps_reviewed(self, db_session: AsyncSession):
+        """ACTIVE -> DEACTIVATED deletes pending rows but keeps approved/rejected."""
+        user = await _make_user(db_session, "e2i")
+        image = await _make_image(db_session, user, "e2i", ImageStatus.ACTIVE)
+        t1 = await _make_tag(db_session, user, "e2i_p")
+        t2 = await _make_tag(db_session, user, "e2i_a")
+        t3 = await _make_tag(db_session, user, "e2i_r")
+        await _make_suggestion(db_session, image, t1, status="pending")
+        await _make_suggestion(db_session, image, t2, status="approved")
+        await _make_suggestion(db_session, image, t3, status="rejected")
+        await db_session.commit()
+
+        await sync_suggestions_for_status_transition(
+            db_session, image.image_id, ImageStatus.ACTIVE, ImageStatus.DEACTIVATED
+        )
+        await db_session.commit()
+
+        rows = await _suggestion_rows(db_session, image.image_id)
+        statuses = sorted(r.status for r in rows)
+        assert statuses == ["approved", "rejected"]
+
+
+class TestNoOpTransitions:
+    async def test_eligible_to_eligible_is_noop(self, db_session: AsyncSession):
+        """ACTIVE -> SPOILER leaves pending rows alone."""
+        user = await _make_user(db_session, "e2e")
+        image = await _make_image(db_session, user, "e2e", ImageStatus.ACTIVE)
+        tag = await _make_tag(db_session, user, "e2e")
+        await _make_suggestion(db_session, image, tag, status="pending")
+        await db_session.commit()
+
+        await sync_suggestions_for_status_transition(
+            db_session, image.image_id, ImageStatus.ACTIVE, ImageStatus.SPOILER
+        )
+        await db_session.commit()
+
+        rows = await _suggestion_rows(db_session, image.image_id)
+        assert len(rows) == 1
+        assert rows[0].status == "pending"
+
+    async def test_ineligible_to_ineligible_is_noop(self, db_session: AsyncSession):
+        """DEACTIVATED -> REVIEW does not touch rows and does not re-seed."""
+        user = await _make_user(db_session, "i2i")
+        image = await _make_image(db_session, user, "i2i", ImageStatus.DEACTIVATED)
+        tag = await _make_tag(db_session, user, "i2i")
+        await _make_suggestion(db_session, image, tag, status="approved")
+        await db_session.commit()
+
+        await sync_suggestions_for_status_transition(
+            db_session, image.image_id, ImageStatus.DEACTIVATED, ImageStatus.REVIEW
+        )
+        await db_session.commit()
+
+        rows = await _suggestion_rows(db_session, image.image_id)
+        assert len(rows) == 1
+        assert rows[0].status == "approved"
+
+
+class TestIneligibleToEligible:
+    async def test_reseeds_pending_from_raw_store(
+        self, db_session: AsyncSession, monkeypatch
+    ):
+        """DEACTIVATED -> ACTIVE re-seeds pending rows from ml_raw_predictions."""
+        monkeypatch.setattr(settings, "ML_MODEL_NAME", MODEL)
+        monkeypatch.setattr(settings, "ML_MIN_CONFIDENCE", 0.35)
+
+        user = await _make_user(db_session, "i2e")
+        image = await _make_image(db_session, user, "i2e", ImageStatus.ACTIVE)
+        tag = await _make_tag(db_session, user, "i2e")
+
+        # Seed the raw store: model -> external tag -> raw prediction.
+        model_row = MlModels(name=MODEL)
+        db_session.add(model_row)
+        await db_session.flush()
+        ext_tag = MlExternalTags(name="lifecycle_ext", category=0)
+        db_session.add(ext_tag)
+        await db_session.flush()
+        db_session.add(
+            MlRawPredictions(
+                image_id=image.image_id,
+                external_tag_id=ext_tag.id,
+                model_id=model_row.id,
+                confidence=0.9,
+            )
+        )
+        await db_session.commit()
+
+        # Patch resolvers so the external tag maps straight to our internal tag
+        # (established pattern from tests/services/test_ml_remap.py).
+        resolved = [{"tag_id": tag.tag_id, "confidence": 0.9, "model_version": MODEL}]
+
+        async def _resolve_to_internal(db, suggestions):
+            return [dict(r) for r in resolved]
+
+        with (
+            patch(f"{PIPELINE}.resolve_external_tags", _resolve_to_internal),
+            patch(f"{PIPELINE}.resolve_tag_relationships", _resolver_passthrough),
+        ):
+            await sync_suggestions_for_status_transition(
+                db_session, image.image_id, ImageStatus.DEACTIVATED, ImageStatus.ACTIVE
+            )
+        await db_session.commit()
+
+        rows = await _suggestion_rows(db_session, image.image_id)
+        assert len(rows) == 1
+        assert rows[0].status == "pending"
+        assert rows[0].tag_id == tag.tag_id

--- a/tests/services/test_ml_suggestion_pipeline.py
+++ b/tests/services/test_ml_suggestion_pipeline.py
@@ -985,6 +985,36 @@ async def test_character_suggestions_stored_when_flag_on(db_session, tmp_path, m
     assert {s.tag_id for s in result.scalars().all()} == {311, 312}
 
 
+async def test_generate_skips_suggestion_ineligible_image(db_session):
+    """generate_and_store_suggestions returns 0 for an ineligible image without
+    touching the filesystem or the model (guard runs before file resolution).
+
+    No local file is created for this image (unlike _make_image) — if the
+    guard did not run before file resolution, this would fail with
+    FileNotFoundError instead.
+    """
+    from app.config import ImageStatus
+
+    user = await _make_user(db_session, "inelig")
+    image = Images(
+        filename="2024-01-01-inelig",
+        ext="jpg",
+        user_id=user.user_id,
+        md5_hash="hash_inelig",
+        filesize=1024,
+        width=800,
+        height=600,
+        status=ImageStatus.REPOST,
+    )
+    db_session.add(image)
+    await db_session.commit()
+
+    # ml_service is never reached: the guard returns before any use.
+    created = await generate_and_store_suggestions(db_session, image, None)  # type: ignore[arg-type]
+
+    assert created == 0
+
+
 async def test_character_child_does_not_supersede_theme_parent_when_gated(
     db_session, tmp_path, monkeypatch
 ):

--- a/tests/services/test_ml_suggestion_pipeline.py
+++ b/tests/services/test_ml_suggestion_pipeline.py
@@ -639,6 +639,52 @@ async def test_store_predictions_persists_without_inference(db_session, tmp_path
     assert all(s.status == "pending" for s in suggestions)
 
 
+async def test_store_predictions_skips_ineligible_image(db_session):
+    """store_predictions is the single creation funnel: it's reached WITHOUT any
+    eligibility check via persist_predictions (arq job's md5 analyze-cache hit
+    path) and via ml_backfill.ingest_results (operator-run bulk ingest), so the
+    guard must live here rather than only in generate_and_store_suggestions.
+
+    Race scenario: upload enqueues the ML job, a mod repost-marks the duplicate
+    before the worker runs — the job must not resurrect pending suggestion rows
+    on the now-repost image.
+    """
+    from app.config import ImageStatus
+
+    tags = [Tags(tag_id=46, title="long hair")]
+    db_session.add_all(tags)
+    await db_session.flush()
+
+    user = await _make_user(db_session, "repost_guard")
+    image = Images(
+        filename="2024-01-01-repost_guard",
+        ext="jpg",
+        user_id=user.user_id,
+        md5_hash="hash_repost_guard",
+        filesize=1024,
+        width=800,
+        height=600,
+        status=ImageStatus.REPOST,
+    )
+    db_session.add(image)
+    await db_session.commit()
+
+    predictions = [{"external_tag": "long_hair", "confidence": 0.92, "model_version": "v3"}]
+    mapped = [{"tag_id": 46, "confidence": 0.92, "model_version": "v3"}]
+
+    with (
+        patch(f"{PIPELINE}.resolve_external_tags", _resolver_to_tag_ids(mapped)),
+        patch(f"{PIPELINE}.resolve_tag_relationships", _passthrough_resolver),
+    ):
+        created = await store_predictions(db_session, image.image_id, predictions)
+
+    assert created == 0
+    result = await db_session.execute(
+        select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+    )
+    assert result.scalars().all() == []
+
+
 @pytest.mark.needs_commit
 async def test_store_predictions_swallows_duplicate_race(db_session, tmp_path, monkeypatch):
     """Two concurrent regenerations of the same image (arq job vs sync generate,


### PR DESCRIPTION
Closes #274.

ML tag-suggestion rows now exist only on **suggestion-eligible** images (`ACTIVE`, `SPOILER` — see `CONTEXT.md`, ADR-0002):

- **Transition hook** (`sync_suggestions_for_status_transition`, new `app/services/ml_suggestion_lifecycle.py`) wired at both status-write sites — `change_image_status()` and the owner-facing `PATCH /images/{id}` path. Leaving eligibility deletes pending rows; returning re-seeds them from the raw-prediction store (no inference, no image file). Atomic with the status change.
- **Repost cleanup** lives inside `migrate_repost_data()` so both repost paths inherit it: ALL of the repost's suggestion rows are wiped (matching the favorites/ratings/tags wipe), and the **original** image's matching pending suggestions are resolved with a NULL reviewer (system resolution — closes the tag-write path #273 missed).
- **Creation guards** in `remap_image()`, `generate_and_store_suggestions()`, and `store_predictions()` (the funnel used by the analyze-cache job branch and bulk backfill ingest) — nothing can resurrect rows on ineligible images, including the upload-then-fast-repost race.
- **Prerequisite refactor**: `remap_image()` is now flush-only; the bulk script and `remap_images_for_tag` own per-image commits (behavior preserved).
- **Backfill migration** `7d98087eabcb` deletes stranded rows (reposts: all; other ineligible statuses: pending only). **Verified on dev**: repost rows 131→0, other-ineligible pending 21→0, eligible images' 2,060,332 rows untouched.

**Deploy notes:**
- Normal migrate-then-deploy. The window between migration and code deploy can strand a handful of new rows (old code, no hooks); both DELETEs are idempotent — re-running them once after the code deploy closes the window, or accept the likely-zero drift (the queue grid hides repost rows regardless once tag_links are wiped... reposts wipe tag_links, so grid anti-join does NOT hide them — hence the re-run recommendation).
- Dev already runs this branch (hot-reload) and its DB is migrated.

**Testing:** TDD throughout; 12 new tests across services + both status-change endpoints; full suite **2300 passed, 0 failed, 10 skipped**; ruff clean repo-wide on app/, mypy clean on touched modules. Whole-branch review (2 reviewer passes) confirmed hook ordering vs `migrate_repost_data` is correct for every transition combination through both paths.

Follow-ups (non-blocking, tracked in a separate issue): bulk-remap now skips deleted/ineligible images silently at INFO; `repost.py` style/efficiency nits; sync-generate returns 200 with 0 created for ineligible images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZ2inonRLKfa6KvJZ32gKu