### PR TITLE
feat(images): context_source_tag_id for compound character searches

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -133,6 +133,7 @@ from app.services.rate_limit import check_similarity_rate_limit
 from app.services.rating import RatingStats, recalculate_image_ratings
 from app.services.recommendations import get_recommended_images
 from app.services.search import sync_tag_to_search
+from app.services.tag_context import stamp_context_sources
 from app.services.tag_type_flags import refresh_image_tag_type_flags
 from app.services.upload import check_upload_rate_limit, link_tags_to_image, save_uploaded_image
 from app.tasks.queue import enqueue_job
@@ -1004,6 +1005,8 @@ async def list_images(
             item.ml_suggestion_count = pending_counts.get(img.image_id, 0)  # type: ignore[arg-type]
         response_items.append(item)
 
+    await stamp_context_sources(db, response_items)
+
     return ImageDetailedListResponse(
         total=total or 0,
         page=pagination.page,
@@ -1109,6 +1112,7 @@ async def get_recommended(
         item = RecommendedImageResponse.from_db_model(img, is_favorited=False)
         item.because_tags = rec.because.get(iid, [])
         items.append(item)
+    await stamp_context_sources(db, items)
     return RecommendedImagesResponse(
         total=rec.total,
         page=pagination.page,
@@ -1218,7 +1222,7 @@ async def get_image(
             )
         )
     )
-    return ImageDetailedResponse.from_db_model(
+    response = ImageDetailedResponse.from_db_model(
         image,
         is_favorited=is_favorited,
         user_rating=user_rating,
@@ -1227,6 +1231,8 @@ async def get_image(
         has_open_report=image_id in open_report_ids,
         can_see_reason=can_see_reason,
     )
+    await stamp_context_sources(db, [response])
+    return response
 
 
 @router.delete("/{image_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -1510,7 +1516,9 @@ async def update_image(
     )
     image = result.scalar_one()
 
-    return ImageDetailedResponse.from_db_model(image)
+    response = ImageDetailedResponse.from_db_model(image)
+    await stamp_context_sources(db, [response])
+    return response
 
 
 @router.get("/{image_id}/tags", response_model=ImageTagsResponse)

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -80,6 +80,7 @@ from app.services.avatar import (
 from app.services.feeds import TAG_TYPE_NAME
 from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 from app.services.rate_limit import check_registration_rate_limit
+from app.services.tag_context import stamp_context_sources
 from app.services.turnstile import verify_turnstile_token
 from app.services.user import build_user_private_response
 from app.tasks.queue import enqueue_job
@@ -1073,6 +1074,8 @@ async def get_user_ratings(
         item.subject_rating = rating_value
         item.rated_at = rated_at
         items.append(item)
+
+    await stamp_context_sources(db, items)
 
     return UserRatingsListResponse(
         total=total,

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -46,6 +46,12 @@ class TagSummary(BaseModel):
     type_id: int = Field(alias="type")  # Maps from Tags.type
     usage_count: int = 0  # Needed by feed title composer; non-breaking.
 
+    # Set only on character-type entries when the image carries EXACTLY ONE
+    # source linked to this character (character_source_links) — the
+    # contextual compound-search rule; None otherwise. Stamped post-build by
+    # app.services.tag_context.stamp_context_sources.
+    context_source_tag_id: int | None = None
+
     # Allow Pydantic to read from SQLAlchemy model attributes (not just dicts)
     model_config = {"from_attributes": True, "populate_by_name": True}
 

--- a/app/services/tag_context.py
+++ b/app/services/tag_context.py
@@ -1,0 +1,83 @@
+"""Stamp contextual compound-search sources onto built image responses.
+
+For each character tag on an image, if the image carries EXACTLY ONE source
+tag linked to that character (character_source_links), that TagSummary gets
+context_source_tag_id = the source's canonical id; zero or multiple linked
+sources leave it None. Measured on dev 2026-07-28 across 1.32M
+image↔linked-character pairs: 97.4% exactly-one / 2.4% zero / 0.2%
+ambiguous — ranking is deliberately absent. At most two small indexed
+queries per request (alias map + links), skipped when the page has no
+character tags.
+"""
+
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import TagType
+from app.models.character_source_link import CharacterSourceLinks
+from app.models.tag import Tags
+from app.schemas.image import ImageDetailedResponse
+
+
+async def stamp_context_sources(
+    db: AsyncSession, responses: Sequence[ImageDetailedResponse]
+) -> None:
+    """Mutate responses in place per the exactly-one rule."""
+    page_tag_ids: set[int] = set()
+    for r in responses:
+        for t in r.tags or []:
+            if t.type_id in (TagType.CHARACTER, TagType.SOURCE):
+                page_tag_ids.add(t.tag_id)
+    if not page_tag_ids:
+        return
+
+    # Canonicalize alias tags among them (usually zero rows).
+    alias_rows = (
+        await db.execute(
+            select(Tags.tag_id, Tags.alias_of).where(
+                Tags.tag_id.in_(page_tag_ids), Tags.alias_of.is_not(None)
+            )
+        )
+    ).all()
+    canon = dict(alias_rows)
+
+    char_ids = {
+        canon.get(t.tag_id, t.tag_id)
+        for r in responses
+        for t in r.tags or []
+        if t.type_id == TagType.CHARACTER
+    }
+    if not char_ids:
+        return
+
+    link_rows = (
+        await db.execute(
+            select(
+                CharacterSourceLinks.character_tag_id,
+                CharacterSourceLinks.source_tag_id,
+            ).where(CharacterSourceLinks.character_tag_id.in_(char_ids))
+        )
+    ).all()
+    links: dict[int, set[int]] = {}
+    for char_id, source_id in link_rows:
+        links.setdefault(char_id, set()).add(source_id)
+    if not links:
+        return
+
+    for r in responses:
+        if not r.tags:
+            continue
+        image_sources = {
+            canon.get(t.tag_id, t.tag_id) for t in r.tags if t.type_id == TagType.SOURCE
+        }
+        for t in r.tags:
+            if t.type_id != TagType.CHARACTER:
+                continue
+            linked = links.get(canon.get(t.tag_id, t.tag_id))
+            if not linked:
+                continue
+            present = image_sources & linked
+            if len(present) == 1:
+                t.context_source_tag_id = next(iter(present))

--- a/app/services/tag_context.py
+++ b/app/services/tag_context.py
@@ -36,12 +36,13 @@ async def stamp_context_sources(
     # Canonicalize alias tags among them (usually zero rows).
     alias_rows = (
         await db.execute(
-            select(Tags.tag_id, Tags.alias_of).where(
-                Tags.tag_id.in_(page_tag_ids), Tags.alias_of.is_not(None)
+            select(Tags.tag_id, Tags.alias_of).where(  # type: ignore[call-overload]
+                Tags.tag_id.in_(page_tag_ids),  # type: ignore[union-attr]
+                Tags.alias_of.is_not(None),  # type: ignore[union-attr]
             )
         )
     ).all()
-    canon = dict(alias_rows)
+    canon: dict[int, int] = dict(alias_rows)  # type: ignore[arg-type]
 
     char_ids = {
         canon.get(t.tag_id, t.tag_id)
@@ -54,10 +55,10 @@ async def stamp_context_sources(
 
     link_rows = (
         await db.execute(
-            select(
+            select(  # type: ignore[call-overload]
                 CharacterSourceLinks.character_tag_id,
                 CharacterSourceLinks.source_tag_id,
-            ).where(CharacterSourceLinks.character_tag_id.in_(char_ids))
+            ).where(CharacterSourceLinks.character_tag_id.in_(char_ids))  # type: ignore[attr-defined]
         )
     ).all()
     links: dict[int, set[int]] = {}

--- a/tests/api/v1/test_image_tag_context.py
+++ b/tests/api/v1/test_image_tag_context.py
@@ -1,0 +1,94 @@
+"""context_source_tag_id stamping on image tag lists (compound-search rule)."""
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, TagType
+from app.models.character_source_link import CharacterSourceLinks
+from app.models.image import Images
+from app.models.tag import Tags
+from app.models.tag_link import TagLinks
+
+
+def _tag(db, tag_id, ttype, title, alias_of=None):
+    db.add(Tags(tag_id=tag_id, type=ttype, title=title, alias_of=alias_of))
+
+
+def _img(db, image_id):
+    # ext is NOT NULL with no default; user 1 is pre-seeded by conftest.
+    db.add(Images(image_id=image_id, user_id=1, ext="jpg", status=ImageStatus.ACTIVE))
+
+
+def _link(db, tag_id, image_id):
+    db.add(TagLinks(tag_id=tag_id, image_id=image_id, user_id=1))
+
+
+async def _setup(db: AsyncSession) -> None:
+    # Sources S1 (801), S2 (802), alias of S2 (803); characters: C-both (811)
+    # linked to S1+S2, C-one (812) linked to S1 only, C-none (813) unlinked.
+    _tag(db, 801, TagType.SOURCE, "ctx src one")
+    _tag(db, 802, TagType.SOURCE, "ctx src two")
+    _tag(db, 803, TagType.SOURCE, "ctx src two alias", alias_of=802)
+    _tag(db, 811, TagType.CHARACTER, "ctx char both")
+    _tag(db, 812, TagType.CHARACTER, "ctx char one")
+    _tag(db, 813, TagType.CHARACTER, "ctx char none")
+    # Flush so the tag rows exist before the link references them: CharacterSourceLinks
+    # intentionally omits an ORM relationship() to Tags (see
+    # app/models/character_source_link.py), so unit-of-work has no dependency edge to
+    # order the two mappers' inserts on its own.
+    await db.flush()
+    db.add(CharacterSourceLinks(character_tag_id=811, source_tag_id=801))
+    db.add(CharacterSourceLinks(character_tag_id=811, source_tag_id=802))
+    db.add(CharacterSourceLinks(character_tag_id=812, source_tag_id=801))
+    # 8001: C-one + S1            -> exactly one linked present -> stamp 801
+    _img(db, 8001)
+    _link(db, 812, 8001)
+    _link(db, 801, 8001)
+    # 8002: C-both + S1 + S2      -> two linked present -> None
+    _img(db, 8002)
+    _link(db, 811, 8002)
+    _link(db, 801, 8002)
+    _link(db, 802, 8002)
+    # 8003: C-one, no source      -> None
+    _img(db, 8003)
+    _link(db, 812, 8003)
+    # 8004: C-both + S2-ALIAS only -> resolves to canonical 802 -> stamp 802
+    _img(db, 8004)
+    _link(db, 811, 8004)
+    _link(db, 803, 8004)
+    await db.commit()
+
+
+def _ctx(payload: dict, tag_id: int):
+    by_id = {t["tag_id"]: t for t in payload["tags"]}
+    return by_id[tag_id]["context_source_tag_id"]
+
+
+async def test_detail_stamps_exactly_one(client: AsyncClient, db_session: AsyncSession):
+    await _setup(db_session)
+    r = await client.get("/api/v1/images/8001")
+    assert r.status_code == 200
+    assert _ctx(r.json(), 812) == 801
+    # source entries are never stamped
+    assert _ctx(r.json(), 801) is None
+
+
+async def test_detail_ambiguous_and_sourceless_are_none(client, db_session):
+    await _setup(db_session)
+    assert _ctx((await client.get("/api/v1/images/8002")).json(), 811) is None
+    assert _ctx((await client.get("/api/v1/images/8003")).json(), 812) is None
+
+
+async def test_detail_alias_source_resolves_to_canonical(client, db_session):
+    await _setup(db_session)
+    assert _ctx((await client.get("/api/v1/images/8004")).json(), 811) == 802
+
+
+async def test_list_endpoint_stamps(client, db_session):
+    await _setup(db_session)
+    r = await client.get("/api/v1/images/", params={"tags": "812", "per_page": 50})
+    assert r.status_code == 200
+    payload = r.json()
+    imgs = {i["image_id"]: i for i in payload["images"]}
+    assert _ctx(imgs[8001], 812) == 801
+    assert _ctx(imgs[8003], 812) is None


### PR DESCRIPTION
Chunk 3 of the character↔source project (spec: shuushuu-frontend `docs/plans/2026-08-09-compound-context-search-design.md`). Companion FE PR follows after this merges (its type regen + e2e read the live dev API).

Every endpoint returning per-image tag lists (detail, list, recommended, user ratings, PATCH response) now stamps a nullable `context_source_tag_id` on character-type tag entries: set when the image carries **exactly one** source linked to that character via `character_source_links` (both sides alias-canonicalized), `null` on zero or multiple. Measured on dev (1.32M image↔linked-character pairs): 97.4% exactly-one / 2.4% zero / 0.2% ambiguous — hence no ranking machinery, by design.

One shared batched helper (`app/services/tag_context.py`): at most two small indexed `IN` queries per request (alias map + links), skipped when the page carries no relevant tags. Additive nullable field — zero impact on existing clients; no migrations.

**Testing:** TDD — 4-case integration suite (exactly-one stamped, two-present → null, sourceless → null, alias-tagged source resolves to canonical), red (`KeyError`) before, green after; `test_images.py` regression 149 passed; ratings + recommended suites 25 passed; ruff clean. One precedented test-setup note: `db.flush()` between `Tags` and `CharacterSourceLinks` inserts (no ORM relationship = no unit-of-work ordering edge; same documented fix as `test_analyze_character_sources.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYyPdyVLMpE3H7sU8qT6rH