### PR TITLE
fix: trim API access log to high-signal requests

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -271,6 +271,10 @@ class Settings(BaseSettings):
     # Logging
     LOG_LEVEL: str = "INFO"
     LOG_FORMAT: str = "json"
+    # Requests slower than this (ms) are logged at INFO even when they succeed;
+    # faster successful requests drop to DEBUG so routine traffic doesn't flood
+    # the aggregated logs. See RequestLoggingMiddleware in app/main.py.
+    SLOW_REQUEST_LOG_MS: float = 1000.0
 
     # Review System
     REVIEW_DEADLINE_DAYS: int = 7  # Default deadline for review voting

--- a/app/main.py
+++ b/app/main.py
@@ -35,6 +35,24 @@ logger = get_logger(__name__)
 _REDACTED_PARAMS = {"token", "code", "access_token", "refresh_token", "password"}
 
 
+def _log_level_for(status_code: int, elapsed_ms: float) -> str:
+    """Pick the access-log level for a completed request.
+
+    Nginx already logs every request (with the real client IP), so the API's
+    per-request log only needs to carry the high-signal lines: server errors,
+    client faults (kept so anonymous 401s can be clustered by source), and slow
+    requests. Routine fast 2xx traffic — the bulk of the volume — drops to DEBUG,
+    which production suppresses.
+    """
+    if status_code >= 500:
+        return "error"
+    if status_code >= 400:
+        return "warning"
+    if elapsed_ms >= settings.SLOW_REQUEST_LOG_MS:
+        return "info"
+    return "debug"
+
+
 def _redact_query(query_string: str) -> str:
     """Redact sensitive query parameters to avoid leaking secrets in logs."""
     params = parse_qs(query_string, keep_blank_values=True)
@@ -72,7 +90,8 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             elapsed_ms = round((time.monotonic() - start) * 1000, 1)
             # Add request ID to response headers for debugging
             response.headers["X-Request-ID"] = request_id
-            logger.info(
+            log = getattr(logger, _log_level_for(response.status_code, elapsed_ms))
+            log(
                 "request_complete",
                 method=request.method,
                 path=str(request.url.path)

--- a/tests/test_request_logging.py
+++ b/tests/test_request_logging.py
@@ -5,19 +5,56 @@ import logging
 import pytest
 from httpx import AsyncClient
 
+from app.config import settings
+from app.main import _log_level_for
+
+
+class TestLogLevelForRequest:
+    """The access-log level is chosen by response status and latency.
+
+    Routine fast 2xx traffic (the bulk of the volume) drops to DEBUG, which is
+    suppressed in production, while server errors, client faults, and slow
+    requests stay visible. Nginx keeps the full per-request access log with real
+    client IPs, so the API log is free to keep only the high-signal lines.
+    """
+
+    def test_fast_success_is_debug(self):
+        assert _log_level_for(200, 5.0) == "debug"
+        assert _log_level_for(204, 0.4) == "debug"
+
+    def test_redirect_is_debug(self):
+        assert _log_level_for(304, 2.0) == "debug"
+
+    def test_slow_success_is_info(self):
+        slow = settings.SLOW_REQUEST_LOG_MS
+        assert _log_level_for(200, slow) == "info"
+        assert _log_level_for(200, slow + 1) == "info"
+
+    def test_client_error_is_warning_regardless_of_latency(self):
+        # 4xx stays visible even when fast so anonymous 401s can be clustered by
+        # source (one user fat-fingering a password vs. credential stuffing).
+        assert _log_level_for(401, 1.0) == "warning"
+        assert _log_level_for(404, 1.0) == "warning"
+
+    def test_server_error_is_error(self):
+        assert _log_level_for(500, 1.0) == "error"
+        assert _log_level_for(503, 1.0) == "error"
+
 
 @pytest.mark.api
-async def test_request_complete_logs_client_host_and_user_agent(
+async def test_client_error_logs_client_host_and_user_agent(
     client: AsyncClient, caplog: pytest.LogCaptureFixture
 ):
-    """The request_complete access log records the client host and user agent.
+    """A 4xx access log records the client host and user agent at WARNING.
 
     Without these, anonymous 401s can't be clustered by source — you can't tell
     one user fat-fingering a password from credential stuffing across many IPs.
     """
-    with caplog.at_level(logging.INFO):
-        response = await client.get("/health", headers={"user-agent": "test-agent/9.9"})
-    assert response.status_code == 200
+    with caplog.at_level(logging.WARNING):
+        response = await client.get(
+            "/api/v1/privmsgs/threads", headers={"user-agent": "test-agent/9.9"}
+        )
+    assert response.status_code in (401, 403)
 
     # The dev ConsoleRenderer interleaves ANSI color codes between a field's key,
     # `=`, and value, so match on the contiguous value tokens rather than `key=value`.
@@ -38,4 +75,30 @@ async def test_request_complete_logs_client_host_and_user_agent(
     # (e.g. a Unix-socket transport with no client), update this expected host.
     assert any("127.0.0.1" in message for message in request_logs), (
         f"client host missing from access log; got {request_logs!r}"
+    )
+
+
+@pytest.mark.api
+async def test_fast_success_request_logged_at_debug(
+    client: AsyncClient, caplog: pytest.LogCaptureFixture
+):
+    """Routine fast 2xx traffic is logged at DEBUG so production (INFO+) drops it.
+
+    The line is still emitted — just below INFO — so it's available in dev/debug
+    but doesn't flood the aggregated logs in production.
+    """
+    with caplog.at_level(logging.DEBUG):
+        response = await client.get("/health")
+    assert response.status_code == 200
+
+    request_logs = [
+        record for record in caplog.records if "request_complete" in record.getMessage()
+    ]
+    assert request_logs, (
+        "no request_complete log emitted; "
+        f"got {[record.getMessage() for record in caplog.records]}"
+    )
+    assert all(record.levelno == logging.DEBUG for record in request_logs), (
+        "fast 2xx request_complete should log at DEBUG; got "
+        f"{[record.levelname for record in request_logs]}"
     )


### PR DESCRIPTION
## Problem

Docker was filling `/` (77G/96G). The single largest growing consumer is the Loki logs volume (~17.6 GB, steady state at 60-day retention). Investigation showed retention is working correctly — the volume is simply driven by log **ingest**:

- **~73%** of all aggregated log volume comes from the `api` service.
- It emits one `INFO` `request_complete` line **per request**, and in production the API runs at the default `INFO` level (`LOG_LEVEL` is only set on `docker-socket-proxy`, not `api`), so every 2xx is shipped to Loki.
- This is redundant with nginx's own per-request access log — which also carries the **real client IP** (the API only sees nginx's internal `172.20.0.5`).

## Change

Pick the access-log level from the response instead of always using `INFO`:

| Response | Level | Kept in prod (INFO+) |
|---|---|---|
| 5xx | `error` | ✅ |
| 4xx | `warning` | ✅ (anonymous 401s stay clusterable by source) |
| slow (≥ `SLOW_REQUEST_LOG_MS`, default 1000ms) | `info` | ✅ |
| fast 2xx/3xx | `debug` | ❌ suppressed |

The rule lives in a small pure helper `_log_level_for(status_code, elapsed_ms)` so it's unit-testable without HTTP. Nginx keeps the full access log, so no observability is lost.

## Expected impact

Sampled API traffic is almost entirely fast 2xx (0.4–15 ms), so nearly all of the API's 73% share drops out. Daily ingest should fall ~1.8 GB → ~0.5 GB and the Loki volume's steady state from ~17 GB toward **~4–5 GB** over the 60-day window.

## Tests

- Unit tests for `_log_level_for` across 2xx/3xx/4xx/5xx and the slow threshold.
- Integration test: a 4xx still records `client_host` + `user_agent` at WARNING (preserves the 401-clustering use case).
- Integration test: a fast 2xx logs at DEBUG.

7/7 pass; ruff + mypy clean.

## Deploy note

Takes effect on the next `api` image rebuild + redeploy. The existing 17 GB drains gradually as smaller new days replace old ones over 60 days; temporarily lowering `retention_period` would reclaim it faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)