### PR TITLE
fix: preserve avatar_in_r2 so ratings/similar avatars use the CDN

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -170,6 +170,11 @@ async def _hydrate_similar_images(
         img = images_by_id.get(int(r["image_id"]))
         if img:
             img_data = ImageResponse.model_validate(img).model_dump()
+            # model_dump() drops the embedded user's avatar_in_r2 (exclude=True),
+            # which would make the avatar_url computed field fall back to the local
+            # URL. Re-validate the uploader from the ORM row to preserve it.
+            if getattr(img, "user", None):
+                img_data["user"] = UserSummary.model_validate(img.user)
             img_data["similarity_score"] = r["score"]
             similar.append(SimilarImageResult(**img_data))
     return similar
@@ -2108,6 +2113,9 @@ async def get_image_ratings_users(
     users_with_ratings = [
         UserWithRatingResponse(
             **UserResponse.model_validate(user).model_dump(),
+            # avatar_in_r2 has exclude=True, so model_dump() drops it; re-supply it
+            # explicitly or the avatar_url computed field falls back to the local URL.
+            avatar_in_r2=user.avatar_in_r2,
             rating=rating,
             rated_at=rated_at,
         )

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -4277,6 +4277,54 @@ class TestGetImageRatings:
         assert "user_id" in first
         assert "username" in first
 
+    async def test_get_image_ratings_avatar_url_uses_cdn_when_avatar_in_r2(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        sample_image_data: dict,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A rater with avatar_in_r2=True must get a CDN avatar_url, not a local one.
+
+        Regression: the route round-tripped the user through model_dump(), which
+        drops the exclude=True avatar_in_r2 bit, so the rebuilt schema defaulted it
+        to False and the avatar_url computed field fell back to the local FS URL.
+        """
+        monkeypatch.setattr(settings, "R2_ENABLED", True)
+        monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test")
+        monkeypatch.setattr(settings, "IMAGE_BASE_URL", "http://local.test")
+
+        image = Images(**sample_image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        user = Users(
+            username="r2_rater",
+            password="hashed",
+            password_type="bcrypt",
+            salt="x" * 16,
+            email="r2rater@example.com",
+            active=1,
+            avatar="abc.png",
+            avatar_in_r2=True,
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        db_session.add(ImageRatings(user_id=user.user_id, image_id=image.image_id, rating=7))
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{image.image_id}/ratings")
+        assert response.status_code == 200
+
+        rated_user = response.json()["users"][0]
+        assert rated_user["avatar"] == "abc.png"
+        # Internal routing bit stays out of the response; clients only see avatar_url.
+        assert "avatar_in_r2" not in rated_user
+        assert rated_user["avatar_url"] == "https://cdn.test/avatars/abc.png"
+
     async def test_get_image_ratings_nonexistent_image(self, client: AsyncClient):
         """Returns 404 for an image that doesn't exist."""
         response = await client.get("/api/v1/images/999999/ratings")

--- a/tests/api/v1/test_similar_images.py
+++ b/tests/api/v1/test_similar_images.py
@@ -101,6 +101,75 @@ class TestSimilarImages:
         assert data["similar_images"][0]["similarity_score"] == 85.3
 
     @pytest.mark.asyncio
+    async def test_similar_images_avatar_url_uses_cdn_when_avatar_in_r2(
+        self, client: AsyncClient, test_image, db_session
+    ):
+        """The embedded uploader's avatar_url must use the CDN when avatar_in_r2=True.
+
+        Regression: the route round-tripped the image through model_dump(), which
+        drops the nested user's exclude=True avatar_in_r2 bit, so the rebuilt
+        SimilarImageResult defaulted it to False and produced a local FS avatar URL.
+        """
+        from unittest.mock import patch as _patch
+
+        from app.config import settings
+        from app.models.image import Images
+        from app.models.user import Users
+
+        with (
+            _patch.object(settings, "R2_ENABLED", True),
+            _patch.object(settings, "R2_PUBLIC_CDN_URL", "https://cdn.test"),
+            _patch.object(settings, "IMAGE_BASE_URL", "http://local.test"),
+        ):
+            uploader = Users(
+                username="r2_uploader",
+                password="hashed",
+                password_type="bcrypt",
+                salt="x" * 16,
+                email="r2uploader@example.com",
+                active=1,
+                avatar="abc.png",
+                avatar_in_r2=True,
+            )
+            db_session.add(uploader)
+            await db_session.commit()
+            await db_session.refresh(uploader)
+
+            similar_image = Images(
+                filename="r2-similar-001",
+                ext="jpg",
+                original_filename="r2sim.jpg",
+                md5_hash="a1b2c3d4e5f600000000000000000000",
+                filesize=1000,
+                width=100,
+                height=100,
+                user_id=uploader.user_id,
+                status=1,
+                locked=False,
+            )
+            db_session.add(similar_image)
+            await db_session.commit()
+            await db_session.refresh(similar_image)
+
+            iqdb_response = [{"image_id": similar_image.image_id, "score": 88.0}]
+
+            with (
+                patch("app.api.v1.images.FilePath.exists", return_value=True),
+                patch(
+                    "app.api.v1.images.check_iqdb_similarity",
+                    new_callable=AsyncMock,
+                    return_value=iqdb_response,
+                ),
+            ):
+                response = await client.get(f"/api/v1/images/{test_image.image_id}/similar")
+
+        assert response.status_code == 200
+        result = response.json()["similar_images"][0]
+        assert result["user"]["avatar"] == "abc.png"
+        assert "avatar_in_r2" not in result["user"]
+        assert result["user"]["avatar_url"] == "https://cdn.test/avatars/abc.png"
+
+    @pytest.mark.asyncio
     async def test_similar_images_ordered_by_score(
         self, client: AsyncClient, test_image, test_images_batch, db_session
     ):


### PR DESCRIPTION
## Problem

Some pages rendered user avatars via the broken local-FS URL
(`https://e-shuushuu.net/images/avatars/<hash>.JPG`) while the same user's
profile page correctly used the CDN (`https://cdn.e-shuushuu.net/avatars/...`).

## Root cause

Avatar URLs come from `avatar_url(filename, in_r2)`, which returns the CDN URL
only when `avatar_in_r2` is `True`. That field is declared `exclude=True`, so
any code that rebuilds a user schema from another schema's `model_dump()`
silently drops it — the reconstructed schema defaults it back to `False` and the
`avatar_url` computed field falls back to the local FS URL. The profile endpoint
serializes the ORM object directly (one pass) and is unaffected.

## Endpoints fixed

| Endpoint | Fix |
|----------|-----|
| `GET /images/{id}/ratings` | Re-supply `avatar_in_r2=user.avatar_in_r2` when rebuilding `UserWithRatingResponse` |
| `GET /images/{id}/similar` | Re-validate the embedded uploader from the ORM row after the `model_dump()`, matching the existing pattern in `schemas/image.py` |

## Scanned but clean (no change needed)

- All direct `UserSummary(...)` constructions already pass `avatar_in_r2`.
- All privmsgs `avatar_url()` calls source the flag from their queries.
- `schemas/image.py` already re-validates the nested user from the ORM.
- The ML worklist JSON cache carries no avatar data.

## Tests

One regression test per endpoint (following the existing precedent in
`test_image_tag_history_endpoint.py`). Each was confirmed to **fail** against the
pre-fix code and **pass** with the fix; 27 tests green across both suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)