### PR TITLE
feat(users): add GET /users/{id}/ratings

### DIFF
--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -78,6 +78,20 @@ class ImageRatingsSortParams(BaseModel):
     sort_order: SortOrder = Field(default="DESC", description="Sort order")
 
 
+class UserRatingsSortParams(BaseModel):
+    """Sorting parameters for the per-user ratings list.
+
+    Defaults to ``image_id`` rather than ``rated_at``: ``image_ratings.date`` is
+    NULL on 98% of rows (the legacy import carried no timestamps), so ordering by
+    it is a near-total tie. ``image_id`` is the usable proxy for recency.
+    """
+
+    sort_by: Literal["image_id", "rating", "rated_at"] = Field(
+        default="image_id", description="Sort field"
+    )
+    sort_order: SortOrder = Field(default="DESC", description="Sort order")
+
+
 TagSortBy = Literal["usage_count", "title", "date_added", "tag_id", "type"]
 """Allowed tag sort fields. Must be a subset of `sortableAttributes`
 configured in `app/services/search.py::configure_tags_index`."""

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -1056,7 +1056,7 @@ async def get_user_ratings(
         )
         # from_db_model has no rating parameter, so assign after construction —
         # the same pattern list_images uses for ml_suggestion_count.
-        item.rating = rating_value
+        item.subject_rating = rating_value
         item.rated_at = rated_at
         items.append(item)
 

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -1048,10 +1048,24 @@ async def get_user_ratings(
 
     rows = (await db.execute(query)).all()
 
+    # Favorite status reflects the *viewer's* favorites, not the ratings subject's —
+    # a mod auditing someone else's ratings sees their own hearts, not the subject's.
+    page_ids = [image.image_id for image, _, _ in rows]
+    favorited_ids: set[int] = set()
+    if page_ids:
+        fav_result = await db.execute(
+            select(Favorites.image_id).where(  # type: ignore[call-overload]
+                Favorites.user_id == current_user.user_id,
+                Favorites.image_id.in_(page_ids),  # type: ignore[attr-defined]
+            )
+        )
+        favorited_ids = set(fav_result.scalars().all())
+
     items: list[ImageWithRatingResponse] = []
     for image, rating_value, rated_at in rows:
         item = ImageWithRatingResponse.from_db_model(
             image,
+            is_favorited=image.image_id in favorited_ids,
             can_see_reason=is_mod or image.user_id == current_user.user_id,
         )
         # from_db_model has no rating parameter, so assign after construction —

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -26,7 +26,12 @@ from sqlalchemy import asc, case, delete, desc, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.api.dependencies import ImageSortParams, PaginationParams, UserSortParams
+from app.api.dependencies import (
+    ImageSortParams,
+    PaginationParams,
+    UserRatingsSortParams,
+    UserSortParams,
+)
 from app.config import ImageStatus, SuspensionAction, settings
 from app.core.auth import (
     get_client_ip,
@@ -42,12 +47,17 @@ from app.core.r2_client import get_r2_storage
 from app.core.redis import get_redis
 from app.core.security import RedactedStr, get_password_hash, validate_password_strength
 from app.core.user_loader import image_uploader_load
-from app.models import Favorites, Images, TagLinks, Tags, Users
+from app.models import Favorites, ImageRatings, Images, TagLinks, Tags, Users
 from app.models.permissions import UserGroups
 from app.models.refresh_token import RefreshTokens
 from app.models.user_suspension import UserSuspensions
 from app.models.user_tag_affinity import UserTagAffinity
-from app.schemas.image import ImageDetailedListResponse, ImageDetailedResponse
+from app.schemas.image import (
+    ImageDetailedListResponse,
+    ImageDetailedResponse,
+    ImageWithRatingResponse,
+    UserRatingsListResponse,
+)
 from app.schemas.taste_profile import TasteProfileResponse, TasteProfileSummary, TasteProfileTag
 from app.schemas.user import (
     AcknowledgeWarningsResponse,
@@ -938,6 +948,123 @@ async def get_user_favorites(
         page=pagination.page,
         per_page=pagination.per_page,
         images=[ImageDetailedResponse.model_validate(img) for img in images],
+    )
+
+
+@router.get("/{user_id}/ratings", response_model=UserRatingsListResponse)
+async def get_user_ratings(
+    user_id: Annotated[int, Path(description="User ID")],
+    pagination: Annotated[PaginationParams, Depends()],
+    sorting: Annotated[UserRatingsSortParams, Depends()],
+    min_rating: Annotated[
+        int | None, Query(ge=1, le=10, description="Only ratings at or above this value")
+    ] = None,
+    max_rating: Annotated[
+        int | None, Query(ge=1, le=10, description="Only ratings at or below this value")
+    ] = None,
+    db: AsyncSession = Depends(get_db),
+    redis_client: redis.Redis = Depends(get_redis),  # type: ignore[type-arg]
+    current_user: Users | None = Depends(get_optional_current_user),
+) -> UserRatingsListResponse:
+    """
+    Get all images a user has rated, with the rating they gave.
+
+    Private: visible only to the user themselves and to moderators holding
+    USER_EDIT_PROFILE. Moderators see every rated image regardless of status,
+    because an audit for rating-bombing needs the deactivated ones.
+
+    `min_rating` / `max_rating` filter on the subject user's own score. Note that
+    `/images?min_rating=` means something different — the image's *average*.
+    """
+    # Existence first: user existence is already public via GET /users/{id}, so a
+    # 404 ahead of the gate leaks nothing new. Matches /users/{id}/favorites.
+    user_result = await db.execute(select(Users).where(Users.user_id == user_id))  # type: ignore[arg-type]
+    if not user_result.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if current_user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required to view ratings",
+        )
+
+    is_self = current_user.user_id == user_id
+    is_mod = await has_permission(db, current_user.id, Permission.USER_EDIT_PROFILE, redis_client)
+    if not (is_self or is_mod):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only view your own ratings",
+        )
+
+    query = (
+        select(
+            Images,
+            ImageRatings.rating.label("rating_value"),  # type: ignore[attr-defined]
+            ImageRatings.date.label("rated_at"),  # type: ignore[union-attr]
+        )
+        .join(ImageRatings, ImageRatings.image_id == Images.image_id)  # type: ignore[arg-type]
+        .where(ImageRatings.user_id == user_id)  # type: ignore[arg-type]
+        .options(
+            image_uploader_load(),
+            selectinload(Images.tag_links).selectinload(TagLinks.tag),  # type: ignore[arg-type]
+        )
+    )
+
+    # Moderators bypass both filters — hiding deactivated images would hide the
+    # evidence a rating-bombing audit is looking for.
+    if not is_mod:
+        query = query.where(
+            or_(
+                Images.status.in_(PUBLIC_IMAGE_STATUSES),  # type: ignore[attr-defined]
+                Images.user_id == current_user.user_id,  # type: ignore[arg-type]
+            )
+        )
+        if current_user.hide_reposts == 1:
+            query = query.where(Images.status != ImageStatus.REPOST)  # type: ignore[arg-type]
+
+    if min_rating is not None:
+        query = query.where(ImageRatings.rating >= min_rating)  # type: ignore[arg-type]
+    if max_rating is not None:
+        query = query.where(ImageRatings.rating <= max_rating)  # type: ignore[arg-type]
+
+    count_query = select(func.count()).select_from(query.subquery())
+    total = (await db.execute(count_query)).scalar() or 0
+
+    sort_columns: dict[str, Any] = {
+        "image_id": Images.image_id,
+        "rating": ImageRatings.rating,
+        "rated_at": ImageRatings.date,
+    }
+    sort_column = sort_columns[sorting.sort_by]
+    primary = desc(sort_column) if sorting.sort_order == "DESC" else asc(sort_column)
+    # Tiebreaker: `rated_at` ties on 98% of rows and `rating` has ten distinct
+    # values, so without this pagination would return unstable pages.
+    tiebreaker: list[Any] = (
+        [] if sorting.sort_by == "image_id" else [desc(Images.image_id)]  # type: ignore[arg-type]
+    )
+    query = (
+        query.order_by(primary, *tiebreaker).offset(pagination.offset).limit(pagination.per_page)
+    )
+
+    rows = (await db.execute(query)).all()
+
+    items: list[ImageWithRatingResponse] = []
+    for image, rating_value, rated_at in rows:
+        item = ImageWithRatingResponse.from_db_model(
+            image,
+            can_see_reason=is_mod or image.user_id == current_user.user_id,
+        )
+        # from_db_model has no rating parameter, so assign after construction —
+        # the same pattern list_images uses for ml_suggestion_count.
+        item.rating = rating_value
+        item.rated_at = rated_at
+        items.append(item)
+
+    return UserRatingsListResponse(
+        total=total,
+        page=pagination.page,
+        per_page=pagination.per_page,
+        images=items,
     )
 
 

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field, computed_field, field_validator
 from app.config import TagType, settings
 from app.core.r2_constants import PUBLIC_IMAGE_STATUSES_FOR_R2, R2Location
 from app.models.image import ImageBase, VariantStatus
-from app.schemas.base import UTCDatetime
+from app.schemas.base import UTCDatetime, UTCDatetimeOptional
 from app.schemas.common import UserSummary
 
 # Sort order for tags in image responses: artist → source → character → theme
@@ -228,6 +228,33 @@ class ImageDetailedResponse(ImageResponse):
             data["status_reason"] = getattr(image, "status_reason", None)
 
         return cls(**data)
+
+
+class ImageWithRatingResponse(ImageDetailedResponse):
+    """An image plus the rating the subject user gave it.
+
+    Mirrors ``UserWithRatingResponse`` (app/schemas/user.py), which serves the
+    opposite direction of the same relation. ``rating`` defaults to 0 — outside
+    the valid 1-10 range — because ``from_db_model`` has no rating parameter, so
+    the endpoint assigns it after construction the way ``list_images`` assigns
+    ``ml_suggestion_count``.
+
+    Do NOT use the inherited ``user_rating`` field for this: it means "the rating
+    *you* gave" everywhere else, and a moderator viewing someone else's ratings
+    would then read the subject's score under a name that says "yours".
+    """
+
+    rating: int = 0
+    rated_at: UTCDatetimeOptional = None
+
+
+class UserRatingsListResponse(BaseModel):
+    """Schema for a paginated list of images a user has rated."""
+
+    total: int
+    page: int
+    per_page: int
+    images: list[ImageWithRatingResponse]
 
 
 class ImageListResponse(BaseModel):

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -234,17 +234,21 @@ class ImageWithRatingResponse(ImageDetailedResponse):
     """An image plus the rating the subject user gave it.
 
     Mirrors ``UserWithRatingResponse`` (app/schemas/user.py), which serves the
-    opposite direction of the same relation. ``rating`` defaults to 0 — outside
-    the valid 1-10 range — because ``from_db_model`` has no rating parameter, so
-    the endpoint assigns it after construction the way ``list_images`` assigns
-    ``ml_suggestion_count``.
+    opposite direction of the same relation. ``subject_rating`` defaults to 0 —
+    outside the valid 1-10 range — because ``from_db_model`` has no rating
+    parameter, so the endpoint assigns it after construction the way
+    ``list_images`` assigns ``ml_suggestion_count``.
 
-    Do NOT use the inherited ``user_rating`` field for this: it means "the rating
-    *you* gave" everywhere else, and a moderator viewing someone else's ratings
-    would then read the subject's score under a name that says "yours".
+    The name is ``subject_rating`` for two reasons. It cannot be ``rating``:
+    ``ImageBase.rating`` is already the image's own average, inherited here as a
+    float, and redeclaring it would drop the average from the response. It
+    cannot be ``user_rating`` either: that means "the rating *you* gave"
+    everywhere else, so a moderator would read the subject's score under a name
+    that says "yours". "Subject" is right in both cases — the user whose list
+    this is, who is the viewer when self and someone else when a moderator.
     """
 
-    rating: int = 0
+    subject_rating: int = 0
     rated_at: UTCDatetimeOptional = None
 
 

--- a/tests/api/v1/test_user_ratings_endpoint.py
+++ b/tests/api/v1/test_user_ratings_endpoint.py
@@ -101,3 +101,54 @@ class TestUserRatingsHappyPath:
         body = response.json()
         assert body["total"] == 1
         assert [img["image_id"] for img in body["images"]] == [mine.image_id]
+
+
+from tests.api.v1.test_users import grant_user_permission
+
+
+class TestUserRatingsAuthorization:
+    async def test_anonymous_is_rejected(self, client: AsyncClient, db_session: AsyncSession):
+        rater = await _make_user(db_session, "rater_anon")
+        image = await _make_image(db_session, rater, "ddd")
+        await _rate(db_session, rater, image, 4)
+
+        response = await client.get(f"/api/v1/users/{rater.user_id}/ratings")
+
+        assert response.status_code == 401
+
+    async def test_other_user_is_forbidden(self, client: AsyncClient, db_session: AsyncSession):
+        rater = await _make_user(db_session, "rater_subject")
+        nosy = await _make_user(db_session, "rater_nosy")
+        image = await _make_image(db_session, rater, "eee")
+        await _rate(db_session, rater, image, 6)
+
+        response = await _authenticate(client, nosy).get(
+            f"/api/v1/users/{rater.user_id}/ratings"
+        )
+
+        assert response.status_code == 403
+
+    async def test_moderator_can_view_another_users_ratings(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        rater = await _make_user(db_session, "rater_audited")
+        mod = await _make_user(db_session, "rater_mod")
+        await grant_user_permission(db_session, mod.user_id, "user_edit_profile")
+        image = await _make_image(db_session, rater, "fff")
+        await _rate(db_session, rater, image, 10)
+
+        response = await _authenticate(client, mod).get(
+            f"/api/v1/users/{rater.user_id}/ratings"
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 1
+        assert body["images"][0]["subject_rating"] == 10
+
+    async def test_unknown_user_is_404(self, client: AsyncClient, db_session: AsyncSession):
+        viewer = await _make_user(db_session, "rater_viewer")
+
+        response = await _authenticate(client, viewer).get("/api/v1/users/99999999/ratings")
+
+        assert response.status_code == 404

--- a/tests/api/v1/test_user_ratings_endpoint.py
+++ b/tests/api/v1/test_user_ratings_endpoint.py
@@ -225,3 +225,91 @@ class TestUserRatingsVisibility:
         )
         assert mod_response.status_code == 200
         assert mod_response.json()["total"] == 1
+
+
+class TestUserRatingsFiltersAndSorting:
+    async def test_min_and_max_rating_bound_the_results(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        rater = await _make_user(db_session, "rater_filter")
+        for index, score in enumerate([2, 5, 9]):
+            image = await _make_image(db_session, rater, f"flt{index}")
+            await _rate(db_session, rater, image, score)
+
+        authed = _authenticate(client, rater)
+        base = f"/api/v1/users/{rater.user_id}/ratings"
+
+        high = await authed.get(f"{base}?min_rating=5")
+        assert high.status_code == 200
+        assert sorted(img["subject_rating"] for img in high.json()["images"]) == [5, 9]
+
+        mid = await authed.get(f"{base}?min_rating=5&max_rating=5")
+        assert mid.status_code == 200
+        assert [img["subject_rating"] for img in mid.json()["images"]] == [5]
+
+    async def test_out_of_range_rating_filter_is_rejected(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        rater = await _make_user(db_session, "rater_range")
+
+        response = await _authenticate(client, rater).get(
+            f"/api/v1/users/{rater.user_id}/ratings?min_rating=11"
+        )
+
+        assert response.status_code == 422
+
+    async def test_default_sort_is_image_id_descending(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        rater = await _make_user(db_session, "rater_sort")
+        images = []
+        for index in range(3):
+            image = await _make_image(db_session, rater, f"srt{index}")
+            await _rate(db_session, rater, image, 5)
+            images.append(image)
+
+        response = await _authenticate(client, rater).get(
+            f"/api/v1/users/{rater.user_id}/ratings"
+        )
+
+        assert response.status_code == 200
+        returned = [img["image_id"] for img in response.json()["images"]]
+        assert returned == sorted([img.image_id for img in images], reverse=True)
+
+    async def test_sort_by_rating_is_stable_across_pages(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """All three rows share one rating value; the image_id tiebreaker must
+        keep pagination from repeating or dropping a row."""
+        rater = await _make_user(db_session, "rater_stable")
+        for index in range(3):
+            image = await _make_image(db_session, rater, f"stb{index}")
+            await _rate(db_session, rater, image, 6)
+
+        authed = _authenticate(client, rater)
+        base = f"/api/v1/users/{rater.user_id}/ratings?sort_by=rating&per_page=2"
+
+        first = await authed.get(f"{base}&page=1")
+        second = await authed.get(f"{base}&page=2")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        first_ids = [img["image_id"] for img in first.json()["images"]]
+        second_ids = [img["image_id"] for img in second.json()["images"]]
+        assert len(first_ids) == 2
+        assert len(second_ids) == 1
+        assert set(first_ids).isdisjoint(second_ids)
+
+    async def test_sort_by_rated_at_is_accepted_despite_null_dates(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        rater = await _make_user(db_session, "rater_dates")
+        image = await _make_image(db_session, rater, "dts")
+        await _rate(db_session, rater, image, 1)
+
+        response = await _authenticate(client, rater).get(
+            f"/api/v1/users/{rater.user_id}/ratings?sort_by=rated_at"
+        )
+
+        assert response.status_code == 200
+        assert response.json()["total"] == 1

--- a/tests/api/v1/test_user_ratings_endpoint.py
+++ b/tests/api/v1/test_user_ratings_endpoint.py
@@ -4,7 +4,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import ImageRatings, Images, Users
+from app.models import Favorites, ImageRatings, Images, Users
 
 pytestmark = pytest.mark.anyio
 
@@ -101,6 +101,26 @@ class TestUserRatingsHappyPath:
         body = response.json()
         assert body["total"] == 1
         assert [img["image_id"] for img in body["images"]] == [mine.image_id]
+
+    async def test_is_favorited_reflects_the_viewers_own_favorites(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        rater = await _make_user(db_session, "rater_favs")
+        loved = await _make_image(db_session, rater, "fv0")
+        plain = await _make_image(db_session, rater, "fv1")
+        await _rate(db_session, rater, loved, 6)
+        await _rate(db_session, rater, plain, 6)
+        db_session.add(Favorites(user_id=rater.user_id, image_id=loved.image_id))
+        await db_session.commit()
+
+        response = await _authenticate(client, rater).get(
+            f"/api/v1/users/{rater.user_id}/ratings"
+        )
+
+        assert response.status_code == 200
+        by_id = {img["image_id"]: img["is_favorited"] for img in response.json()["images"]}
+        assert by_id[loved.image_id] is True
+        assert by_id[plain.image_id] is False
 
 
 from tests.api.v1.test_users import grant_user_permission

--- a/tests/api/v1/test_user_ratings_endpoint.py
+++ b/tests/api/v1/test_user_ratings_endpoint.py
@@ -242,10 +242,12 @@ class TestUserRatingsFiltersAndSorting:
         high = await authed.get(f"{base}?min_rating=5")
         assert high.status_code == 200
         assert sorted(img["subject_rating"] for img in high.json()["images"]) == [5, 9]
+        assert high.json()["total"] == 2
 
         mid = await authed.get(f"{base}?min_rating=5&max_rating=5")
         assert mid.status_code == 200
         assert [img["subject_rating"] for img in mid.json()["images"]] == [5]
+        assert mid.json()["total"] == 1
 
     async def test_out_of_range_rating_filter_is_rejected(
         self, client: AsyncClient, db_session: AsyncSession
@@ -292,9 +294,7 @@ class TestUserRatingsFiltersAndSorting:
         the tiebreaker removed, because `image_ratings`' primary key is
         `(user_id, image_id)`, so InnoDB's clustered-index scan for
         `WHERE user_id = X` already returns rows in `image_id` order. The
-        tiebreaker is belt-and-braces: `image_id` is already unique within a
-        single user's result set, so no ORDER BY tie is actually possible here
-        regardless of whether the tiebreaker clause is present.
+        tiebreaker is belt-and-braces.
         """
         rater = await _make_user(db_session, "rater_stable")
         for index in range(3):

--- a/tests/api/v1/test_user_ratings_endpoint.py
+++ b/tests/api/v1/test_user_ratings_endpoint.py
@@ -77,7 +77,11 @@ class TestUserRatingsHappyPath:
         assert body["page"] == 1
         assert len(body["images"]) == 1
         assert body["images"][0]["image_id"] == image.image_id
-        assert body["images"][0]["rating"] == 7
+        # The inherited `rating` (the image's own average) must still be present
+        # and distinct from the subject's score — this is the field the old name
+        # was silently shadowing.
+        assert "rating" in body["images"][0]
+        assert body["images"][0]["subject_rating"] == 7
 
     async def test_other_users_ratings_are_excluded(
         self, client: AsyncClient, db_session: AsyncSession

--- a/tests/api/v1/test_user_ratings_endpoint.py
+++ b/tests/api/v1/test_user_ratings_endpoint.py
@@ -263,9 +263,13 @@ class TestUserRatingsFiltersAndSorting:
     ):
         rater = await _make_user(db_session, "rater_sort")
         images = []
-        for index in range(3):
+        # Ratings must be distinct AND assigned out of image_id creation order.
+        # If they were all equal (or monotonic with creation order), a
+        # regression of the default `sort_by` to "rating" would tie (or
+        # coincide) with `image_id` DESC and this test would pass either way.
+        for index, score in enumerate([7, 3, 9]):
             image = await _make_image(db_session, rater, f"srt{index}")
-            await _rate(db_session, rater, image, 5)
+            await _rate(db_session, rater, image, score)
             images.append(image)
 
         response = await _authenticate(client, rater).get(
@@ -276,11 +280,22 @@ class TestUserRatingsFiltersAndSorting:
         returned = [img["image_id"] for img in response.json()["images"]]
         assert returned == sorted([img.image_id for img in images], reverse=True)
 
-    async def test_sort_by_rating_is_stable_across_pages(
+    async def test_pagination_returns_disjoint_complete_pages(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """All three rows share one rating value; the image_id tiebreaker must
-        keep pagination from repeating or dropping a row."""
+        """All three rows share one rating value, so this exercises `sort_by=rating`
+        paging under a tie on the primary sort key.
+
+        This proves pagination doesn't repeat or drop rows across pages — it
+        does NOT prove the `image_id` tiebreaker is doing anything: verified
+        empirically (see task-4-report.md) that this test still passes with
+        the tiebreaker removed, because `image_ratings`' primary key is
+        `(user_id, image_id)`, so InnoDB's clustered-index scan for
+        `WHERE user_id = X` already returns rows in `image_id` order. The
+        tiebreaker is belt-and-braces: `image_id` is already unique within a
+        single user's result set, so no ORDER BY tie is actually possible here
+        regardless of whether the tiebreaker clause is present.
+        """
         rater = await _make_user(db_session, "rater_stable")
         for index in range(3):
             image = await _make_image(db_session, rater, f"stb{index}")

--- a/tests/api/v1/test_user_ratings_endpoint.py
+++ b/tests/api/v1/test_user_ratings_endpoint.py
@@ -1,0 +1,99 @@
+"""Tests for GET /api/v1/users/{user_id}/ratings."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ImageRatings, Images, Users
+
+pytestmark = pytest.mark.anyio
+
+
+async def _make_user(db_session: AsyncSession, username: str) -> Users:
+    user = Users(
+        username=username,
+        password="hashed_password_here",
+        password_type="bcrypt",
+        salt="saltsalt12345678",
+        email=f"{username}@example.com",
+        active=1,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+async def _make_image(db_session: AsyncSession, owner: Users, suffix: str, status: int = 1) -> Images:
+    # Field set mirrors the `test_image` fixture in tests/conftest.py — `rating`
+    # and `locked` are not nullable and have no server default.
+    image = Images(
+        filename=f"ratings-test-{suffix}",
+        ext="jpg",
+        original_filename=f"{suffix}.jpg",
+        md5_hash=(suffix * 32)[:32],
+        filesize=1234,
+        width=800,
+        height=600,
+        caption=f"Ratings test image {suffix}",
+        rating=0.0,
+        user_id=owner.user_id,
+        status=status,
+        locked=False,
+    )
+    db_session.add(image)
+    await db_session.commit()
+    await db_session.refresh(image)
+    return image
+
+
+async def _rate(db_session: AsyncSession, user: Users, image: Images, rating: int) -> None:
+    db_session.add(ImageRatings(user_id=user.user_id, image_id=image.image_id, rating=rating))
+    await db_session.commit()
+
+
+def _authenticate(client: AsyncClient, user: Users) -> AsyncClient:
+    from app.core.security import create_access_token
+
+    client.headers.update({"Authorization": f"Bearer {create_access_token(user.id)}"})
+    return client
+
+
+class TestUserRatingsHappyPath:
+    async def test_self_sees_own_ratings_with_values(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        rater = await _make_user(db_session, "rater_self")
+        image = await _make_image(db_session, rater, "aaa")
+        await _rate(db_session, rater, image, 7)
+
+        response = await _authenticate(client, rater).get(
+            f"/api/v1/users/{rater.user_id}/ratings"
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 1
+        assert body["page"] == 1
+        assert len(body["images"]) == 1
+        assert body["images"][0]["image_id"] == image.image_id
+        assert body["images"][0]["rating"] == 7
+
+    async def test_other_users_ratings_are_excluded(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        rater = await _make_user(db_session, "rater_mine")
+        stranger = await _make_user(db_session, "rater_theirs")
+        mine = await _make_image(db_session, rater, "bbb")
+        theirs = await _make_image(db_session, stranger, "ccc")
+        await _rate(db_session, rater, mine, 5)
+        await _rate(db_session, stranger, theirs, 9)
+
+        response = await _authenticate(client, rater).get(
+            f"/api/v1/users/{rater.user_id}/ratings"
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 1
+        assert [img["image_id"] for img in body["images"]] == [mine.image_id]

--- a/tests/api/v1/test_user_ratings_endpoint.py
+++ b/tests/api/v1/test_user_ratings_endpoint.py
@@ -152,3 +152,76 @@ class TestUserRatingsAuthorization:
         response = await _authenticate(client, viewer).get("/api/v1/users/99999999/ratings")
 
         assert response.status_code == 404
+
+
+from app.config import ImageStatus
+
+
+class TestUserRatingsVisibility:
+    async def test_subject_does_not_see_rating_on_deactivated_image(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        rater = await _make_user(db_session, "rater_vis_self")
+        uploader = await _make_user(db_session, "rater_vis_owner")
+        visible = await _make_image(db_session, uploader, "ggg", status=ImageStatus.ACTIVE)
+        hidden = await _make_image(db_session, uploader, "hhh", status=ImageStatus.DEACTIVATED)
+        await _rate(db_session, rater, visible, 3)
+        await _rate(db_session, rater, hidden, 8)
+
+        response = await _authenticate(client, rater).get(
+            f"/api/v1/users/{rater.user_id}/ratings"
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 1
+        assert [img["image_id"] for img in body["images"]] == [visible.image_id]
+
+    async def test_moderator_sees_rating_on_deactivated_image(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        rater = await _make_user(db_session, "rater_vis_subject")
+        uploader = await _make_user(db_session, "rater_vis_up2")
+        mod = await _make_user(db_session, "rater_vis_mod")
+        await grant_user_permission(db_session, mod.user_id, "user_edit_profile")
+        visible = await _make_image(db_session, uploader, "iii", status=ImageStatus.ACTIVE)
+        hidden = await _make_image(db_session, uploader, "jjj", status=ImageStatus.DEACTIVATED)
+        await _rate(db_session, rater, visible, 3)
+        await _rate(db_session, rater, hidden, 8)
+
+        response = await _authenticate(client, mod).get(
+            f"/api/v1/users/{rater.user_id}/ratings"
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 2
+        assert {img["image_id"] for img in body["images"]} == {visible.image_id, hidden.image_id}
+
+    async def test_hide_reposts_applies_to_self_and_is_ignored_for_moderators(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        uploader = await _make_user(db_session, "rater_rp_owner")
+        repost = await _make_image(db_session, uploader, "kkk", status=ImageStatus.REPOST)
+
+        rater = await _make_user(db_session, "rater_rp_self")
+        rater.hide_reposts = 1
+        mod = await _make_user(db_session, "rater_rp_mod")
+        mod.hide_reposts = 1
+        db_session.add_all([rater, mod])
+        await db_session.commit()
+        await grant_user_permission(db_session, mod.user_id, "user_edit_profile")
+        await _rate(db_session, rater, repost, 2)
+
+        self_response = await _authenticate(client, rater).get(
+            f"/api/v1/users/{rater.user_id}/ratings"
+        )
+        assert self_response.status_code == 200
+        assert self_response.json()["total"] == 0
+
+        client.headers.pop("Authorization", None)
+        mod_response = await _authenticate(client, mod).get(
+            f"/api/v1/users/{rater.user_id}/ratings"
+        )
+        assert mod_response.status_code == 200
+        assert mod_response.json()["total"] == 1


### PR DESCRIPTION
Adds the one missing cell in the favorites/ratings matrix: reading a **user's** ratings. Previously ratings could only be read per-image (`GET /images/{id}/ratings`), while favorites had the user→items direction three ways over.

Two use cases: a user browsing what they have rated, and a moderator auditing rating behaviour (vote-stuffing, rating-bombing, a user inflating their own uploads).

## The endpoint

```
GET /api/v1/users/{user_id}/ratings
    ?page&per_page
    &sort_by=image_id|rating|rated_at   (default image_id, DESC)
    &sort_order=ASC|DESC
    &min_rating&max_rating              (1-10, the SUBJECT's own score)
→ { total, page, per_page, images: [ImageWithRatingResponse] }
```

**Private.** 404 unknown user → 401 anonymous → 403 authenticated non-self non-moderator. The gate is `Permission.USER_EDIT_PROFILE`.

**Moderators see everything** — no image-status filter, `hide_reposts` ignored. Deliberate: hiding deactivated images would hide the evidence a rating-bombing audit needs. Self gets the same restricted view as `/users/{id}/favorites`.

## Three things worth knowing

**No migration.** `image_ratings` is already `PRIMARY KEY (user_id, image_id)`, so `WHERE user_id = ?` is a PK prefix scan.

**The field is `subject_rating`, not `rating`.** `ImageBase.rating` is already the image's own average, inherited down to `ImageDetailedResponse` as a float. An earlier revision named this field `rating` and silently shadowed it, dropping the average from the response. Caught in review and renamed.

**`RATING_REVOKE` is a trap.** In this database it is a *penalty* group ("Revoke Rates", 7 members) for users who lost rating rights — not a moderator power, and nothing in the codebase checks it. Gating on it would have granted access to the 7 punished users and zero moderators.

## Default sort is `image_id`, never `rated_at`

`image_ratings.date` is NULL on **98.1%** of rows (893,800 of 911,423) — the legacy import carried no timestamps. Ordering by it is a near-total tie, so `image_id` DESC is the usable proxy for recency. `rated_at` is still offered.

## Tests

15 tests in `tests/api/v1/test_user_ratings_endpoint.py`: happy path, the full authorization matrix, moderator visibility bypass, `hide_reposts`, rating filters, sort stability, and `is_favorited` scoping.

Two of them originally could not catch the regression their names claimed. Both were fixed after being settled empirically rather than argued: flipping the default sort now genuinely fails the default-sort test, and the pagination test was proven *not* to guard the tiebreaker (passed 5/5 with it disabled) and renamed honestly instead of deleted.

## Known limit

Deep `OFFSET` will be slow for the user with 186,119 ratings. `/users/{id}/favorites` has the identical exposure today with no cap, so this stays consistent rather than introducing keyset pagination for one endpoint.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ysk73Y2HFf9dsQ1Lo7hU8