### PR TITLE
fix(deploy): roll arq-worker with deploys, gate frontend on warmed SSR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ help:
 	@echo "  prod-build   Build all production images"
 	@echo "  prod-build-frontend  Rebuild frontend image"
 	@echo "  prod-migrate Apply DB migrations (run BEFORE prod-deploy when a release has one)"
-	@echo "  prod-deploy  Zero-downtime rollout of app service(s) (default: api frontend)"
+	@echo "  prod-deploy  Zero-downtime rollout of app service(s) (default: api frontend arq-worker)"
 	@echo "  prod-restart Force-recreate service(s) — CAUSES DOWNTIME; use for nginx/infra"
 	@echo ""
 	@echo "Other:"
@@ -72,10 +72,13 @@ COMPOSE_PROD = docker compose -f docker-compose.yml -f docker-compose.prod.yml
 # and self-documents the expected window (plugin default is only 60s).
 ROLLOUT_PROD = docker rollout --timeout 90 -f docker-compose.yml -f docker-compose.prod.yml
 
-# App services that support zero-downtime rollout: stateless, fronted by nginx
-# which re-resolves their service name via Docker DNS at request time. Override
-# by passing service names, e.g. `make prod-deploy api`.
-ROLLOUT_SERVICES = api frontend
+# App services that support zero-downtime rollout. api/frontend are stateless
+# and fronted by nginx, which re-resolves their service name via Docker DNS at
+# request time. arq-worker is queue-fed rather than nginx-fronted, but rolls
+# just as safely: arq claims jobs atomically and cron jobs dedup via
+# deterministic ids, so the transient two-replica overlap never double-runs
+# anything. Override by passing service names, e.g. `make prod-deploy api`.
+ROLLOUT_SERVICES = api frontend arq-worker
 DEPLOY_SERVICES = $(if $(ARGS),$(ARGS),$(ROLLOUT_SERVICES))
 
 # Development targets
@@ -193,8 +196,14 @@ prod-migrate: check-env-prod
 # time. docker-rollout starts a new replica, waits for its healthcheck, then
 # drains the old one — nginx re-resolves the service name via Docker DNS, so no
 # requests are dropped. Does NOT run migrations (see prod-migrate).
+#
+# arq-worker is always built, even when ARGS narrows the rollout set: skipping
+# its rebuild is how the worker once kept running an image whose deps predated
+# a uv.lock bump until its freshness check crash-looped it (2026-08). The
+# rollout no-ops when the built image is unchanged, so this costs nothing on
+# deploys that don't touch Python code.
 prod-deploy: check-env-prod
-	$(COMPOSE_PROD) build $(DEPLOY_SERVICES)
+	$(COMPOSE_PROD) build $(sort $(DEPLOY_SERVICES) arq-worker)
 	@for svc in $(DEPLOY_SERVICES); do \
 		echo "==> Rolling out $$svc (zero-downtime)"; \
 		$(ROLLOUT_PROD) $$svc || exit 1; \

--- a/app/tasks/worker.py
+++ b/app/tasks/worker.py
@@ -6,6 +6,7 @@ Run worker with: uv run arq app.tasks.worker.WorkerSettings
 
 import asyncio
 import hashlib
+import socket
 from pathlib import Path
 from typing import Any
 
@@ -218,6 +219,16 @@ class WorkerSettings:
     max_jobs = 10  # Process up to 10 jobs concurrently
     job_timeout = 300  # 5 minutes max per job
     keep_result = settings.ARQ_KEEP_RESULT  # Keep results for 1 hour
+
+    # Health: the compose healthcheck runs `arq --check` against this class.
+    # arq's default health key is queue-scoped, so during a zero-downtime
+    # rollout the OLD replica would keep it fresh and mask a broken NEW one —
+    # rollout would drain the healthy worker and leave zero. Keying by hostname
+    # (= container id) makes the check reflect this container's worker only;
+    # `arq --check` runs in the same container, so it computes the same key.
+    # Stale keys self-clean: arq sets the key with TTL = interval + 1s.
+    health_check_interval = 15
+    health_check_key = f"arq:health:{socket.gethostname()}"
 
     # Lifecycle hooks
     on_startup = startup

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -78,12 +78,19 @@ services:
       - NODE_OPTIONS=--max-old-space-size=4096
     depends_on:
       - api
+    # The production image starts via a warm-before-listen entry
+    # (server.production.js in the frontend repo): the server renders the
+    # homepage through the real SSR path BEFORE binding :3000, so this check
+    # can only pass — and docker-rollout can only drain the old replica — once
+    # the container is genuinely warm. Until then connections are refused and
+    # nginx fails over to the old replica. start_period covers node start +
+    # the warmup render on a loaded host.
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/health"]
       interval: 10s
       timeout: 5s
       retries: 3
-      start_period: 30s
+      start_period: 60s
     restart: unless-stopped
     networks:
       - default
@@ -180,7 +187,12 @@ services:
     logging: *default-logging
 
   arq-worker:
-    container_name: shuushuu-arq-worker-prod
+    # No container_name: like api, docker-rollout scales this service to two
+    # replicas transiently during a deploy, so its name can't be fixed. The
+    # overlap is safe: arq claims jobs atomically and cron jobs enqueue with
+    # deterministic ids (name + scheduled time), so two live workers never
+    # double-run anything.
+    container_name: !reset null
     user: "1003:1003"  # shuushuu user — matches storage directory ownership
     ports: []
     environment:
@@ -191,6 +203,18 @@ services:
       - PYTHONDONTWRITEBYTECODE=1
     volumes:
       - ${STORAGE_PATH:-/shuushuu/images}:${STORAGE_PATH:-/shuushuu/images}
+    # docker-rollout waits for this healthcheck on the new replica before
+    # draining the old one. `arq --check` reads a per-container health key that
+    # the worker refreshes every 15s (see WorkerSettings) — per-container so the
+    # old replica's heartbeat can't vouch for a broken new one. start_period
+    # covers Meilisearch config + ML model load (~5s observed; headroom for a
+    # loaded host).
+    healthcheck:
+      test: ["CMD", "uv", "run", "--no-project", "arq", "--check", "app.tasks.worker.WorkerSettings"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     # List form replaces base depends_on entirely (removes mariadb dependency)
     depends_on:
       - redis


### PR DESCRIPTION
## Problem

Two deploy-pipeline gaps surfaced this week:

1. **arq-worker never deployed.** It wasn't in `ROLLOUT_SERVICES`, so `make prod-deploy` never rebuilt it. After the uv.lock bump (0be3921) the worker kept running a stale image until its lockfile freshness check crash-looped it (~7 min outage window, 2026-08-06 02:00 UTC).
2. **Cold frontends served traffic after every deploy.** The `/health` check passes the instant node binds :3000 — before the SSR server has ever rendered a page. Worse, Docker service DNS registers a replica at network-attach regardless of health, so nginx round-robins real users onto the cold container. Result: 10-15s first page loads after each deploy.

## Fix

- **arq-worker joins the zero-downtime rollout.** Fixed `container_name` dropped (docker-rollout scales to 2 replicas transiently — safe: arq claims jobs atomically, cron jobs dedup via deterministic `name:timestamp` ids, verified against arq 0.27.0 source). New `arq --check` healthcheck gates the old replica's drain.
- **Per-container worker health key** (`arq:health:<hostname>`): arq's default key is queue-scoped, so the old replica's heartbeat would vouch for a broken new one and rollout would drain the only healthy worker. Hostname-keyed, `--check` in a container can only see its own worker.
- **Worker image always builds**, even when ARGS narrows the rollout set — it can't silently drift stale again.
- **Frontend healthcheck gates on a warmed server**: the image now starts via a warm-before-listen entry (companion PR in shuushuu-frontend) that renders the homepage through the real SSR path before binding :3000. Until then connections are refused and nginx fails over to the old replica. `start_period` raised to 60s to cover the warmup.

## Verification

1s-interval probe through nginx across a full prod deploy (api + frontend + arq-worker):
- 73/74 requests: HTTP 200, max 0.19s (previously 10-15s stalls)
- 1 request: 3ms fast-fail 502 during old-api drain (nginx resolver cache edge, `valid=10s`) — known residual, fails fast instead of hanging
- Worker's first rollout transitioned the legacy fixed-name container with no intervention; new replica went healthy via the per-container key before the old one drained

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014L2gTHDgwt2BVnTERymqww