### PR TITLE
fix(search): disable typo tolerance on numeric tokens

### DIFF
--- a/app/services/search.py
+++ b/app/services/search.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from meilisearch_python_sdk import AsyncClient
 from meilisearch_python_sdk.errors import MeilisearchApiError
-from meilisearch_python_sdk.models.settings import Pagination
+from meilisearch_python_sdk.models.settings import Pagination, TypoTolerance
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -242,6 +242,10 @@ async def configure_tags_index(client: AsyncClient) -> None:
     await index.update_filterable_attributes(["type", "alias_of"])
     await index.update_searchable_attributes(["title", "desc", "external_urls"])
     await index.update_sortable_attributes(["usage_count", "title", "type", "date_added", "tag_id"])
+    # Numeric tokens must match exactly: mods paste pixiv artist IDs to check
+    # whether an artist exists, and a one-digit-off fuzzy match silently
+    # returns the wrong artist. Text keeps normal typo tolerance.
+    await index.update_typo_tolerance(TypoTolerance(disable_on_numbers=True))
     # Default Meilisearch max_total_hits is 1000, which clamps both the
     # estimatedTotalHits the frontend shows and the maximum offset+limit.
     # Set well above current tag count so list-all views report the true

--- a/tests/integration/test_search_integration.py
+++ b/tests/integration/test_search_integration.py
@@ -161,3 +161,30 @@ class TestSearchServiceIntegration:
 
         result = await search_service.search_tags("swimsuit")
         assert result.tag_ids[0] == 51  # Higher usage_count first
+
+    async def test_numeric_query_does_not_typo_match_close_numbers(
+        self, search_service, meilisearch_client
+    ):
+        """A numeric query must only match its exact digits, never a close number.
+
+        Mods paste pixiv artist IDs to check whether the artist already exists;
+        a one-digit-off fuzzy match silently returns the wrong artist.
+        """
+        tag = Tags(tag_id=60, title="TKennshou", type=TagType.ARTIST, usage_count=5)
+        await search_service.index_tag(tag, external_urls=["https://www.pixiv.net/users/21412050"])
+        await _wait_for_indexing(meilisearch_client, TEST_INDEX_NAME)
+
+        exact = await search_service.search_tags("21412050")
+        assert 60 in exact.tag_ids
+
+        off_by_one = await search_service.search_tags("21412051")
+        assert 60 not in off_by_one.tag_ids
+
+    async def test_text_typo_tolerance_still_applies(self, search_service, meilisearch_client):
+        """Disabling typos on numbers must not affect typo tolerance for text."""
+        tag = Tags(tag_id=61, title="Kinomoto", type=TagType.CHARACTER, usage_count=10)
+        await search_service.index_tag(tag)
+        await _wait_for_indexing(meilisearch_client, TEST_INDEX_NAME)
+
+        result = await search_service.search_tags("kinomto")
+        assert 61 in result.tag_ids


### PR DESCRIPTION
## Problem

Mods paste pixiv artist IDs into tag search to check whether an artist already exists. Meilisearch's default typo tolerance (1 typo allowed on words ≥5 chars) applies to numeric tokens too, so an off-by-one ID silently returns the wrong artist — a confident-looking false positive that leads to mis-tagging or a missed new-artist creation. Reported by WhiteKitten; reproduced on dev.

## Fix

`typoTolerance.disableOnNumbers: true` on the tags index — numeric tokens must match exactly, text keeps normal typo tolerance. Applied in `configure_tags_index`, which runs on every startup, so it reaches existing indexes on deploy with no reindex needed.

## Evidence (dev, real index)

| Query | Before | After |
|---|---|---|
| `21412050` (exact) | artist ✓ | artist ✓ |
| `21412051` (off-by-one) | **wrong artist, silently** | 0 hits ✓ |
| `2141205` (partial) | 6 hits incl. unrelated IDs | true-prefix hits only |
| `21412` (short partial) | 112 hits of numeric soup | 3 true-prefix hits |
| `kinomto` (typo'd text) | matches "Kinomoto" | still matches ✓ |

Prefix typeahead on partial IDs is unaffected (only true prefixes match).

## Tests

TDD against a real Meilisearch instance in `tests/integration/test_search_integration.py`: the numeric test failed before the fix (off-by-one matched) and passes after; a companion test pins that text typo tolerance still applies. Full suite: 2394 passed, 11 skipped (pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GufY7U2VRVuj1zmcdFFXAw