### PR TITLE
fix(url-import): classify login-gated pixiv works as restricted, not upstream errors

### DIFF
--- a/app/services/url_import/pixiv.py
+++ b/app/services/url_import/pixiv.py
@@ -5,6 +5,7 @@ spike-verified 2026-07-06 (see the design doc).
 """
 
 import re
+from typing import Any
 
 import httpx
 
@@ -20,6 +21,22 @@ from app.services.url_import.base import (
 
 _URL_RE = re.compile(r"^https?://(?:www\.)?pixiv\.net/(?:[a-z]{2}/)?artworks/(\d+)")
 _REFERER = {"Referer": "https://www.pixiv.net/"}
+
+# pixiv's "sanity level"; 4 and up is flagged sensitive (but not R-18 — that is
+# xRestrict). Verified 2026-08-01 against 11 works that failed in production.
+_SENSITIVE_SANITY_LEVEL = 4
+
+
+def _is_login_gated(body: dict[str, Any]) -> bool:
+    """True if pixiv withheld this work's image URLs pending a login.
+
+    For works behind the login gate the ajax API still answers 200 with
+    error:false and a full metadata body, but every value in `urls` is null.
+    Two conditions trigger it, neither of which sets xRestrict, so the R-18
+    check misses both: the artist restricting the work to logged-in viewers,
+    and pixiv flagging it sensitive (sl >= 4).
+    """
+    return bool(body.get("isLoginOnly")) or (body.get("sl") or 0) >= _SENSITIVE_SANITY_LEVEL
 
 
 class PixivResolver:
@@ -47,6 +64,15 @@ class PixivResolver:
             raise RestrictedContentError("Restricted (R-18) pixiv works cannot be imported")
         if body.get("illustType") == 2:
             raise RestrictedContentError("Ugoira (animated) pixiv works cannot be imported")
+        # Checked before the pageCount branch: pixiv nulls the whole `urls` block
+        # on the illust body, which carries p0 even for multi-page works — so this
+        # covers both shapes and spares a pointless /pages round-trip.
+        if not (body.get("urls") or {}).get("original") and _is_login_gated(body):
+            raise RestrictedContentError(
+                "This pixiv work is only viewable while logged in to pixiv. "
+                "Save the image and upload it manually, or paste a mirror URL "
+                "(danbooru, gelbooru, zerochan) if one exists."
+            )
 
         if body.get("pageCount", 1) > 1:
             pages = await fetch_json(

--- a/app/services/url_import/pixiv.py
+++ b/app/services/url_import/pixiv.py
@@ -23,7 +23,7 @@ _URL_RE = re.compile(r"^https?://(?:www\.)?pixiv\.net/(?:[a-z]{2}/)?artworks/(\d
 _REFERER = {"Referer": "https://www.pixiv.net/"}
 
 # pixiv's "sanity level"; 4 and up is flagged sensitive (but not R-18 — that is
-# xRestrict). Verified 2026-08-01 against 11 works that failed in production.
+# xRestrict). Verified 2026-08-01 against 12 works that failed in production.
 _SENSITIVE_SANITY_LEVEL = 4
 
 

--- a/tests/unit/test_url_import_pixiv.py
+++ b/tests/unit/test_url_import_pixiv.py
@@ -137,6 +137,54 @@ class TestResolve:
             with pytest.raises(UpstreamError):
                 await PixivResolver().resolve("https://www.pixiv.net/artworks/138823691", client)
 
+    @pytest.mark.parametrize(
+        "gate",
+        [
+            {"sl": 4},  # flagged sensitive
+            {"sl": 6},  # flagged more sensitive
+            {"isLoginOnly": True},  # artist restricted it to logged-in viewers
+        ],
+    )
+    async def test_login_gated_work_rejected_as_restricted(self, gate):
+        """pixiv answers 200/error:false with every `urls` value null for works
+        behind its login gate, and leaves xRestrict at 0 (live-verified
+        2026-08-01). Must not surface as a 502."""
+        body = _illust_body(urls=dict.fromkeys(["small", "original"]), **gate)
+        async with _client(body) as client:
+            with pytest.raises(RestrictedContentError, match="logged in to pixiv"):
+                await PixivResolver().resolve("https://www.pixiv.net/artworks/138823691", client)
+
+    async def test_login_gated_multi_page_work_rejected_without_pages_fetch(self):
+        pages_requested = []
+
+        def handler(request):
+            path = request.url.path
+            if path == "/ajax/illust/138823691":
+                body = _illust_body(pageCount=3, sl=4, urls=dict.fromkeys(["small", "original"]))
+                return httpx.Response(200, json={"error": False, "body": body})
+            pages_requested.append(path)
+            return httpx.Response(200, json={"error": False, "body": []})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(RestrictedContentError, match="logged in to pixiv"):
+                await PixivResolver().resolve("https://www.pixiv.net/artworks/138823691", client)
+        assert pages_requested == []
+
+    async def test_null_urls_without_gate_flags_stays_upstream_error(self):
+        """No gate flag means pixiv changed something we don't understand —
+        that is a 502, not a restriction we can explain to the user."""
+        body = _illust_body(urls=dict.fromkeys(["small", "original"]), sl=2)
+        async with _client(body) as client:
+            with pytest.raises(UpstreamError):
+                await PixivResolver().resolve("https://www.pixiv.net/artworks/138823691", client)
+
+    async def test_gate_flags_ignored_when_urls_are_present(self):
+        """Only the missing-URL case is a restriction. If pixiv ever serves
+        originals for sensitive works, keep importing them."""
+        async with _client(_illust_body(sl=4)) as client:
+            post = await PixivResolver().resolve("https://www.pixiv.net/artworks/138823691", client)
+        assert post.images[0].full_url.endswith("_p0.png")
+
     async def test_off_host_original_url_rejects_whole_post(self):
         body = _illust_body(urls={
             "small": "https://i.pximg.net/c/540x540_70/img-master/img/x/138823691_p0_master1200.jpg",


### PR DESCRIPTION
## Problem

Users reported URL imports failing on pixiv links with an unhelpful toast. Example: https://www.pixiv.net/en/artworks/131609195

Pixiv's anonymous ajax API answers `200` with `error: false` and a complete metadata body — but with **every value in `urls` set to `null`** — for works behind its login gate. Two conditions trigger this, and neither sets `xRestrict`, so the existing R-18 check missed both:

- the artist restricting a work to logged-in viewers (`isLoginOnly`)
- pixiv flagging it sensitive (`sl >= 4`)

The resolver then tripped on the missing `urls.original` and raised `UpstreamError` → **HTTP 502**, `"pixiv response missing expected fields"`. That names neither the cause nor anything the user can do about it.

## Scope

Over the 26 days before this change, `/api/v1/images/resolve-url` served **206 × 200 and 27 × 502**. Of the 502s, **25 were this bug** (identifiable by an exactly 51-byte response body). The other 2 were unrelated twitter/bluesky upstream timeouts.

## Verification

Checked against the live pixiv API on 2026-08-01, using artwork IDs pulled from production logs:

| Condition | `urls.original` | Sample |
|---|---|---|
| `sl >= 4` | `null` | 8/8 failures |
| `isLoginOnly: true` | `null` | 4/4 failures |
| neither | present | 5/5 successes |

`xRestrict` is `0` for every gated work, confirming the R-18 gate can't catch them.

## Change

`_is_login_gated()` checks the two gate flags, and fires **only when `urls.original` is actually absent**. That keeps two cases honest:

- null `urls` with no gate flag stays an `UpstreamError` — a genuine pixiv schema change should remain a 502, not get mislabeled as a restriction
- if pixiv ever starts serving originals for sensitive works, they keep importing

The check sits **before** the `pageCount` branch: pixiv nulls the `urls` block on the illust body, which carries p0 even for multi-page works, so one check covers both shapes and spares a pointless `/pages` round-trip.

`RestrictedContentError` maps to the existing 403 handler, so users now get:

> This pixiv work is only viewable while logged in to pixiv. Save the image and upload it manually, or paste a mirror URL (danbooru, gelbooru, zerochan) if one exists.

## Tests

6 new cases: parametrized over `sl=4` / `sl=6` / `isLoginOnly`, one asserting the multi-page path never issues the `/pages` request, and two guarding the negative cases above. `ruff check`, `ruff format --check` and `mypy` clean on the changed module; full unit suite + upload API tests pass (758 passed, 11 skipped — skips pre-existing, Redis not reachable locally).

## Deployed for verification

Rolled out to prod as `api-8` ahead of this PR. Confirmed live — the gated URL now returns 403 with the new message instead of a 502:

```
-> GET pixiv.net/ajax/illust/131609195  "HTTP/2 200 OK"
01:43:47  REQ 403  user 2   327.4 ms
```

## Note

This does not make gated works importable — it makes the failure legible. Fetching them would require authenticated pixiv requests (danbooru does this via an operator-supplied `PHPSESSID` cookie), which is a separate decision with its own ToS considerations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Smymy6riKzQ3o3kUn4mQeQ