### PR TITLE
fix: populate uploader groups in image_uploader_load

### DIFF
--- a/app/core/user_loader.py
+++ b/app/core/user_loader.py
@@ -1,8 +1,10 @@
 """
-User loading utilities with standard eager loading options.
+User loading utilities with standard eager-loading options.
 
-Use USER_WITH_GROUPS_OPTIONS when loading users that need groups populated.
-This ensures UserSummary.model_validate(user) automatically includes groups.
+USER_WITH_GROUPS_OPTIONS eager-loads a user's groups so
+UserSummary.model_validate(user) includes them — splat it into a query
+selecting Users directly. image_uploader_load() composes it with a
+column-restricted load for the common case of an image's uploader summary.
 """
 
 from sqlalchemy.orm import Load, load_only, selectinload
@@ -11,26 +13,13 @@ from app.models.image import Images
 from app.models.permissions import UserGroups
 from app.models.user import Users
 
-# Standard options for loading users with their groups
+# Canonical eager-load for a user's groups, so the User.groups property (and
+# UserSummary.groups) resolve without a lazy load. Single source of truth for
+# the user_groups→group chain; reuse it rather than re-inlining it.
 # Usage: select(Users).options(*USER_WITH_GROUPS_OPTIONS)
 USER_WITH_GROUPS_OPTIONS = (
     selectinload(Users.user_groups).selectinload(UserGroups.group),  # type: ignore[arg-type]
 )
-
-
-def user_with_groups_options() -> tuple:  # type: ignore[type-arg]
-    """
-    Return SQLAlchemy options for loading a user with their groups.
-
-    Usage for loading via relationship:
-        selectinload(Images.user).options(*user_with_groups_options())
-
-    Returns options that eager load user_groups and their associated groups,
-    so the User.groups property works without additional queries.
-    """
-    return (
-        selectinload(Users.user_groups).selectinload(UserGroups.group),  # type: ignore[arg-type]
-    )
 
 
 def image_uploader_load() -> Load:
@@ -53,5 +42,5 @@ def image_uploader_load() -> Load:
             Users.avatar_in_r2,  # type: ignore[arg-type]
             Users.user_title,  # type: ignore[arg-type]
         ),
-        selectinload(Users.user_groups).selectinload(UserGroups.group),  # type: ignore[arg-type]
+        *USER_WITH_GROUPS_OPTIONS,
     )

--- a/app/core/user_loader.py
+++ b/app/core/user_loader.py
@@ -5,7 +5,7 @@ Use USER_WITH_GROUPS_OPTIONS when loading users that need groups populated.
 This ensures UserSummary.model_validate(user) automatically includes groups.
 """
 
-from sqlalchemy.orm import Load, selectinload
+from sqlalchemy.orm import Load, load_only, selectinload
 
 from app.models.image import Images
 from app.models.permissions import UserGroups
@@ -40,12 +40,18 @@ def image_uploader_load() -> Load:
     Usage: select(Images).options(image_uploader_load())
 
     Loads only the columns UserSummary needs (id, username, avatar,
-    avatar_in_r2, user_title), avoiding a full Users row fetch.
+    avatar_in_r2, user_title), avoiding a full Users row fetch, PLUS the
+    user_groups→group relationship so UserSummary.groups is populated
+    (without it, User.groups returns [] and the frontend can't colour
+    admin/mod/tagger usernames — e.g. the /ml-suggestions hover popup).
     """
-    return selectinload(Images.user).load_only(  # type: ignore[arg-type, return-value]
-        Users.user_id,  # type: ignore[arg-type]
-        Users.username,  # type: ignore[arg-type]
-        Users.avatar,  # type: ignore[arg-type]
-        Users.avatar_in_r2,  # type: ignore[arg-type]
-        Users.user_title,  # type: ignore[arg-type]
+    return selectinload(Images.user).options(  # type: ignore[arg-type, return-value]
+        load_only(
+            Users.user_id,  # type: ignore[arg-type]
+            Users.username,  # type: ignore[arg-type]
+            Users.avatar,  # type: ignore[arg-type]
+            Users.avatar_in_r2,  # type: ignore[arg-type]
+            Users.user_title,  # type: ignore[arg-type]
+        ),
+        selectinload(Users.user_groups).selectinload(UserGroups.group),  # type: ignore[arg-type]
     )

--- a/tests/api/v1/test_ml_suggestion_queue.py
+++ b/tests/api/v1/test_ml_suggestion_queue.py
@@ -216,8 +216,10 @@ class TestSuggestionGridEndpoint:
         The /ml-suggestions hover popup colours the uploader's username by group
         (e.g. admins red). That needs image.user.groups populated in the grid
         response — a regression when the endpoint's uploader loader omitted groups.
+        The colour is driven by group membership, not the admin flag, so this
+        user is a plain tagger placed in the admins group.
         """
-        user = await _make_user(db_session, "gridgroups", admin=True)
+        user = await _make_user(db_session, "gridgroups")
         await _grant_image_tag_add(db_session, user)
         # Put the uploader in the admins group.
         group = Groups(title="admins", desc="Administrators")

--- a/tests/api/v1/test_ml_suggestion_queue.py
+++ b/tests/api/v1/test_ml_suggestion_queue.py
@@ -25,7 +25,7 @@ from app.config import TagType
 from app.core.security import create_access_token
 from app.models.image import Images
 from app.models.ml_tag_suggestion import MlTagSuggestions
-from app.models.permissions import Perms, UserPerms
+from app.models.permissions import Groups, Perms, UserGroups, UserPerms
 from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
@@ -207,6 +207,38 @@ class TestSuggestionGridEndpoint:
         assert thumb
         assert thumb.endswith(f"/thumbs/{image_hi.filename}.webp")
         assert "/" in thumb  # a URL path, not just the bare filename
+
+    async def test_grid_item_uploader_carries_groups(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """The embedded uploader must include its group memberships.
+
+        The /ml-suggestions hover popup colours the uploader's username by group
+        (e.g. admins red). That needs image.user.groups populated in the grid
+        response — a regression when the endpoint's uploader loader omitted groups.
+        """
+        user = await _make_user(db_session, "gridgroups", admin=True)
+        await _grant_image_tag_add(db_session, user)
+        # Put the uploader in the admins group.
+        group = Groups(title="admins", desc="Administrators")
+        db_session.add(group)
+        await db_session.flush()
+        db_session.add(UserGroups(user_id=user.user_id, group_id=group.group_id))
+        image = await _make_image(db_session, user, "gridgroups_img")
+        tag = await _make_tag(db_session, user, "gridgroups_tag")
+        await _make_suggestion(db_session, image, tag)
+        await db_session.commit()
+
+        token = create_access_token(user_id=user.user_id)
+        response = await client.get(
+            f"/api/v1/ml-suggestions?tag_id={tag.tag_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["image"]["user"]["groups"] == ["admins"]
 
     async def test_min_confidence_filters_grid(self, client: AsyncClient, db_session: AsyncSession):
         """min_confidence excludes suggestions below the threshold."""

--- a/tests/unit/test_user_loader.py
+++ b/tests/unit/test_user_loader.py
@@ -3,7 +3,8 @@
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.user_loader import USER_WITH_GROUPS_OPTIONS
+from app.core.user_loader import USER_WITH_GROUPS_OPTIONS, image_uploader_load
+from app.models.image import Images
 from app.models.permissions import Groups, UserGroups
 from app.models.user import Users
 from app.schemas.common import UserSummary
@@ -52,6 +53,47 @@ async def test_user_summary_auto_populates_groups(db_session: AsyncSession):
     summary = UserSummary.model_validate(user)
 
     assert summary.groups == ["auto_test"]
+
+
+@pytest.mark.asyncio
+async def test_image_uploader_load_populates_groups(db_session: AsyncSession):
+    """image_uploader_load() must eager-load the uploader's groups.
+
+    Every endpoint that serialises an image's uploader as a UserSummary relies
+    on this helper; if it omits user_groups the summary's groups come back empty
+    and the frontend can't colour admin/mod/tagger usernames (the /ml-suggestions
+    hover-popup regression).
+    """
+    from sqlalchemy import select
+
+    # Put the fixture user (user 1) in the admins group.
+    group = Groups(title="admins", desc="Administrators")
+    db_session.add(group)
+    await db_session.flush()
+    db_session.add(UserGroups(user_id=1, group_id=group.group_id))
+
+    image = Images(
+        filename="uploader-load-groups",
+        ext="jpg",
+        md5_hash="uploaderloadgroupshash",
+        filesize=1000,
+        width=100,
+        height=100,
+        user_id=1,
+        status=1,
+        locked=0,
+    )
+    db_session.add(image)
+    await db_session.commit()
+
+    result = await db_session.execute(
+        select(Images).options(image_uploader_load()).where(Images.image_id == image.image_id)
+    )
+    loaded = result.scalar_one()
+
+    # The uploader summary must carry the group so username colouring works.
+    summary = UserSummary.model_validate(loaded.user)
+    assert summary.groups == ["admins"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Username colors on the `/ml-suggestions` image hover popups were wrong — e.g. admin uploaders showed the default username color instead of red.

## Root cause

The hover popup (`ImageTooltip`) colors the uploader via `getUsernameColor(image.user.groups)` — the same component and code path the main board uses correctly. The difference was the data:

- The main board (`list_images`) eager-loads `Images.user → user_groups → group`, so `user.groups` arrives populated.
- The ML suggestions grid endpoint sends its images through the shared `image_uploader_load()` helper, which did `load_only(user_id, username, avatar, avatar_in_r2, user_title)` and **never loaded `user_groups`**.

Since `Users.groups` returns `[]` when `user_groups` isn't eager-loaded, `UserSummary.groups` serialized as an empty list, `getUsernameColor()` returned null, and the tooltip fell back to the default color.

This is a **shared-helper bug**: `image_uploader_load()` also feeds favorites, the tag board, similar images, by-hash search, bookmark, and user galleries — all of which render uploader usernames and had the same latent empty-groups bug. (The dedicated `USER_WITH_GROUPS_OPTIONS` helper existed but was dead code.)

## Fix

Add the `user_groups → group` `selectinload` to `image_uploader_load()`, alongside the existing `load_only`. This is one extra batched query per request — mirroring what the main board's `list_images` already does — and fixes every consumer of the helper at once.

No frontend change is needed: the frontend already reads `image.user.groups`, and `UserSummary.groups` is already declared in the generated types.

## Tests

- `tests/unit/test_user_loader.py::test_image_uploader_load_populates_groups` — asserts the helper populates `UserSummary.groups`.
- `tests/api/v1/test_ml_suggestion_queue.py::...::test_grid_item_uploader_carries_groups` — HTTP-level assertion that the grid response includes the uploader's groups.

Both failed before the fix (`[] != ['admins']`) and pass after. Full suites for all 5 files using the helper pass (441 passed, 1 env-skipped); `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)