### PR TITLE
fix(ml): demote superseded parents on upload instead of dropping them

### DIFF
--- a/app/api/v1/ml_analyze.py
+++ b/app/api/v1/ml_analyze.py
@@ -24,7 +24,7 @@ from app.services.ml_categories import SUGGESTION_CATEGORIES  # light: no onnxru
 from app.services.ml_runtime import get_ml_service, inference_slot
 from app.services.ml_suggestion_pipeline import (  # light: no onnxruntime
     filter_character_suggestions,
-    filter_superseded_parents,
+    find_superseded_parents,
 )
 from app.services.rate_limit import check_analyze_rate_limit
 from app.services.tag_mapping_service import resolve_external_tags
@@ -130,11 +130,6 @@ async def _resolve_to_response(db: AsyncSession, raw: list[dict[str, Any]]) -> A
     # child can't first supersede a theme parent (both chips would be lost).
     resolved = await filter_character_suggestions(db, resolved)
 
-    # Drop a suggested parent when a confident suggested child supersedes it.
-    resolved = await filter_superseded_parents(
-        db, resolved, settings.ML_PARENT_SUPERSEDE_MIN_CONFIDENCE
-    )
-
     # Keep the best confidence per tag_id (resolve can collapse aliases to one id).
     best: dict[int, float] = {}
     for r in resolved:
@@ -165,4 +160,19 @@ async def _resolve_to_response(db: AsyncSession, raw: list[dict[str, Any]]) -> A
     for _type, rows in by_type.items():
         rows.sort(key=lambda x: x[0], reverse=True)
         suggestions.extend(at for _conf, at in rows[: settings.ML_ANALYZE_MAX_SUGGESTIONS])
+
+    # Mark (never drop) ancestors that a more specific chip already covers, so the
+    # form can tuck them behind a disclosure. Deliberately AFTER the display floor
+    # and per-type cap: only a chip the uploader can actually see may demote
+    # another, or a parent would vanish under a child that never rendered. The
+    # write path's ML_PARENT_SUPERSEDE_MIN_CONFIDENCE gate does not apply here —
+    # it exists because dropping a stored suggestion is irreversible, whereas a
+    # demoted chip is still one click away.
+    superseded = await find_superseded_parents(
+        db,
+        [{"tag_id": s.tag_id, "confidence": s.confidence} for s in suggestions],
+        min_child_confidence=0.0,
+    )
+    for s in suggestions:
+        s.superseded_by_tag_ids = superseded.get(s.tag_id, [])
     return AnalyzeTagsResponse(suggestions=suggestions)

--- a/app/config.py
+++ b/app/config.py
@@ -172,7 +172,12 @@ class Settings(BaseSettings):
         description=(
             "A suggested child tag supersedes (drops) its suggested parent tags "
             "only when the child's confidence is at least this; a weaker child "
-            "leaves the parent in place; default chosen from tag-hierarchy precision analysis (2026-07)"
+            "leaves the parent in place; default chosen from tag-hierarchy precision analysis (2026-07). "
+            "WRITE PATH ONLY (stored suggestions for the review queue). The upload "
+            "form does NOT use this: it demotes superseded parents behind a "
+            "disclosure rather than dropping them, so it needs no confidence gate. "
+            "Raising this once regressed the upload form back when the two shared "
+            "it — evaluate any change against the queue alone."
         ),
     )
 

--- a/app/schemas/ml_analyze.py
+++ b/app/schemas/ml_analyze.py
@@ -1,6 +1,6 @@
 """Response schema for the upload-form analyze endpoint."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class AnalyzedTag(BaseModel):
@@ -10,6 +10,15 @@ class AnalyzedTag(BaseModel):
     title: str
     type: int  # internal tag type: theme=1, source=2, artist=3, character=4
     confidence: float  # mapping-scaled model confidence, 0-1 (surfaced for evaluation)
+    superseded_by_tag_ids: list[int] = Field(
+        default_factory=list,
+        description=(
+            "Suggested descendants of this tag that are also in this response."
+            " Non-empty means the tag is redundant (hierarchy expansion at search"
+            " time already covers it) and the form should demote it rather than"
+            " offer it alongside its own children."
+        ),
+    )
 
 
 class AnalyzeTagsResponse(BaseModel):

--- a/app/services/ml_suggestion_pipeline.py
+++ b/app/services/ml_suggestion_pipeline.py
@@ -174,21 +174,27 @@ async def fetch_parent_map(db: AsyncSession, tag_ids: set[int]) -> dict[int, int
     return parent_of
 
 
-async def filter_superseded_parents(
+async def find_superseded_parents(
     db: AsyncSession,
     suggestions: list[dict[str, Any]],
     min_child_confidence: float,
-) -> list[dict[str, Any]]:
-    """Drop a suggested tag when a more-specific suggested descendant (via
+) -> dict[int, list[int]]:
+    """Map each superseded ancestor to the suggested descendants that supersede it.
+
+    A suggested tag is superseded when a more-specific suggested descendant (via
     Tags.inheritedfrom_id) is present and that descendant's confidence is
-    >= min_child_confidence. The ancestor chain is walked through the Tags
-    table, so a suggested grandparent is dropped even when intermediate tags
-    in the chain are not themselves suggested. Only tags that are in the
-    suggestion set are ever dropped. A low-confidence child does not suppress
-    its ancestors (all kept). Input dicts have at least tag_id + confidence.
+    >= min_child_confidence. The ancestor chain is walked through the Tags table,
+    so a suggested grandparent is found even when intermediate tags in the chain
+    are not themselves suggested. Only tags in the suggestion set appear as keys.
+    A low-confidence child supersedes nothing. Input dicts have at least
+    tag_id + confidence.
+
+    Callers pick what to do with the result: the write path drops the ancestors
+    (filter_superseded_parents), while the upload form demotes them behind a
+    disclosure so the uploader can still reach one when the child is wrong.
     """
     if len(suggestions) < 2:
-        return suggestions
+        return {}
 
     conf_by_id: dict[int, float] = {}
     for s in suggestions:
@@ -198,18 +204,32 @@ async def filter_superseded_parents(
 
     parent_of = await fetch_parent_map(db, suggested_ids)
 
-    superseded: set[int] = set()
-    for child_id, conf in conf_by_id.items():
+    superseded: dict[int, list[int]] = {}
+    for child_id, conf in sorted(conf_by_id.items()):
         if conf < min_child_confidence:
             continue
         cur = parent_of.get(child_id)
         depth = 0
         while cur is not None and depth < 10:
             if cur in suggested_ids:
-                superseded.add(cur)
+                superseded.setdefault(cur, []).append(child_id)
             cur = parent_of.get(cur)
             depth += 1
 
+    return superseded
+
+
+async def filter_superseded_parents(
+    db: AsyncSession,
+    suggestions: list[dict[str, Any]],
+    min_child_confidence: float,
+) -> list[dict[str, Any]]:
+    """Drop every ancestor that find_superseded_parents reports as superseded.
+
+    Used on the write path, where a redundant stored suggestion has no reviewer
+    affordance to recover from — see find_superseded_parents for the rule.
+    """
+    superseded = await find_superseded_parents(db, suggestions, min_child_confidence)
     if not superseded:
         return suggestions
     return [s for s in suggestions if s["tag_id"] not in superseded]

--- a/tests/api/v1/test_ml_analyze.py
+++ b/tests/api/v1/test_ml_analyze.py
@@ -356,12 +356,15 @@ async def test_analyze_caches_predictions(
     assert any(key.startswith("ml:analyze:") for key in cache_keys)
 
 
-async def test_analyze_confident_child_supersedes_parent(
+async def test_analyze_child_demotes_parent_instead_of_dropping_it(
     analyze_client: AsyncClient, db_session: AsyncSession, monkeypatch
 ):
-    """A confident suggested child (>= supersede floor) drops its suggested parent.
+    """The upload form DEMOTES a superseded parent rather than dropping it.
 
-    sundress 0.70 + dress 0.85 -> keep sundress, drop dress.
+    sundress 0.70 + dress 0.85 -> both returned, with dress marked as superseded
+    by sundress so the form can tuck it behind a disclosure. Dropping it here
+    would be wrong: unlike the review queue, the uploader has no other way back
+    to the parent when the child turns out to be the wrong specialisation.
     """
     monkeypatch.setattr(settings, "ML_TAG_SUGGESTIONS_ENABLED", True)
     monkeypatch.setattr(settings, "ML_ANALYZE_MIN_CONFIDENCE", 0.5)  # display floor
@@ -400,22 +403,24 @@ async def test_analyze_confident_child_supersedes_parent(
         response = await analyze_client.post("/api/v1/ml-tag-suggestions/analyze", files=_files())
 
     assert response.status_code == 200, response.text
-    titles = {s["title"] for s in response.json()["suggestions"]}
-    assert "sundress" in titles  # confident child kept
-    assert "dress" not in titles  # superseded parent dropped
+    by_title = {s["title"]: s for s in response.json()["suggestions"]}
+    assert by_title["sundress"]["superseded_by_tag_ids"] == []  # child stays primary
+    assert by_title["dress"]["superseded_by_tag_ids"] == [child.tag_id]  # parent demoted
 
 
-async def test_analyze_weak_child_keeps_parent(
+async def test_analyze_weak_child_still_demotes_parent(
     analyze_client: AsyncClient, db_session: AsyncSession, monkeypatch
 ):
-    """A weak suggested child (< supersede floor) does NOT suppress its parent; both
-    render as long as each clears the display floor.
+    """Any child the uploader can SEE demotes its parent, however weak.
 
-    Bands: display floor 0.5, supersede floor 0.6, child 0.55 (>= display, < supersede).
+    The write path's confidence floor exists because dropping is destructive;
+    demotion is not, so the upload form gates on visibility (the display floor)
+    alone and ignores ML_PARENT_SUPERSEDE_MIN_CONFIDENCE entirely. Child 0.55 is
+    above the 0.5 display floor but far below the 0.9 supersede floor.
     """
     monkeypatch.setattr(settings, "ML_TAG_SUGGESTIONS_ENABLED", True)
     monkeypatch.setattr(settings, "ML_ANALYZE_MIN_CONFIDENCE", 0.5)  # display floor
-    monkeypatch.setattr(settings, "ML_PARENT_SUPERSEDE_MIN_CONFIDENCE", 0.6)
+    monkeypatch.setattr(settings, "ML_PARENT_SUPERSEDE_MIN_CONFIDENCE", 0.9)
 
     parent = Tags(title="dress", type=TagType.THEME)
     db_session.add(parent)
@@ -450,9 +455,61 @@ async def test_analyze_weak_child_keeps_parent(
         response = await analyze_client.post("/api/v1/ml-tag-suggestions/analyze", files=_files())
 
     assert response.status_code == 200, response.text
-    titles = {s["title"] for s in response.json()["suggestions"]}
-    assert "sundress" in titles  # weak child still rendered (clears display floor)
-    assert "dress" in titles  # parent NOT superseded by a weak child
+    by_title = {s["title"]: s for s in response.json()["suggestions"]}
+    assert by_title["sundress"]["superseded_by_tag_ids"] == []
+    assert by_title["dress"]["superseded_by_tag_ids"] == [child.tag_id]
+
+
+async def test_analyze_child_below_display_floor_does_not_demote_parent(
+    analyze_client: AsyncClient, db_session: AsyncSession, monkeypatch
+):
+    """A child that never renders cannot demote a parent that does.
+
+    Inference runs at the storage floor (0.35), so a 0.40 child reaches the
+    resolver but is cut by the 0.5 display floor. If supersede ran before that
+    cut, the uploader would see NEITHER chip: the parent tucked away as
+    "covered by" a child that isn't on screen.
+    """
+    monkeypatch.setattr(settings, "ML_TAG_SUGGESTIONS_ENABLED", True)
+    monkeypatch.setattr(settings, "ML_MIN_CONFIDENCE", 0.35)
+    monkeypatch.setattr(settings, "ML_ANALYZE_MIN_CONFIDENCE", 0.5)  # display floor
+
+    parent = Tags(title="dress", type=TagType.THEME)
+    db_session.add(parent)
+    await db_session.commit()
+    await db_session.refresh(parent)
+    child = Tags(title="sundress", type=TagType.THEME, inheritedfrom_id=parent.tag_id)
+    db_session.add(child)
+    await db_session.commit()
+    await db_session.refresh(child)
+
+    raw_preds = [
+        {"external_tag": "dress", "confidence": 0.80, "category": 0, "model_version": "v1"},
+        {"external_tag": "sundress", "confidence": 0.40, "category": 0, "model_version": "v1"},
+    ]
+    resolved = [
+        {"tag_id": parent.tag_id, "confidence": 0.80, "model_version": "v1"},
+        {"tag_id": child.tag_id, "confidence": 0.40, "model_version": "v1"},
+    ]
+
+    with (
+        patch(
+            "app.api.v1.ml_analyze.get_ml_service",
+            new_callable=AsyncMock,
+            return_value=_fake_ml_service(raw_preds),
+        ),
+        patch(
+            "app.api.v1.ml_analyze.resolve_external_tags",
+            new_callable=AsyncMock,
+            return_value=resolved,
+        ),
+    ):
+        response = await analyze_client.post("/api/v1/ml-tag-suggestions/analyze", files=_files())
+
+    assert response.status_code == 200, response.text
+    suggestions = response.json()["suggestions"]
+    assert {s["title"] for s in suggestions} == {"dress"}  # sub-floor child not rendered
+    assert suggestions[0]["superseded_by_tag_ids"] == []  # ...so it demotes nothing
 
 
 async def test_analyze_infers_at_storage_floor_but_displays_at_higher_floor(

--- a/tests/services/test_ml_suggestion_pipeline.py
+++ b/tests/services/test_ml_suggestion_pipeline.py
@@ -26,6 +26,7 @@ from app.models.user import Users
 from app.services.ml_suggestion_pipeline import (
     compute_implied_suggestions,
     filter_superseded_parents,
+    find_superseded_parents,
     generate_and_store_suggestions,
     store_predictions,
 )
@@ -996,6 +997,61 @@ async def test_filter_superseded_parents_gap_chain_weak_child_keeps_grandparent(
     result = await filter_superseded_parents(db_session, suggestions, 0.6)
 
     assert {s["tag_id"] for s in result} == {670, 672}
+
+
+async def test_find_superseded_parents_maps_parent_to_its_children(db_session):
+    """The map names WHICH suggested descendants supersede each parent, so a
+    caller can demote (upload form) instead of drop (write path)."""
+    parent = Tags(tag_id=680, title="animal ears")
+    cat = Tags(tag_id=681, title="cat ears", inheritedfrom_id=680)
+    dog = Tags(tag_id=682, title="dog ears", inheritedfrom_id=680)
+    db_session.add_all([parent, cat, dog])
+    await db_session.commit()
+
+    suggestions = [
+        {"tag_id": 680, "confidence": 0.94, "model_version": "v3"},
+        {"tag_id": 681, "confidence": 0.82, "model_version": "v3"},
+        {"tag_id": 682, "confidence": 0.61, "model_version": "v3"},
+    ]
+
+    result = await find_superseded_parents(db_session, suggestions, 0.6)
+
+    assert set(result) == {680}
+    assert sorted(result[680]) == [681, 682]
+
+
+async def test_find_superseded_parents_reaches_through_a_gap(db_session):
+    """A grandparent is superseded even when the middle tag is not suggested,
+    and the map credits the actual suggested descendant."""
+    grand = Tags(tag_id=690, title="bag")
+    middle = Tags(tag_id=691, title="school bag", inheritedfrom_id=690)
+    child = Tags(tag_id=692, title="randoseru", inheritedfrom_id=691)
+    db_session.add_all([grand, middle, child])
+    await db_session.commit()
+
+    suggestions = [
+        {"tag_id": 690, "confidence": 0.88, "model_version": "v3"},
+        {"tag_id": 692, "confidence": 0.75, "model_version": "v3"},
+    ]
+
+    result = await find_superseded_parents(db_session, suggestions, 0.6)
+
+    assert result == {690: [692]}
+
+
+async def test_find_superseded_parents_ignores_weak_children(db_session):
+    """Below min_child_confidence a child supersedes nothing (empty map)."""
+    parent = Tags(tag_id=695, title="dress")
+    child = Tags(tag_id=696, title="sundress", inheritedfrom_id=695)
+    db_session.add_all([parent, child])
+    await db_session.commit()
+
+    suggestions = [
+        {"tag_id": 695, "confidence": 0.80, "model_version": "v3"},
+        {"tag_id": 696, "confidence": 0.55, "model_version": "v3"},
+    ]
+
+    assert await find_superseded_parents(db_session, suggestions, 0.6) == {}
 
 
 async def test_character_suggestions_dropped_when_flag_off(db_session, tmp_path, monkeypatch):


### PR DESCRIPTION
Reported by whitekitten:

> When uploading could we also have a system that suggests the child primarily? It's suggesting new users use both animal ears and cat ears, and bag and school bag, etc

## Root cause — a regression from #288

The upload `/analyze` endpoint shared `ML_PARENT_SUPERSEDE_MIN_CONFIDENCE` with the write path (`app/api/v1/ml_analyze.py:134`). Raising that default 0.6 → 0.9 in 4fed643 — a review-queue fix — widened the upload form's "offer both parent and child" band from `[0.5, 0.6)` to `[0.5, 0.9)`.

Measured on dev's raw store, for whitekitten's exact examples:

| pair | child ≥0.9, parent hidden | both shown |
|---|---|---|
| cat ears / animal ears | 20,615 | **13,418 (39%)** — was ~3% at 0.6 |
| school bag / bag | 211 | **5,357 (96%)** |

The queue can afford 0.9 because it has two safety nets: descendant-hiding in `list_pending_for_tag`, and the approve-cascade cleanup. The upload form has neither — it's a flat chip row shown to a new user.

**Takeaway for future tuning: this knob is per-path. It was only ever safe for the queue.**

## Why demote rather than drop

Dropping the parent on upload is destructive: the uploader has no other route back to it when the model picked the wrong specialisation. Measured against `tag_links`, suppressing at the display floor loses a warranted parent in 9.1% of cases.

I checked whether that number was inflated by children that are correct but simply never got tagged — restricting to thoroughly-tagged images (≥10 theme tags) moved it to **9.3%**. It didn't budge, so the cost is real.

So `/analyze` now **marks** superseded ancestors and the form tucks them behind a disclosure. That needs no confidence threshold at all — demotion is non-destructive, so visibility is the only gate, and **no fourth config knob was added**.

## Changes

- extract `find_superseded_parents()` returning `{ancestor: [descendants]}`; `filter_superseded_parents()` becomes a thin drop-wrapper over it, so the write path is unchanged (its 8 tests pass untouched)
- `AnalyzedTag.superseded_by_tag_ids`, mirroring the review panel's `superseded_suggestion_ids`
- **run the marking AFTER the display floor and per-type cap rather than before.** Previously a child below `ML_ANALYZE_MIN_CONFIDENCE` could suppress a parent and then be cut itself, leaving the uploader with *neither* chip. Latent at 0.9, but it would have bitten the first time anyone tuned this. New regression test.

## Rejected alternative

A relative rule (child wins when close to the parent's confidence) is **dominated**: `cc >= 0.85*pc` gives 15,904 bad suppressions and 30,703 redundant pairs, where flat 0.70 gives 15,680 and 24,620 — worse on both axes. Real images routinely score the parent higher (animal ears 0.92 vs cat ears 0.83), which is exactly where a ratio rule fails.

## Testing

176 ML tests pass. Also drove the real `_resolve_to_response` path against real stored predictions for 3 images — everything but the ONNX call — and all three demoted correctly.

Frontend counterpart: anonymousobject/shuushuu-frontend#316. **Merge this first**; the frontend `?? []`-guards the missing field, so the deploy order is safe either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mNdmr81BUJ81WwrPwA7Lq