### PR TITLE
fix(ml): stop redundant ancestor tags surviving suggestions and review

### DIFF
--- a/app/api/v1/ml_tag_suggestions.py
+++ b/app/api/v1/ml_tag_suggestions.py
@@ -33,7 +33,7 @@ from app.schemas.ml_tag_suggestion import (
 )
 from app.schemas.tag import TagResponse
 from app.services.ml_runtime import get_ml_service, inference_slot
-from app.services.ml_suggestion_pipeline import generate_and_store_suggestions
+from app.services.ml_suggestion_pipeline import fetch_parent_map, generate_and_store_suggestions
 from app.services.ml_suggestion_review import review_ml_tag_suggestions as apply_review
 from app.services.rate_limit import check_analyze_rate_limit
 from app.tasks.queue import enqueue_job
@@ -160,6 +160,29 @@ async def get_ml_tag_suggestions(
     )
     tags_by_id = {tag.tag_id: tag for tag in tag_result.scalars().all()}
 
+    # For each pending suggestion, the OTHER pending suggestions its approval
+    # would cascade-delete: ancestors via inheritedfrom_id, walked through the
+    # full chain so a gap (intermediate tag not suggested) still links child to
+    # grandparent. Mirrors delete_pending_ancestor_suggestions semantics, so
+    # the panel's "related" grouping can never disagree with what approval
+    # actually does. Reviewed rows create no edges and report [].
+    pending_by_tag = {sugg.tag_id: sugg for sugg in suggestions if sugg.status == "pending"}
+    superseded_by_id: dict[int, list[int]] = {}
+    if len(pending_by_tag) > 1:
+        parent_of = await fetch_parent_map(db, set(pending_by_tag))
+        for tag_id, sugg in pending_by_tag.items():
+            ancestors: list[int] = []
+            cur = parent_of.get(tag_id)
+            depth = 0
+            while cur is not None and depth < 10:
+                anc = pending_by_tag.get(cur)
+                if anc is not None and anc.suggestion_id is not None:
+                    ancestors.append(anc.suggestion_id)
+                cur = parent_of.get(cur)
+                depth += 1
+            if ancestors and sugg.suggestion_id is not None:
+                superseded_by_id[sugg.suggestion_id] = ancestors
+
     # Batch fetch reviewers in one query (same pattern as the public
     # tag-history endpoint; groups drive username coloring).
     reviewer_ids = {
@@ -198,6 +221,7 @@ async def get_ml_tag_suggestions(
             created_at=sugg.created_at,  # type: ignore[arg-type]
             reviewed_at=sugg.reviewed_at,
             reviewed_by=_reviewer_summary(sugg.reviewed_by_user_id),
+            superseded_suggestion_ids=superseded_by_id.get(sugg.suggestion_id, []),  # type: ignore[arg-type]
         )
         for sugg in suggestions
     ]

--- a/app/config.py
+++ b/app/config.py
@@ -166,13 +166,13 @@ class Settings(BaseSettings):
         description="Minimum model probability for a prediction to become a suggestion",
     )
     ML_PARENT_SUPERSEDE_MIN_CONFIDENCE: float = Field(
-        default=0.6,
+        default=0.9,
         ge=0.0,
         le=1.0,
         description=(
             "A suggested child tag supersedes (drops) its suggested parent tags "
             "only when the child's confidence is at least this; a weaker child "
-            "leaves the parent in place"
+            "leaves the parent in place; default chosen from tag-hierarchy precision analysis (2026-07)"
         ),
     )
 

--- a/app/schemas/ml_tag_suggestion.py
+++ b/app/schemas/ml_tag_suggestion.py
@@ -190,6 +190,13 @@ class ReviewSuggestionsResponse(BaseModel):
         default_factory=list,
         description="List of error messages for suggestions that failed to process",
     )
+    removed_suggestion_ids: list[int] = Field(
+        default_factory=list,
+        description=(
+            "suggestion_ids of PENDING ancestor suggestions cascade-deleted because a "
+            "more specific descendant tag was applied during this review"
+        ),
+    )
 
 
 class GenerateSuggestionsResponse(BaseModel):

--- a/app/schemas/ml_tag_suggestion.py
+++ b/app/schemas/ml_tag_suggestion.py
@@ -63,6 +63,14 @@ class MlTagSuggestionResponse(BaseModel):
             "system resolutions (backfill, repost tag migration)."
         ),
     )
+    superseded_suggestion_ids: list[int] = Field(
+        default_factory=list,
+        description=(
+            "suggestion_ids of OTHER pending suggestions on this image that "
+            "approving this suggestion would cascade-delete (its ancestor tags "
+            "via Tags.inheritedfrom_id). Always empty for reviewed suggestions."
+        ),
+    )
 
 
 class MlTagSuggestionsListResponse(BaseModel):

--- a/app/services/ml_suggestion_pipeline.py
+++ b/app/services/ml_suggestion_pipeline.py
@@ -145,6 +145,35 @@ async def filter_redundant_suggestions(
     return filtered
 
 
+async def fetch_parent_map(db: AsyncSession, tag_ids: set[int]) -> dict[int, int | None]:
+    """tag_id -> inheritedfrom_id covering the full ancestry of ``tag_ids``.
+
+    Iteratively fetches parents not yet seen, so chains can be walked through
+    tags outside the input set. Depth-capped at 10 like
+    filter_redundant_suggestions' walk.
+    """
+    parent_of: dict[int, int | None] = {}
+    to_fetch = set(tag_ids)
+    for _ in range(10):
+        if not to_fetch:
+            break
+        rows = (
+            await db.execute(
+                select(Tags.tag_id, Tags.inheritedfrom_id).where(  # type: ignore[call-overload]
+                    Tags.tag_id.in_(to_fetch)  # type: ignore[union-attr]
+                )
+            )
+        ).all()
+        for tag_id, parent_id in rows:
+            parent_of[tag_id] = parent_id
+        to_fetch = {
+            parent_id
+            for _, parent_id in rows
+            if parent_id is not None and parent_id not in parent_of
+        }
+    return parent_of
+
+
 async def filter_superseded_parents(
     db: AsyncSession,
     suggestions: list[dict[str, Any]],
@@ -152,9 +181,11 @@ async def filter_superseded_parents(
 ) -> list[dict[str, Any]]:
     """Drop a suggested tag when a more-specific suggested descendant (via
     Tags.inheritedfrom_id) is present and that descendant's confidence is
-    >= min_child_confidence. Operates only WITHIN the suggestion set — never
-    drops a tag that isn't itself suggested. A low-confidence child does not
-    suppress its parent (both kept). Input dicts have at least tag_id + confidence.
+    >= min_child_confidence. The ancestor chain is walked through the Tags
+    table, so a suggested grandparent is dropped even when intermediate tags
+    in the chain are not themselves suggested. Only tags that are in the
+    suggestion set are ever dropped. A low-confidence child does not suppress
+    its ancestors (all kept). Input dicts have at least tag_id + confidence.
     """
     if len(suggestions) < 2:
         return suggestions
@@ -165,26 +196,18 @@ async def filter_superseded_parents(
         conf_by_id[tid] = max(conf_by_id.get(tid, 0.0), s["confidence"])
     suggested_ids = set(conf_by_id)
 
-    # inheritedfrom_id for every suggested tag (one query). A suggested ancestor
-    # is itself in this map, so the chain can be walked entirely within the set.
-    rows = (
-        await db.execute(
-            select(Tags.tag_id, Tags.inheritedfrom_id).where(  # type: ignore[call-overload]
-                Tags.tag_id.in_(suggested_ids)  # type: ignore[union-attr]
-            )
-        )
-    ).all()
-    parent_of: dict[int, int | None] = {row[0]: row[1] for row in rows}
+    parent_of = await fetch_parent_map(db, suggested_ids)
 
     superseded: set[int] = set()
     for child_id, conf in conf_by_id.items():
         if conf < min_child_confidence:
             continue
-        cur = parent_of.get(child_id)  # the child's direct parent
+        cur = parent_of.get(child_id)
         depth = 0
-        while cur is not None and cur in suggested_ids and depth < 10:
-            superseded.add(cur)
-            cur = parent_of.get(cur)  # cur is suggested -> present in parent_of
+        while cur is not None and depth < 10:
+            if cur in suggested_ids:
+                superseded.add(cur)
+            cur = parent_of.get(cur)
             depth += 1
 
     if not superseded:

--- a/app/services/ml_suggestion_queue.py
+++ b/app/services/ml_suggestion_queue.py
@@ -138,7 +138,11 @@ async def list_pending_for_tag(
     _TAG_NOT_ALREADY_APPLIED).  Also excludes suggestions on images that
     still have a pending suggestion for a DESCENDANT of ``tag_id`` — per-tag
     review is most-specific-first; rejecting the descendant resurfaces the
-    ancestor here.  Pagination is 1-based (page=1 is the first page).
+    ancestor here.  This descendant-pending exclusion applies regardless of
+    the descendant's own confidence — even a pending descendant below this
+    call's min_confidence still hides the ancestor here, since the
+    most-specific-pending-wins rule is deliberately confidence-agnostic.
+    Pagination is 1-based (page=1 is the first page).
 
     Returns (items, total) where:
     - items is a list of (suggestion_id, image_id, confidence)

--- a/app/services/ml_suggestion_queue.py
+++ b/app/services/ml_suggestion_queue.py
@@ -12,6 +12,7 @@ after receiving the (suggestion_id, image_id, confidence) tuples from this layer
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from app.models.ml_tag_suggestion import MlTagSuggestions
 from app.models.tag import Tags
@@ -31,6 +32,28 @@ _TAG_NOT_ALREADY_APPLIED = ~(
 )
 
 
+async def _descendant_tag_ids(db: AsyncSession, tag_id: int) -> set[int]:
+    """All tags whose inheritedfrom chain leads to ``tag_id`` (children,
+    grandchildren, ...), excluding ``tag_id`` itself. Breadth-first with the
+    same depth cap the pipeline's ancestor walks use."""
+    descendants: set[int] = set()
+    frontier = {tag_id}
+    for _ in range(10):
+        rows = (
+            await db.execute(
+                select(Tags.tag_id).where(  # type: ignore[call-overload]
+                    Tags.inheritedfrom_id.in_(frontier)  # type: ignore[union-attr]
+                )
+            )
+        ).all()
+        new_ids = {row[0] for row in rows} - descendants
+        if not new_ids:
+            break
+        descendants |= new_ids
+        frontier = new_ids
+    return descendants
+
+
 async def count_pending_by_tag(
     db: AsyncSession,
     type_filter: int | None = None,
@@ -48,7 +71,9 @@ async def count_pending_by_tag(
     Unlike list_pending_for_tag, this does NOT exclude suggestions whose tag
     is already applied to the image: the anti-join over every pending row was
     measured at 7-11s on production-sized data (vs ~0.9s without), so counts
-    may run slightly ahead of what the per-tag grid actually shows.
+    may run slightly ahead of what the per-tag grid actually shows. For the
+    same accepted-overcount/perf reason, it likewise does not exclude rows
+    hidden by list_pending_for_tag's descendant-pending check.
 
     When search is provided, only tags whose title contains the search string
     (case-insensitive LIKE %search%) are included.
@@ -110,19 +135,36 @@ async def list_pending_for_tag(
     Fetches MlTagSuggestions rows with status='pending', tag_id=tag_id, and
     confidence >= min_confidence, ordered by confidence DESC, excluding
     suggestions whose tag is already applied to the image (see
-    _TAG_NOT_ALREADY_APPLIED).  Pagination is 1-based (page=1 is the first
-    page).
+    _TAG_NOT_ALREADY_APPLIED).  Also excludes suggestions on images that
+    still have a pending suggestion for a DESCENDANT of ``tag_id`` — per-tag
+    review is most-specific-first; rejecting the descendant resurfaces the
+    ancestor here.  Pagination is 1-based (page=1 is the first page).
 
     Returns (items, total) where:
     - items is a list of (suggestion_id, image_id, confidence)
     - total is the full count matching tag_id + min_confidence (before pagination)
     """
-    base_filter = (
+    descendant_ids = await _descendant_tag_ids(db, tag_id)
+
+    base_filter = [
         MlTagSuggestions.status == "pending",
         MlTagSuggestions.tag_id == tag_id,
         MlTagSuggestions.confidence >= min_confidence,
         _TAG_NOT_ALREADY_APPLIED,
-    )
+    ]
+    if descendant_ids:
+        descendant_pending = aliased(MlTagSuggestions)
+        base_filter.append(
+            ~(
+                select(descendant_pending.suggestion_id)  # type: ignore[call-overload]
+                .where(
+                    descendant_pending.image_id == MlTagSuggestions.image_id,
+                    descendant_pending.status == "pending",
+                    descendant_pending.tag_id.in_(descendant_ids),  # type: ignore[attr-defined]
+                )
+                .exists()
+            )
+        )
 
     count_stmt = select(func.count(MlTagSuggestions.suggestion_id)).where(*base_filter)  # type: ignore[arg-type]
     total: int = (await db.execute(count_stmt)).scalar_one()

--- a/app/services/ml_suggestion_review.py
+++ b/app/services/ml_suggestion_review.py
@@ -72,7 +72,7 @@ async def approve_pending_suggestions_for_links(
 async def delete_pending_ancestor_suggestions(
     db: AsyncSession,
     links: Iterable[tuple[int, int]],
-) -> None:
+) -> list[int]:
     """Delete pending suggestions made redundant by a newly applied descendant.
 
     ``links`` is the (image_id, tag_id) pairs for TagLinks the caller just
@@ -84,11 +84,12 @@ async def delete_pending_ancestor_suggestions(
     and only ancestors are affected: a pending suggestion for a DESCENDANT of
     the applied tag keeps its own review.
 
-    Flush-only; the caller owns the transaction and commit.
+    Flush-only; the caller owns the transaction and commit. Returns the
+    suggestion_ids of the deleted rows so callers can report them to clients.
     """
     pairs = list(links)
     if not pairs:
-        return
+        return []
 
     # Flush first: the session is autoflush=False and callers in this module
     # (_apply_reviews_for_image) set suggestion.status as unflushed ORM
@@ -109,7 +110,15 @@ async def delete_pending_ancestor_suggestions(
             depth += 1
 
     if not doomed:
-        return
+        return []
+
+    doomed_ids_result = await db.execute(
+        select(MlTagSuggestions.suggestion_id).where(  # type: ignore[call-overload]
+            MlTagSuggestions.status == "pending",
+            tuple_(MlTagSuggestions.image_id, MlTagSuggestions.tag_id).in_(doomed),  # type: ignore[arg-type]
+        )
+    )
+    doomed_ids = list(doomed_ids_result.scalars().all())
 
     await db.execute(
         delete(MlTagSuggestions).where(
@@ -118,13 +127,15 @@ async def delete_pending_ancestor_suggestions(
         )
     )
 
+    return doomed_ids
+
 
 async def _apply_reviews_for_image(
     db: AsyncSession,
     image_id: int,
     items: list[ReviewSuggestionRequest],
     user_id: int,
-) -> set[int]:
+) -> tuple[set[int], list[int]]:
     """Apply approve/reject decisions for all suggestions on a single image.
 
     Performs:
@@ -133,7 +144,10 @@ async def _apply_reviews_for_image(
     - refresh_image_tag_type_flags(db, image_id) when any TagLink was created
 
     Does NOT call db.commit() and does NOT call sync_tags_to_search.
-    Returns the set of canonical tag_ids for which a new TagLink was created.
+    Returns (created_link_tag_ids, removed_suggestion_ids): the set of
+    canonical tag_ids for which a new TagLink was created, and the
+    suggestion_ids of any PENDING ancestor suggestions cascade-deleted as a
+    result (empty when no TagLink was created).
     """
     suggestion_ids = [item.suggestion_id for item in items]
     suggestions_result = await db.execute(
@@ -209,8 +223,9 @@ async def _apply_reviews_for_image(
             suggestion.reviewed_at = review_time
             suggestion.reviewed_by_user_id = user_id
 
+    removed_suggestion_ids: list[int] = []
     if created_link_tag_ids:
-        await delete_pending_ancestor_suggestions(
+        removed_suggestion_ids = await delete_pending_ancestor_suggestions(
             db, [(image_id, tag_id) for tag_id in created_link_tag_ids]
         )
 
@@ -218,7 +233,7 @@ async def _apply_reviews_for_image(
     if created_link_tag_ids:
         await refresh_image_tag_type_flags(db, image_id)
 
-    return created_link_tag_ids
+    return created_link_tag_ids, removed_suggestion_ids
 
 
 async def review_ml_tag_suggestions(
@@ -259,7 +274,9 @@ async def review_ml_tag_suggestions(
             elif review_item.action == "reject":
                 rejected_count += 1
 
-    created = await _apply_reviews_for_image(db, image_id, found_items, user_id)
+    created, removed_suggestion_ids = await _apply_reviews_for_image(
+        db, image_id, found_items, user_id
+    )
 
     await db.commit()
 
@@ -274,6 +291,7 @@ async def review_ml_tag_suggestions(
         approved=approved_count,
         rejected=rejected_count,
         errors=errors,
+        removed_suggestion_ids=removed_suggestion_ids,
     )
 
 
@@ -320,11 +338,16 @@ async def bulk_review_suggestions(
         elif action == "reject":
             rejected_count += 1
 
-    # Process each image's suggestions; accumulate created tag_ids.
+    # Process each image's suggestions; accumulate created tag_ids and
+    # cascade-deleted ancestor suggestion_ids.
     all_created_tag_ids: set[int] = set()
+    all_removed_suggestion_ids: list[int] = []
     for image_id, items in items_by_image.items():
-        created = await _apply_reviews_for_image(db, image_id, items, user_id)
+        created, removed_suggestion_ids = await _apply_reviews_for_image(
+            db, image_id, items, user_id
+        )
         all_created_tag_ids |= created
+        all_removed_suggestion_ids.extend(removed_suggestion_ids)
 
     # Single commit spanning all images.
     await db.commit()
@@ -340,4 +363,5 @@ async def bulk_review_suggestions(
         approved=approved_count,
         rejected=rejected_count,
         errors=errors,
+        removed_suggestion_ids=all_removed_suggestion_ids,
     )

--- a/app/services/ml_suggestion_review.py
+++ b/app/services/ml_suggestion_review.py
@@ -90,6 +90,13 @@ async def delete_pending_ancestor_suggestions(
     if not pairs:
         return
 
+    # Flush first: the session is autoflush=False and callers in this module
+    # (_apply_reviews_for_image) set suggestion.status as unflushed ORM
+    # attribute mutations before reaching here. Without this, the pending-only
+    # DELETE below reads stale pre-flush status and can delete a row the
+    # same-batch review just marked approved/rejected.
+    await db.flush()
+
     parent_of = await fetch_parent_map(db, {tag_id for _, tag_id in pairs})
 
     doomed: set[tuple[int, int]] = set()

--- a/app/services/ml_suggestion_review.py
+++ b/app/services/ml_suggestion_review.py
@@ -15,6 +15,7 @@ from typing import Any
 from sqlalchemy import delete, select, tuple_, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.db_retry import retry_on_snapshot_conflict
 from app.models.ml_tag_suggestion import MlTagSuggestions
 from app.models.tag import Tags
 from app.models.tag_history import TagHistory
@@ -250,37 +251,61 @@ async def review_ml_tag_suggestions(
     suggestion row keeps its original tag_id regardless of alias resolution.
     """
     suggestion_ids = [item.suggestion_id for item in request.suggestions]
-    suggestions_result = await db.execute(
-        select(MlTagSuggestions).where(
-            MlTagSuggestions.suggestion_id.in_(suggestion_ids),  # type: ignore[union-attr]
-            MlTagSuggestions.image_id == image_id,  # type: ignore[arg-type]
+
+    # A concurrent ml_remap run (or another reviewer) can rewrite these same
+    # suggestion rows between our fetch and our commit, tripping MariaDB
+    # ER_CHECKREAD (1020) under innodb_snapshot_isolation (see
+    # app/core/db_retry.py). Retry the whole fetch-through-commit unit on a
+    # fresh snapshot. Re-running _apply() after a rollback is idempotent-safe
+    # by construction: the fresh fetch re-reads current suggestion statuses,
+    # so changes already committed by the other writer are visible under the
+    # new snapshot (no double-apply), and a suggestion the other writer
+    # removed simply falls through to the missing-suggestion errors path.
+    async def _apply() -> tuple[int, int, list[str], set[int], list[int]]:
+        suggestions_result = await db.execute(
+            select(MlTagSuggestions).where(
+                MlTagSuggestions.suggestion_id.in_(suggestion_ids),  # type: ignore[union-attr]
+                MlTagSuggestions.image_id == image_id,  # type: ignore[arg-type]
+            )
         )
-    )
-    suggestions_by_id = {sugg.suggestion_id: sugg for sugg in suggestions_result.scalars().all()}
+        suggestions_by_id = {
+            sugg.suggestion_id: sugg for sugg in suggestions_result.scalars().all()
+        }
 
-    approved_count = 0
-    rejected_count = 0
-    errors: list[str] = []
+        approved_count = 0
+        rejected_count = 0
+        errors: list[str] = []
 
-    # Separate items into found (processed by helper) and missing (errors).
-    found_items: list[ReviewSuggestionRequest] = []
-    for review_item in request.suggestions:
-        if review_item.suggestion_id not in suggestions_by_id:
-            errors.append(f"Suggestion {review_item.suggestion_id} not found")
-        else:
-            found_items.append(review_item)
-            if review_item.action == "approve":
-                approved_count += 1
-            elif review_item.action == "reject":
-                rejected_count += 1
+        # Separate items into found (processed by helper) and missing (errors).
+        found_items: list[ReviewSuggestionRequest] = []
+        for review_item in request.suggestions:
+            if review_item.suggestion_id not in suggestions_by_id:
+                errors.append(f"Suggestion {review_item.suggestion_id} not found")
+            else:
+                found_items.append(review_item)
+                if review_item.action == "approve":
+                    approved_count += 1
+                elif review_item.action == "reject":
+                    rejected_count += 1
 
-    created, removed_suggestion_ids = await _apply_reviews_for_image(
-        db, image_id, found_items, user_id
-    )
+        created, removed_suggestion_ids = await _apply_reviews_for_image(
+            db, image_id, found_items, user_id
+        )
 
-    await db.commit()
+        await db.commit()
+
+        return approved_count, rejected_count, errors, created, removed_suggestion_ids
+
+    (
+        approved_count,
+        rejected_count,
+        errors,
+        created,
+        removed_suggestion_ids,
+    ) = await retry_on_snapshot_conflict(db, _apply, what="ml_review_apply")
 
     # Sync affected tags to Meilisearch (usage_count updated by DB trigger).
+    # Non-DB side effect: stays outside the retried unit so it never repeats.
     if created:
         tag_results = await db.execute(
             select(Tags).where(Tags.tag_id.in_(created))  # type: ignore[union-attr]
@@ -310,49 +335,79 @@ async def bulk_review_suggestions(
     all created TagLinks — never N commits or N syncs.
     """
     suggestion_ids = [r["suggestion_id"] for r in reviews]
-    suggestions_result = await db.execute(
-        select(MlTagSuggestions).where(
-            MlTagSuggestions.suggestion_id.in_(suggestion_ids)  # type: ignore[union-attr]
+
+    # Same snapshot-conflict exposure as review_ml_tag_suggestions (a
+    # concurrent ml_remap run or another reviewer rewriting these rows), but
+    # spanning every image in the batch. Retry the whole fetch-through-commit
+    # unit on a fresh snapshot (see app/core/db_retry.py). Re-running _apply()
+    # after a rollback is idempotent-safe by construction: the fresh fetch
+    # re-reads current suggestion statuses, so changes already committed by
+    # the other writer are visible under the new snapshot (no double-apply),
+    # and rows the other writer removed simply fall through to the
+    # missing-suggestion errors path.
+    async def _apply() -> tuple[int, int, list[str], set[int], list[int]]:
+        suggestions_result = await db.execute(
+            select(MlTagSuggestions).where(
+                MlTagSuggestions.suggestion_id.in_(suggestion_ids)  # type: ignore[union-attr]
+            )
         )
-    )
-    suggestions_by_id = {sugg.suggestion_id: sugg for sugg in suggestions_result.scalars().all()}
+        suggestions_by_id = {
+            sugg.suggestion_id: sugg for sugg in suggestions_result.scalars().all()
+        }
 
-    approved_count = 0
-    rejected_count = 0
-    errors: list[str] = []
+        approved_count = 0
+        rejected_count = 0
+        errors: list[str] = []
 
-    # Group found suggestions by image_id; record errors for missing ids.
-    items_by_image: dict[int, list[ReviewSuggestionRequest]] = defaultdict(list)
-    for r in reviews:
-        sid = r["suggestion_id"]
-        action = r["action"]
-        if sid not in suggestions_by_id:
-            errors.append(f"Suggestion {sid} not found")
-            continue
-        sugg = suggestions_by_id[sid]
-        items_by_image[sugg.image_id].append(
-            ReviewSuggestionRequest(suggestion_id=sid, action=action)
+        # Group found suggestions by image_id; record errors for missing ids.
+        items_by_image: dict[int, list[ReviewSuggestionRequest]] = defaultdict(list)
+        for r in reviews:
+            sid = r["suggestion_id"]
+            action = r["action"]
+            if sid not in suggestions_by_id:
+                errors.append(f"Suggestion {sid} not found")
+                continue
+            sugg = suggestions_by_id[sid]
+            items_by_image[sugg.image_id].append(
+                ReviewSuggestionRequest(suggestion_id=sid, action=action)
+            )
+            if action == "approve":
+                approved_count += 1
+            elif action == "reject":
+                rejected_count += 1
+
+        # Process each image's suggestions; accumulate created tag_ids and
+        # cascade-deleted ancestor suggestion_ids.
+        all_created_tag_ids: set[int] = set()
+        all_removed_suggestion_ids: list[int] = []
+        for image_id, items in items_by_image.items():
+            created, removed_suggestion_ids = await _apply_reviews_for_image(
+                db, image_id, items, user_id
+            )
+            all_created_tag_ids |= created
+            all_removed_suggestion_ids.extend(removed_suggestion_ids)
+
+        # Single commit spanning all images.
+        await db.commit()
+
+        return (
+            approved_count,
+            rejected_count,
+            errors,
+            all_created_tag_ids,
+            all_removed_suggestion_ids,
         )
-        if action == "approve":
-            approved_count += 1
-        elif action == "reject":
-            rejected_count += 1
 
-    # Process each image's suggestions; accumulate created tag_ids and
-    # cascade-deleted ancestor suggestion_ids.
-    all_created_tag_ids: set[int] = set()
-    all_removed_suggestion_ids: list[int] = []
-    for image_id, items in items_by_image.items():
-        created, removed_suggestion_ids = await _apply_reviews_for_image(
-            db, image_id, items, user_id
-        )
-        all_created_tag_ids |= created
-        all_removed_suggestion_ids.extend(removed_suggestion_ids)
-
-    # Single commit spanning all images.
-    await db.commit()
+    (
+        approved_count,
+        rejected_count,
+        errors,
+        all_created_tag_ids,
+        all_removed_suggestion_ids,
+    ) = await retry_on_snapshot_conflict(db, _apply, what="ml_review_bulk_apply")
 
     # Single batched search-sync over the union of created tag_ids.
+    # Non-DB side effect: stays outside the retried unit so it never repeats.
     if all_created_tag_ids:
         tag_results = await db.execute(
             select(Tags).where(Tags.tag_id.in_(all_created_tag_ids))  # type: ignore[union-attr]

--- a/app/services/ml_suggestion_review.py
+++ b/app/services/ml_suggestion_review.py
@@ -12,7 +12,7 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import select, tuple_, update
+from sqlalchemy import delete, select, tuple_, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.ml_tag_suggestion import MlTagSuggestions
@@ -24,6 +24,7 @@ from app.schemas.ml_tag_suggestion import (
     ReviewSuggestionsRequest,
     ReviewSuggestionsResponse,
 )
+from app.services.ml_suggestion_pipeline import fetch_parent_map
 from app.services.search import sync_tags_to_search
 from app.services.tag_type_flags import refresh_image_tag_type_flags
 
@@ -62,6 +63,51 @@ async def approve_pending_suggestions_for_links(
             status="approved",
             reviewed_at=datetime.now(UTC),
             reviewed_by_user_id=user_id,
+        )
+    )
+
+    await delete_pending_ancestor_suggestions(db, pairs)
+
+
+async def delete_pending_ancestor_suggestions(
+    db: AsyncSession,
+    links: Iterable[tuple[int, int]],
+) -> None:
+    """Delete pending suggestions made redundant by a newly applied descendant.
+
+    ``links`` is the (image_id, tag_id) pairs for TagLinks the caller just
+    created. Each applied tag's Tags.inheritedfrom_id chain is walked and any
+    PENDING suggestion rows for those ancestors on that image are deleted —
+    once the more specific tag is on the image, suggesting the generic one is
+    redundant (generation applies the same rule via
+    filter_redundant_suggestions). Approved/rejected rows are never touched,
+    and only ancestors are affected: a pending suggestion for a DESCENDANT of
+    the applied tag keeps its own review.
+
+    Flush-only; the caller owns the transaction and commit.
+    """
+    pairs = list(links)
+    if not pairs:
+        return
+
+    parent_of = await fetch_parent_map(db, {tag_id for _, tag_id in pairs})
+
+    doomed: set[tuple[int, int]] = set()
+    for image_id, tag_id in pairs:
+        cur = parent_of.get(tag_id)
+        depth = 0
+        while cur is not None and depth < 10:
+            doomed.add((image_id, cur))
+            cur = parent_of.get(cur)
+            depth += 1
+
+    if not doomed:
+        return
+
+    await db.execute(
+        delete(MlTagSuggestions).where(
+            MlTagSuggestions.status == "pending",  # type: ignore[arg-type]
+            tuple_(MlTagSuggestions.image_id, MlTagSuggestions.tag_id).in_(doomed),  # type: ignore[arg-type]
         )
     )
 
@@ -155,6 +201,11 @@ async def _apply_reviews_for_image(
             suggestion.status = "rejected"
             suggestion.reviewed_at = review_time
             suggestion.reviewed_by_user_id = user_id
+
+    if created_link_tag_ids:
+        await delete_pending_ancestor_suggestions(
+            db, [(image_id, tag_id) for tag_id in created_link_tag_ids]
+        )
 
     # Refresh denormalized tag-type flags (per-image; flush only, no commit).
     if created_link_tag_ids:

--- a/tests/api/v1/test_ml_tag_suggestions.py
+++ b/tests/api/v1/test_ml_tag_suggestions.py
@@ -1624,6 +1624,118 @@ class TestReviewMlTagSuggestions:
 
 
 @pytest.mark.api
+class TestReviewMlTagSuggestionsSnapshotConflictRetry:
+    """A background ml_remap run rewriting ml_tag_suggestions rows while a
+    reviewer approves on the same image trips MariaDB ER_CHECKREAD (errno
+    1020) under innodb_snapshot_isolation — reproduced on dev 2026-07-23. The
+    review apply must retry on a fresh snapshot instead of surfacing a 500
+    (see app/core/db_retry.py and app/services/ml_suggestion_review.py)."""
+
+    @pytest.mark.needs_commit
+    async def test_review_approve_retries_snapshot_conflict_and_succeeds(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A transient 1020 on the review commit is retried and the approval succeeds.
+
+        needs_commit: the retry performs a real session rollback for a fresh
+        snapshot; under the default SAVEPOINT isolation that rollback would
+        unwind the fixture's committed image/tag/suggestion rows too, which
+        can't happen in production where they are durably committed.
+        """
+        from unittest.mock import patch
+
+        import pymysql
+        from sqlalchemy.exc import OperationalError
+
+        user = Users(
+            username="snapshotreview",
+            email="snapshotreview@example.com",
+            password="hashed",
+            password_type="bcrypt",
+            salt="testsalt12345678",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        image = Images(
+            filename="test",
+            ext="jpg",
+            user_id=user.user_id,
+            md5_hash="snapshotreview123",
+            filesize=1024,
+            width=800,
+            height=600,
+        )
+        db_session.add(image)
+        await db_session.flush()
+
+        tag = Tags(title="snapshot conflict tag", type=1, user_id=user.user_id)
+        db_session.add(tag)
+        await db_session.flush()
+
+        suggestion = MlTagSuggestions(
+            image_id=image.image_id,
+            tag_id=tag.tag_id,
+            confidence=0.9,
+            model_version="v1",
+            status="pending",
+        )
+        db_session.add(suggestion)
+        await db_session.commit()
+
+        # Capture plain ids before the retry runs: the retry's inter-attempt
+        # rollback expires every ORM instance in this shared session (see
+        # app/core/db_retry.py), so touching image/tag/suggestion attributes
+        # again afterward would raise MissingGreenlet.
+        image_id = image.image_id
+        tag_id = tag.tag_id
+        suggestion_id = suggestion.suggestion_id
+
+        real_commit = AsyncSession.commit
+        calls: list[int] = []
+
+        async def flaky_commit(self, *args, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                raise OperationalError(
+                    "UPDATE ml_tag_suggestions ...",
+                    None,
+                    pymysql.err.OperationalError(
+                        1020,
+                        "Record has changed since last read in table 'ml_tag_suggestions'",
+                    ),
+                )
+            await real_commit(self, *args, **kwargs)
+
+        access_token = create_access_token(user_id=user.user_id)
+        with patch.object(AsyncSession, "commit", flaky_commit):
+            response = await client.post(
+                f"/api/v1/images/{image_id}/ml-tag-suggestions/review",
+                json={"suggestions": [{"suggestion_id": suggestion_id, "action": "approve"}]},
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["approved"] == 1
+        assert data["errors"] == []
+        assert len(calls) >= 2  # failed attempt + successful retry
+
+        result = await db_session.execute(
+            select(TagLinks).where(TagLinks.image_id == image_id, TagLinks.tag_id == tag_id)
+        )
+        assert result.scalar_one_or_none() is not None
+
+        refreshed = (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.suggestion_id == suggestion_id)
+            )
+        ).scalar_one()
+        assert refreshed.status == "approved"
+
+
+@pytest.mark.api
 class TestGenerateMlTagSuggestions:
     """Tests for POST /api/v1/images/{image_id}/ml-tag-suggestions/generate endpoint."""
 

--- a/tests/api/v1/test_ml_tag_suggestions.py
+++ b/tests/api/v1/test_ml_tag_suggestions.py
@@ -450,6 +450,164 @@ class TestGetMlTagSuggestions:
         )
         assert response.status_code == 200
 
+    async def test_get_suggestions_reports_superseded_ancestors(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A pending gap chain (child + grandparent suggested, intermediate tag
+        NOT suggested): the child's superseded_suggestion_ids names the
+        grandparent's row; grandparent and an unrelated pending tag get []."""
+        user = Users(
+            username="test_superseded",
+            email="test_superseded@example.com",
+            password="hashed",
+            password_type="bcrypt",
+            salt="testsalt12345678",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        image = Images(
+            filename="test_superseded",
+            ext="jpg",
+            user_id=user.user_id,
+            md5_hash="superseded123",
+            filesize=1024,
+            width=800,
+            height=600,
+        )
+        db_session.add(image)
+        await db_session.flush()
+
+        grandparent = Tags(title="bag sup", type=1, user_id=user.user_id)
+        db_session.add(grandparent)
+        await db_session.flush()
+        parent = Tags(
+            title="school bag sup",
+            type=1,
+            user_id=user.user_id,
+            inheritedfrom_id=grandparent.tag_id,
+        )
+        db_session.add(parent)
+        await db_session.flush()
+        child = Tags(
+            title="randoseru sup",
+            type=1,
+            user_id=user.user_id,
+            inheritedfrom_id=parent.tag_id,
+        )
+        unrelated = Tags(title="smile sup", type=1, user_id=user.user_id)
+        db_session.add_all([child, unrelated])
+        await db_session.flush()
+
+        # Pending rows for child + grandparent + unrelated; the intermediate
+        # tag deliberately has NO suggestion row (the gap).
+        sugg_child = MlTagSuggestions(
+            image_id=image.image_id,
+            tag_id=child.tag_id,
+            confidence=0.9,
+            model_version="v1",
+            status="pending",
+        )
+        sugg_gp = MlTagSuggestions(
+            image_id=image.image_id,
+            tag_id=grandparent.tag_id,
+            confidence=0.8,
+            model_version="v1",
+            status="pending",
+        )
+        sugg_unrelated = MlTagSuggestions(
+            image_id=image.image_id,
+            tag_id=unrelated.tag_id,
+            confidence=0.7,
+            model_version="v1",
+            status="pending",
+        )
+        db_session.add_all([sugg_child, sugg_gp, sugg_unrelated])
+        await db_session.commit()
+
+        access_token = create_access_token(user_id=user.user_id)
+        response = await client.get(
+            f"/api/v1/images/{image.image_id}/ml-tag-suggestions",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == 200
+        by_id = {s["suggestion_id"]: s for s in response.json()["suggestions"]}
+        assert by_id[sugg_child.suggestion_id]["superseded_suggestion_ids"] == [
+            sugg_gp.suggestion_id
+        ]
+        assert by_id[sugg_gp.suggestion_id]["superseded_suggestion_ids"] == []
+        assert by_id[sugg_unrelated.suggestion_id]["superseded_suggestion_ids"] == []
+
+    async def test_superseded_ignores_reviewed_rows(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A REJECTED ancestor row creates no edge: the pending child reports []
+        and the rejected row itself reports []."""
+        user = Users(
+            username="test_superseded2",
+            email="test_superseded2@example.com",
+            password="hashed",
+            password_type="bcrypt",
+            salt="testsalt12345678",
+            active=1,
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        image = Images(
+            filename="test_superseded2",
+            ext="jpg",
+            user_id=user.user_id,
+            md5_hash="superseded456",
+            filesize=1024,
+            width=800,
+            height=600,
+        )
+        db_session.add(image)
+        await db_session.flush()
+
+        parent_tag = Tags(title="dress sup", type=1, user_id=user.user_id)
+        db_session.add(parent_tag)
+        await db_session.flush()
+        child_tag = Tags(
+            title="sundress sup",
+            type=1,
+            user_id=user.user_id,
+            inheritedfrom_id=parent_tag.tag_id,
+        )
+        db_session.add(child_tag)
+        await db_session.flush()
+
+        sugg_child = MlTagSuggestions(
+            image_id=image.image_id,
+            tag_id=child_tag.tag_id,
+            confidence=0.9,
+            model_version="v1",
+            status="pending",
+        )
+        sugg_parent_rejected = MlTagSuggestions(
+            image_id=image.image_id,
+            tag_id=parent_tag.tag_id,
+            confidence=0.8,
+            model_version="v1",
+            status="rejected",
+        )
+        db_session.add_all([sugg_child, sugg_parent_rejected])
+        await db_session.commit()
+
+        access_token = create_access_token(user_id=user.user_id)
+        response = await client.get(
+            f"/api/v1/images/{image.image_id}/ml-tag-suggestions",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == 200
+        by_id = {s["suggestion_id"]: s for s in response.json()["suggestions"]}
+        assert by_id[sugg_child.suggestion_id]["superseded_suggestion_ids"] == []
+        assert by_id[sugg_parent_rejected.suggestion_id]["superseded_suggestion_ids"] == []
+
 
 @pytest.mark.api
 class TestReviewMlTagSuggestions:

--- a/tests/services/test_ml_suggestion_pipeline.py
+++ b/tests/services/test_ml_suggestion_pipeline.py
@@ -959,6 +959,45 @@ async def test_filter_superseded_parents_parent_not_suggested_kept(db_session):
     assert {s["tag_id"] for s in result} == {651, 652}
 
 
+async def test_filter_superseded_parents_gap_in_chain_drops_grandparent(db_session):
+    """A confident child drops a suggested GRANDPARENT even when the
+    intermediate parent is not itself suggested (randoseru -> school bag ->
+    bag with only randoseru + bag suggested)."""
+    grandparent = Tags(tag_id=660, title="bag")
+    parent = Tags(tag_id=661, title="school bag", inheritedfrom_id=660)
+    child = Tags(tag_id=662, title="randoseru", inheritedfrom_id=661)
+    db_session.add_all([grandparent, parent, child])
+    await db_session.commit()
+
+    # Intermediate 661 is NOT suggested — the chain must be walked through it.
+    suggestions = [
+        {"tag_id": 660, "confidence": 0.90, "model_version": "v3"},  # bag (grandparent)
+        {"tag_id": 662, "confidence": 0.70, "model_version": "v3"},  # randoseru (child)
+    ]
+
+    result = await filter_superseded_parents(db_session, suggestions, 0.6)
+
+    assert {s["tag_id"] for s in result} == {662}
+
+
+async def test_filter_superseded_parents_gap_chain_weak_child_keeps_grandparent(db_session):
+    """A below-threshold child does not suppress ancestors across a gap either."""
+    grandparent = Tags(tag_id=670, title="bag")
+    parent = Tags(tag_id=671, title="school bag", inheritedfrom_id=670)
+    child = Tags(tag_id=672, title="randoseru", inheritedfrom_id=671)
+    db_session.add_all([grandparent, parent, child])
+    await db_session.commit()
+
+    suggestions = [
+        {"tag_id": 670, "confidence": 0.90, "model_version": "v3"},
+        {"tag_id": 672, "confidence": 0.55, "model_version": "v3"},
+    ]
+
+    result = await filter_superseded_parents(db_session, suggestions, 0.6)
+
+    assert {s["tag_id"] for s in result} == {670, 672}
+
+
 async def test_character_suggestions_dropped_when_flag_off(db_session, tmp_path, monkeypatch):
     """Flag off: suggestions resolving to character-type tags are not stored;
     theme suggestions are unaffected. Raw inference/ingest is untouched by this

--- a/tests/services/test_ml_suggestion_pipeline.py
+++ b/tests/services/test_ml_suggestion_pipeline.py
@@ -1148,3 +1148,12 @@ async def test_character_child_does_not_supersede_theme_parent_when_gated(
         select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
     )
     assert {s.tag_id for s in result.scalars().all()} == {401}
+
+
+def test_parent_supersede_default_threshold_is_conservative():
+    """Default raised 0.6 -> 0.9 (2026-07-23 analysis: at 0.6 ~24% of marginal
+    supersedes suppressed a parent the human applied; at 0.9 that is ~7%).
+    Ambiguous child/parent pairs are left for the review queue to sequence."""
+    from app.config import Settings
+
+    assert Settings.model_fields["ML_PARENT_SUPERSEDE_MIN_CONFIDENCE"].default == 0.9

--- a/tests/services/test_ml_suggestion_queue.py
+++ b/tests/services/test_ml_suggestion_queue.py
@@ -492,3 +492,107 @@ class TestCountPendingByTagPagination:
         assert len(seeded) == 2
         seeded_ids = [item[0] for item in seeded]
         assert seeded_ids.index(tag_hi.tag_id) < seeded_ids.index(tag_lo.tag_id)
+
+
+async def _make_child_tag(
+    db: AsyncSession, user: Users, suffix: str, parent: Tags
+) -> Tags:
+    tag = Tags(
+        title=f"queue tag {suffix}", type=TagType.THEME, user_id=user.user_id,
+        inheritedfrom_id=parent.tag_id,
+    )
+    db.add(tag)
+    await db.flush()
+    return tag
+
+
+class TestListPendingDescendantHiding:
+    """An ancestor's pending suggestion is hidden from its per-tag queue while
+    a more-specific descendant suggestion is pending on the same image, so
+    per-tag review is most-specific-first by construction."""
+
+    async def test_pending_child_hides_parent_row(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "hide1")
+        image = await _make_image(db_session, user, "hide1")
+        parent = await _make_tag(db_session, user, "hide1_parent")
+        child = await _make_child_tag(db_session, user, "hide1_child", parent)
+        await _make_suggestion(db_session, image, parent)
+        await _make_suggestion(db_session, image, child)
+        await db_session.commit()
+
+        items, total = await list_pending_for_tag(
+            db_session, parent.tag_id, min_confidence=0.0, page=1, per_page=10
+        )
+        assert total == 0 and items == []
+
+        # The child's own queue still shows the image.
+        items, total = await list_pending_for_tag(
+            db_session, child.tag_id, min_confidence=0.0, page=1, per_page=10
+        )
+        assert total == 1
+
+    async def test_pending_grandchild_hides_grandparent_row(
+        self, db_session: AsyncSession
+    ):
+        """Transitive: the intermediate tag has NO suggestion row at all."""
+        user = await _make_user(db_session, "hide2")
+        image = await _make_image(db_session, user, "hide2")
+        grandparent = await _make_tag(db_session, user, "hide2_gp")
+        parent = await _make_child_tag(db_session, user, "hide2_p", grandparent)
+        grandchild = await _make_child_tag(db_session, user, "hide2_c", parent)
+        await _make_suggestion(db_session, image, grandparent)
+        await _make_suggestion(db_session, image, grandchild)
+        await db_session.commit()
+
+        items, total = await list_pending_for_tag(
+            db_session, grandparent.tag_id, min_confidence=0.0, page=1, per_page=10
+        )
+        assert total == 0 and items == []
+
+    async def test_rejected_descendant_does_not_hide(self, db_session: AsyncSession):
+        """Rejecting the child resurfaces the parent — the cascade."""
+        user = await _make_user(db_session, "hide3")
+        image = await _make_image(db_session, user, "hide3")
+        parent = await _make_tag(db_session, user, "hide3_parent")
+        child = await _make_child_tag(db_session, user, "hide3_child", parent)
+        await _make_suggestion(db_session, image, parent)
+        await _make_suggestion(db_session, image, child, status="rejected")
+        await db_session.commit()
+
+        items, total = await list_pending_for_tag(
+            db_session, parent.tag_id, min_confidence=0.0, page=1, per_page=10
+        )
+        assert total == 1
+
+    async def test_unrelated_pending_does_not_hide(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "hide4")
+        image = await _make_image(db_session, user, "hide4")
+        parent = await _make_tag(db_session, user, "hide4_parent")
+        unrelated = await _make_tag(db_session, user, "hide4_other")
+        await _make_suggestion(db_session, image, parent)
+        await _make_suggestion(db_session, image, unrelated)
+        await db_session.commit()
+
+        items, total = await list_pending_for_tag(
+            db_session, parent.tag_id, min_confidence=0.0, page=1, per_page=10
+        )
+        assert total == 1
+
+    async def test_hiding_is_per_image(self, db_session: AsyncSession):
+        """Another image whose parent suggestion has no pending descendant
+        stays listed while the blocked image is hidden."""
+        user = await _make_user(db_session, "hide5")
+        image_blocked = await _make_image(db_session, user, "hide5a")
+        image_free = await _make_image(db_session, user, "hide5b")
+        parent = await _make_tag(db_session, user, "hide5_parent")
+        child = await _make_child_tag(db_session, user, "hide5_child", parent)
+        await _make_suggestion(db_session, image_blocked, parent)
+        await _make_suggestion(db_session, image_blocked, child)
+        await _make_suggestion(db_session, image_free, parent)
+        await db_session.commit()
+
+        items, total = await list_pending_for_tag(
+            db_session, parent.tag_id, min_confidence=0.0, page=1, per_page=10
+        )
+        assert total == 1
+        assert [item[1] for item in items] == [image_free.image_id]

--- a/tests/services/test_ml_suggestion_review_bulk.py
+++ b/tests/services/test_ml_suggestion_review_bulk.py
@@ -5,6 +5,7 @@ No mocked behavior is asserted; all assertions target real DB rows written
 by the service.
 """
 
+import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -429,3 +430,83 @@ class TestAncestorCleanupOnApprove:
         by_tag = {r.tag_id: r.status for r in rows}
         assert by_tag[parent.tag_id] == "rejected"
         assert by_tag[child.tag_id] == "approved"
+
+
+class TestBulkReviewSnapshotConflictRetry:
+    """A background ml_remap run rewriting ml_tag_suggestions rows while a
+    bulk review commits over the same rows trips MariaDB ER_CHECKREAD (errno
+    1020) under innodb_snapshot_isolation. bulk_review_suggestions must retry
+    on a fresh snapshot instead of propagating the 500 (see
+    app/core/db_retry.py and app/services/ml_suggestion_review.py)."""
+
+    @pytest.mark.needs_commit
+    async def test_bulk_review_approve_retries_snapshot_conflict_and_succeeds(
+        self, db_session: AsyncSession
+    ):
+        """A transient 1020 on the bulk commit is retried and the approval succeeds.
+
+        needs_commit: the retry performs a real session rollback for a fresh
+        snapshot; under the default SAVEPOINT isolation that rollback would
+        unwind the fixture's committed image/tag/suggestion rows too, which
+        can't happen in production where they are durably committed.
+        """
+        from unittest.mock import patch
+
+        import pymysql
+        from sqlalchemy.exc import OperationalError
+
+        user = await _make_user(db_session, "snapshot")
+        image = await _make_image(db_session, user, "snapshot")
+        tag = await _make_tag(db_session, user, "snapshot")
+        suggestion = await _make_suggestion(db_session, image, tag)
+        await db_session.commit()
+
+        # Capture plain ids before the retry runs: the retry's inter-attempt
+        # rollback expires every ORM instance in this session (see
+        # app/core/db_retry.py), so touching image/tag/suggestion attributes
+        # again afterward would raise MissingGreenlet.
+        image_id = image.image_id
+        tag_id = tag.tag_id
+        suggestion_id = suggestion.suggestion_id
+
+        real_commit = AsyncSession.commit
+        calls: list[int] = []
+
+        async def flaky_commit(self, *args, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                raise OperationalError(
+                    "UPDATE ml_tag_suggestions ...",
+                    None,
+                    pymysql.err.OperationalError(
+                        1020,
+                        "Record has changed since last read in table 'ml_tag_suggestions'",
+                    ),
+                )
+            await real_commit(self, *args, **kwargs)
+
+        with patch.object(AsyncSession, "commit", flaky_commit):
+            result = await bulk_review_suggestions(
+                db_session,
+                [{"suggestion_id": suggestion_id, "action": "approve"}],
+                user.user_id,
+            )
+
+        assert result.approved == 1
+        assert result.errors == []
+        assert len(calls) >= 2  # failed attempt + successful retry
+
+        link_result = await db_session.execute(
+            select(TagLinks).where(
+                TagLinks.image_id == image_id,
+                TagLinks.tag_id == tag_id,
+            )
+        )
+        assert link_result.scalar_one_or_none() is not None
+
+        refreshed = (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.suggestion_id == suggestion_id)
+            )
+        ).scalar_one()
+        assert refreshed.status == "approved"

--- a/tests/services/test_ml_suggestion_review_bulk.py
+++ b/tests/services/test_ml_suggestion_review_bulk.py
@@ -5,7 +5,6 @@ No mocked behavior is asserted; all assertions target real DB rows written
 by the service.
 """
 
-import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -376,3 +375,49 @@ class TestAncestorCleanupOnApprove:
             .one_or_none()
         )
         assert refreshed is not None and refreshed.status == "pending"
+
+    async def test_same_batch_reject_ancestor_approve_child_keeps_rejection(
+        self, db_session: AsyncSession
+    ):
+        """A moderator rejecting the parent and approving the child in ONE
+        request must keep the parent row as 'rejected' — the cleanup DELETE
+        must see the same-batch status changes (autoflush=False session).
+
+        The db_session fixture itself runs with autoflush=True (unlike the
+        production sessionmaker in app/core/database.py), which would flush
+        the pending 'rejected' status ahead of the DELETE regardless of the
+        fix under test. no_autoflush reproduces the production autoflush=False
+        setting for the call so this test actually exercises the bug.
+        """
+        user = await _make_user(db_session, "anc6")
+        image = await _make_image(db_session, user, "anc6")
+        _grandparent, parent, child = await _make_chain(db_session, user, "anc6")
+        sugg_p = await _make_suggestion(db_session, image, parent)
+        sugg_c = await _make_suggestion(db_session, image, child)
+        await db_session.commit()
+
+        with db_session.no_autoflush:
+            result = await bulk_review_suggestions(
+                db_session,
+                [
+                    {"suggestion_id": sugg_p.suggestion_id, "action": "reject"},
+                    {"suggestion_id": sugg_c.suggestion_id, "action": "approve"},
+                ],
+                user.user_id,
+            )
+        assert result.approved == 1 and result.rejected == 1
+
+        rows = (
+            (
+                await db_session.execute(
+                    select(MlTagSuggestions).where(
+                        MlTagSuggestions.image_id == image.image_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        by_tag = {r.tag_id: r.status for r in rows}
+        assert by_tag[parent.tag_id] == "rejected"
+        assert by_tag[child.tag_id] == "approved"

--- a/tests/services/test_ml_suggestion_review_bulk.py
+++ b/tests/services/test_ml_suggestion_review_bulk.py
@@ -14,7 +14,10 @@ from app.models.ml_tag_suggestion import MlTagSuggestions
 from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
-from app.services.ml_suggestion_review import bulk_review_suggestions
+from app.services.ml_suggestion_review import (
+    approve_pending_suggestions_for_links,
+    bulk_review_suggestions,
+)
 
 
 async def _make_user(db: AsyncSession, suffix: str) -> Users:
@@ -189,3 +192,187 @@ class TestBulkReviewSuggestions:
             )
         )
         assert len(links_result.scalars().all()) == 1
+
+
+async def _make_chain(db: AsyncSession, user: Users, suffix: str) -> tuple[Tags, Tags, Tags]:
+    """grandparent <- parent <- child via inheritedfrom_id."""
+    grandparent = await _make_tag(db, user, f"gp_{suffix}")
+    parent = Tags(
+        title=f"bulk tag p_{suffix}", type=1, user_id=user.user_id,
+        inheritedfrom_id=grandparent.tag_id,
+    )
+    db.add(parent)
+    await db.flush()
+    child = Tags(
+        title=f"bulk tag c_{suffix}", type=1, user_id=user.user_id,
+        inheritedfrom_id=parent.tag_id,
+    )
+    db.add(child)
+    await db.flush()
+    return grandparent, parent, child
+
+
+class TestAncestorCleanupOnApprove:
+    """Creating a TagLink deletes now-redundant pending ancestor suggestions."""
+
+    async def test_review_approve_child_deletes_pending_ancestors(
+        self, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "anc1")
+        image = await _make_image(db_session, user, "anc1")
+        grandparent, parent, child = await _make_chain(db_session, user, "anc1")
+        await _make_suggestion(db_session, image, grandparent)
+        await _make_suggestion(db_session, image, parent)
+        sugg_c = await _make_suggestion(db_session, image, child)
+        await db_session.commit()
+
+        result = await bulk_review_suggestions(
+            db_session,
+            [{"suggestion_id": sugg_c.suggestion_id, "action": "approve"}],
+            user.user_id,
+        )
+        assert result.approved == 1
+
+        rows = (
+            (
+                await db_session.execute(
+                    select(MlTagSuggestions).where(
+                        MlTagSuggestions.image_id == image.image_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        by_tag = {r.tag_id: r for r in rows}
+        assert by_tag[child.tag_id].status == "approved"
+        # Both pending ancestors are deleted — including the grandparent.
+        assert parent.tag_id not in by_tag
+        assert grandparent.tag_id not in by_tag
+
+    async def test_reviewed_ancestor_rows_are_never_touched(
+        self, db_session: AsyncSession
+    ):
+        user = await _make_user(db_session, "anc2")
+        image = await _make_image(db_session, user, "anc2")
+        grandparent, parent, child = await _make_chain(db_session, user, "anc2")
+        await _make_suggestion(db_session, image, grandparent, status="rejected")
+        await _make_suggestion(db_session, image, parent, status="approved")
+        sugg_c = await _make_suggestion(db_session, image, child)
+        await db_session.commit()
+
+        await bulk_review_suggestions(
+            db_session,
+            [{"suggestion_id": sugg_c.suggestion_id, "action": "approve"}],
+            user.user_id,
+        )
+
+        rows = (
+            (
+                await db_session.execute(
+                    select(MlTagSuggestions).where(
+                        MlTagSuggestions.image_id == image.image_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        by_tag = {r.tag_id: r.status for r in rows}
+        assert by_tag[grandparent.tag_id] == "rejected"
+        assert by_tag[parent.tag_id] == "approved"
+        assert by_tag[child.tag_id] == "approved"
+
+    async def test_reject_does_not_delete_ancestors(self, db_session: AsyncSession):
+        user = await _make_user(db_session, "anc3")
+        image = await _make_image(db_session, user, "anc3")
+        _grandparent, parent, child = await _make_chain(db_session, user, "anc3")
+        sugg_p = await _make_suggestion(db_session, image, parent)
+        sugg_c = await _make_suggestion(db_session, image, child)
+        await db_session.commit()
+
+        await bulk_review_suggestions(
+            db_session,
+            [{"suggestion_id": sugg_c.suggestion_id, "action": "reject"}],
+            user.user_id,
+        )
+
+        refreshed = (
+            (
+                await db_session.execute(
+                    select(MlTagSuggestions).where(
+                        MlTagSuggestions.suggestion_id == sugg_p.suggestion_id
+                    )
+                )
+            )
+            .scalars()
+            .one_or_none()
+        )
+        assert refreshed is not None and refreshed.status == "pending"
+
+    async def test_out_of_band_link_approval_deletes_pending_ancestors(
+        self, db_session: AsyncSession
+    ):
+        """approve_pending_suggestions_for_links (manual add / batch tagging
+        path) also deletes pending ancestor rows."""
+        user = await _make_user(db_session, "anc4")
+        image = await _make_image(db_session, user, "anc4")
+        grandparent, _parent, child = await _make_chain(db_session, user, "anc4")
+        await _make_suggestion(db_session, image, grandparent)
+        await _make_suggestion(db_session, image, child)
+        db_session.add(
+            TagLinks(image_id=image.image_id, tag_id=child.tag_id, user_id=user.user_id)
+        )
+        await db_session.flush()
+
+        await approve_pending_suggestions_for_links(
+            db_session, [(image.image_id, child.tag_id)], user.user_id
+        )
+        await db_session.commit()
+
+        rows = (
+            (
+                await db_session.execute(
+                    select(MlTagSuggestions).where(
+                        MlTagSuggestions.image_id == image.image_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        by_tag = {r.tag_id: r.status for r in rows}
+        assert by_tag[child.tag_id] == "approved"
+        assert grandparent.tag_id not in by_tag
+
+    async def test_pending_descendant_of_applied_tag_survives(
+        self, db_session: AsyncSession
+    ):
+        """Applying a PARENT tag must not delete the more-specific pending
+        child suggestion (cleanup goes up the chain only)."""
+        user = await _make_user(db_session, "anc5")
+        image = await _make_image(db_session, user, "anc5")
+        _grandparent, parent, child = await _make_chain(db_session, user, "anc5")
+        sugg_c = await _make_suggestion(db_session, image, child)
+        db_session.add(
+            TagLinks(image_id=image.image_id, tag_id=parent.tag_id, user_id=user.user_id)
+        )
+        await db_session.flush()
+
+        await approve_pending_suggestions_for_links(
+            db_session, [(image.image_id, parent.tag_id)], user.user_id
+        )
+        await db_session.commit()
+
+        refreshed = (
+            (
+                await db_session.execute(
+                    select(MlTagSuggestions).where(
+                        MlTagSuggestions.suggestion_id == sugg_c.suggestion_id
+                    )
+                )
+            )
+            .scalars()
+            .one_or_none()
+        )
+        assert refreshed is not None and refreshed.status == "pending"

--- a/tests/services/test_ml_suggestion_review_bulk.py
+++ b/tests/services/test_ml_suggestion_review_bulk.py
@@ -220,8 +220,8 @@ class TestAncestorCleanupOnApprove:
         user = await _make_user(db_session, "anc1")
         image = await _make_image(db_session, user, "anc1")
         grandparent, parent, child = await _make_chain(db_session, user, "anc1")
-        await _make_suggestion(db_session, image, grandparent)
-        await _make_suggestion(db_session, image, parent)
+        sugg_gp = await _make_suggestion(db_session, image, grandparent)
+        sugg_p = await _make_suggestion(db_session, image, parent)
         sugg_c = await _make_suggestion(db_session, image, child)
         await db_session.commit()
 
@@ -231,6 +231,12 @@ class TestAncestorCleanupOnApprove:
             user.user_id,
         )
         assert result.approved == 1
+        # Reports exactly the deleted pending ancestor rows, not the reviewed child.
+        assert set(result.removed_suggestion_ids) == {
+            sugg_gp.suggestion_id,
+            sugg_p.suggestion_id,
+        }
+        assert sugg_c.suggestion_id not in result.removed_suggestion_ids
 
         rows = (
             (
@@ -290,11 +296,13 @@ class TestAncestorCleanupOnApprove:
         sugg_c = await _make_suggestion(db_session, image, child)
         await db_session.commit()
 
-        await bulk_review_suggestions(
+        result = await bulk_review_suggestions(
             db_session,
             [{"suggestion_id": sugg_c.suggestion_id, "action": "reject"}],
             user.user_id,
         )
+        # A reject never deletes ancestors — nothing to report.
+        assert result.removed_suggestion_ids == []
 
         refreshed = (
             (


### PR DESCRIPTION
Fixes whitekitten's report: randoseru images still get "bag" suggested (and grandparents leak past the supersede filter whenever the intermediate tag isn't itself suggested).

## Root causes found

1. `filter_superseded_parents` only walked ancestors that were themselves in the suggestion set — the model routinely predicts leaf + grandparent without the intermediate (`randoseru` + `bag`, no `school bag`), so grandparents survived.
2. The 0.6 supersede threshold was too low: ground-truth analysis over the raw-prediction store vs human tagging showed ~24% of marginal supersedes suppressed a parent tag humans actually applied.
3. Nothing removed now-redundant pending ancestor suggestions once a tag landed on the image.
4. Per-tag review queues showed ancestors while a more specific candidate sat undecided — mods judging "bag" couldn't know "randoseru" was pending, and approving it produced exactly the redundant tagging being reported.

## Changes

- **Full-chain supersede walk** via new shared `fetch_parent_map` (depth-capped, cycle-safe): a confident child now drops suggested ancestors through unsuggested intermediates. Only suggested tags are ever dropped; weak children suppress nothing.
- **`ML_PARENT_SUPERSEDE_MIN_CONFIDENCE` 0.6 → 0.9** (data-driven: bad-suppress 24% → ~7%; ambiguous pairs deliberately left for human sequencing via the queue).
- **Ancestor cleanup on TagLink creation** (`delete_pending_ancestor_suggestions`): review approvals and all out-of-band tag-add paths delete pending ancestor rows. Pending only — approved/rejected rows and descendants are never touched. Includes a flush before the delete: the session is `autoflush=False`, and without it a same-batch "reject parent + approve child" review read stale statuses and 500'd (regression-tested under `no_autoflush`).
- **Most-specific-first queues**: `list_pending_for_tag` hides a tag's pending suggestion while any transitive-descendant suggestion is pending on the same image. Rejecting the descendant resurfaces the ancestor; approving it cascade-cleans. `count_pending_by_tag` intentionally unchanged (documented overcount, same perf rationale as the existing applied-tag exclusion).
- **Response plumbing for the frontend pair PR**: review responses report `removed_suggestion_ids` (cascade-deleted rows) so the panel can drop stale chips without a reload; the GET endpoint reports per-suggestion `superseded_suggestion_ids` (what approving it would remove) powering the grouped "related" UI.
- **Snapshot-conflict retry**: both review entry points wrap fetch-through-commit in `retry_on_snapshot_conflict` (err 1020, reproduced live when a review raced `ml_remap`; search sync stays outside the retried unit).

## Testing

Full suite green (2,330 passed) on the isolated pytest DB; ruff/mypy clean. Every change TDD'd; notable regression tests: gap-chain supersede, same-batch reject/approve under `no_autoflush`, synthetic-1020 retry at the endpoint level.

## Deploy notes (after merge, before/with the frontend pair PR)

1. Deploy API to test + prod.
2. Tag-mapping data fixes (already applied on dev): `UPDATE tag_mappings SET internal_tag_id=73 WHERE external_tag='cosplay';` and `INSERT INTO tag_mappings (external_tag, internal_tag_id, confidence) VALUES ('japanese_clothes', 171386, 1);`
3. Run a full `scripts/ml_remap.py --model swinv2_base_window8_256.dbv4-full` on each — purges stored redundant-ancestor rows under the new rules. Verified: remap never resurrects rejected suggestions and never touches reviewed rows.

Frontend pair PR (merge second): shuushuu-frontend `fix/ml-suggestion-stale-ancestor-chips`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mNdmr81BUJ81WwrPwA7Lq