### PR TITLE
chore: pin MariaDB image to 11.8 matching prod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ DEBUG=true
 
 # Database (MariaDB)
 # Used by docker-compose for MariaDB container
+# Pin to prod's version. Prod runs MariaDB 11.8 on a dedicated DB server.
+# Set to a specific point release (e.g. mariadb:11.8.2) for full reproducibility.
+MARIADB_IMAGE=mariadb:11.8
 MARIADB_ROOT_PASSWORD=change_this_root_password
 MARIADB_DATABASE=shuushuu
 MARIADB_USER=shuushuu

--- a/.env.test
+++ b/.env.test
@@ -8,6 +8,8 @@ DOMAIN=test.shuushuu.com
 PROTOCOL=https
 
 # Database
+# Keep aligned with .env — prod runs MariaDB 11.8.
+MARIADB_IMAGE=mariadb:11.8
 MARIADB_ROOT_PASSWORD=change_this_root_password
 MARIADB_DATABASE=shuushuu_test
 MARIADB_USER=shuushuu_test

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -58,7 +58,7 @@ Tests run against a real MariaDB database using GitHub Actions service container
 ```yaml
 services:
   mysql:
-    image: mariadb:12
+    image: mariadb:11.8
     env:
       MYSQL_ROOT_PASSWORD: root_password
       MYSQL_DATABASE: shuushuu_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
     services:
       mysql:
-        image: mariadb:12
+        image: mariadb:11.8
         env:
           MARIADB_ROOT_PASSWORD: root_password
           MARIADB_DATABASE: shuushuu_test
@@ -93,7 +93,7 @@ jobs:
       - name: Wait for MySQL to be ready
         run: |
           for i in {1..30}; do
-            if docker exec $(docker ps -q --filter ancestor=mariadb:12) mariadb-admin ping -h localhost --silent 2>/dev/null; then
+            if docker exec $(docker ps -q --filter ancestor=mariadb:11.8) mariadb-admin ping -h localhost --silent 2>/dev/null; then
               echo "MySQL is ready!"
               break
             fi

--- a/app/core/db_retry.py
+++ b/app/core/db_retry.py
@@ -1,6 +1,6 @@
 """Retry helper for MariaDB snapshot-isolation conflicts (ER_CHECKREAD, errno 1020).
 
-With ``innodb_snapshot_isolation=ON`` (prod 11.8.6, dev mariadb:12), a locking
+With ``innodb_snapshot_isolation=ON`` (MariaDB 11.8), a locking
 statement that meets row/index versions committed *after* the transaction's
 snapshot aborts with error 1020 instead of returning stale data. The snapshot
 is pinned by the request's first read — the auth query — so the conflict

--- a/docker-compose.pytest.yml
+++ b/docker-compose.pytest.yml
@@ -42,7 +42,7 @@
 #   make pytest-db-down    # stop and remove it
 services:
   mariadb-pytest:
-    image: mariadb:12
+    image: ${MARIADB_IMAGE:-mariadb:11.8}
     container_name: shuushuu-mariadb-pytest
     environment:
       MARIADB_ROOT_PASSWORD: root_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,10 @@
 services:
   # MariaDB Database
   mariadb:
-    image: mariadb:12
+    # Pin to prod's version (dedicated DB server runs MariaDB 11.8). Bump
+    # MARIADB_IMAGE in .env to move dev+test+pytest together; do not use a
+    # floating major tag (:11/:12) here — silent drift will bite prod.
+    image: ${MARIADB_IMAGE:-mariadb:11.8}
     container_name: shuushuu-mariadb
     environment:
       MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD:-root_password}


### PR DESCRIPTION
## Summary

Dev and test environments were using a floating `mariadb:12` tag while prod runs MariaDB 11.8 on a dedicated DB server. This pins the compose image to match prod.

## Changes

- `docker-compose.yml`: `mariadb:12` → `${MARIADB_IMAGE:-mariadb:11.8}` (dev + test stacks)
- `docker-compose.pytest.yml`: same pin for the pytest DB
- `.env.example` / `.env.test`: add `MARIADB_IMAGE=mariadb:11.8`

## Why

- Floating major tags (`:12`) silently change under you — what runs locally today differs from tomorrow's pull
- Dev was on 12.x, prod is on 11.8 — SQL/features tested against 12 may not exist in 11.8
- Externalizing to `MARIADB_IMAGE` means dev/test/pytest all move together when bumped

## Verification

- Dev env already migrated from 12.1.2 → 11.8.8 (dump + reload, all data preserved, 0 errors)
- `docker compose config` renders the correct image tag for dev, pytest, and test stacks