### PR TITLE
feat(ml): embed reviewer identity in ML tag suggestion responses

### DIFF
--- a/app/api/v1/ml_tag_suggestions.py
+++ b/app/api/v1/ml_tag_suggestions.py
@@ -10,6 +10,7 @@ import redis.asyncio as redis
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.config import settings
 from app.core.auth import CurrentUser
@@ -19,8 +20,10 @@ from app.core.permissions import Permission, has_permission
 from app.core.redis import get_redis
 from app.models.image import Images
 from app.models.ml_tag_suggestion import MlTagSuggestions
+from app.models.permissions import UserGroups
 from app.models.tag import Tags
 from app.models.user import Users
+from app.schemas.common import UserSummary
 from app.schemas.ml_tag_suggestion import (
     GenerateSuggestionsResponse,
     MlTagSuggestionResponse,
@@ -157,6 +160,33 @@ async def get_ml_tag_suggestions(
     )
     tags_by_id = {tag.tag_id: tag for tag in tag_result.scalars().all()}
 
+    # Batch fetch reviewers in one query (same pattern as the public
+    # tag-history endpoint; groups drive username coloring).
+    reviewer_ids = {
+        sugg.reviewed_by_user_id for sugg in suggestions if sugg.reviewed_by_user_id is not None
+    }
+    reviewers_by_id: dict[int, Users] = {}
+    if reviewer_ids:
+        reviewer_result = await db.execute(
+            select(Users)
+            .options(selectinload(Users.user_groups).selectinload(UserGroups.group))  # type: ignore[arg-type]
+            .where(Users.user_id.in_(reviewer_ids))  # type: ignore[union-attr]
+        )
+        reviewers_by_id = {u.user_id: u for u in reviewer_result.scalars().all()}  # type: ignore[misc]
+
+    def _reviewer_summary(user_id: int | None) -> UserSummary | None:
+        user = reviewers_by_id.get(user_id) if user_id is not None else None
+        if user is None or user.user_id is None:
+            return None
+        return UserSummary(
+            user_id=user.user_id,
+            username=user.username,
+            avatar=user.avatar,
+            avatar_in_r2=user.avatar_in_r2,
+            user_title=user.user_title,
+            groups=user.groups,
+        )
+
     # Build suggestion responses
     suggestion_responses = [
         MlTagSuggestionResponse(
@@ -167,6 +197,7 @@ async def get_ml_tag_suggestions(
             status=sugg.status,  # type: ignore[arg-type]
             created_at=sugg.created_at,  # type: ignore[arg-type]
             reviewed_at=sugg.reviewed_at,
+            reviewed_by=_reviewer_summary(sugg.reviewed_by_user_id),
         )
         for sugg in suggestions
     ]

--- a/app/schemas/ml_tag_suggestion.py
+++ b/app/schemas/ml_tag_suggestion.py
@@ -86,6 +86,7 @@ class MlTagSuggestionsListResponse(BaseModel):
                         "status": "pending",
                         "created_at": "2025-12-04T12:00:00Z",
                         "reviewed_at": None,
+                        "reviewed_by": None,
                     },
                     {
                         "suggestion_id": 2,
@@ -95,6 +96,7 @@ class MlTagSuggestionsListResponse(BaseModel):
                         "status": "pending",
                         "created_at": "2025-12-04T12:00:00Z",
                         "reviewed_at": None,
+                        "reviewed_by": None,
                     },
                 ],
                 "total": 2,

--- a/app/schemas/ml_tag_suggestion.py
+++ b/app/schemas/ml_tag_suggestion.py
@@ -9,6 +9,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.schemas.common import UserSummary
 from app.schemas.tag import TagResponse
 
 
@@ -35,6 +36,7 @@ class MlTagSuggestionResponse(BaseModel):
                 "status": "pending",
                 "created_at": "2025-12-04T12:00:00Z",
                 "reviewed_at": None,
+                "reviewed_by": None,
             }
         },
     )
@@ -53,6 +55,13 @@ class MlTagSuggestionResponse(BaseModel):
     created_at: datetime = Field(description="When this suggestion was generated")
     reviewed_at: datetime | None = Field(
         default=None, description="When this suggestion was reviewed (null if not yet reviewed)"
+    )
+    reviewed_by: UserSummary | None = Field(
+        default=None,
+        description=(
+            "Who reviewed this suggestion. Null for unreviewed rows and for "
+            "system resolutions (backfill, repost tag migration)."
+        ),
     )
 
 

--- a/tests/api/v1/test_ml_tag_suggestions.py
+++ b/tests/api/v1/test_ml_tag_suggestions.py
@@ -1963,3 +1963,82 @@ class TestGenerateMlTagSuggestions:
             )
 
         assert response.status_code == 202
+
+
+@pytest.mark.api
+class TestSuggestionReviewerAttribution:
+    """GET /images/{id}/ml-tag-suggestions embeds reviewer identity."""
+
+    async def test_reviewed_by_embedded_and_null_for_system(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        owner = Users(
+            username="hist_owner",
+            email="hist_owner@example.com",
+            password="hashed",
+            password_type="bcrypt",
+            salt="testsalt12345678",
+            active=1,
+        )
+        reviewer = Users(
+            username="hist_reviewer",
+            email="hist_reviewer@example.com",
+            password="hashed",
+            password_type="bcrypt",
+            salt="testsalt12345678",
+            active=1,
+        )
+        db_session.add_all([owner, reviewer])
+        await db_session.flush()
+
+        image = Images(
+            filename="2024-01-01-hist",
+            ext="jpg",
+            user_id=owner.user_id,
+            md5_hash="hist_md5_hash_000000000000000000",
+            filesize=1024,
+            width=800,
+            height=600,
+        )
+        db_session.add(image)
+        await db_session.flush()
+
+        tag_human = Tags(title="hist tag human", type=1)
+        tag_system = Tags(title="hist tag system", type=1)
+        db_session.add_all([tag_human, tag_system])
+        await db_session.flush()
+
+        db_session.add(
+            MlTagSuggestions(
+                image_id=image.image_id,
+                tag_id=tag_human.tag_id,
+                confidence=0.9,
+                model_version="test-model",
+                status="approved",
+                reviewed_by_user_id=reviewer.user_id,
+            )
+        )
+        db_session.add(
+            MlTagSuggestions(
+                image_id=image.image_id,
+                tag_id=tag_system.tag_id,
+                confidence=0.8,
+                model_version="test-model",
+                status="approved",
+                reviewed_by_user_id=None,  # system resolution
+            )
+        )
+        await db_session.commit()
+
+        token = create_access_token(owner.id)
+        response = await client.get(
+            f"/api/v1/images/{image.image_id}/ml-tag-suggestions?status=approved",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        suggestions = response.json()["suggestions"]
+        by_tag = {s["tag"]["title"]: s for s in suggestions}
+
+        assert by_tag["hist tag human"]["reviewed_by"]["username"] == "hist_reviewer"
+        assert by_tag["hist tag human"]["reviewed_by"]["user_id"] == reviewer.user_id
+        assert by_tag["hist tag system"]["reviewed_by"] is None


### PR DESCRIPTION
API half of #275 (per-image ML suggestion history). Adds nullable `reviewed_by` (`UserSummary`) to `MlTagSuggestionResponse`, batch-loaded in one query in the per-image GET endpoint (same pattern and field set as the public tag-history endpoint's `to_summary()`). NULL for unreviewed rows and system resolutions (backfill / repost tag migration). Existing permission gate (owner/admin/IMAGE_TAG_ADD) unchanged.

Independent of #276 (branched off main); the frontend history PR in shuushuu-frontend consumes this and should merge after it.

Testing: TDD (RED = KeyError 'reviewed_by'); tests/api/v1/test_ml_tag_suggestions.py 37 passed; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZ2inonRLKfa6KvJZ32gKu