### PR TITLE
A manual status change supersedes the image's open review

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,3 +17,9 @@ _Avoid_: auto-approval (implies no human involvement)
 **System resolution**:
 A pending suggestion resolved to approved by data movement rather than any person's tagging action — the stale-row backfill, or tag migration during repost-marking. Reviewer is empty and displays as "—".
 _Avoid_: auto-approval, implicit approval (both imply a human actor)
+
+### Moderation reviews
+
+**Superseded review**:
+An open review closed with no verdict of its own because a moderator settled the image's status by hand while the vote was running. Outcome `SUPERSEDED`; only the status-change hook sets it, never `/reviews/{id}/close`.
+_Avoid_: cancelled (nothing was undone — the votes cast stay on record), keep/remove (those name a verdict the review never reached)

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1816,11 +1816,17 @@ async def get_image_status_history(
 
 
 def get_review_outcome_label(outcome: int) -> str:
-    """Get human-readable label for review outcome."""
+    """Get human-readable label for review outcome.
+
+    Second copy of the map on ReviewResponse (app/schemas/report.py) — this one
+    backs the public per-image endpoint, that one the admin views. Both have to
+    learn every new ReviewOutcome or the label degrades to "unknown" here.
+    """
     outcome_labels = {
         ReviewOutcome.PENDING: "pending",
         ReviewOutcome.KEEP: "keep",
         ReviewOutcome.REMOVE: "remove",
+        ReviewOutcome.SUPERSEDED: "superseded",
     }
     return outcome_labels.get(outcome, "unknown")
 

--- a/app/config.py
+++ b/app/config.py
@@ -495,6 +495,10 @@ class ReviewOutcome:
     PENDING = 0
     KEEP = 1
     REMOVE = 2
+    # Closed without a verdict of its own: a moderator settled the image's status
+    # by hand while the vote was still running (see review_lifecycle.py). Not a
+    # choice /reviews/{id}/close accepts — only the status-change hook sets it.
+    SUPERSEDED = 3
 
 
 class AdminActionType:

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -353,7 +353,7 @@ class ReviewResponse(BaseModel):
         status_labels = {0: "Open", 1: "Closed"}
         self.status_label = status_labels.get(self.status, "Unknown")
         # Outcome
-        outcome_labels = {0: "Pending", 1: "Keep", 2: "Remove"}
+        outcome_labels = {0: "Pending", 1: "Keep", 2: "Remove", 3: "Superseded"}
         self.outcome_label = outcome_labels.get(self.outcome, "Unknown")
 
 

--- a/app/services/image_status.py
+++ b/app/services/image_status.py
@@ -21,6 +21,7 @@ from app.models.image_status_history import ImageStatusHistory
 from app.models.user import Users
 from app.services.ml_suggestion_lifecycle import sync_suggestions_for_status_transition
 from app.services.repost import migrate_repost_data
+from app.services.review_lifecycle import supersede_open_reviews_for_status_change
 from app.tasks.queue import enqueue_job
 
 
@@ -141,6 +142,17 @@ async def change_image_status(
             await sync_suggestions_for_status_transition(
                 db, image.image_id, previous_status, new_status
             )
+
+            # A moderator deciding the image's status by hand settles any review
+            # still voting on it. Skipped when review_id is set, because then the
+            # caller IS a review action: REVIEW_START would close the review it
+            # just opened, and REVIEW_CLOSE would overwrite the outcome it just
+            # recorded (its own status write is unflushed, so a SELECT here would
+            # still read the review as open).
+            if review_id is None:
+                await supersede_open_reviews_for_status_change(
+                    db, image.image_id, actor_id, new_status
+                )
 
     if locked is not None:
         image.locked = 1 if locked else 0

--- a/app/services/review_lifecycle.py
+++ b/app/services/review_lifecycle.py
@@ -1,0 +1,80 @@
+"""Couple open review sessions to the image-status lifecycle.
+
+A review is a vote on what should happen to an image. Once a moderator settles
+that question by hand, the vote is moot: leaving it open keeps collecting
+votes on a decision already made, keeps the image in the review queue, and —
+worst — leaves check_review_deadlines free to close it later and re-apply its
+own outcome, so a KEEP close silently reactivates an image a moderator
+deactivated.
+
+This module owns the transition hook called by change_image_status. The
+suggestion-row twin lives in app/services/ml_suggestion_lifecycle.py.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import AdminActionType, ReviewOutcome, ReviewStatus
+from app.models.admin_action import AdminActions
+from app.models.image_review import ImageReviews
+
+
+async def supersede_open_reviews_for_status_change(
+    db: AsyncSession,
+    image_id: int,
+    actor_id: int | None,
+    new_status: int,
+) -> list[int]:
+    """Close any open review on ``image_id`` as SUPERSEDED.
+
+    Called only when the status change is NOT itself a review action — see the
+    review_id guard at the call site. Writes a REVIEW_CLOSE audit row per
+    review closed, alongside the status-change row change_image_status writes.
+
+    Only one review per image may be open (enforced at application level), but
+    legacy rows predate that rule, so every open one is closed.
+
+    Flush-only; the caller owns the transaction. Returns the closed review_ids.
+    """
+    reviews = (
+        (
+            await db.execute(
+                select(ImageReviews).where(
+                    ImageReviews.image_id == image_id,  # type: ignore[arg-type]
+                    ImageReviews.status == ReviewStatus.OPEN,  # type: ignore[arg-type]
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not reviews:
+        return []
+
+    now = datetime.now(UTC)
+    closed_ids: list[int] = []
+    for review in reviews:
+        review.status = ReviewStatus.CLOSED
+        review.outcome = ReviewOutcome.SUPERSEDED
+        review.closed_at = now
+        review.closed_by = actor_id
+        db.add(
+            AdminActions(
+                user_id=actor_id,
+                action_type=AdminActionType.REVIEW_CLOSE,
+                review_id=review.review_id,
+                image_id=image_id,
+                details={
+                    "outcome": ReviewOutcome.SUPERSEDED,
+                    "outcome_label": "superseded",
+                    "close_reason": "manual_status_change",
+                    "new_status": new_status,
+                    "automatic": False,
+                },
+            )
+        )
+        closed_ids.append(review.review_id)  # type: ignore[arg-type]
+
+    return closed_ids

--- a/app/services/review_lifecycle.py
+++ b/app/services/review_lifecycle.py
@@ -26,7 +26,7 @@ async def supersede_open_reviews_for_status_change(
     image_id: int,
     actor_id: int | None,
     new_status: int,
-) -> list[int]:
+) -> None:
     """Close any open review on ``image_id`` as SUPERSEDED.
 
     Called only when the status change is NOT itself a review action — see the
@@ -36,7 +36,7 @@ async def supersede_open_reviews_for_status_change(
     Only one review per image may be open (enforced at application level), but
     legacy rows predate that rule, so every open one is closed.
 
-    Flush-only; the caller owns the transaction. Returns the closed review_ids.
+    Flush-only; the caller owns the transaction.
     """
     reviews = (
         (
@@ -50,11 +50,7 @@ async def supersede_open_reviews_for_status_change(
         .scalars()
         .all()
     )
-    if not reviews:
-        return []
-
     now = datetime.now(UTC)
-    closed_ids: list[int] = []
     for review in reviews:
         review.status = ReviewStatus.CLOSED
         review.outcome = ReviewOutcome.SUPERSEDED
@@ -75,6 +71,3 @@ async def supersede_open_reviews_for_status_change(
                 },
             )
         )
-        closed_ids.append(review.review_id)  # type: ignore[arg-type]
-
-    return closed_ids

--- a/docs/adr/0003-manual-status-change-supersedes-open-review.md
+++ b/docs/adr/0003-manual-status-change-supersedes-open-review.md
@@ -1,0 +1,17 @@
+# A manual status change supersedes the image's open review
+
+A review is a vote on what should happen to an image. When a moderator answers that question by hand, `change_image_status()` closes any open review on the image with outcome `SUPERSEDED` and writes a `REVIEW_CLOSE` audit row. Votes already cast stay on record. The hook is skipped when the caller passes `review_id` — then the status change IS a review action (`REVIEW_START` setting the image to `REVIEW`, `REVIEW_CLOSE` applying an outcome it just recorded), and firing would close the review it just opened or overwrite the verdict it just reached.
+
+## Considered Options
+
+- **Leaving the review open** is what shipped, and it costs more than a stale queue entry: the review keeps collecting votes on a settled question, and `check_review_deadlines()` later closes it and re-applies its own outcome. With no quorum after one extension that outcome is `KEEP`, which calls `change_image_status(new_status=ACTIVE)` — silently reactivating an image a moderator deactivated, with no reason recorded (the un-hide reason guard exempts `REVIEW_CLOSE`).
+- **Leaving it open but making the deadline close a no-op when the status moved** keeps the vote alive for its full term and avoids the reactivation, but the image sits in the review queue looking unresolved and moderators keep spending votes on it.
+- **Filtering the queue by image status** hides the symptom and leaves the reactivation in place.
+- **Recording the outcome as KEEP or REMOVE** to match the new status would put a verdict in the record that the voters never reached.
+
+## Consequences
+
+- `SUPERSEDED` is set only by this hook. `/reviews/{id}/close` still accepts `KEEP`/`REMOVE` only (`ge=1, le=2`), so a moderator cannot pick it by hand.
+- Reviews closed this way have `closed_by` set to the acting moderator (NULL for system actors) and `outcome_label` "Superseded"; the frontend renders them as a neutral badge, not as a keep.
+- The guard is `review_id is None`, not an `action_type` check: the session is `autoflush=False`, so `_close_review()`'s own unflushed status write is invisible to a `SELECT` here and ordering alone would not protect it.
+- Rows that predate this hook keep their open status; closing them is a separate data cleanup.

--- a/tests/api/v1/test_image_reviews_endpoint.py
+++ b/tests/api/v1/test_image_reviews_endpoint.py
@@ -237,7 +237,14 @@ class TestGetImageReviews:
             outcome=ReviewOutcome.REMOVE,
             initiated_by=user.user_id,
         )
-        db_session.add_all([review_keep, review_remove])
+        review_superseded = ImageReviews(
+            image_id=image.image_id,
+            reason_category=DeactivationReason.INAPPROPRIATE,
+            status=ReviewStatus.CLOSED,
+            outcome=ReviewOutcome.SUPERSEDED,
+            initiated_by=user.user_id,
+        )
+        db_session.add_all([review_keep, review_remove, review_superseded])
         await db_session.commit()
 
         # GET image reviews
@@ -245,7 +252,7 @@ class TestGetImageReviews:
         assert response.status_code == 200
 
         data = response.json()
-        assert data["total"] == 2
+        assert data["total"] == 3
 
         # Build map by outcome for verification
         items_by_outcome = {item["outcome"]: item for item in data["items"]}
@@ -257,6 +264,9 @@ class TestGetImageReviews:
         # Check outcome_label
         assert items_by_outcome[ReviewOutcome.KEEP]["outcome_label"] == "keep"
         assert items_by_outcome[ReviewOutcome.REMOVE]["outcome_label"] == "remove"
+        # This public map is a second copy of the one on ReviewResponse; both have
+        # to learn every new outcome or the label silently degrades to "unknown".
+        assert items_by_outcome[ReviewOutcome.SUPERSEDED]["outcome_label"] == "superseded"
 
     async def test_does_not_include_hidden_fields(
         self, client: AsyncClient, db_session: AsyncSession

--- a/tests/services/test_image_status_service.py
+++ b/tests/services/test_image_status_service.py
@@ -5,10 +5,17 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import AdminActionType, DeactivationReason, ImageStatus
+from app.config import (
+    AdminActionType,
+    DeactivationReason,
+    ImageStatus,
+    ReviewOutcome,
+    ReviewStatus,
+)
 from app.models.admin_action import AdminActions
 from app.models.image import Images
 from app.models.image_report import ImageReports
+from app.models.image_review import ImageReviews
 from app.models.image_status_history import ImageStatusHistory
 from app.models.user import Users
 from app.services.image_status import change_image_status
@@ -20,6 +27,20 @@ async def _mk_image(db: AsyncSession, user_id: int, status: int = ImageStatus.AC
     await db.commit()
     await db.refresh(img)
     return img
+
+
+async def _mk_open_review(db: AsyncSession, image_id: int, initiated_by: int) -> ImageReviews:
+    review = ImageReviews(
+        image_id=image_id,
+        initiated_by=initiated_by,
+        reason_category=DeactivationReason.OTHER,
+        status=ReviewStatus.OPEN,
+        outcome=ReviewOutcome.PENDING,
+    )
+    db.add(review)
+    await db.commit()
+    await db.refresh(review)
+    return review
 
 
 async def test_deactivate_sets_fields_history_and_audit(db_session: AsyncSession):
@@ -225,3 +246,119 @@ async def test_status_change_syncs_ml_suggestions(db_session: AsyncSession):
         )
     ).scalars().all()
     assert remaining == []
+
+
+async def test_manual_status_change_supersedes_open_review(db_session: AsyncSession):
+    """A mod deciding the image's fate by hand closes the open review.
+
+    Otherwise the review keeps collecting votes on a decision already made, and
+    check_review_deadlines eventually re-applies its own outcome — a KEEP close
+    silently reactivating the image the mod just deactivated.
+    """
+    actor = (await db_session.execute(select(Users).where(Users.user_id == 1))).scalar_one()
+    img = await _mk_image(db_session, actor.user_id, status=ImageStatus.REVIEW)
+    review = await _mk_open_review(db_session, img.image_id, actor.user_id)
+
+    await change_image_status(
+        db_session,
+        img,
+        actor,
+        new_status=ImageStatus.DEACTIVATED,
+        reason_category=DeactivationReason.OTHER,
+        reason="low quality edit",
+    )
+    await db_session.commit()
+    await db_session.refresh(review)
+
+    assert review.status == ReviewStatus.CLOSED
+    assert review.outcome == ReviewOutcome.SUPERSEDED
+    assert review.closed_by == actor.user_id
+    assert review.closed_at is not None
+
+    close_action = (
+        await db_session.execute(
+            select(AdminActions).where(
+                AdminActions.review_id == review.review_id,
+                AdminActions.action_type == AdminActionType.REVIEW_CLOSE,
+            )
+        )
+    ).scalar_one()
+    assert close_action.details["outcome"] == ReviewOutcome.SUPERSEDED
+    assert close_action.details["new_status"] == ImageStatus.DEACTIVATED
+
+
+async def test_supersede_fires_on_any_manual_status_change(db_session: AsyncSession):
+    """Not just deactivation — restoring the image by hand also settles the review."""
+    actor = (await db_session.execute(select(Users).where(Users.user_id == 1))).scalar_one()
+    img = await _mk_image(db_session, actor.user_id, status=ImageStatus.REVIEW)
+    review = await _mk_open_review(db_session, img.image_id, actor.user_id)
+
+    await change_image_status(
+        db_session, img, actor, new_status=ImageStatus.ACTIVE, reason="looks fine after all"
+    )
+    await db_session.commit()
+    await db_session.refresh(review)
+
+    assert review.status == ReviewStatus.CLOSED
+    assert review.outcome == ReviewOutcome.SUPERSEDED
+
+
+async def test_review_start_does_not_supersede_its_own_review(db_session: AsyncSession):
+    """Opening a review sets the image to REVIEW through this same service —
+    that status change must not close the review it was made for."""
+    actor = (await db_session.execute(select(Users).where(Users.user_id == 1))).scalar_one()
+    img = await _mk_image(db_session, actor.user_id)
+    review = await _mk_open_review(db_session, img.image_id, actor.user_id)
+
+    await change_image_status(
+        db_session,
+        img,
+        actor,
+        new_status=ImageStatus.REVIEW,
+        action_type=AdminActionType.REVIEW_START,
+        review_id=review.review_id,
+    )
+    await db_session.commit()
+    await db_session.refresh(review)
+
+    assert review.status == ReviewStatus.OPEN
+    assert review.outcome == ReviewOutcome.PENDING
+
+
+async def test_review_close_keeps_its_own_outcome(db_session: AsyncSession):
+    """The deadline job closes the review itself, then applies the outcome through
+    this service. The hook must not overwrite that outcome with SUPERSEDED."""
+    actor = (await db_session.execute(select(Users).where(Users.user_id == 1))).scalar_one()
+    img = await _mk_image(db_session, actor.user_id, status=ImageStatus.REVIEW)
+    review = await _mk_open_review(db_session, img.image_id, actor.user_id)
+    # Deliberately unflushed, mirroring _close_review: the session is
+    # autoflush=False, so a SELECT here still sees status=OPEN in the database.
+    # Only the review_id guard keeps the hook off this path.
+    review.status = ReviewStatus.CLOSED
+    review.outcome = ReviewOutcome.KEEP
+
+    await change_image_status(
+        db_session,
+        img,
+        None,
+        new_status=ImageStatus.ACTIVE,
+        action_type=AdminActionType.REVIEW_CLOSE,
+        review_id=review.review_id,
+    )
+    await db_session.commit()
+    await db_session.refresh(review)
+
+    assert review.outcome == ReviewOutcome.KEEP
+
+
+async def test_lock_only_change_leaves_review_open(db_session: AsyncSession):
+    """Locking an image is not a verdict on it — the review keeps running."""
+    actor = (await db_session.execute(select(Users).where(Users.user_id == 1))).scalar_one()
+    img = await _mk_image(db_session, actor.user_id, status=ImageStatus.REVIEW)
+    review = await _mk_open_review(db_session, img.image_id, actor.user_id)
+
+    await change_image_status(db_session, img, actor, locked=True)
+    await db_session.commit()
+    await db_session.refresh(review)
+
+    assert review.status == ReviewStatus.OPEN


### PR DESCRIPTION
## Summary

When a moderator manually changes an image's status (DEACTIVATED, ACTIVE, SPOILER, etc.) while a review is open on that image, the API now automatically closes the open review with outcome SUPERSEDED. Previously, the review would stay open indefinitely, allowing voters to cast votes on a question the moderator had already answered by hand.

## Why this matters

The old behavior created a data integrity problem: if a mod deactivated an image, the open review would stay in the queue collecting votes. When the review deadline passed with no quorum after one extension, `check_review_deadlines()` would apply outcome KEEP and call `change_image_status(new_status=ACTIVE)` — silently re-activating the deactivated image with no reason recorded (the un-hide reason guard exempts REVIEW_CLOSE).

## Implementation

- **New service**: `app/services/review_lifecycle.py` with `supersede_open_reviews_for_status_change()` hook
- **New enum value**: `ReviewOutcome.SUPERSEDED = 3` 
- **Updated flow**: `change_image_status()` calls the hook when `review_id is None` (the guard protects against closing reviews the caller just opened or modified)
- **Guard explanation**: The session uses `autoflush=False`, so `_close_review()`'s own unflushed status write is invisible to a SELECT in the hook. Call ordering alone does not protect it; the guard is load-bearing.

## Documentation

Added ADR-0003 documenting the decision, considered options, and consequences.

## Test coverage

Added 5 new tests covering:
- Basic supersede on status change
- Guard against closing reviews we just opened (REVIEW_START path)
- Guard against closing reviews we just closed with verdicts (REVIEW_CLOSE path)
- Unflushed write visibility trap in autoflush=False sessions
- Outcome label rendering

All existing tests pass.