### PR TITLE
fix(test): stop Meilisearch waits timing out under parallel load

### DIFF
--- a/tests/integration/test_search_integration.py
+++ b/tests/integration/test_search_integration.py
@@ -61,16 +61,83 @@ async def search_service(meilisearch_client):
     search_module.TAGS_INDEX_NAME = original_name
 
 
-async def _wait_for_indexing(client: AsyncClient, index_name: str, timeout: float = 5.0):
+# Wall-clock ceiling for Meilisearch to settle. Generous on purpose: the loop
+# below returns the moment nothing is pending, so a large budget costs nothing
+# when the host is healthy and only buys patience when it is not. The suite
+# runs under `-n auto`, and parallelism alone stretches these waits well past
+# their serial cost (measured 0.83s serial vs 2.77s in a full parallel run) —
+# a tight budget turns ordinary load into an intermittent failure in whichever
+# test happens to be running when Meilisearch is slowest.
+_INDEXING_TIMEOUT_SECONDS = 30.0
+
+
+async def _wait_for_indexing(
+    client: AsyncClient, index_name: str, timeout: float = _INDEXING_TIMEOUT_SECONDS
+):
     """Wait for Meilisearch to finish processing all pending tasks for the index."""
     start = time.monotonic()
-    while time.monotonic() - start < timeout:
+    pending_count = 0
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed >= timeout:
+            break
         tasks = await client.get_tasks(index_ids=[index_name])
         pending = [t for t in tasks.results if t.status in ("enqueued", "processing")]
         if not pending:
             return
+        pending_count = len(pending)
         await asyncio.sleep(0.1)
-    raise TimeoutError("Meilisearch did not finish indexing in time")
+    raise TimeoutError(
+        f"Meilisearch did not settle for index {index_name!r}: "
+        f"{pending_count} task(s) still enqueued or processing "
+        f"after {timeout}s"
+    )
+
+
+class _FakeTask:
+    def __init__(self, status: str):
+        self.status = status
+
+
+class _FakeTaskList:
+    def __init__(self, results):
+        self.results = results
+
+
+class _StubClient:
+    """Reports a fixed set of task states; no Meilisearch required."""
+
+    def __init__(self, statuses):
+        self._statuses = statuses
+
+    async def get_tasks(self, index_ids=None):
+        return _FakeTaskList([_FakeTask(s) for s in self._statuses])
+
+
+class TestWaitForIndexing:
+    """The helper's timeout contract.
+
+    Its budget is a wall-clock ceiling on how long Meilisearch may take to
+    settle, and blowing it is how this file fails when the host is loaded.
+    The message therefore has to say what was still pending and how long it
+    waited — a bare "did not finish indexing in time" sends whoever hits it
+    hunting through unrelated parts of the suite.
+    """
+
+    async def test_returns_once_no_tasks_are_pending(self):
+        client = _StubClient(["succeeded", "succeeded"])
+        await _wait_for_indexing(client, "tags_test", timeout=0.5)
+
+    async def test_timeout_reports_index_pending_count_and_budget(self):
+        client = _StubClient(["processing", "enqueued", "succeeded"])
+
+        with pytest.raises(TimeoutError) as exc_info:
+            await _wait_for_indexing(client, "tags_test_gw3", timeout=0.3)
+
+        message = str(exc_info.value)
+        assert "tags_test_gw3" in message
+        assert "2" in message  # the two still-pending tasks
+        assert "0.3" in message  # the budget that was exceeded
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Fixes the long-standing intermittent failures in `tests/integration/test_search_integration.py` — the ones where a *different* test in that file fails each time and everything passes on a retry.

## Root cause

`_wait_for_indexing` capped the wait for Meilisearch to settle at **5 seconds**. That budget is not generous enough once the suite runs under `-n auto`.

Measured on an **idle** host, same tests, serial vs. full parallel run:

| Test | Serial | Full suite (`-n auto`) |
|---|---:|---:|
| `test_delete_tag_removes_from_search` | 0.83s | **2.77s** |
| `test_text_typo_tolerance_still_applies` | 0.16s | **1.78s** |
| `test_type_filter` | 0.26s | **1.75s** |

Parallelism alone inflates these 3–11×, putting the worst case at 55% of the budget before any *other* load exists. Add a busy host and the wait crosses 5s, and whichever test happens to be running when Meilisearch is slowest raises `TimeoutError`. That is why the failure looks random, and why it always lands somewhere in this one file: it is the only test file that talks to a real Meilisearch instance (the other four search-related files all mock it).

Confirmed the mechanism by shrinking the budget to 1s, which reproduces the exact error in several tests of the file:

```
E   TimeoutError: Meilisearch did not finish indexing in time
tests/integration/test_search_integration.py:73: TimeoutError
```

## What this changes

**Raise the ceiling to 30s.** The poll loop returns the moment nothing is pending, so a larger budget costs nothing when the host is healthy — it only buys patience when it is not. For reference, the Meilisearch SDK's own `wait_for_task` uses a 100s default.

**Make the timeout message diagnostic.** It now names the index, how many tasks are still enqueued or processing, and the budget exceeded:

```
Meilisearch did not settle for index 'tags_test_gw3': 2 task(s) still
enqueued or processing after 30.0s
```

The previous bare `did not finish indexing in time` said nothing about which index or how far off it was, which cost real time to diagnose.

## Things ruled out along the way

- **Cross-worker index collision** — not possible. The file already derives a per-worker index (`tags_test_{PYTEST_XDIST_WORKER}`), added in 2770cce.
- **Cross-file interference on a shared index** — not possible. The other four search-touching test files (`test_search.py`, `test_search_service.py`, `test_search_sync.py`, `test_worker.py`) all use `AsyncMock`/`MagicMock`.
- **Teardown deleting an index out from under the next test** — not possible. `delete_index_if_exists` waits for its own task.
- **Randomised test ordering** — `pytest-randomly` is not installed.

## Testing

Two unit tests added for the helper's contract, using a stub client and needing no Meilisearch: one that it returns once nothing is pending, one that the timeout message carries the index, pending count, and budget. Written first, confirmed failing against the old message.

- `make pytest` → **2410 passed**, 11 skipped
- `ruff check` clean

Note: `ruff format --check` still reports this file, on a pre-existing line 19 that is byte-identical on `main` (pre-commit skips ruff on `tests/`). Left alone rather than mixing an unrelated reformat into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AkD3wDN9rgvzoQLEFJ6N9