### PR TITLE
feat(history): give user-feed items a stable event_id

### DIFF
--- a/app/api/v1/history.py
+++ b/app/api/v1/history.py
@@ -397,24 +397,28 @@ async def get_user_history(
     linked_tags_map = await _load_linked_tags(db, {r.id_a for r in rows if r.kind == 3})
     status_items = await _hydrate_status_change_items(db, [r.id_a for r in rows if r.kind == 4])
 
+    # (kind, id_a, id_b) is the row identity the union already sorts on, so it
+    # is the natural per-event id to hand clients. Stamped here rather than in
+    # the hydration helpers, which are keyed by id and don't know `kind`.
     items: list[UserHistoryItem] = []
     for row in rows:
+        event_id = f"{row.kind}-{row.id_a}-{row.id_b}"
         if row.kind == 1:
-            items.append(metadata_items[row.id_a])
+            item = metadata_items[row.id_a]
         elif row.kind == 2:
-            items.append(usage_items[row.id_a])
+            item = usage_items[row.id_a]
         elif row.kind == 3:
-            items.append(
-                UserHistoryItem(
-                    type="tag_usage",
-                    action="added",
-                    tag=linked_tags_map.get(row.id_a),
-                    image_id=row.id_b,
-                    date=row.ts,
-                )
+            item = UserHistoryItem(
+                type="tag_usage",
+                action="added",
+                tag=linked_tags_map.get(row.id_a),
+                image_id=row.id_b,
+                date=row.ts,
             )
         else:
-            items.append(status_items[row.id_a])
+            item = status_items[row.id_a]
+        item.event_id = event_id
+        items.append(item)
 
     return UserHistoryListResponse(
         total=total,

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -248,6 +248,16 @@ class UserHistoryItem(BaseModel):
 
     type: Literal["tag_metadata", "tag_usage", "status_change"]
 
+    # Stable unique id for one feed event: "{kind}-{id_a}-{id_b}", the identity
+    # tuple the union in app.api.v1.history already computes to re-fetch each
+    # row. Exists so clients have a real key to render by: nothing else in this
+    # schema is reliably unique, since one save can write several audit rows
+    # sharing (action_type, tag_id, created_at) — created_at is a bare
+    # current_timestamp(), so rows written in the same second are identical on
+    # it. Set by the endpoint, not by the hydration helpers; "" never reaches a
+    # response.
+    event_id: str = ""
+
     # Common timestamp fields (different types use different fields)
     created_at: UTCDatetime | None = None  # For tag_metadata and status_change
     date: UTCDatetime | None = None  # For tag_usage (uses 'date' field)

--- a/tests/api/v1/test_user_history_endpoint.py
+++ b/tests/api/v1/test_user_history_endpoint.py
@@ -1120,6 +1120,125 @@ class TestUserHistoryTagLinks:
         # missing from a 12-item list) and an outright omission.
         assert sorted(seen_tag_ids) == sorted(tag.tag_id for tag in tags)
 
+    async def test_event_id_distinguishes_audit_rows_sharing_a_timestamp(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """Audit rows identical in every other rendered field still get
+        distinct event_ids.
+
+        tag_audit_log.created_at is a bare current_timestamp(), so the rows one
+        save writes are identical on it; editing a tag's external links emits a
+        link_added row per link that way. Nothing else in the payload separates
+        them either — same action_type, same tag — so a client with only the
+        rendered fields to work from cannot tell them apart. That is exactly
+        what broke the frontend feed, which keyed its rows on
+        (action_type, tag_id, created_at) and crashed on the collision.
+        """
+        user = await self._make_user(db_session, "userhisteventiduser")
+        tag = Tags(title="event id link tag", type=TagType.ARTIST)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        shared_date = datetime(2026, 1, 1, tzinfo=UTC)
+        urls = [
+            "https://profcard.info/u/6di8O8hVq9dt",
+            "https://x.com/NzzZ_",
+            "https://www.pixiv.net/member.php?id=14693767",
+        ]
+        for url in urls:
+            db_session.add(
+                TagAuditLog(
+                    tag_id=tag.tag_id,
+                    user_id=user.user_id,
+                    action_type=TagAuditActionType.LINK_ADDED,
+                    link_url=url,
+                    created_at=shared_date,
+                )
+            )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/users/{user.user_id}/history")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 3
+
+        # The rows really are indistinguishable on the fields a client renders.
+        rendered = {(i["action_type"], i["tag"]["tag_id"], i["created_at"]) for i in data["items"]}
+        assert len(rendered) == 1
+
+        event_ids = [item["event_id"] for item in data["items"]]
+        assert all(event_ids)
+        assert len(set(event_ids)) == 3
+
+    async def test_event_id_unique_across_all_four_kinds(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """event_id is unique across a page mixing every union branch.
+
+        The id is built from (kind, id_a, id_b), and the four branches draw
+        id_a from unrelated id spaces (tag_audit_log.id, tag_history_id,
+        tag_links.tag_id, image_status_history.id) that freely overlap — the
+        leading kind is what keeps them apart.
+        """
+        user = await self._make_user(db_session, "userhisteventidkinduser")
+        tag = Tags(title="event id kind tag", type=TagType.THEME)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+        image = await self._make_image(db_session, user, "userhisteventidkind")
+
+        base_date = datetime(2026, 1, 1, tzinfo=UTC)
+        db_session.add(
+            TagAuditLog(
+                tag_id=tag.tag_id,
+                user_id=user.user_id,
+                action_type=TagAuditActionType.RENAME,
+                old_title="old",
+                new_title="event id kind tag",
+                created_at=base_date,
+            )
+        )
+        db_session.add(
+            ImageStatusHistory(
+                image_id=image.image_id,
+                user_id=user.user_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.REPOST,
+                created_at=base_date + timedelta(days=1),
+            )
+        )
+        db_session.add(
+            TagHistory(
+                tag_id=tag.tag_id,
+                image_id=image.image_id,
+                action="r",
+                user_id=user.user_id,
+                date=base_date + timedelta(days=2),
+            )
+        )
+        db_session.add(
+            TagLinks(
+                tag_id=tag.tag_id,
+                image_id=image.image_id,
+                user_id=user.user_id,
+                date_linked=base_date + timedelta(days=3),
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/users/{user.user_id}/history")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 4
+
+        event_ids = [item["event_id"] for item in data["items"]]
+        assert all(event_ids)
+        assert len(set(event_ids)) == 4
+        # Kind prefixes: 3=tag_links, 2=tag_history, 4=status, 1=audit, in the
+        # newest-first order the previous test pins.
+        assert [eid.split("-")[0] for eid in event_ids] == ["3", "2", "4", "1"]
+
 
 @pytest.mark.api
 class TestUserHistoryLinkedTags:


### PR DESCRIPTION
Nothing in a `UserHistoryItem` was reliably unique, so clients had nothing real to key rows by. This adds `event_id`.

## Why

`tag_audit_log.created_at` is a bare `current_timestamp()`, so the rows one save writes are identical on it — editing a tag's external links emits a `link_added` row per link that way — and the rest of the payload (`action_type`, `tag`) matches too. A client with only the rendered fields to work from cannot tell two such rows apart.

That is not hypothetical: the frontend feed keyed on `(action_type, tag_id, created_at)` and crashed on the collision. `/users/59006/history?page=9` held three `link_added` rows on *Enu (Pixiv 14693767)* at `17:19:23Z`, Svelte threw `each_key_duplicate` while the keyed each block mounted, and hydration died with the server HTML already painted. Fixed on the client in anonymousobject/shuushuu-frontend#322; this is the durable half.

Every other history endpoint already hands clients a real id (`tag_audit_log.id`, `tag_history_id`, `review_id`, `image_status_history.id`). This closes the one gap.

## What

`_user_history_union` already computes the row identity that settles it: `(kind, id_a, id_b)`, documented there as enough to re-fetch any row. Surface it as `event_id`.

Stamped in the assembly loop rather than in the `_hydrate_*` helpers, which are keyed by id and don't know `kind`. The leading kind is load-bearing — the four branches draw `id_a` from unrelated id spaces (`tag_audit_log.id`, `tag_history_id`, `tag_links.tag_id`, `image_status_history.id`) that freely overlap.

## Tests

Two additions to `TestUserHistoryTagLinks`:

- three audit rows sharing a timestamp, asserting first that they really are indistinguishable on the rendered fields (`{(action_type, tag_id, created_at)}` has size 1) and then that their `event_id`s differ
- a page mixing all four union branches, asserting 4 distinct ids with kind prefixes `["3","2","4","1"]`

31/31 pass; both new tests fail when the `event_id` assignment is removed. ruff and mypy clean.

## Deploy

Ship before the frontend follow-up (anonymousobject/shuushuu-frontend `feat/user-history-event-id`), which keys on this field. That branch carries an index fallback so an ordering slip degrades instead of crashing, but the intended order is API first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)