### PR TITLE
chore(compose): bind-mount scripts/ read-only in dev and test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,10 @@ services:
       - ./uv.lock:/app/uv.lock:ro
       - ${STORAGE_PATH:-/shuushuu/images}:${STORAGE_PATH:-/shuushuu/images}
       - ./ml_models:/app/ml_models:ro
+      # Read-only so ad-hoc scripts always match the checkout (the image's baked
+      # copy goes stale — a months-old ml_remap.py silently no-opped a full test
+      # remap on 2026-07-24). Scripts must write run artifacts elsewhere (/tmp).
+      - ./scripts:/app/scripts:ro
     depends_on:
       mariadb:
         condition: service_healthy
@@ -191,6 +195,10 @@ services:
       - ./uv.lock:/app/uv.lock:ro
       - ${STORAGE_PATH:-/shuushuu/images}:${STORAGE_PATH:-/shuushuu/images}
       - ./ml_models:/app/ml_models:ro
+      # Read-only so ad-hoc scripts always match the checkout (the image's baked
+      # copy goes stale — a months-old ml_remap.py silently no-opped a full test
+      # remap on 2026-07-24). Scripts must write run artifacts elsewhere (/tmp).
+      - ./scripts:/app/scripts:ro
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
The api and arq-worker containers run the image's baked copy of `scripts/`, which goes stale the moment the checkout moves. This bit for real on 2026-07-24: the test api container's months-old `ml_remap.py` (predating the per-image commit in its full-run loop) silently no-opped an entire full remap — all reconcile work accumulated in one never-committed transaction.

`app/` and `alembic/` are already checkout-mounted in dev/test; `scripts/` is the same class of operational code, and it's what gets invoked ad hoc months after an image build. Mounted `:ro` — run artifacts (checkpoints etc.) belong in `/tmp`, and the container can't dirty the checkout.

**Prod is deliberately untouched:** `docker-compose.prod.yml` replaces the service volumes lists, so prod keeps running the sealed image with no source mounts, and gets fresh scripts through the deploy-time image rebuild as today.

Verified with `docker compose config`: the mount renders for api + arq-worker in the dev-default and test merges, and does not appear in the prod merge.

Note for existing environments: running containers pick up the new mount only on their next recreate (`up -d`), not on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mNdmr81BUJ81WwrPwA7Lq