### PR TITLE
ci: have Claude review consult CI check results

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,6 +16,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      # actions: read lets the reviewer read CI check results (gh pr checks)
       actions: read
 
     steps:
@@ -29,6 +30,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
-          prompt: "Review this pull request for code quality, correctness, and security. Follow the project conventions in AGENTS.md. Leave inline comments for concrete issues; skip nitpicks."
+          prompt: "Review this pull request for code quality, correctness, and security. Follow the project conventions in AGENTS.md. Check the PR's CI results first (gh pr checks) and factor them into the review — do not attempt to run tests, linters, or type checkers yourself; CI already gates the same commit. Leave inline comments for concrete issues; skip nitpicks."
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*)"


### PR DESCRIPTION
## What

Lets the automated Claude PR review read the PR's CI check results instead of caveating every review with "I wasn't able to run pytest/mypy in this sandbox":

- Adds `Bash(gh pr checks:*)` to the review job's `--allowedTools` (the `actions: read` permission it needs was already granted).
- Prompt now tells the reviewer to check CI results first and factor them in, and explicitly not to run tests/linters/type checkers itself.

## Why not let it run the tests instead?

Considered and rejected (for now):

- **Redundant** — the Tests and Lint jobs already gate the exact same commit; the reviewer re-running them adds compute, not signal.
- **Environment mirroring** — the review job has no `uv sync` and no MariaDB service; making pytest work means duplicating the test env from `ci.yml` and keeping it in sync forever.
- **Exec-with-secrets** — pytest executes PR-branch code (any `conftest.py`) in a job holding `CLAUDE_CODE_OAUTH_TOKEN` plus a write-scoped GitHub token. Low risk while all PRs are ours, but a needless widening.

Reading the existing check results closes the part of the gap that actually matters ("did tests pass on this commit?") at zero cost. A possible future upgrade — reviewer checks out the merge-base and runs only the PR's *new* tests to verify they fail before the fix (TDD red verification) — is deliberately out of scope.

Companion frontend PR applies the identical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHQd5H2STWM6YWQdUkkBk2