### PR TITLE
feat(tags): audit external links and creation-time relationships

### DIFF
--- a/alembic/versions/6dda18b955d8_add_link_columns_to_tag_audit_log.py
+++ b/alembic/versions/6dda18b955d8_add_link_columns_to_tag_audit_log.py
@@ -1,0 +1,41 @@
+"""add link columns to tag_audit_log
+
+Revision ID: 6dda18b955d8
+Revises: acc9162c52ae
+Create Date: 2026-07-31 21:07:24.602801
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6dda18b955d8'
+down_revision: str | Sequence[str] | None = 'acc9162c52ae'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add external-link columns so link add/remove/dead/archive can be audited."""
+    op.add_column(
+        "tag_audit_log",
+        sa.Column("link_url", sa.String(length=2000), nullable=True),
+    )
+    op.add_column(
+        "tag_audit_log",
+        sa.Column("old_archive_url", sa.String(length=2000), nullable=True),
+    )
+    op.add_column(
+        "tag_audit_log",
+        sa.Column("new_archive_url", sa.String(length=2000), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("tag_audit_log", "new_archive_url")
+    op.drop_column("tag_audit_log", "old_archive_url")
+    op.drop_column("tag_audit_log", "link_url")

--- a/app/api/v1/history.py
+++ b/app/api/v1/history.py
@@ -294,6 +294,9 @@ async def _hydrate_tag_metadata_items(
                 if audit_log.character_tag_id and audit_log.source_tag_id
                 else None
             ),
+            link_url=audit_log.link_url,
+            old_archive_url=audit_log.old_archive_url,
+            new_archive_url=audit_log.new_archive_url,
         )
     return items
 

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1530,13 +1530,15 @@ async def create_tag(
         user_id=current_user.user_id,
     )
     db.add(new_tag)
-    await db.commit()
-    await db.refresh(new_tag)
+    await db.flush()
 
     # A tag born as an alias or a child had no history at all: only update_tag
     # logged relationship changes, so these rows were simply never written.
     # NULL on the old_* side is how update_tag already represents "set from
-    # nothing", so no new action type is needed.
+    # nothing", so no new action type is needed. The flush (not a commit)
+    # above gives us new_tag.tag_id for these rows while keeping the tag
+    # insert and its audit rows in a single transaction, same as update_tag
+    # bundles its audit rows with the row they describe.
     creation_audit: list[TagAuditLog] = []
     if new_tag.alias_of is not None:
         creation_audit.append(
@@ -1558,7 +1560,9 @@ async def create_tag(
         )
     if creation_audit:
         db.add_all(creation_audit)
-        await db.commit()
+
+    await db.commit()
+    await db.refresh(new_tag)
 
     await sync_tag_to_search(new_tag, db=db)
 

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1533,6 +1533,33 @@ async def create_tag(
     await db.commit()
     await db.refresh(new_tag)
 
+    # A tag born as an alias or a child had no history at all: only update_tag
+    # logged relationship changes, so these rows were simply never written.
+    # NULL on the old_* side is how update_tag already represents "set from
+    # nothing", so no new action type is needed.
+    creation_audit: list[TagAuditLog] = []
+    if new_tag.alias_of is not None:
+        creation_audit.append(
+            TagAuditLog(
+                tag_id=new_tag.tag_id,
+                action_type=TagAuditActionType.ALIAS_SET,
+                new_alias_of=new_tag.alias_of,
+                user_id=current_user.user_id,
+            )
+        )
+    if new_tag.inheritedfrom_id is not None:
+        creation_audit.append(
+            TagAuditLog(
+                tag_id=new_tag.tag_id,
+                action_type=TagAuditActionType.PARENT_SET,
+                new_parent_id=new_tag.inheritedfrom_id,
+                user_id=current_user.user_id,
+            )
+        )
+    if creation_audit:
+        db.add_all(creation_audit)
+        await db.commit()
+
     await sync_tag_to_search(new_tag, db=db)
 
     return TagResponse.model_validate(new_tag)

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1864,6 +1864,7 @@ async def delete_tag(
 async def add_tag_link(
     tag_id: Annotated[int, Path(description="Tag ID")],
     link_data: TagExternalLinkCreate,
+    current_user: Annotated[Users, Depends(get_current_user)],
     _: Annotated[None, Depends(require_permission(Permission.TAG_UPDATE))],
     db: AsyncSession = Depends(get_db),
 ) -> TagExternalLinkResponse:
@@ -1894,6 +1895,17 @@ async def add_tag_link(
         ).scalar()
         new_link.position = (min_pos if min_pos is not None else 0) - 1
     db.add(new_link)
+
+    # Audit in the same transaction as the insert: a 409 rollback below must
+    # take the audit row with it.
+    db.add(
+        TagAuditLog(
+            tag_id=tag_id,
+            action_type=TagAuditActionType.LINK_ADDED,
+            link_url=link_data.url,
+            user_id=current_user.user_id,
+        )
+    )
 
     try:
         await db.commit()
@@ -1957,6 +1969,7 @@ async def reorder_tag_links(
 async def delete_tag_link(
     tag_id: Annotated[int, Path(description="Tag ID")],
     link_id: Annotated[int, Path(description="Link ID")],
+    current_user: Annotated[Users, Depends(get_current_user)],
     _: Annotated[None, Depends(require_permission(Permission.TAG_UPDATE))],
     db: AsyncSession = Depends(get_db),
 ) -> None:
@@ -1980,6 +1993,16 @@ async def delete_tag_link(
             detail="Link not found or does not belong to this tag",
         )
 
+    # Capture the URL while the row is still loaded — after db.delete it is gone,
+    # and the audit entry has to outlive it.
+    db.add(
+        TagAuditLog(
+            tag_id=tag_id,
+            action_type=TagAuditActionType.LINK_REMOVED,
+            link_url=link.url,
+            user_id=current_user.user_id,
+        )
+    )
     await db.delete(link)
     await db.commit()
 

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -95,6 +95,29 @@ def _shuu_wiki_sql_flag() -> ColumnElement[bool]:
     return or_(*(TagExternalLinks.url.like(f"%{m}%") for m in _SHUU_WIKI_URL_MARKERS))  # type: ignore[attr-defined]
 
 
+def _record_link_audit(
+    db: AsyncSession,
+    *,
+    tag_id: int,
+    action_type: str,
+    link_url: str,
+    user_id: int | None,
+    old_archive_url: str | None = None,
+    new_archive_url: str | None = None,
+) -> None:
+    """Queue an external-link audit row. Caller owns the commit."""
+    db.add(
+        TagAuditLog(
+            tag_id=tag_id,
+            action_type=action_type,
+            link_url=link_url,
+            user_id=user_id,
+            old_archive_url=old_archive_url,
+            new_archive_url=new_archive_url,
+        )
+    )
+
+
 async def _ordered_tag_links(tag_id: int, db: AsyncSession) -> list[TagExternalLinks]:
     """A tag's external links in display order.
 
@@ -1898,13 +1921,12 @@ async def add_tag_link(
 
     # Audit in the same transaction as the insert: a 409 rollback below must
     # take the audit row with it.
-    db.add(
-        TagAuditLog(
-            tag_id=tag_id,
-            action_type=TagAuditActionType.LINK_ADDED,
-            link_url=link_data.url,
-            user_id=current_user.user_id,
-        )
+    _record_link_audit(
+        db,
+        tag_id=tag_id,
+        action_type=TagAuditActionType.LINK_ADDED,
+        link_url=link_data.url,
+        user_id=current_user.user_id,
     )
 
     try:
@@ -1995,13 +2017,12 @@ async def delete_tag_link(
 
     # Capture the URL while the row is still loaded — after db.delete it is gone,
     # and the audit entry has to outlive it.
-    db.add(
-        TagAuditLog(
-            tag_id=tag_id,
-            action_type=TagAuditActionType.LINK_REMOVED,
-            link_url=link.url,
-            user_id=current_user.user_id,
-        )
+    _record_link_audit(
+        db,
+        tag_id=tag_id,
+        action_type=TagAuditActionType.LINK_REMOVED,
+        link_url=link.url,
+        user_id=current_user.user_id,
     )
     await db.delete(link)
     await db.commit()
@@ -2018,6 +2039,7 @@ async def update_tag_link(
     tag_id: Annotated[int, Path(description="Tag ID")],
     link_id: Annotated[int, Path(description="Link ID")],
     link_update: TagExternalLinkUpdate,
+    current_user: Annotated[Users, Depends(get_current_user)],
     _: Annotated[None, Depends(require_permission(Permission.TAG_UPDATE))],
     db: AsyncSession = Depends(get_db),
 ) -> TagExternalLinkResponse:
@@ -2040,12 +2062,41 @@ async def update_tag_link(
             detail="Link not found or does not belong to this tag",
         )
 
+    # The dead flag and the archive URL are independent inputs on one endpoint,
+    # so a call that changes both records both. Each write is conditioned on an
+    # actual change: a no-op PATCH must not manufacture history.
     if link_update.is_dead is True and link.dead_at is None:
         link.dead_at = datetime.now(UTC)
-    elif link_update.is_dead is False:
+        _record_link_audit(
+            db,
+            tag_id=tag_id,
+            action_type=TagAuditActionType.LINK_DEAD_MARKED,
+            link_url=link.url,
+            user_id=current_user.user_id,
+        )
+    elif link_update.is_dead is False and link.dead_at is not None:
         link.dead_at = None
+        _record_link_audit(
+            db,
+            tag_id=tag_id,
+            action_type=TagAuditActionType.LINK_DEAD_CLEARED,
+            link_url=link.url,
+            user_id=current_user.user_id,
+        )
 
-    if "archive_url" in link_update.model_fields_set:
+    if (
+        "archive_url" in link_update.model_fields_set
+        and link_update.archive_url != link.archive_url
+    ):
+        _record_link_audit(
+            db,
+            tag_id=tag_id,
+            action_type=TagAuditActionType.LINK_ARCHIVE_CHANGED,
+            link_url=link.url,
+            old_archive_url=link.archive_url,
+            new_archive_url=link_update.archive_url,
+            user_id=current_user.user_id,
+        )
         link.archive_url = link_update.archive_url
 
     await db.commit()

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1171,6 +1171,14 @@ async def get_tag_history(
             (TagAuditLog.tag_id == tag_id)  # type: ignore[arg-type]
             | (TagAuditLog.character_tag_id == tag_id)
             | (TagAuditLog.source_tag_id == tag_id)
+            # Relationships pointed AT this tag. The alias_set/parent_set row
+            # lives on the other tag, so without these a canonical tag never
+            # learns that something was aliased to it. All four columns carry
+            # MariaDB's auto-created FK indexes.
+            | (TagAuditLog.old_alias_of == tag_id)
+            | (TagAuditLog.new_alias_of == tag_id)
+            | (TagAuditLog.old_parent_id == tag_id)
+            | (TagAuditLog.new_parent_id == tag_id)
         )
     )
 
@@ -1196,6 +1204,8 @@ async def get_tag_history(
     # Includes: character_tag, source_tag, alias targets, parent tags
     tag_ids_to_load: set[int] = set()
     for audit, _ in rows:
+        # The row's own subject, so an incoming entry can name the other side.
+        tag_ids_to_load.add(audit.tag_id)
         if audit.character_tag_id:
             tag_ids_to_load.add(audit.character_tag_id)
         if audit.source_tag_id:
@@ -1245,9 +1255,18 @@ async def get_tag_history(
             new_alias_of=audit.new_alias_of,
             old_parent_id=audit.old_parent_id,
             new_parent_id=audit.new_parent_id,
+            link_url=audit.link_url,
+            old_archive_url=audit.old_archive_url,
+            new_archive_url=audit.new_archive_url,
             user=user_summary,
             created_at=audit.created_at,
         )
+
+        subject_info = tags_map.get(audit.tag_id)
+        if subject_info:
+            response.subject_tag = LinkedTag(
+                tag_id=audit.tag_id, title=subject_info[0], type=subject_info[1]
+            )
 
         # Enrich with resolved tag info for related tags
         # Character-source links

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -1773,6 +1773,33 @@ async def update_tag(
         )
         existing_urls = {row[0] for row in existing_urls_result}
 
+        # Audit before the bulk delete/update erase the evidence. Every one of the
+        # alias's links leaves it: colliding URLs are deleted, the rest move. A
+        # moved link is also an add on the canonical side, so each tag's history
+        # stays self-consistent — no link silently appears or vanishes.
+        alias_link_urls = [
+            row[0]
+            for row in await db.execute(
+                select(TagExternalLinks.url).where(TagExternalLinks.tag_id == tag_id)  # type: ignore[call-overload]
+            )
+        ]
+        for url in alias_link_urls:
+            _record_link_audit(
+                db,
+                tag_id=tag_id,
+                action_type=TagAuditActionType.LINK_REMOVED,
+                link_url=url,
+                user_id=current_user.user_id,
+            )
+            if url not in existing_urls:
+                _record_link_audit(
+                    db,
+                    tag_id=canonical_id,
+                    action_type=TagAuditActionType.LINK_ADDED,
+                    link_url=url,
+                    user_id=current_user.user_id,
+                )
+
         # Delete alias external links that would conflict (same URL on canonical)
         if existing_urls:
             await db.execute(

--- a/app/config.py
+++ b/app/config.py
@@ -524,6 +524,14 @@ class TagAuditActionType:
     SOURCE_LINKED = "source_linked"
     SOURCE_UNLINKED = "source_unlinked"
 
+    # External-link events. link_url on the audit row identifies the affected
+    # link; reordering is deliberately not audited (cosmetic display order).
+    LINK_ADDED = "link_added"
+    LINK_REMOVED = "link_removed"
+    LINK_DEAD_MARKED = "link_dead_marked"
+    LINK_DEAD_CLEARED = "link_dead_cleared"
+    LINK_ARCHIVE_CHANGED = "link_archive_changed"
+
 
 class TagType:
     """Tag type constants"""

--- a/app/models/tag_audit_log.py
+++ b/app/models/tag_audit_log.py
@@ -54,6 +54,14 @@ class TagAuditLogBase(SQLModel):
     character_tag_id: int | None = Field(default=None)
     source_tag_id: int | None = Field(default=None)
 
+    # External-link fields. link_url identifies the affected link for every
+    # link_* action. It is deliberately NOT a foreign key to
+    # tag_external_links.link_id: a link_removed entry has to outlive the row it
+    # describes, so the URL text is the durable identifier.
+    link_url: str | None = Field(default=None, max_length=2000)
+    old_archive_url: str | None = Field(default=None, max_length=2000)
+    new_archive_url: str | None = Field(default=None, max_length=2000)
+
 
 class TagAuditLog(TagAuditLogBase, table=True):
     """

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -239,7 +239,9 @@ class UserHistoryItem(BaseModel):
     - tag_metadata: action_type, tag, old_title/new_title (for rename),
       old_type/new_type (for type_change), old_desc/new_desc (for
       description_change), alias_tag/parent_tag/source_tag/character_tag
-      (for the corresponding link/unlink actions), created_at
+      (for the corresponding link/unlink actions),
+      link_url/old_archive_url/new_archive_url (for the link_* actions),
+      created_at
     - tag_usage: action, tag, image_id, date
     - status_change: image_id, old_status, new_status, new_status_label, created_at
     """
@@ -286,6 +288,13 @@ class UserHistoryItem(BaseModel):
     parent_tag: LinkedTag | None = None
     source_tag: LinkedTag | None = None
     character_tag: LinkedTag | None = None
+
+    # For tag_metadata: external-link actions. The feed is scoped to one user's
+    # own actions, so the row's tag_id is always the right subject and no
+    # perspective flip is needed here.
+    link_url: str | None = None
+    old_archive_url: str | None = None
+    new_archive_url: str | None = None
 
 
 class UserHistoryListResponse(BaseModel):

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -60,6 +60,17 @@ class TagAuditLogResponse(BaseModel):
     character_tag: LinkedTag | None = None
     source_tag: LinkedTag | None = None
 
+    # The tag this entry is ABOUT — resolved for every entry, not only the
+    # incoming ones. An alias_set row is stored against the alias tag, so the
+    # canonical tag's history needs this to name the other side rather than
+    # rendering a badge that points back at itself.
+    subject_tag: LinkedTag | None = None
+
+    # External-link fields
+    link_url: str | None = None
+    old_archive_url: str | None = None
+    new_archive_url: str | None = None
+
     # Who made the change
     user: UserSummary | None = None
 

--- a/tests/api/v1/test_tag_audit_log.py
+++ b/tests/api/v1/test_tag_audit_log.py
@@ -2376,3 +2376,48 @@ class TestUserHistoryLinkEvents:
         assert items[0]["action_type"] == TagAuditActionType.LINK_ADDED
         assert items[0]["link_url"] == "https://example.com/feed"
         assert items[0]["tag"]["tag_id"] == tag.tag_id
+
+    async def test_user_history_exposes_archive_url_fields(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A link_archive_changed row must survive with link_url AND both
+        archive-url sides intact — the handler passes all three through
+        together, but the sibling link-fields test above only asserts
+        link_url, so losing old_archive_url/new_archive_url would render as
+        silently wrong data rather than a caught error."""
+        actor = Users(
+            username="feedarchiveuser",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="feedarchiveuser@example.com",
+            active=1,
+        )
+        tag = Tags(title="feed archive tag", type=TagType.THEME)
+        db_session.add_all([actor, tag])
+        await db_session.commit()
+        await db_session.refresh(actor)
+        await db_session.refresh(tag)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=tag.tag_id,
+                action_type=TagAuditActionType.LINK_ARCHIVE_CHANGED,
+                link_url="https://example.com/feed",
+                old_archive_url=None,
+                new_archive_url="https://web.archive.org/feed",
+                user_id=actor.user_id,
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/users/{actor.user_id}/history")
+        assert response.status_code == 200
+
+        items = [i for i in response.json()["items"] if i["type"] == "tag_metadata"]
+        assert len(items) == 1
+        assert items[0]["action_type"] == TagAuditActionType.LINK_ARCHIVE_CHANGED
+        assert items[0]["link_url"] == "https://example.com/feed"
+        assert items[0]["old_archive_url"] is None
+        assert items[0]["new_archive_url"] == "https://web.archive.org/feed"
+        assert items[0]["tag"]["tag_id"] == tag.tag_id

--- a/tests/api/v1/test_tag_audit_log.py
+++ b/tests/api/v1/test_tag_audit_log.py
@@ -1631,3 +1631,168 @@ class TestGetTagHistory:
         assert parent_entry["parent_tag"]["tag_id"] == parent_tag.tag_id
         assert parent_entry["parent_tag"]["title"] == "Parent Source"
         assert parent_entry["parent_tag"]["type"] == TagType.SOURCE
+
+
+@pytest.mark.api
+class TestTagAuditLogExternalLinks:
+    """Tests for external-link audit logging."""
+
+    async def _admin_and_token(
+        self, client: AsyncClient, db_session: AsyncSession, username: str
+    ) -> tuple[Users, str]:
+        """Create a TAG_UPDATE admin and return them with a bearer token."""
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        admin = Users(
+            username=username,
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email=f"{username}@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        db_session.add(UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1))
+        await db_session.commit()
+
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={"username": username, "password": "AdminPassword123!"},
+        )
+        return admin, login.json()["access_token"]
+
+    async def _tag(self, db_session: AsyncSession, title: str) -> Tags:
+        tag = Tags(title=title, type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+        return tag
+
+    async def test_add_link_creates_link_added_entry(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        admin, token = await self._admin_and_token(client, db_session, "linkaudit1")
+        tag = await self._tag(db_session, "link audit add")
+
+        response = await client.post(
+            f"/api/v1/tags/{tag.tag_id}/links",
+            json={"url": "https://example.com/artist"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 201
+
+        entries = (
+            await db_session.execute(
+                select(TagAuditLog).where(TagAuditLog.tag_id == tag.tag_id)
+            )
+        ).scalars().all()
+
+        assert len(entries) == 1
+        assert entries[0].action_type == TagAuditActionType.LINK_ADDED
+        assert entries[0].link_url == "https://example.com/artist"
+        assert entries[0].user_id == admin.user_id
+
+    @pytest.mark.needs_commit
+    async def test_duplicate_link_creates_no_audit_entry(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """The 409 path rolls back; the audit row must roll back with it.
+
+        needs_commit: the duplicate-URL path performs a real session rollback;
+        under the default SAVEPOINT isolation that rollback would unwind the
+        first (successful) link_added row too, which can't happen in
+        production where it is durably committed before the second request.
+        """
+        _, token = await self._admin_and_token(client, db_session, "linkaudit2")
+        tag = await self._tag(db_session, "link audit dupe")
+        # Captured before the request that rolls back: the rollback expires every
+        # object loaded in this session (it's shared with the app via the get_db
+        # override), and a bare `tag.tag_id` access afterward would try to
+        # lazy-refresh the expired attribute outside of a greenlet context.
+        tag_id = tag.tag_id
+        headers = {"Authorization": f"Bearer {token}"}
+        payload = {"url": "https://example.com/dupe"}
+
+        assert (
+            await client.post(f"/api/v1/tags/{tag_id}/links", json=payload, headers=headers)
+        ).status_code == 201
+        assert (
+            await client.post(f"/api/v1/tags/{tag_id}/links", json=payload, headers=headers)
+        ).status_code == 409
+
+        entries = (
+            await db_session.execute(
+                select(TagAuditLog).where(TagAuditLog.tag_id == tag_id)
+            )
+        ).scalars().all()
+        assert len(entries) == 1
+
+    async def test_delete_link_creates_link_removed_entry(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        admin, token = await self._admin_and_token(client, db_session, "linkaudit3")
+        tag = await self._tag(db_session, "link audit delete")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        created = await client.post(
+            f"/api/v1/tags/{tag.tag_id}/links",
+            json={"url": "https://example.com/gone"},
+            headers=headers,
+        )
+        link_id = created.json()["link_id"]
+
+        response = await client.delete(
+            f"/api/v1/tags/{tag.tag_id}/links/{link_id}", headers=headers
+        )
+        assert response.status_code == 204
+
+        entries = (
+            await db_session.execute(
+                select(TagAuditLog)
+                .where(TagAuditLog.tag_id == tag.tag_id)
+                .where(TagAuditLog.action_type == TagAuditActionType.LINK_REMOVED)
+            )
+        ).scalars().all()
+
+        assert len(entries) == 1
+        assert entries[0].link_url == "https://example.com/gone"
+        assert entries[0].user_id == admin.user_id
+
+    async def test_reorder_links_creates_no_audit_entries(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        # Display order is cosmetic; auditing it would be history noise.
+        _, token = await self._admin_and_token(client, db_session, "linkaudit4")
+        tag = await self._tag(db_session, "link audit reorder")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        ids = []
+        for suffix in ("one", "two"):
+            created = await client.post(
+                f"/api/v1/tags/{tag.tag_id}/links",
+                json={"url": f"https://example.com/{suffix}"},
+                headers=headers,
+            )
+            ids.append(created.json()["link_id"])
+
+        response = await client.patch(
+            f"/api/v1/tags/{tag.tag_id}/links/reorder",
+            json={"link_ids": list(reversed(ids))},
+            headers=headers,
+        )
+        assert response.status_code == 200
+
+        entries = (
+            await db_session.execute(
+                select(TagAuditLog).where(TagAuditLog.tag_id == tag.tag_id)
+            )
+        ).scalars().all()
+        # Only the two link_added rows from setup.
+        assert [e.action_type for e in entries] == [TagAuditActionType.LINK_ADDED] * 2

--- a/tests/api/v1/test_tag_audit_log.py
+++ b/tests/api/v1/test_tag_audit_log.py
@@ -1814,6 +1814,7 @@ class TestTagAuditLogExternalLinks:
                 select(TagAuditLog)
                 .where(TagAuditLog.tag_id == tag_id)
                 .where(TagAuditLog.action_type == action)
+                .order_by(TagAuditLog.id)
             )
         ).scalars().all()
 
@@ -1960,3 +1961,48 @@ class TestTagAuditLogExternalLinks:
         )
         assert len(archive) == 1
         assert archive[0].new_archive_url == "https://web.archive.org/both"
+
+    async def test_alias_migration_audits_moved_and_deleted_links(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        # Setting an alias silently moves the alias's external links onto the
+        # canonical tag and drops URL collisions. Without these rows a link
+        # appears on the canonical tag with no history explaining how.
+        _, token = await self._admin_and_token(client, db_session, "linkaudit11")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        canonical = await self._tag(db_session, "alias migration canonical")
+        alias = await self._tag(db_session, "alias migration alias")
+
+        shared = "https://example.com/shared"
+        unique = "https://example.com/unique"
+
+        for tag_id, url in ((canonical.tag_id, shared), (alias.tag_id, shared), (alias.tag_id, unique)):
+            created = await client.post(
+                f"/api/v1/tags/{tag_id}/links", json={"url": url}, headers=headers
+            )
+            assert created.status_code == 201
+
+        response = await client.put(
+            f"/api/v1/tags/{alias.tag_id}",
+            json={
+                "title": "alias migration alias",
+                "type": TagType.THEME,
+                "alias_of": canonical.tag_id,
+            },
+            headers=headers,
+        )
+        assert response.status_code == 200
+
+        removed = await self._link_entries(
+            db_session, alias.tag_id, TagAuditActionType.LINK_REMOVED
+        )
+        # Both of the alias's links leave it: one deleted as a collision, one moved.
+        assert sorted(e.link_url for e in removed) == [shared, unique]
+
+        added = await self._link_entries(
+            db_session, canonical.tag_id, TagAuditActionType.LINK_ADDED
+        )
+        # The canonical tag's own setup link, plus the one that moved. The
+        # colliding URL must NOT be added again.
+        assert sorted(e.link_url for e in added) == [shared, unique]

--- a/tests/api/v1/test_tag_audit_log.py
+++ b/tests/api/v1/test_tag_audit_log.py
@@ -2163,3 +2163,118 @@ class TestTagAuditLogCreation:
             )
         ).scalars().all()
         assert entries == []
+
+
+@pytest.mark.api
+class TestTagHistoryIncomingRelations:
+    """A target tag's history must show relationships pointed at it."""
+
+    async def test_canonical_tag_sees_incoming_alias(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        # The alias_set row is stored against the ALIAS tag, so the canonical tag
+        # never saw that something was aliased to it.
+        canonical = Tags(title="incoming canonical", type=TagType.THEME)
+        alias = Tags(title="incoming alias", type=TagType.THEME)
+        db_session.add_all([canonical, alias])
+        await db_session.commit()
+        await db_session.refresh(canonical)
+        await db_session.refresh(alias)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=alias.tag_id,
+                action_type=TagAuditActionType.ALIAS_SET,
+                new_alias_of=canonical.tag_id,
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/tags/{canonical.tag_id}/history")
+        assert response.status_code == 200
+        items = response.json()["items"]
+
+        assert len(items) == 1
+        assert items[0]["action_type"] == TagAuditActionType.ALIAS_SET
+        assert items[0]["tag_id"] == alias.tag_id
+        # subject_tag names the tag the row is ABOUT, so the frontend can render
+        # "Alias added: <alias>" instead of a badge pointing back at itself.
+        assert items[0]["subject_tag"]["tag_id"] == alias.tag_id
+        assert items[0]["subject_tag"]["title"] == "incoming alias"
+
+    async def test_parent_tag_sees_incoming_child(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        parent = Tags(title="incoming parent", type=TagType.THEME)
+        child = Tags(title="incoming child", type=TagType.THEME)
+        db_session.add_all([parent, child])
+        await db_session.commit()
+        await db_session.refresh(parent)
+        await db_session.refresh(child)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=child.tag_id,
+                action_type=TagAuditActionType.PARENT_SET,
+                new_parent_id=parent.tag_id,
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/tags/{parent.tag_id}/history")
+        items = response.json()["items"]
+
+        assert len(items) == 1
+        assert items[0]["subject_tag"]["tag_id"] == child.tag_id
+
+    async def test_own_history_still_returns_its_own_rows(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        # Regression guard: broadening the WHERE must not drop the original rows.
+        tag = Tags(title="own rows", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=tag.tag_id,
+                action_type=TagAuditActionType.RENAME,
+                old_title="before",
+                new_title="own rows",
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}/history")
+        items = response.json()["items"]
+
+        assert len(items) == 1
+        assert items[0]["action_type"] == TagAuditActionType.RENAME
+        assert items[0]["subject_tag"]["tag_id"] == tag.tag_id
+
+    async def test_link_fields_are_exposed(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        tag = Tags(title="link fields exposed", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=tag.tag_id,
+                action_type=TagAuditActionType.LINK_ARCHIVE_CHANGED,
+                link_url="https://example.com/subject",
+                old_archive_url=None,
+                new_archive_url="https://web.archive.org/x",
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}/history")
+        item = response.json()["items"][0]
+
+        assert item["link_url"] == "https://example.com/subject"
+        assert item["old_archive_url"] is None
+        assert item["new_archive_url"] == "https://web.archive.org/x"

--- a/tests/api/v1/test_tag_audit_log.py
+++ b/tests/api/v1/test_tag_audit_log.py
@@ -1796,3 +1796,167 @@ class TestTagAuditLogExternalLinks:
         ).scalars().all()
         # Only the two link_added rows from setup.
         assert [e.action_type for e in entries] == [TagAuditActionType.LINK_ADDED] * 2
+
+    async def _tag_with_link(
+        self, client: AsyncClient, db_session: AsyncSession, title: str, token: str
+    ) -> tuple[Tags, int]:
+        tag = await self._tag(db_session, title)
+        created = await client.post(
+            f"/api/v1/tags/{tag.tag_id}/links",
+            json={"url": "https://example.com/subject"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        return tag, created.json()["link_id"]
+
+    async def _link_entries(self, db_session: AsyncSession, tag_id: int, action: str):
+        return (
+            await db_session.execute(
+                select(TagAuditLog)
+                .where(TagAuditLog.tag_id == tag_id)
+                .where(TagAuditLog.action_type == action)
+            )
+        ).scalars().all()
+
+    async def test_marking_link_dead_creates_entry(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        admin, token = await self._admin_and_token(client, db_session, "linkaudit5")
+        headers = {"Authorization": f"Bearer {token}"}
+        tag, link_id = await self._tag_with_link(client, db_session, "dead mark", token)
+
+        response = await client.patch(
+            f"/api/v1/tags/{tag.tag_id}/links/{link_id}",
+            json={"is_dead": True},
+            headers=headers,
+        )
+        assert response.status_code == 200
+
+        entries = await self._link_entries(
+            db_session, tag.tag_id, TagAuditActionType.LINK_DEAD_MARKED
+        )
+        assert len(entries) == 1
+        assert entries[0].link_url == "https://example.com/subject"
+        assert entries[0].user_id == admin.user_id
+
+    async def test_clearing_dead_flag_creates_entry(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        _, token = await self._admin_and_token(client, db_session, "linkaudit6")
+        headers = {"Authorization": f"Bearer {token}"}
+        tag, link_id = await self._tag_with_link(client, db_session, "dead clear", token)
+
+        await client.patch(
+            f"/api/v1/tags/{tag.tag_id}/links/{link_id}",
+            json={"is_dead": True},
+            headers=headers,
+        )
+        await client.patch(
+            f"/api/v1/tags/{tag.tag_id}/links/{link_id}",
+            json={"is_dead": False},
+            headers=headers,
+        )
+
+        entries = await self._link_entries(
+            db_session, tag.tag_id, TagAuditActionType.LINK_DEAD_CLEARED
+        )
+        assert len(entries) == 1
+        assert entries[0].link_url == "https://example.com/subject"
+
+    async def test_redundant_dead_flag_creates_no_entry(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        # Clearing a flag that was never set changes nothing, so it logs nothing.
+        # Mirrors test_rename_with_same_name_creates_no_audit_log.
+        _, token = await self._admin_and_token(client, db_session, "linkaudit7")
+        headers = {"Authorization": f"Bearer {token}"}
+        tag, link_id = await self._tag_with_link(client, db_session, "dead noop", token)
+
+        await client.patch(
+            f"/api/v1/tags/{tag.tag_id}/links/{link_id}",
+            json={"is_dead": False},
+            headers=headers,
+        )
+
+        assert (
+            await self._link_entries(
+                db_session, tag.tag_id, TagAuditActionType.LINK_DEAD_CLEARED
+            )
+            == []
+        )
+
+    async def test_archive_url_change_records_old_and_new(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        _, token = await self._admin_and_token(client, db_session, "linkaudit8")
+        headers = {"Authorization": f"Bearer {token}"}
+        tag, link_id = await self._tag_with_link(client, db_session, "archive set", token)
+
+        await client.patch(
+            f"/api/v1/tags/{tag.tag_id}/links/{link_id}",
+            json={"archive_url": "https://web.archive.org/first"},
+            headers=headers,
+        )
+        await client.patch(
+            f"/api/v1/tags/{tag.tag_id}/links/{link_id}",
+            json={"archive_url": "https://web.archive.org/second"},
+            headers=headers,
+        )
+
+        entries = await self._link_entries(
+            db_session, tag.tag_id, TagAuditActionType.LINK_ARCHIVE_CHANGED
+        )
+        assert len(entries) == 2
+        assert entries[0].old_archive_url is None
+        assert entries[0].new_archive_url == "https://web.archive.org/first"
+        assert entries[1].old_archive_url == "https://web.archive.org/first"
+        assert entries[1].new_archive_url == "https://web.archive.org/second"
+        assert all(e.link_url == "https://example.com/subject" for e in entries)
+
+    async def test_unchanged_archive_url_creates_no_entry(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        _, token = await self._admin_and_token(client, db_session, "linkaudit9")
+        headers = {"Authorization": f"Bearer {token}"}
+        tag, link_id = await self._tag_with_link(client, db_session, "archive noop", token)
+
+        for _ in range(2):
+            await client.patch(
+                f"/api/v1/tags/{tag.tag_id}/links/{link_id}",
+                json={"archive_url": "https://web.archive.org/same"},
+                headers=headers,
+            )
+
+        entries = await self._link_entries(
+            db_session, tag.tag_id, TagAuditActionType.LINK_ARCHIVE_CHANGED
+        )
+        assert len(entries) == 1
+
+    async def test_dead_and_archive_in_one_call_create_two_entries(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        # The two are independent inputs on one endpoint; collapsing them into a
+        # single row would lose one of the two facts.
+        _, token = await self._admin_and_token(client, db_session, "linkaudit10")
+        headers = {"Authorization": f"Bearer {token}"}
+        tag, link_id = await self._tag_with_link(client, db_session, "dead plus archive", token)
+
+        response = await client.patch(
+            f"/api/v1/tags/{tag.tag_id}/links/{link_id}",
+            json={"is_dead": True, "archive_url": "https://web.archive.org/both"},
+            headers=headers,
+        )
+        assert response.status_code == 200
+
+        assert (
+            len(
+                await self._link_entries(
+                    db_session, tag.tag_id, TagAuditActionType.LINK_DEAD_MARKED
+                )
+            )
+            == 1
+        )
+        archive = await self._link_entries(
+            db_session, tag.tag_id, TagAuditActionType.LINK_ARCHIVE_CHANGED
+        )
+        assert len(archive) == 1
+        assert archive[0].new_archive_url == "https://web.archive.org/both"

--- a/tests/api/v1/test_tag_audit_log.py
+++ b/tests/api/v1/test_tag_audit_log.py
@@ -2107,6 +2107,44 @@ class TestTagAuditLogCreation:
         assert entries[0].old_parent_id is None
         assert entries[0].new_parent_id == parent.tag_id
 
+    async def test_creating_a_tag_with_both_alias_and_parent_logs_both(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        token = await self._admin_token(client, db_session, "createaudit4")
+        target = Tags(title="create audit both target", type=TagType.THEME)
+        parent = Tags(title="create audit both parent", type=TagType.THEME)
+        db_session.add(target)
+        db_session.add(parent)
+        await db_session.commit()
+        await db_session.refresh(target)
+        await db_session.refresh(parent)
+
+        response = await client.post(
+            "/api/v1/tags",
+            json={
+                "title": "create audit both",
+                "type": TagType.THEME,
+                "alias_of": target.tag_id,
+                "inheritedfrom_id": parent.tag_id,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        new_id = response.json()["tag_id"]
+
+        entries = (
+            await db_session.execute(
+                select(TagAuditLog).where(TagAuditLog.tag_id == new_id)
+            )
+        ).scalars().all()
+
+        assert len(entries) == 2
+        by_action = {entry.action_type: entry for entry in entries}
+        assert by_action[TagAuditActionType.ALIAS_SET].old_alias_of is None
+        assert by_action[TagAuditActionType.ALIAS_SET].new_alias_of == target.tag_id
+        assert by_action[TagAuditActionType.PARENT_SET].old_parent_id is None
+        assert by_action[TagAuditActionType.PARENT_SET].new_parent_id == parent.tag_id
+
     async def test_creating_a_plain_tag_logs_nothing(
         self, client: AsyncClient, db_session: AsyncSession
     ):

--- a/tests/api/v1/test_tag_audit_log.py
+++ b/tests/api/v1/test_tag_audit_log.py
@@ -2278,3 +2278,101 @@ class TestTagHistoryIncomingRelations:
         assert item["link_url"] == "https://example.com/subject"
         assert item["old_archive_url"] is None
         assert item["new_archive_url"] == "https://web.archive.org/x"
+
+    async def test_canonical_tag_sees_incoming_removed_alias(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        # A tag that a *removed* alias used to point at must still see the
+        # alias_removed row, via the old_alias_of disjunct.
+        canonical = Tags(title="incoming canonical removed", type=TagType.THEME)
+        former_alias = Tags(title="incoming former alias", type=TagType.THEME)
+        db_session.add_all([canonical, former_alias])
+        await db_session.commit()
+        await db_session.refresh(canonical)
+        await db_session.refresh(former_alias)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=former_alias.tag_id,
+                action_type=TagAuditActionType.ALIAS_REMOVED,
+                old_alias_of=canonical.tag_id,
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/tags/{canonical.tag_id}/history")
+        assert response.status_code == 200
+        items = response.json()["items"]
+
+        assert len(items) == 1
+        assert items[0]["action_type"] == TagAuditActionType.ALIAS_REMOVED
+        assert items[0]["subject_tag"]["tag_id"] == former_alias.tag_id
+
+    async def test_parent_tag_sees_incoming_removed_child(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        # Same as above, but for a removed parent link via old_parent_id.
+        parent = Tags(title="incoming parent removed", type=TagType.THEME)
+        former_child = Tags(title="incoming former child", type=TagType.THEME)
+        db_session.add_all([parent, former_child])
+        await db_session.commit()
+        await db_session.refresh(parent)
+        await db_session.refresh(former_child)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=former_child.tag_id,
+                action_type=TagAuditActionType.PARENT_REMOVED,
+                old_parent_id=parent.tag_id,
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/tags/{parent.tag_id}/history")
+        assert response.status_code == 200
+        items = response.json()["items"]
+
+        assert len(items) == 1
+        assert items[0]["action_type"] == TagAuditActionType.PARENT_REMOVED
+        assert items[0]["subject_tag"]["tag_id"] == former_child.tag_id
+
+
+@pytest.mark.api
+class TestUserHistoryLinkEvents:
+    """Link rows reach the user activity feed whether or not we plan for it."""
+
+    async def test_user_history_exposes_link_fields(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        actor = Users(
+            username="feedlinkuser",
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="feedlinkuser@example.com",
+            active=1,
+        )
+        tag = Tags(title="feed link tag", type=TagType.THEME)
+        db_session.add_all([actor, tag])
+        await db_session.commit()
+        await db_session.refresh(actor)
+        await db_session.refresh(tag)
+
+        db_session.add(
+            TagAuditLog(
+                tag_id=tag.tag_id,
+                action_type=TagAuditActionType.LINK_ADDED,
+                link_url="https://example.com/feed",
+                user_id=actor.user_id,
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/users/{actor.user_id}/history")
+        assert response.status_code == 200
+
+        items = [i for i in response.json()["items"] if i["type"] == "tag_metadata"]
+        assert len(items) == 1
+        assert items[0]["action_type"] == TagAuditActionType.LINK_ADDED
+        assert items[0]["link_url"] == "https://example.com/feed"
+        assert items[0]["tag"]["tag_id"] == tag.tag_id

--- a/tests/api/v1/test_tag_audit_log.py
+++ b/tests/api/v1/test_tag_audit_log.py
@@ -2006,3 +2006,122 @@ class TestTagAuditLogExternalLinks:
         # The canonical tag's own setup link, plus the one that moved. The
         # colliding URL must NOT be added again.
         assert sorted(e.link_url for e in added) == [shared, unique]
+
+
+@pytest.mark.api
+class TestTagAuditLogCreation:
+    """A tag born as an alias or child must have that recorded."""
+
+    async def _admin_token(self, client: AsyncClient, db_session: AsyncSession, username: str) -> str:
+        for title, desc in (("tag_create", "Create tags"), ("tag_update", "Update tags")):
+            db_session.add(Perms(title=title, desc=desc))
+        await db_session.commit()
+
+        admin = Users(
+            username=username,
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email=f"{username}@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        perms = (await db_session.execute(select(Perms))).scalars().all()
+        for perm in perms:
+            db_session.add(
+                UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1)
+            )
+        await db_session.commit()
+
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={"username": username, "password": "AdminPassword123!"},
+        )
+        return login.json()["access_token"]
+
+    async def test_creating_a_tag_as_an_alias_logs_alias_set(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        token = await self._admin_token(client, db_session, "createaudit1")
+        target = Tags(title="create audit target", type=TagType.THEME)
+        db_session.add(target)
+        await db_session.commit()
+        await db_session.refresh(target)
+
+        response = await client.post(
+            "/api/v1/tags",
+            json={
+                "title": "create audit alias",
+                "type": TagType.THEME,
+                "alias_of": target.tag_id,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        new_id = response.json()["tag_id"]
+
+        entries = (
+            await db_session.execute(
+                select(TagAuditLog).where(TagAuditLog.tag_id == new_id)
+            )
+        ).scalars().all()
+
+        assert len(entries) == 1
+        assert entries[0].action_type == TagAuditActionType.ALIAS_SET
+        assert entries[0].old_alias_of is None
+        assert entries[0].new_alias_of == target.tag_id
+
+    async def test_creating_a_tag_with_a_parent_logs_parent_set(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        token = await self._admin_token(client, db_session, "createaudit2")
+        parent = Tags(title="create audit parent", type=TagType.THEME)
+        db_session.add(parent)
+        await db_session.commit()
+        await db_session.refresh(parent)
+
+        response = await client.post(
+            "/api/v1/tags",
+            json={
+                "title": "create audit child",
+                "type": TagType.THEME,
+                "inheritedfrom_id": parent.tag_id,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        new_id = response.json()["tag_id"]
+
+        entries = (
+            await db_session.execute(
+                select(TagAuditLog).where(TagAuditLog.tag_id == new_id)
+            )
+        ).scalars().all()
+
+        assert len(entries) == 1
+        assert entries[0].action_type == TagAuditActionType.PARENT_SET
+        assert entries[0].old_parent_id is None
+        assert entries[0].new_parent_id == parent.tag_id
+
+    async def test_creating_a_plain_tag_logs_nothing(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        token = await self._admin_token(client, db_session, "createaudit3")
+
+        response = await client.post(
+            "/api/v1/tags",
+            json={"title": "create audit plain", "type": TagType.THEME},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+
+        entries = (
+            await db_session.execute(
+                select(TagAuditLog).where(TagAuditLog.tag_id == response.json()["tag_id"])
+            )
+        ).scalars().all()
+        assert entries == []

--- a/tests/unit/test_models_tag_audit_log.py
+++ b/tests/unit/test_models_tag_audit_log.py
@@ -1,5 +1,6 @@
 """Tests for TagAuditLog model."""
 
+from app.config import TagAuditActionType
 from app.models.tag_audit_log import TagAuditLog
 
 
@@ -36,3 +37,38 @@ class TestTagAuditLogModel:
         assert log.character_tag_id is None
         assert log.source_tag_id is None
         assert log.user_id is None
+
+
+class TestTagAuditLogLinkFields:
+    """The external-link columns and action types added for link history."""
+
+    def test_link_action_types_are_defined(self):
+        assert TagAuditActionType.LINK_ADDED == "link_added"
+        assert TagAuditActionType.LINK_REMOVED == "link_removed"
+        assert TagAuditActionType.LINK_DEAD_MARKED == "link_dead_marked"
+        assert TagAuditActionType.LINK_DEAD_CLEARED == "link_dead_cleared"
+        assert TagAuditActionType.LINK_ARCHIVE_CHANGED == "link_archive_changed"
+
+    def test_link_columns_default_to_none(self):
+        entry = TagAuditLog(tag_id=1, action_type=TagAuditActionType.RENAME)
+        assert entry.link_url is None
+        assert entry.old_archive_url is None
+        assert entry.new_archive_url is None
+
+    def test_link_columns_accept_long_urls(self):
+        url = "https://example.com/" + ("a" * 1900)
+        entry = TagAuditLog(
+            tag_id=1,
+            action_type=TagAuditActionType.LINK_ARCHIVE_CHANGED,
+            link_url=url,
+            old_archive_url=None,
+            new_archive_url="https://web.archive.org/web/2026/x",
+        )
+        assert entry.link_url == url
+        assert entry.new_archive_url == "https://web.archive.org/web/2026/x"
+
+    def test_link_url_is_not_a_foreign_key(self):
+        # A link_removed entry must outlive the tag_external_links row it
+        # describes, so link_url is plain text with no FK constraint.
+        column = TagAuditLog.__table__.c.link_url
+        assert len(column.foreign_keys) == 0


### PR DESCRIPTION
## Summary

Three reported gaps in tag history:

- Nothing recorded who added, removed, or dead-marked a tag's external links. The four link endpoints wrote no audit rows and did not even resolve the acting user.
- `create_tag` wrote no audit rows at all, so a tag born as an alias had an empty history.
- An `alias_set` row is stored against the alias tag, so the canonical tag never showed that something was aliased to it.

Parent relationships had the same two gaps and get the same treatment.

## Notes for review

- `link_url` is plain `VARCHAR(2000)`, not an FK — a `link_removed` row has to outlive the link it describes.
- `update_tag_link`'s dead-clear branch gained an `and link.dead_at is not None` guard so a no-op PATCH writes no history.
- Setting an alias migrates external links via bulk statements; the URLs are now read first so the movement can be audited on both tags.
- The four link endpoints now take `current_user` explicitly. This does **not** change their status codes: `require_permission`'s checker already depends on `get_current_user` (`app/core/permission_deps.py`), so anonymous calls have always returned 401. The added parameter only exposes the already-resolved user to the endpoint body so it can attribute the audit row. (Corrected — the original wording here was wrong; thanks to the review bot for catching it.)
- No backfill: the 4,222 existing links get no history. We do not know who added them.

Design doc: `docs/plans/2026-07-31-tag-link-and-alias-history-design.md` in shuushuu-frontend.

Frontend PR follows once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AkD3wDN9rgvzoQLEFJ6N9
