### PR TITLE
feat(scripts): --conflated report mode for character↔source multi-link review

### DIFF
--- a/scripts/analyze_character_sources.py
+++ b/scripts/analyze_character_sources.py
@@ -362,7 +362,7 @@ def main() -> None:
         "--min-images",
         type=int,
         default=5,
-        help="Minimum images for a character to be considered (default: 5)",
+        help="Dominant mode: minimum images for a character to be considered; --conflated mode: minimum per-source image count (default: 5)",
     )
     parser.add_argument(
         "--output",

--- a/scripts/analyze_character_sources.py
+++ b/scripts/analyze_character_sources.py
@@ -14,6 +14,9 @@ Usage:
 
     # Create links in database
     uv run python scripts/analyze_character_sources.py --create-links [--user-id 1]
+
+    # Report conflated-candidate characters (>= 2 dominant sources; report-only)
+    uv run python scripts/analyze_character_sources.py --conflated [--min-usage 20] [--min-share 0.05]
 """
 
 import argparse
@@ -64,8 +67,7 @@ async def analyze_character_sources(
         for char_id, char_title in character_tags:
             # Get count of images with this character
             count_result = await db.execute(
-                select(func.count(TagLinks.image_id))
-                .where(TagLinks.tag_id == char_id)
+                select(func.count(TagLinks.image_id)).where(TagLinks.tag_id == char_id)
             )
             total_images = count_result.scalar() or 0
 
@@ -88,15 +90,17 @@ async def analyze_character_sources(
             for source_id, source_title, count in source_counts_result.all():
                 percentage = count / total_images
                 if percentage >= threshold:
-                    results.append({
-                        "character_tag_id": char_id,
-                        "character_title": char_title,
-                        "source_tag_id": source_id,
-                        "source_title": source_title,
-                        "co_occurrence_count": count,
-                        "total_character_images": total_images,
-                        "percentage": round(percentage * 100, 1),
-                    })
+                    results.append(
+                        {
+                            "character_tag_id": char_id,
+                            "character_title": char_title,
+                            "source_tag_id": source_id,
+                            "source_title": source_title,
+                            "co_occurrence_count": count,
+                            "total_character_images": total_images,
+                            "percentage": round(percentage * 100, 1),
+                        }
+                    )
 
     await engine.dispose()
 
@@ -192,6 +196,160 @@ async def create_links_from_results(
     return created, skipped
 
 
+async def find_conflated_characters(
+    db: AsyncSession,
+    *,
+    min_usage: int = 20,
+    min_images: int = 5,
+    min_share: float = 0.05,
+) -> list[dict]:
+    """
+    Report character tags whose images split across >= 2 dominant sources.
+
+    A source qualifies when it co-occurs on >= min_images of the character's
+    images AND covers >= min_share of the character's source-tagged images.
+    Alias source tags roll up into their canonical tag. Report-only: a human
+    decides which combinations get links (true conflation and legitimate
+    multi-franchise appearances both warrant them).
+    """
+    char_rows = (
+        await db.execute(
+            select(Tags.tag_id, Tags.title)
+            .where(Tags.type == TagType.CHARACTER)
+            .where(Tags.usage_count >= min_usage)
+            .order_by(Tags.tag_id)
+        )
+    ).all()
+
+    link_count_rows = (
+        await db.execute(
+            select(CharacterSourceLinks.character_tag_id, func.count()).group_by(
+                CharacterSourceLinks.character_tag_id
+            )
+        )
+    ).all()
+    link_counts = dict(link_count_rows)
+
+    results: list[dict] = []
+    for char_id, char_title in char_rows:
+        image_subquery = select(TagLinks.image_id).where(TagLinks.tag_id == char_id).subquery()
+
+        total_images = (
+            await db.execute(
+                select(func.count(TagLinks.image_id)).where(TagLinks.tag_id == char_id)
+            )
+        ).scalar() or 0
+        # usage_count is denormalized and can drift; re-check against live links
+        if total_images < min_usage:
+            continue
+
+        canonical_id = func.coalesce(Tags.alias_of, Tags.tag_id).label("source_tag_id")
+        source_rows = (
+            await db.execute(
+                select(canonical_id, func.count(func.distinct(TagLinks.image_id)).label("count"))
+                .join(TagLinks, Tags.tag_id == TagLinks.tag_id)
+                .where(Tags.type == TagType.SOURCE)
+                .where(TagLinks.image_id.in_(select(image_subquery)))
+                .group_by(canonical_id)
+            )
+        ).all()
+
+        source_tagged = (
+            await db.execute(
+                select(func.count(func.distinct(TagLinks.image_id)))
+                .join(Tags, Tags.tag_id == TagLinks.tag_id)
+                .where(Tags.type == TagType.SOURCE)
+                .where(TagLinks.image_id.in_(select(image_subquery)))
+            )
+        ).scalar() or 0
+        if source_tagged == 0:
+            continue
+
+        qualifying = [
+            (source_id, count)
+            for source_id, count in source_rows
+            if count >= min_images and count / source_tagged >= min_share
+        ]
+        if len(qualifying) < 2:
+            continue
+        qualifying.sort(key=lambda pair: -pair[1])
+
+        results.append(
+            {
+                "character_tag_id": char_id,
+                "character_title": char_title,
+                "total_character_images": total_images,
+                "source_tagged_images": source_tagged,
+                "linked_count": link_counts.get(char_id, 0),
+                "sources": [
+                    {
+                        "source_tag_id": source_id,
+                        "count": count,
+                        "share": round(count / source_tagged, 3),
+                    }
+                    for source_id, count in qualifying
+                ],
+            }
+        )
+
+    source_ids = {s["source_tag_id"] for r in results for s in r["sources"]}
+    if source_ids:
+        title_rows = (
+            await db.execute(select(Tags.tag_id, Tags.title).where(Tags.tag_id.in_(source_ids)))
+        ).all()
+        titles = dict(title_rows)
+        for r in results:
+            for s in r["sources"]:
+                s["source_title"] = titles.get(s["source_tag_id"])
+
+    results.sort(key=lambda r: -r["total_character_images"])
+    return results
+
+
+async def run_conflated(
+    min_usage: int, min_images: int, min_share: float, output_file: str | None
+) -> list[dict]:
+    """CLI wrapper: open a session, run the report, print, optionally CSV."""
+    engine = create_async_engine(settings.DATABASE_URL, echo=False)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as db:
+        results = await find_conflated_characters(
+            db, min_usage=min_usage, min_images=min_images, min_share=min_share
+        )
+    await engine.dispose()
+
+    print(
+        f"\n{len(results)} conflated-candidate character tags "
+        f"(>= 2 sources with >= {min_images} images and >= {min_share:.0%} share):\n"
+    )
+    for r in results:
+        sources = ", ".join(f"{s['source_title']} ({s['count']})" for s in r["sources"])
+        print(
+            f"  #{r['character_tag_id']} {r['character_title']} — "
+            f"{r['total_character_images']} images, links: {r['linked_count']} — {sources}"
+        )
+
+    if output_file:
+        char_fields = [
+            "character_tag_id",
+            "character_title",
+            "total_character_images",
+            "source_tagged_images",
+            "linked_count",
+        ]
+        with open(output_file, "w", newline="") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=char_fields + ["source_tag_id", "source_title", "count", "share"]
+            )
+            writer.writeheader()
+            for r in results:
+                for s in r["sources"]:
+                    writer.writerow({**{k: r[k] for k in char_fields}, **s})
+        print(f"\nResults written to {output_file}")
+
+    return results
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Analyze character-source co-occurrence")
     parser.add_argument(
@@ -223,6 +381,23 @@ def main() -> None:
         default=None,
         help="User ID to record as link creator (optional, used with --create-links)",
     )
+    parser.add_argument(
+        "--conflated",
+        action="store_true",
+        help="Report characters whose images split across >= 2 dominant sources (report-only)",
+    )
+    parser.add_argument(
+        "--min-usage",
+        type=int,
+        default=20,
+        help="(--conflated) minimum character tag usage (default: 20)",
+    )
+    parser.add_argument(
+        "--min-share",
+        type=float,
+        default=0.05,
+        help="(--conflated) minimum share of source-tagged images per source (default: 0.05)",
+    )
     args = parser.parse_args()
 
     if not 0.0 <= args.threshold <= 1.0:
@@ -231,8 +406,18 @@ def main() -> None:
         parser.error("--min-images must be at least 1")
     if args.user_id is not None and args.user_id < 1:
         parser.error("--user-id must be a positive integer")
+    if args.conflated and args.create_links:
+        parser.error("--conflated is report-only and cannot be combined with --create-links")
+    if not 0.0 <= args.min_share <= 1.0:
+        parser.error("--min-share must be between 0.0 and 1.0")
+    if args.min_usage < 1:
+        parser.error("--min-usage must be at least 1")
 
     try:
+        if args.conflated:
+            asyncio.run(run_conflated(args.min_usage, args.min_images, args.min_share, args.output))
+            return
+
         results = asyncio.run(
             analyze_character_sources(
                 threshold=args.threshold,

--- a/tests/integration/test_analyze_character_sources.py
+++ b/tests/integration/test_analyze_character_sources.py
@@ -1,0 +1,87 @@
+"""Tests for the --conflated report mode of scripts/analyze_character_sources.py."""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import TagType
+from app.models.character_source_link import CharacterSourceLinks
+from app.models.image import Images
+from app.models.tag import Tags
+from app.models.tag_link import TagLinks
+from scripts.analyze_character_sources import find_conflated_characters
+
+
+def _tag(db, tag_id, ttype, title, usage_count=0, alias_of=None):
+    db.add(Tags(tag_id=tag_id, type=ttype, title=title, usage_count=usage_count, alias_of=alias_of))
+
+
+def _img(db, image_id):
+    # Images.ext is NOT NULL with no default; user 1 is pre-seeded by conftest.
+    db.add(Images(image_id=image_id, user_id=1, ext="jpg"))
+
+
+def _link(db, tag_id, image_id):
+    db.add(TagLinks(tag_id=tag_id, image_id=image_id, user_id=1))
+
+
+async def test_conflated_detection(db_session: AsyncSession):
+    # Sources: S1 (901), S2 (902), and an alias of S2 (903).
+    _tag(db_session, 901, TagType.SOURCE, "Series One")
+    _tag(db_session, 902, TagType.SOURCE, "Series Two")
+    _tag(db_session, 903, TagType.SOURCE, "Series Two Alias", alias_of=902)
+
+    # A: conflated — 30 images: 20 on S1, 10 on S2 (4 of them via the alias).
+    _tag(db_session, 911, TagType.CHARACTER, "Conflated", usage_count=30)
+    # B: single-source — 30 images, all S1.
+    _tag(db_session, 912, TagType.CHARACTER, "SingleSource", usage_count=30)
+    # C: split sources but usage below min_usage.
+    _tag(db_session, 913, TagType.CHARACTER, "BelowUsage", usage_count=10)
+
+    image_id = 9000
+
+    def add_image() -> int:
+        nonlocal image_id
+        image_id += 1
+        _img(db_session, image_id)
+        return image_id
+
+    for i in range(30):
+        iid = add_image()
+        _link(db_session, 911, iid)
+        if i < 20:
+            _link(db_session, 901, iid)  # S1
+        elif i < 26:
+            _link(db_session, 902, iid)  # S2 directly
+        else:
+            _link(db_session, 903, iid)  # S2 via alias
+    for _ in range(30):
+        iid = add_image()
+        _link(db_session, 912, iid)
+        _link(db_session, 901, iid)
+    for i in range(10):
+        iid = add_image()
+        _link(db_session, 913, iid)
+        _link(db_session, 901 if i % 2 else 902, iid)
+
+    # Flush so the tag rows exist before the link references them: CharacterSourceLinks
+    # intentionally omits an ORM relationship() to Tags (see app/models/character_source_link.py),
+    # so unit-of-work has no dependency edge to order the two mappers' inserts on its own.
+    await db_session.flush()
+
+    # A already has one link (to S1): reported, not excluded.
+    db_session.add(CharacterSourceLinks(character_tag_id=911, source_tag_id=901))
+    await db_session.commit()
+
+    results = await find_conflated_characters(
+        db_session, min_usage=20, min_images=5, min_share=0.15
+    )
+
+    assert [r["character_tag_id"] for r in results] == [911]
+    row = results[0]
+    assert row["character_title"] == "Conflated"
+    assert row["total_character_images"] == 30
+    assert row["source_tagged_images"] == 30
+    assert row["linked_count"] == 1
+    # Alias-tagged images roll up into the canonical source; count-descending.
+    assert [(s["source_tag_id"], s["count"]) for s in row["sources"]] == [(901, 20), (902, 10)]
+    assert row["sources"][0]["source_title"] == "Series One"
+    assert row["sources"][1]["source_title"] == "Series Two"


### PR DESCRIPTION
## Summary

Adds a **`--conflated` report mode** to the existing `scripts/analyze_character_sources.py`: for each character tag with usage ≥ `--min-usage` (default 20), it counts distinct images per co-occurring canonical source tag (aliases resolved via `COALESCE(alias_of, tag_id)`) and reports characters where **≥ 2 sources** each clear `--min-images` (default 5) **and** `--min-share` (default 0.05) of the character's source-tagged images — the human review worklist for multi-linking. Output is per-character stdout lines (id, title, usage, current link count, qualifying sources with counts) plus optional `--output` CSV (one row per character-source pair). Strictly report-only: `--conflated --create-links` is rejected. The dominant-mode behavior is unchanged.

## Why

Companion to frontend PR anonymousobject/shuushuu-frontend#318 (combined character+source search click-through). The original backfill only auto-linked at ≥80% single-source dominance, so the unlinked backlog is precisely the multi-source population: of 284 unlinked ≥100-usage character tags on dev, 76% have a second source at ≥15% share (Fate umbrella, Pokémon Adventures, SINoALICE fairytales), and only 5 clear 80%. This mode surfaces that worklist; humans decide link-vs-retag per case (the mode deliberately doesn't distinguish true conflation from legitimate multi-franchise appearances — both warrant "appears in" links).

**Why `--min-share` defaults to 0.05, not something stricter:** heavily-used conflated tags have a one-dominant-plus-small-tail shape — Sakura #102013's runner-up source is 6.1% — so 0.15 excluded the motivating case (dev landscape survey in the design doc, committed on the frontend branch: `docs/plans/2026-07-26-char-source-clickthrough-design.md`). At the ≥100-usage floor, `min-images 5` ≈ 5% share, so the two floors coincide.

## Testing

- `tests/integration/test_analyze_character_sources.py`: TDD (red at collection → green), real-row integration test seeding a conflated character (incl. alias roll-up into the canonical source), a single-source character, and a below-usage character; asserts exact report contents, ordering, and `linked_count`.
- Sanity gate on dev at pure defaults (`--conflated --min-usage 100`): `#102013 Sakura — 796 images, links: 3 — Tsubasa: Reservoir Chronicle (555), Sakura-Hime Kaden (47)`. 871 candidates, runtime ~46s at that floor (the per-character query loop matches the existing mode's shape; expect proportionally longer at lower `--min-usage` — acceptable for a one-off report script).
- Full suite: 2335 passed, 15 skipped (documented env skips), 0 failures. Ruff check + format clean.

## Notes for review

- The diff includes two ruff-format reflow hunks in untouched dominant-mode code (a `select(...)` wrap and a dict-literal rewrap) — tool-driven formatting only, no behavior change.
- One deviation from the drafted test: an added `await db_session.flush()` before creating the `CharacterSourceLinks` row — the model intentionally has no ORM `relationship()` to `Tags`, so the unit of work needs the explicit flush to order the FK inserts (matches every existing test that seeds this model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxSVEjjWPTPNtNVEZhFkpQ
