### PR TITLE
ci: re-enable Claude PR review, disable PR-Agent

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,15 +1,11 @@
 name: Claude PR Review
 
-# DISABLED — Anthropic subscription paused. Automated review moved to
-# .github/workflows/pr-agent.yml (Qodo PR-Agent via OpenRouter).
-# To re-enable: restore the `on:` block below to
-#   on:
-#     pull_request:
-#       types: [opened, synchronize]
-# and ensure the CLAUDE_CODE_OAUTH_TOKEN secret is set. The job body below
-# is intentionally left intact so nothing is lost.
+# Anthropic Claude review — the active automated PR reviewer.
+# (Qodo PR-Agent in .github/workflows/pr-agent.yml is disabled but kept.)
+# Requires the CLAUDE_CODE_OAUTH_TOKEN secret to be set.
 on:
-  workflow_dispatch: {}
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   review:

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,12 +1,18 @@
 name: PR Agent Review
 
+# DISABLED — automated review moved back to
+# .github/workflows/claude-review.yml (Anthropic Claude review).
 # Qodo PR-Agent (https://github.com/qodo-ai/pr-agent) — OpenRouter-backed.
-# Replaces the subscription-gated Claude review. Model + review behavior live
-# in .pr_agent.toml (picked up via the GitHub API, no checkout needed).
-
+# Model + review behavior live in .pr_agent.toml (picked up via the GitHub
+# API, no checkout needed).
+# To re-enable: restore the `on:` block below to
+#   on:
+#     pull_request:
+#       types: [opened, synchronize, ready_for_review]
+# and ensure the OPENROUTER_API_KEY secret is set. The job body below is
+# intentionally left intact so nothing is lost.
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review]
+  workflow_dispatch: {}
 
 jobs:
   pr_agent_job:


### PR DESCRIPTION
## Summary

Swaps the active automated PR reviewer back to the Anthropic **Claude review** workflow, disabling the Qodo **PR-Agent** workflow without deleting it.

- **`claude-review.yml`** — re-enabled. `on:` restored to `pull_request: [opened, synchronize]` so it runs automatically on PRs again.
- **`pr-agent.yml`** — disabled but kept. `on:` changed to `workflow_dispatch: {}` (manual-only), so it no longer runs automatically. The full job body is untouched.

Both files keep header comments documenting how to re-enable each one (restore its `on:` block + ensure the relevant secret is set). Nothing is deleted, so either reviewer can be switched back later.

## Note

The Claude review job depends on the `CLAUDE_CODE_OAUTH_TOKEN` repo secret. The prior disable note cited a paused Anthropic subscription — that secret needs to be valid/present for the workflow to succeed on the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)