### PR TITLE
fix: thumbnail error handling + stale image guard for arq worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,11 @@ COPY pyproject.toml uv.lock ./
 # the app/ source isn't copied yet — installed in the layer below.
 RUN uv sync --frozen --no-install-project --no-dev
 
+# Bake the lockfile hash so the worker can detect a stale image at startup.
+# docker-compose mounts ./uv.lock from the host at runtime; if the hash
+# differs, the image was built against an older lockfile and must be rebuilt.
+RUN sha256sum uv.lock | awk '{print $1}' > /app/.uv-lock-hash
+
 # Copy only what's needed for runtime (explicit allowlist)
 COPY app/ ./app/
 COPY alembic/ ./alembic/

--- a/app/services/image_processing.py
+++ b/app/services/image_processing.py
@@ -324,6 +324,7 @@ def create_thumbnail(source_path: FilePath, image_id: int, ext: str, storage_pat
             error_type=type(e).__name__,
             source_path=str(source_path),
         )
+        raise
 
 
 def create_medium_variant(

--- a/app/tasks/image_jobs.py
+++ b/app/tasks/image_jobs.py
@@ -54,7 +54,7 @@ async def create_thumbnail_job(
 
         # Derive thumb filename from source file stem (preserves date prefix)
         src_stem = FilePath(source_path).stem
-        thumb_path = f"{storage_path}/thumbs/{src_stem}.jpeg"
+        thumb_path = f"{storage_path}/thumbs/{src_stem}.webp"
         logger.info("thumbnail_job_completed", image_id=image_id, path=thumb_path)
 
         return {"success": True, "thumbnail_path": thumb_path}

--- a/app/tasks/worker.py
+++ b/app/tasks/worker.py
@@ -5,6 +5,8 @@ Run worker with: uv run arq app.tasks.worker.WorkerSettings
 """
 
 import asyncio
+import hashlib
+from pathlib import Path
 from typing import Any
 
 # arq's Worker.__init__ calls asyncio.get_event_loop() which raises RuntimeError
@@ -102,6 +104,42 @@ async def process_review_deadlines(ctx: dict[str, Any]) -> None:
             )
 
 
+def _check_lockfile_freshness(logger: Any) -> None:
+    """Verify the mounted uv.lock matches the one used to build the image.
+
+    The Dockerfile bakes a sha256 of uv.lock into /app/.uv-lock-hash at
+    build time. docker-compose mounts the host's uv.lock at /app/uv.lock
+    at runtime. If the hashes differ, the image was built against an older
+    lockfile — installed packages are stale and the worker will crash-loop
+    on the first import of a missing dependency.
+
+    Raises SystemExit(1) with an actionable message so the operator knows
+    to rebuild instead of debugging a raw ModuleNotFoundError traceback.
+    """
+    hash_file = Path("/app/.uv-lock-hash")
+    lock_file = Path("/app/uv.lock")
+
+    # Older image without the hash file — skip check (no false positive).
+    if not hash_file.exists() or not lock_file.exists():
+        return
+
+    expected = hash_file.read_text().strip()
+    actual = hashlib.sha256(lock_file.read_bytes()).hexdigest()
+
+    if expected != actual:
+        logger.error(
+            "worker_lockfile_mismatch",
+            expected_hash=expected,
+            actual_hash=actual,
+            hint="Rebuild the Docker image: docker compose build --no-cache arq-worker",
+        )
+        raise SystemExit(
+            "uv.lock has changed since the Docker image was built — "
+            "installed packages are stale.\n"
+            "Rebuild: docker compose build --no-cache arq-worker"
+        )
+
+
 async def startup(ctx: dict[str, Any]) -> None:
     """Worker startup - initialize any shared resources."""
     from meilisearch_python_sdk import AsyncClient as MeilisearchClient
@@ -111,6 +149,12 @@ async def startup(ctx: dict[str, Any]) -> None:
 
     logger = get_logger(__name__)
     logger.info("arq_worker_starting", redis_url=settings.ARQ_REDIS_URL)
+
+    # Verify the Docker image isn't stale: compare the baked-in lockfile
+    # hash against the host's uv.lock mounted at runtime. A mismatch means
+    # deps were added to uv.lock but the image wasn't rebuilt — the worker
+    # would crash-loop on the first missing import.
+    _check_lockfile_freshness(logger)
 
     # Initialize Meilisearch search service so worker tasks calling
     # sync_tag_to_search / sync_tags_to_search actually sync (rather than

--- a/tests/unit/test_arq_jobs.py
+++ b/tests/unit/test_arq_jobs.py
@@ -1,12 +1,13 @@
 """Tests for arq background jobs."""
 
+import hashlib
 import pytest
 from pathlib import Path as FilePath
 from unittest.mock import AsyncMock, Mock, patch
 
 from app.models.image import VariantStatus
 from app.tasks.image_jobs import create_thumbnail_job, create_variant_job
-from app.tasks.worker import WorkerSettings
+from app.tasks.worker import WorkerSettings, _check_lockfile_freshness
 
 
 @pytest.mark.unit
@@ -34,7 +35,8 @@ async def test_create_thumbnail_job_success():
 
         # Assert
         assert result["success"] is True
-        assert "thumbnail_path" in result
+        assert result["thumbnail_path"].endswith(".webp")
+        assert ".jpeg" not in result["thumbnail_path"]
         mock_create.assert_called_once()
 
 
@@ -135,3 +137,90 @@ async def test_create_thumbnail_job_retry_on_failure():
         # Act & Assert
         with pytest.raises(Retry):
             await create_thumbnail_job(ctx, 123, "/test/image.jpg", "jpg", "/test/storage")
+
+
+# ---------------------------------------------------------------------------
+# Lockfile freshness check
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_lockfile_check_passes_when_hash_matches(tmp_path):
+    """No error when the mounted uv.lock hash matches the baked-in hash."""
+    lock_content = b'lockfile content'
+    lock_path = tmp_path / "uv.lock"
+    hash_path = tmp_path / ".uv-lock-hash"
+    lock_path.write_bytes(lock_content)
+    hash_path.write_text(hashlib.sha256(lock_content).hexdigest())
+
+    logger = Mock()
+    with patch("app.tasks.worker.Path") as mock_path_cls:
+        def _path_side_effect(p):
+            s = str(p)
+            if s.endswith(".uv-lock-hash"):
+                return hash_path
+            if s.endswith("uv.lock"):
+                return lock_path
+            return p
+
+        mock_path_cls.side_effect = _path_side_effect
+
+        # Should not raise
+        _check_lockfile_freshness(logger)
+
+    logger.error.assert_not_called()
+
+
+@pytest.mark.unit
+def test_lockfile_check_exits_when_hash_differs(tmp_path):
+    """SystemExit when the mounted uv.lock differs from the baked-in hash."""
+    lock_content = b'new lockfile content'
+    old_hash = hashlib.sha256(b'old lockfile content').hexdigest()
+
+    lock_path = tmp_path / "uv.lock"
+    hash_path = tmp_path / ".uv-lock-hash"
+    lock_path.write_bytes(lock_content)
+    hash_path.write_text(old_hash)
+
+    logger = Mock()
+    with patch("app.tasks.worker.Path") as mock_path_cls:
+        def _path_side_effect(p):
+            s = str(p)
+            if s.endswith(".uv-lock-hash"):
+                return hash_path
+            if s.endswith("uv.lock"):
+                return lock_path
+            return p
+
+        mock_path_cls.side_effect = _path_side_effect
+
+        with pytest.raises(SystemExit) as exc_info:
+            _check_lockfile_freshness(logger)
+
+    assert "Rebuild" in str(exc_info.value)
+    assert "uv.lock" in str(exc_info.value)
+    logger.error.assert_called_once()
+    assert logger.error.call_args.args[0] == "worker_lockfile_mismatch"
+
+
+@pytest.mark.unit
+def test_lockfile_check_skips_when_no_hash_file(tmp_path):
+    """No error when the image predates the hash file (backward compatible)."""
+    lock_path = tmp_path / "uv.lock"
+    lock_path.write_bytes(b'some lockfile')
+
+    logger = Mock()
+    with patch("app.tasks.worker.Path") as mock_path_cls:
+        def _path_side_effect(p):
+            s = str(p)
+            if s.endswith(".uv-lock-hash"):
+                return tmp_path / ".uv-lock-hash"  # does not exist
+            if s.endswith("uv.lock"):
+                return lock_path
+            return p
+
+        mock_path_cls.side_effect = _path_side_effect
+
+        # Should not raise — hash file missing means older image
+        _check_lockfile_freshness(logger)
+
+    logger.error.assert_not_called()


### PR DESCRIPTION
### **User description**
Background: The arq worker was crash-looping due to a stale Docker image missing numpy, blocking all background jobs including thumbnail generation. Changes: (1) re-raise exception in create_thumbnail so arq retries, (2) fix .jpeg to .webp extension in job return value, (3) lockfile freshness check that bakes uv.lock hash into the image and compares at startup. All 22 tests pass.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Re-raise exception in `create_thumbnail()` so arq retries failed thumbnail generation

- Fix thumbnail path extension from `.jpeg` to `.webp` in job return value

- Add lockfile freshness check at worker startup to detect stale Docker images

- Add unit tests for lockfile check and update existing test for `.webp` extension

- Bake `uv.lock` hash into Docker image for runtime verification


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["create_thumbnail() re-raises exception"] --> B["arq retries job"]
    C["create_thumbnail_job() returns .webp path"]
    D["worker startup"] --> E["_check_lockfile_freshness()"]
    E -->|hash mismatch| F["SystemExit with rebuild message"]
    E -->|hash match| G["proceed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>image_processing.py</strong><dd><code>Re-raise thumbnail generation errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/services/image_processing.py

<ul><li>Re-raise exception in <code>create_thumbnail()</code> after logging, so arq can <br>retry the job</ul>


</details>


  </td>
  <td><a href="https://github.com/anonymousobject/shuushuu-api/pull/281/files#diff-382828034b94ed8f711820dc191b37765a3b45ee458e0be1f3a3243124c4762c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>image_jobs.py</strong><dd><code>Correct thumbnail extension to .webp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/tasks/image_jobs.py

<ul><li>Fix thumbnail path extension from <code>.jpeg</code> to <code>.webp</code> in <br><code>create_thumbnail_job()</code> return value</ul>


</details>


  </td>
  <td><a href="https://github.com/anonymousobject/shuushuu-api/pull/281/files#diff-a195cd14890d399820175623c25180eb51ec66f7377feb241c481cd9d9f79c97">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.py</strong><dd><code>Add lockfile freshness check at worker startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/tasks/worker.py

<ul><li>Add <code>_check_lockfile_freshness()</code> function that compares baked-in <br><code>uv.lock</code> hash with runtime lockfile<br> <li> Call it in <code>startup()</code> to exit with actionable message if image is stale</ul>


</details>


  </td>
  <td><a href="https://github.com/anonymousobject/shuushuu-api/pull/281/files#diff-d55ce3e1510eb15fc4a93469143720127c5324e73dde60ed495cc0506d6d4e13">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_arq_jobs.py</strong><dd><code>Add tests for lockfile check and webp extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_arq_jobs.py

<ul><li>Add unit tests for lockfile freshness check (match, mismatch, skip <br>when no hash file)<br> <li> Update existing thumbnail test to assert <code>.webp</code> extension and absence <br>of <code>.jpeg</code></ul>


</details>


  </td>
  <td><a href="https://github.com/anonymousobject/shuushuu-api/pull/281/files#diff-27c0d002883617ec71e195e9aa725c3ae7dbedcca497ea5f0b83504d96ba372d">+91/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Bake lockfile hash into Docker image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<ul><li>Bake sha256 hash of <code>uv.lock</code> into <code>/app/.uv-lock-hash</code> for runtime <br>freshness verification</ul>


</details>


  </td>
  <td><a href="https://github.com/anonymousobject/shuushuu-api/pull/281/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

