### PR TITLE
fix(ml): surface canonical tags on analyze, scope redundant-title filter to themes

### DIFF
--- a/app/api/v1/ml_analyze.py
+++ b/app/api/v1/ml_analyze.py
@@ -28,6 +28,7 @@ from app.services.ml_suggestion_pipeline import (  # light: no onnxruntime
 )
 from app.services.rate_limit import check_analyze_rate_limit
 from app.services.tag_mapping_service import resolve_external_tags
+from app.services.tag_resolver import resolve_tag_relationships
 
 logger = get_logger(__name__)
 
@@ -125,6 +126,13 @@ async def _resolve_to_response(db: AsyncSession, raw: list[dict[str, Any]]) -> A
     resolved = await resolve_external_tags(db, raw)  # [{tag_id, confidence, model_version}]
     if not resolved:
         return AnalyzeTagsResponse(suggestions=[])
+
+    # Collapse aliases to their canonical tag, exactly as the stored-suggestion
+    # pipeline does before persisting. Without this a mapping that points at an
+    # alias row surfaces the alias title here ("miko") while the review queue
+    # shows the canonical one ("shrine maiden") for the same prediction.
+    # Must run before the character gate so aliases of character tags are caught.
+    resolved = await resolve_tag_relationships(db, resolved)
 
     # Character gate: must run before parent-supersede so a gated character
     # child can't first supersede a theme parent (both chips would be lost).

--- a/app/services/ml_suggestion_pipeline.py
+++ b/app/services/ml_suggestion_pipeline.py
@@ -87,8 +87,14 @@ async def filter_redundant_suggestions(
 
         tags_to_check = [t for t in tags_to_check if t not in checked_ids]
 
-    # Build set of existing tag titles (lowercase for comparison)
-    existing_titles = {(t.title or "").lower() for t in existing_tags}
+    # Build set of existing THEME tag titles (lowercase for comparison).
+    # Theme-only on purpose: the substring rule below is about theme compounds
+    # ("kimono" in "short kimono"). Source/character/artist titles are proper
+    # nouns that merely happen to contain theme words — "Fruits Basket" says
+    # nothing about whether a basket is depicted. Including them silently
+    # dropped correct suggestions. The ancestor check above stays unrestricted,
+    # since cross-type inheritedfrom chains are real.
+    existing_titles = {(t.title or "").lower() for t in existing_tags if t.type == TagType.THEME}
 
     # Fetch suggested tags to get their titles
     suggested_tag_ids = [s["tag_id"] for s in suggestions]
@@ -112,8 +118,11 @@ async def filter_redundant_suggestions(
             )
             continue
 
-        # Skip if tag title is contained in an existing tag's title
-        if tag and tag.title:
+        # Skip if this THEME tag's title is contained in an existing theme title.
+        # Non-theme suggestions are exempt for the same reason non-theme existing
+        # titles are: a character named "Blue" is not made redundant by the theme
+        # "blue hair" already being on the image.
+        if tag and tag.title and tag.type == TagType.THEME:
             tag_title_lower = tag.title.lower()
             # Check if this tag's title appears as a whole word (or contiguous
             # word phrase) inside any existing tag's title. Only filter if it's a

--- a/tests/api/v1/test_ml_analyze.py
+++ b/tests/api/v1/test_ml_analyze.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import TagType, settings
 from app.core.security import create_access_token
 from app.models.tag import Tags
+from app.models.tag_mapping import TagMappings
 from app.models.user import Users
 from app.services import ml_runtime
 
@@ -136,6 +137,44 @@ async def test_analyze_returns_theme_and_character_tags(
     # confidence is surfaced for evaluation (mapping-scaled; mapping.confidence=1.0 in this fake)
     assert by_title["smile"]["confidence"] == 0.9
     assert by_title["hatsune miku"]["confidence"] == 0.95
+
+
+async def test_analyze_surfaces_canonical_tag_for_alias_mapping(
+    analyze_client: AsyncClient, db_session: AsyncSession, monkeypatch
+):
+    """A mapping pointing at an ALIAS surfaces the canonical tag, not the alias.
+
+    Mirrors the stored-suggestion pipeline, which resolves Tags.alias_of before
+    persisting. Uses a real tag_mappings row so the whole map->resolve chain runs.
+    """
+    monkeypatch.setattr(settings, "ML_TAG_SUGGESTIONS_ENABLED", True)
+
+    canonical = Tags(title="shrine maiden", type=TagType.THEME)
+    db_session.add(canonical)
+    await db_session.commit()
+    await db_session.refresh(canonical)
+
+    alias = Tags(title="miko", type=TagType.THEME, alias_of=canonical.tag_id)
+    db_session.add(alias)
+    await db_session.commit()
+    await db_session.refresh(alias)
+
+    db_session.add(TagMappings(external_tag="miko", internal_tag_id=alias.tag_id, confidence=1.0))
+    await db_session.commit()
+
+    raw_preds = [{"external_tag": "miko", "confidence": 0.9, "category": 0, "model_version": "v1"}]
+
+    with patch(
+        "app.api.v1.ml_analyze.get_ml_service",
+        new_callable=AsyncMock,
+        return_value=_fake_ml_service(raw_preds),
+    ):
+        response = await analyze_client.post("/api/v1/ml-tag-suggestions/analyze", files=_files())
+
+    assert response.status_code == 200, response.text
+    suggestions = response.json()["suggestions"]
+    assert [s["title"] for s in suggestions] == ["shrine maiden"]
+    assert suggestions[0]["tag_id"] == canonical.tag_id
 
 
 async def test_analyze_omits_character_tags_when_flag_off(

--- a/tests/services/test_ml_suggestion_pipeline.py
+++ b/tests/services/test_ml_suggestion_pipeline.py
@@ -437,6 +437,80 @@ async def test_keeps_substring_inside_word(db_session, tmp_path, monkeypatch):
     assert {s.tag_id for s in suggestions} == {211}
 
 
+async def test_keeps_theme_substring_of_non_theme_tag(db_session, tmp_path, monkeypatch):
+    """A source/character/artist title must not swallow a theme suggestion.
+
+    The substring rule exists for theme compounds ("kimono" in "short kimono").
+    An image tagged with the SOURCE "Fruits Basket" says nothing about whether a
+    basket is depicted, so suggested theme "basket" must survive.
+    """
+    monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+
+    existing = Tags(tag_id=220, title="Fruits Basket", type=TagType.SOURCE)
+    suggested = Tags(tag_id=221, title="basket", type=TagType.THEME)
+    db_session.add_all([existing, suggested])
+    await db_session.flush()
+
+    user = await _make_user(db_session, "crosstype")
+    image = await _make_image(db_session, user, "crosstype", tmp_path)
+    await db_session.flush()
+
+    db_session.add(TagLinks(image_id=image.image_id, tag_id=220, user_id=user.user_id))
+    await db_session.commit()
+
+    ml = FakeMLService(_predictions("basket"))
+    mapped = [{"tag_id": 221, "confidence": 0.9, "model_version": "v3"}]
+
+    with (
+        patch(f"{PIPELINE}.resolve_external_tags", _resolver_to_tag_ids(mapped)),
+        patch(f"{PIPELINE}.resolve_tag_relationships", _passthrough_resolver),
+    ):
+        created = await generate_and_store_suggestions(db_session, image, ml)
+
+    assert created == 1
+    result = await db_session.execute(
+        select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+    )
+    assert {s.tag_id for s in result.scalars().all()} == {221}
+
+
+async def test_keeps_non_theme_substring_of_theme_tag(db_session, tmp_path, monkeypatch):
+    """An existing theme title must not swallow a character suggestion.
+
+    The reverse of the above: characters named "Blue" would otherwise be dropped
+    on every image already tagged with the theme "blue hair".
+    """
+    monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+    monkeypatch.setattr(settings, "ML_CHARACTER_SUGGESTIONS_ENABLED", True)
+
+    existing = Tags(tag_id=230, title="blue hair", type=TagType.THEME)
+    suggested = Tags(tag_id=231, title="Blue", type=TagType.CHARACTER)
+    db_session.add_all([existing, suggested])
+    await db_session.flush()
+
+    user = await _make_user(db_session, "revcrosstype")
+    image = await _make_image(db_session, user, "revcrosstype", tmp_path)
+    await db_session.flush()
+
+    db_session.add(TagLinks(image_id=image.image_id, tag_id=230, user_id=user.user_id))
+    await db_session.commit()
+
+    ml = FakeMLService(_predictions("blue"))
+    mapped = [{"tag_id": 231, "confidence": 0.9, "model_version": "v3"}]
+
+    with (
+        patch(f"{PIPELINE}.resolve_external_tags", _resolver_to_tag_ids(mapped)),
+        patch(f"{PIPELINE}.resolve_tag_relationships", _passthrough_resolver),
+    ):
+        created = await generate_and_store_suggestions(db_session, image, ml)
+
+    assert created == 1
+    result = await db_session.execute(
+        select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+    )
+    assert {s.tag_id for s in result.scalars().all()} == {231}
+
+
 async def test_no_mappings_creates_nothing(db_session, tmp_path, monkeypatch):
     """When nothing maps to an internal tag, the pipeline completes with 0 created."""
     monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))


### PR DESCRIPTION
Two independent bugs in the ML tag-suggestion path, both found while auditing which theme tags lack a mapping.

## 1. Analyze path surfaced alias titles

`ml_analyze._resolve_to_response` mapped external tags but never resolved aliases, so a `tag_mappings` row pointing at an alias surfaced the **alias** title on the upload form while the stored-suggestion pipeline — which does resolve — showed the **canonical** one for the same prediction. A reviewer saw "shrine maiden"; the uploader saw "miko".

15 mappings currently point at alias rows (`miko`, `rabbit_ears`, `personification`, `comic`, `kitsune`, `cape`, `collar`, `drink`, `spear`, `scythe`, …), so the two views disagreed in production. There was no alias test coverage on this path, which is likely why it went unnoticed.

Fix: call `resolve_tag_relationships` between mapping and the character gate, matching `ml_suggestion_pipeline`'s order. The gate must run *after* alias resolution so aliases of character tags are still caught.

## 2. Redundant-title filter matched across tag types

`filter_redundant_suggestions` compared a suggestion's title against **every** tag on the image regardless of type. The rule exists for theme compounds ("kimono" in "short kimono"), but source/character/artist titles are proper nouns that merely contain theme words, so correct suggestions were silently dropped:

| Image tagged | Suggestion dropped |
|---|---|
| Kingdom Hearts: Birth by Sleep (527 imgs) | `sleep` |
| Fruits Basket (499) | `basket` |
| Aikatsu Stars! (391) | `stars` |
| Sket Dance (188) | `dance` |
| Devil May Cry (185) | `devil` |
| Tobiichi Origami (90, character) | `origami` |

~6,550 tagged-image instances in dev. The reverse held too — 99 non-theme tags sit inside theme titles, so characters named Blue/Green/Red were dropped on any image already tagged `blue hair` or `green eyes`.

Fix: restrict **both** sides of the comparison to theme tags. The ancestor check is deliberately left unrestricted — cross-type `inheritedfrom` chains are real, and the character gate already runs before parent-supersede to handle them.

## Verification

TDD throughout; each test was confirmed red before its fix. Three new tests: alias→canonical on analyze, and both cross-type directions. The existing `short kimono`/`catgirl` tests stayed green, which was the constraint that mattered.

**Full suite: 2342 passed, 10 skipped.** mypy and ruff clean on all changed files.

Verified end-to-end against dev data: the two images tagged `Fruits Basket` carrying raw `basket` predictions (0.531 and 0.870) had zero `basket` suggestions before, and both were pending after a remap.

## Rollout note

These change which suggestions survive *generation*; previously-dropped ones were never written and won't reappear on their own. Dev has had a full remap (1,052,286 images, 0 errors, +284,833 pending). Prod needs the same import + remap sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xno5FgzioadwndNM49sBir