### PR TITLE
feat(tags): per-link character pictures — table, endpoints, tag-detail embed

### DIFF
--- a/alembic/versions/40205fe4b1b6_add_character_source_link_pictures_table.py
+++ b/alembic/versions/40205fe4b1b6_add_character_source_link_pictures_table.py
@@ -1,0 +1,70 @@
+"""add character_source_link_pictures table
+
+Revision ID: 40205fe4b1b6
+Revises: 6dda18b955d8
+Create Date: 2026-08-09 18:28:36.833700
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '40205fe4b1b6'
+down_revision: str | Sequence[str] | None = '6dda18b955d8'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "character_source_link_pictures",
+        sa.Column("link_id", mysql.INTEGER(unsigned=True), nullable=False),
+        sa.Column("image_id", mysql.INTEGER(unsigned=True), nullable=False),
+        sa.Column("crop_x", sa.Float(), nullable=False),
+        sa.Column("crop_y", sa.Float(), nullable=False),
+        sa.Column("crop_w", sa.Float(), nullable=False),
+        sa.Column("crop_h", sa.Float(), nullable=False),
+        sa.Column("set_by_user_id", mysql.INTEGER(unsigned=True), nullable=True),
+        sa.Column(
+            "set_at",
+            sa.DateTime(),
+            server_default=sa.text("current_timestamp()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("link_id"),
+        sa.ForeignKeyConstraint(
+            ["link_id"],
+            ["character_source_links.id"],
+            name="fk_cslink_pictures_link_id",
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["image_id"],
+            ["images.image_id"],
+            name="fk_cslink_pictures_image_id",
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["set_by_user_id"],
+            ["users.user_id"],
+            name="fk_cslink_pictures_set_by_user_id",
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+        ),
+    )
+    op.create_index(
+        "idx_cslink_pictures_image_id", "character_source_link_pictures", ["image_id"]
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("idx_cslink_pictures_image_id", table_name="character_source_link_pictures")
+    op.drop_table("character_source_link_pictures")

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -51,7 +51,7 @@ from app.schemas.audit import (
     TagHistoryResponse,
 )
 from app.schemas.common import UserSummary
-from app.schemas.image import ImageListResponse, ImageResponse
+from app.schemas.image import ImageListResponse, ImageResponse, thumbnail_url_for
 from app.schemas.tag import (
     BatchTagAction,
     BatchTagRequest,
@@ -966,6 +966,44 @@ async def get_characters_for_source(
     )
 
 
+def _linked_tag_entry(row: Any) -> dict[str, Any]:
+    """Build a LinkedTagWithPicture dict from a get_tag relationship row."""
+    (
+        tag_id,
+        title,
+        tag_type,
+        usage_count,
+        link_id,
+        pic_image_id,
+        crop_x,
+        crop_y,
+        crop_w,
+        crop_h,
+        filename,
+        status,
+        r2_location,
+    ) = row
+    entry: dict[str, Any] = {
+        "tag_id": tag_id,
+        "title": title,
+        "type": tag_type,
+        "usage_count": usage_count,
+        "link_id": link_id,
+    }
+    # Re-checked at read time: an image deactivated after being chosen must
+    # not leak through the embed — the card falls back to its placeholder.
+    if pic_image_id is not None and status in PUBLIC_IMAGE_STATUSES:
+        entry["picture"] = {
+            "image_id": pic_image_id,
+            "thumbnail_url": thumbnail_url_for(filename, status, r2_location),
+            "crop_x": crop_x,
+            "crop_y": crop_y,
+            "crop_w": crop_w,
+            "crop_h": crop_h,
+        }
+    return entry
+
+
 @router.get("/{tag_id}", response_model=TagWithStats)
 async def get_tag(
     tag_id: Annotated[int, Path(description="Tag ID")],
@@ -1094,35 +1132,67 @@ async def get_tag(
         # Get all sources linked to this character
         # Sorted by usage_count descending with title as tiebreaker
         sources_result = await db.execute(
-            select(Tags.tag_id, Tags.title, Tags.type, Tags.usage_count)  # type: ignore[call-overload]
+            select(  # type: ignore[call-overload]
+                Tags.tag_id,
+                Tags.title,
+                Tags.type,
+                Tags.usage_count,
+                CharacterSourceLinks.id,
+                CharacterSourceLinkPictures.image_id,
+                CharacterSourceLinkPictures.crop_x,
+                CharacterSourceLinkPictures.crop_y,
+                CharacterSourceLinkPictures.crop_w,
+                CharacterSourceLinkPictures.crop_h,
+                Images.filename,
+                Images.status,
+                Images.r2_location,
+            )
             .join(
                 CharacterSourceLinks,
                 Tags.tag_id == CharacterSourceLinks.source_tag_id,
             )
+            .outerjoin(
+                CharacterSourceLinkPictures,
+                CharacterSourceLinkPictures.link_id == CharacterSourceLinks.id,
+            )
+            .outerjoin(Images, Images.image_id == CharacterSourceLinkPictures.image_id)
             .where(CharacterSourceLinks.character_tag_id == tag_id)
             .order_by(desc(Tags.usage_count), Tags.title)  # type: ignore[arg-type]
         )
-        sources = [
-            {"tag_id": row[0], "title": row[1], "type": row[2], "usage_count": row[3]}
-            for row in sources_result.all()
-        ]
+        sources = [_linked_tag_entry(row) for row in sources_result.all()]
 
     elif tag.type == TagType.SOURCE:
         # Get all characters linked to this source
         # Sorted by usage_count descending with title as tiebreaker
         characters_result = await db.execute(
-            select(Tags.tag_id, Tags.title, Tags.type, Tags.usage_count)  # type: ignore[call-overload]
+            select(  # type: ignore[call-overload]
+                Tags.tag_id,
+                Tags.title,
+                Tags.type,
+                Tags.usage_count,
+                CharacterSourceLinks.id,
+                CharacterSourceLinkPictures.image_id,
+                CharacterSourceLinkPictures.crop_x,
+                CharacterSourceLinkPictures.crop_y,
+                CharacterSourceLinkPictures.crop_w,
+                CharacterSourceLinkPictures.crop_h,
+                Images.filename,
+                Images.status,
+                Images.r2_location,
+            )
             .join(
                 CharacterSourceLinks,
                 Tags.tag_id == CharacterSourceLinks.character_tag_id,
             )
+            .outerjoin(
+                CharacterSourceLinkPictures,
+                CharacterSourceLinkPictures.link_id == CharacterSourceLinks.id,
+            )
+            .outerjoin(Images, Images.image_id == CharacterSourceLinkPictures.image_id)
             .where(CharacterSourceLinks.source_tag_id == tag_id)
             .order_by(desc(Tags.usage_count), Tags.title)  # type: ignore[arg-type]
         )
-        characters = [
-            {"tag_id": row[0], "title": row[1], "type": row[2], "usage_count": row[3]}
-            for row in characters_result.all()
-        ]
+        characters = [_linked_tag_entry(row) for row in characters_result.all()]
 
     return TagWithStats(
         tag_id=tag.tag_id or 0,

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -38,6 +38,7 @@ from app.core.redis import get_redis
 from app.core.user_loader import image_uploader_load
 from app.models import Images, TagExternalLinks, TagLinks, Tags, Users
 from app.models.character_source_link import CharacterSourceLinks
+from app.models.character_source_link_picture import CharacterSourceLinkPictures
 from app.models.image_report import ImageReports
 from app.models.image_report_tag_suggestion import ImageReportTagSuggestions
 from app.models.permissions import UserGroups
@@ -59,6 +60,8 @@ from app.schemas.tag import (
     CharacterSourceLinkListResponse,
     CharacterSourceLinkResponse,
     LinkedTag,
+    LinkPictureResponse,
+    LinkPictureSet,
     TagCreate,
     TagExternalLinkCreate,
     TagExternalLinkReorder,
@@ -2474,4 +2477,132 @@ async def delete_character_source_link(
     db.add(audit)
 
     await db.delete(link)
+    await db.commit()
+
+
+@character_source_links_router.put("/{link_id}/picture", response_model=LinkPictureResponse)
+async def set_character_source_link_picture(
+    link_id: Annotated[int, Path(description="Link ID")],
+    body: LinkPictureSet,
+    current_user: Annotated[Users, Depends(get_current_user)],
+    _: Annotated[None, Depends(require_permission(Permission.TAG_CREATE))],
+    db: AsyncSession = Depends(get_db),
+) -> LinkPictureResponse:
+    """Set or replace a link's representative picture. Requires TAG_CREATE."""
+    link_result = await db.execute(
+        select(CharacterSourceLinks).where(CharacterSourceLinks.id == link_id)  # type: ignore[arg-type]
+    )
+    link = link_result.scalar_one_or_none()
+    if not link:
+        raise HTTPException(status_code=404, detail="Link not found")
+
+    image_result = await db.execute(
+        select(Images).where(Images.image_id == body.image_id)  # type: ignore[arg-type]
+    )
+    image = image_result.scalar_one_or_none()
+    if not image:
+        raise HTTPException(status_code=404, detail="Image not found")
+    if image.status not in PUBLIC_IMAGE_STATUSES:
+        raise HTTPException(status_code=400, detail="Image is not publicly visible")
+
+    # The picture must actually depict this pair: the image has to carry both
+    # the character and the source tag. Alias tags deliberately don't count —
+    # links themselves are canonical-only (see create_character_source_link).
+    tag_rows = await db.execute(
+        select(TagLinks.tag_id).where(  # type: ignore[call-overload]
+            TagLinks.image_id == body.image_id,
+            TagLinks.tag_id.in_([link.character_tag_id, link.source_tag_id]),  # type: ignore[attr-defined]
+        )
+    )
+    present = {row[0] for row in tag_rows.all()}
+    missing = {link.character_tag_id, link.source_tag_id} - present
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Image must carry both linked tags (missing tag ids: {sorted(missing)})",
+        )
+
+    if body.crop_x + body.crop_w > 1 or body.crop_y + body.crop_h > 1:
+        raise HTTPException(status_code=400, detail="Crop rectangle extends beyond the image")
+
+    # Roughly square in pixel terms (5% tolerance). Skipped when stored
+    # dimensions are 0 (legacy rows) — squareness is unknowable there.
+    if image.width and image.height:
+        crop_px_w = body.crop_w * image.width
+        crop_px_h = body.crop_h * image.height
+        if abs(crop_px_w - crop_px_h) > 0.05 * max(crop_px_w, crop_px_h):
+            raise HTTPException(status_code=400, detail="Crop must be square (within 5% tolerance)")
+
+    existing_result = await db.execute(
+        select(CharacterSourceLinkPictures).where(
+            CharacterSourceLinkPictures.link_id == link_id  # type: ignore[arg-type]
+        )
+    )
+    picture = existing_result.scalar_one_or_none()
+    if picture:
+        picture.image_id = body.image_id
+        picture.crop_x = body.crop_x
+        picture.crop_y = body.crop_y
+        picture.crop_w = body.crop_w
+        picture.crop_h = body.crop_h
+        picture.set_by_user_id = current_user.user_id
+        picture.set_at = datetime.now(UTC)
+    else:
+        picture = CharacterSourceLinkPictures(
+            link_id=link_id,
+            image_id=body.image_id,
+            crop_x=body.crop_x,
+            crop_y=body.crop_y,
+            crop_w=body.crop_w,
+            crop_h=body.crop_h,
+            set_by_user_id=current_user.user_id,
+        )
+        db.add(picture)
+
+    db.add(
+        TagAuditLog(
+            tag_id=link.character_tag_id,
+            action_type=TagAuditActionType.PICTURE_SET,
+            character_tag_id=link.character_tag_id,
+            source_tag_id=link.source_tag_id,
+            user_id=current_user.user_id,
+        )
+    )
+
+    await db.commit()
+    await db.refresh(picture)
+    return LinkPictureResponse.model_validate(picture)
+
+
+@character_source_links_router.delete("/{link_id}/picture", status_code=204)
+async def delete_character_source_link_picture(
+    link_id: Annotated[int, Path(description="Link ID")],
+    current_user: Annotated[Users, Depends(get_current_user)],
+    _: Annotated[None, Depends(require_permission(Permission.TAG_CREATE))],
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Remove a link's representative picture. Requires TAG_CREATE."""
+    result = await db.execute(
+        select(CharacterSourceLinkPictures).where(
+            CharacterSourceLinkPictures.link_id == link_id  # type: ignore[arg-type]
+        )
+    )
+    picture = result.scalar_one_or_none()
+    if not picture:
+        raise HTTPException(status_code=404, detail="Link has no picture")
+
+    link_result = await db.execute(
+        select(CharacterSourceLinks).where(CharacterSourceLinks.id == link_id)  # type: ignore[arg-type]
+    )
+    link = link_result.scalar_one()
+    db.add(
+        TagAuditLog(
+            tag_id=link.character_tag_id,
+            action_type=TagAuditActionType.PICTURE_REMOVED,
+            character_tag_id=link.character_tag_id,
+            source_tag_id=link.source_tag_id,
+            user_id=current_user.user_id,
+        )
+    )
+    await db.delete(picture)
     await db.commit()

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -2565,6 +2565,13 @@ async def set_character_source_link_picture(
     link = link_result.scalar_one_or_none()
     if not link:
         raise HTTPException(status_code=404, detail="Link not found")
+    # Captured now: the IntegrityError fallback below does a db.rollback(),
+    # which expires every ORM object in the session (link and current_user
+    # included). Re-reading their attributes afterwards would trigger an
+    # implicit lazy load that raises MissingGreenlet in an async session.
+    character_tag_id = link.character_tag_id
+    source_tag_id = link.source_tag_id
+    current_user_id = current_user.user_id
 
     image_result = await db.execute(
         select(Images).where(Images.image_id == body.image_id)  # type: ignore[arg-type]
@@ -2581,11 +2588,11 @@ async def set_character_source_link_picture(
     tag_rows = await db.execute(
         select(TagLinks.tag_id).where(  # type: ignore[call-overload]
             TagLinks.image_id == body.image_id,
-            TagLinks.tag_id.in_([link.character_tag_id, link.source_tag_id]),  # type: ignore[attr-defined]
+            TagLinks.tag_id.in_([character_tag_id, source_tag_id]),  # type: ignore[attr-defined]
         )
     )
     present = {row[0] for row in tag_rows.all()}
-    missing = {link.character_tag_id, link.source_tag_id} - present
+    missing = {character_tag_id, source_tag_id} - present
     if missing:
         raise HTTPException(
             status_code=400,
@@ -2603,6 +2610,27 @@ async def set_character_source_link_picture(
         if abs(crop_px_w - crop_px_h) > 0.05 * max(crop_px_w, crop_px_h):
             raise HTTPException(status_code=400, detail="Crop must be square (within 5% tolerance)")
 
+    def _apply_fields(pic: CharacterSourceLinkPictures) -> None:
+        """Overwrite an existing picture row's fields and bump set_at."""
+        pic.image_id = body.image_id
+        pic.crop_x = body.crop_x
+        pic.crop_y = body.crop_y
+        pic.crop_w = body.crop_w
+        pic.crop_h = body.crop_h
+        pic.set_by_user_id = current_user_id
+        pic.set_at = datetime.now(UTC)
+
+    def _add_audit() -> None:
+        db.add(
+            TagAuditLog(
+                tag_id=character_tag_id,
+                action_type=TagAuditActionType.PICTURE_SET,
+                character_tag_id=character_tag_id,
+                source_tag_id=source_tag_id,
+                user_id=current_user_id,
+            )
+        )
+
     existing_result = await db.execute(
         select(CharacterSourceLinkPictures).where(
             CharacterSourceLinkPictures.link_id == link_id  # type: ignore[arg-type]
@@ -2610,13 +2638,7 @@ async def set_character_source_link_picture(
     )
     picture = existing_result.scalar_one_or_none()
     if picture:
-        picture.image_id = body.image_id
-        picture.crop_x = body.crop_x
-        picture.crop_y = body.crop_y
-        picture.crop_w = body.crop_w
-        picture.crop_h = body.crop_h
-        picture.set_by_user_id = current_user.user_id
-        picture.set_at = datetime.now(UTC)
+        _apply_fields(picture)
     else:
         picture = CharacterSourceLinkPictures(
             link_id=link_id,
@@ -2625,21 +2647,32 @@ async def set_character_source_link_picture(
             crop_y=body.crop_y,
             crop_w=body.crop_w,
             crop_h=body.crop_h,
-            set_by_user_id=current_user.user_id,
+            set_by_user_id=current_user_id,
         )
         db.add(picture)
 
-    db.add(
-        TagAuditLog(
-            tag_id=link.character_tag_id,
-            action_type=TagAuditActionType.PICTURE_SET,
-            character_tag_id=link.character_tag_id,
-            source_tag_id=link.source_tag_id,
-            user_id=current_user.user_id,
-        )
-    )
+    _add_audit()
 
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError:
+        # Two concurrent PUTs on a link with no existing picture both see
+        # `picture is None` above and both try to INSERT with the same PK
+        # (link_id). The loser's INSERT collides with the winner's on
+        # commit. A 409 here would break PUT's idempotent-set semantics, so
+        # fall back to an UPDATE against the row the winner just committed —
+        # the loser's crop still lands as the final state.
+        await db.rollback()
+        existing_result = await db.execute(
+            select(CharacterSourceLinkPictures).where(
+                CharacterSourceLinkPictures.link_id == link_id  # type: ignore[arg-type]
+            )
+        )
+        picture = existing_result.scalar_one()
+        _apply_fields(picture)
+        _add_audit()
+        await db.commit()
+
     await db.refresh(picture)
     return LinkPictureResponse.model_validate(picture)
 

--- a/app/config.py
+++ b/app/config.py
@@ -528,6 +528,11 @@ class TagAuditActionType:
     SOURCE_LINKED = "source_linked"
     SOURCE_UNLINKED = "source_unlinked"
 
+    # Character-source link picture events. Rows carry character_tag_id +
+    # source_tag_id, same shape as SOURCE_LINKED/UNLINKED.
+    PICTURE_SET = "picture_set"
+    PICTURE_REMOVED = "picture_removed"
+
     # External-link events. link_url on the audit row identifies the affected
     # link; reordering is deliberately not audited (cosmetic display order).
     LINK_ADDED = "link_added"

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -16,6 +16,7 @@ from app.models.admin_action import AdminActions
 # User-related models
 from app.models.ban import Bans
 from app.models.character_source_link import CharacterSourceLinks
+from app.models.character_source_link_picture import CharacterSourceLinkPictures
 from app.models.comment import Comments
 from app.models.comment_report import CommentReports
 
@@ -74,6 +75,7 @@ __all__ = [
     "TagExternalLinks",
     "TagMappings",
     "CharacterSourceLinks",
+    "CharacterSourceLinkPictures",
     "TagAuditLog",
     "TagHistory",
     "ImageRatings",

--- a/app/models/character_source_link_picture.py
+++ b/app/models/character_source_link_picture.py
@@ -1,0 +1,76 @@
+"""
+SQLModel-based CharacterSourceLinkPicture model.
+
+One representative picture per character-source link: an existing image plus a
+normalized square crop rectangle (fractions of the image's natural dimensions).
+The rect is the source of truth — rendering is CSS math today and could become
+server-generated crop files later without data loss.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
+from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
+
+
+class CharacterSourceLinkPictureBase(SQLModel):
+    """Shared public fields for a link's representative picture."""
+
+    image_id: int
+    crop_x: float
+    crop_y: float
+    crop_w: float
+    crop_h: float
+
+
+class CharacterSourceLinkPictures(CharacterSourceLinkPictureBase, table=True):
+    """
+    Database table for character-source link pictures (1:1 with links).
+
+    Deleting the link or the image deletes the picture whole (CASCADE both
+    ways) — no half-null states.
+    """
+
+    __tablename__ = "character_source_link_pictures"
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["link_id"],
+            ["character_source_links.id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="fk_cslink_pictures_link_id",
+        ),
+        ForeignKeyConstraint(
+            ["image_id"],
+            ["images.image_id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="fk_cslink_pictures_image_id",
+        ),
+        ForeignKeyConstraint(
+            ["set_by_user_id"],
+            ["users.user_id"],
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+            name="fk_cslink_pictures_set_by_user_id",
+        ),
+        Index("idx_cslink_pictures_image_id", "image_id"),
+    )
+
+    # 1:1 with the link — the link id IS the primary key.
+    # FK constraints (with CASCADE) live in __table_args__; do NOT add
+    # foreign_key= to the Fields (duplicates the FK without CASCADE).
+    link_id: int = Field(primary_key=True)
+
+    set_by_user_id: int | None = Field(default=None)
+
+    set_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
+    )
+
+    # Relationships intentionally omitted (house style — see
+    # character_source_link.py's closing comment).

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -38,6 +38,27 @@ def sort_tag_links_for_display(tag_links: list) -> list:  # type: ignore[type-ar
     )
 
 
+def _cdn_eligible(status: int, r2_location: int) -> bool:
+    """True when a direct-CDN URL can be emitted for these storage fields.
+
+    All three must hold: R2 enabled, status publicly-viewable, and the
+    canonical object in the public bucket. A mismatch falls back to the
+    protected path, which routes on current r2_location.
+    """
+    return (
+        settings.R2_ENABLED
+        and status in PUBLIC_IMAGE_STATUSES_FOR_R2
+        and r2_location == R2Location.PUBLIC
+    )
+
+
+def thumbnail_url_for(filename: str | None, status: int, r2_location: int) -> str:
+    """Thumbnail URL (always WebP). Shared by ImageResponse and tag embeds."""
+    if _cdn_eligible(status, r2_location):
+        return f"{settings.R2_PUBLIC_CDN_URL}/thumbs/{filename}.webp"
+    return f"{settings.IMAGE_BASE_URL}/thumbs/{filename}.webp"
+
+
 class TagSummary(BaseModel):
     """Minimal tag info for embedding"""
 
@@ -127,11 +148,7 @@ class ImageResponse(ImageBase):
         status but PRIVATE location during a bucket move) falls back to the
         /images/ path, which the endpoint routes based on current r2_location.
         """
-        return (
-            settings.R2_ENABLED
-            and self.status in PUBLIC_IMAGE_STATUSES_FOR_R2
-            and self.r2_location == R2Location.PUBLIC
-        )
+        return _cdn_eligible(self.status, self.r2_location)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -145,9 +162,7 @@ class ImageResponse(ImageBase):
     @property
     def thumbnail_url(self) -> str:
         """Thumbnail URL (always WebP)."""
-        if self._should_use_cdn():
-            return f"{settings.R2_PUBLIC_CDN_URL}/thumbs/{self.filename}.webp"
-        return f"{settings.IMAGE_BASE_URL}/thumbs/{self.filename}.webp"
+        return thumbnail_url_for(self.filename, self.status, self.r2_location)
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -267,6 +267,36 @@ class CharacterSourceLinkWithTitles(CharacterSourceLinkResponse):
     source_title: str | None = None
 
 
+class LinkPictureSet(BaseModel):
+    """Request body for setting a character-source link's picture.
+
+    Crop values are normalized 0-1 fractions of the image's natural
+    dimensions. Per-field ranges are enforced here (422); cross-field sums
+    and pixel-space squareness are checked in the endpoint (400).
+    """
+
+    image_id: int
+    crop_x: float = Field(ge=0.0, lt=1.0)
+    crop_y: float = Field(ge=0.0, lt=1.0)
+    crop_w: float = Field(gt=0.0, le=1.0)
+    crop_h: float = Field(gt=0.0, le=1.0)
+
+
+class LinkPictureResponse(BaseModel):
+    """Schema for a link picture (PUT response)"""
+
+    link_id: int
+    image_id: int
+    crop_x: float
+    crop_y: float
+    crop_w: float
+    crop_h: float
+    set_by_user_id: int | None = None
+    set_at: UTCDatetime
+
+    model_config = {"from_attributes": True}
+
+
 class BatchTagAction(StrEnum):
     """Supported batch tag actions."""
 

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -145,6 +145,24 @@ class LinkedTag(BaseModel):
     usage_count: int | None = None  # Nullable: None means usage count not loaded
 
 
+class LinkPictureInfo(BaseModel):
+    """A link's representative picture as embedded in tag detail responses"""
+
+    image_id: int
+    thumbnail_url: str
+    crop_x: float
+    crop_y: float
+    crop_w: float
+    crop_h: float
+
+
+class LinkedTagWithPicture(LinkedTag):
+    """LinkedTag + the character-source link's id and optional picture"""
+
+    link_id: int
+    picture: LinkPictureInfo | None = None
+
+
 class TagWithStats(TagResponse):
     """Schema for tag response with usage statistics"""
 
@@ -158,8 +176,8 @@ class TagWithStats(TagResponse):
     date_added: UTCDatetime  # When the tag was created
     links: list[TagExternalLinkResponse] = []  # External links associated with this tag
     # Character-source links
-    sources: list[LinkedTag] = []  # For character tags: linked sources
-    characters: list[LinkedTag] = []  # For source tags: linked characters
+    sources: list[LinkedTagWithPicture] = []  # For character tags: linked sources
+    characters: list[LinkedTagWithPicture] = []  # For source tags: linked characters
 
 
 class TagListResponse(BaseModel):

--- a/tests/api/v1/test_link_pictures.py
+++ b/tests/api/v1/test_link_pictures.py
@@ -346,6 +346,7 @@ class TestDeleteLinkPicture:
             f"/api/v1/character-source-links/{link_id}/picture", headers=headers
         )
         assert response.status_code == 404
+        assert "Link has no picture" in response.json()["detail"]
 
 
 class TestTagDetailEmbed:

--- a/tests/api/v1/test_link_pictures.py
+++ b/tests/api/v1/test_link_pictures.py
@@ -1,0 +1,348 @@
+"""Tests for character-source link picture endpoints (PUT/DELETE .../picture)."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, TagAuditActionType, TagType
+from app.core.security import get_password_hash
+from app.models.character_source_link import CharacterSourceLinks
+from app.models.character_source_link_picture import CharacterSourceLinkPictures
+from app.models.image import Images
+from app.models.permissions import Perms, UserPerms
+from app.models.tag import Tags
+from app.models.tag_audit_log import TagAuditLog
+from app.models.tag_link import TagLinks
+from app.models.user import Users
+
+# Fixture ids far from other test modules' ranges (image_tag_context uses 8xx).
+CHAR_ID = 9401
+SRC_ID = 9402
+OTHER_SRC_ID = 9403
+IMG_OK = 9411  # tagged with both, 1000x800
+IMG_MISSING_TAG = 9412  # tagged with character only
+IMG_HIDDEN = 9413  # both tags but non-public status
+IMG_NO_DIMS = 9414  # both tags, width=height=0 (legacy rows)
+
+
+async def _setup(db: AsyncSession) -> int:
+    """Seed tags, images, tag-links and one character-source link; return link id."""
+    db.add(Tags(tag_id=CHAR_ID, type=TagType.CHARACTER, title="lp char"))
+    db.add(Tags(tag_id=SRC_ID, type=TagType.SOURCE, title="lp source"))
+    db.add(Tags(tag_id=OTHER_SRC_ID, type=TagType.SOURCE, title="lp other source"))
+    db.add(
+        Images(
+            image_id=IMG_OK,
+            user_id=1,
+            ext="jpg",
+            status=ImageStatus.ACTIVE,
+            width=1000,
+            height=800,
+        )
+    )
+    db.add(
+        Images(
+            image_id=IMG_MISSING_TAG,
+            user_id=1,
+            ext="jpg",
+            status=ImageStatus.ACTIVE,
+            width=1000,
+            height=800,
+        )
+    )
+    db.add(
+        Images(
+            image_id=IMG_HIDDEN,
+            user_id=1,
+            ext="jpg",
+            status=ImageStatus.DEACTIVATED,
+            width=1000,
+            height=800,
+        )
+    )
+    db.add(
+        Images(
+            image_id=IMG_NO_DIMS,
+            user_id=1,
+            ext="jpg",
+            status=ImageStatus.ACTIVE,
+            width=0,
+            height=0,
+        )
+    )
+    # Flush so tag/image rows exist before rows that reference them (no ORM
+    # relationships -> unit-of-work can't order the inserts itself).
+    await db.flush()
+    for img in (IMG_OK, IMG_HIDDEN, IMG_NO_DIMS):
+        db.add(TagLinks(tag_id=CHAR_ID, image_id=img, user_id=1))
+        db.add(TagLinks(tag_id=SRC_ID, image_id=img, user_id=1))
+    db.add(TagLinks(tag_id=CHAR_ID, image_id=IMG_MISSING_TAG, user_id=1))
+    link = CharacterSourceLinks(character_tag_id=CHAR_ID, source_tag_id=SRC_ID)
+    db.add(link)
+    await db.commit()
+    await db.refresh(link)
+    assert link.id is not None
+    return link.id
+
+
+@pytest.fixture
+async def tag_create_admin(db_session: AsyncSession) -> Users:
+    """Admin user holding TAG_CREATE."""
+    perm = Perms(title="tag_create", desc="Create tags and tag links")
+    db_session.add(perm)
+    await db_session.commit()
+    await db_session.refresh(perm)
+    admin = Users(
+        username="lp_admin",
+        password=get_password_hash("AdminPassword123!"),
+        password_type="bcrypt",
+        salt="",
+        email="lp_admin@example.com",
+        active=1,
+        admin=1,
+    )
+    db_session.add(admin)
+    await db_session.commit()
+    await db_session.refresh(admin)
+    db_session.add(UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1))
+    await db_session.commit()
+    return admin
+
+
+async def _login(client: AsyncClient, username: str, password: str) -> dict[str, str]:
+    response = await client.post(
+        "/api/v1/auth/login", json={"username": username, "password": password}
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+GOOD_CROP = {"crop_x": 0.1, "crop_y": 0.1, "crop_w": 0.4, "crop_h": 0.5}
+# 0.4*1000=400px wide, 0.5*800=400px tall -> exactly square on a 1000x800 image.
+
+
+class TestSetLinkPicture:
+    async def test_set_creates_row_audit_and_response(
+        self, client: AsyncClient, db_session: AsyncSession, tag_create_admin: Users
+    ) -> None:
+        link_id = await _setup(db_session)
+        headers = await _login(client, "lp_admin", "AdminPassword123!")
+        response = await client.put(
+            f"/api/v1/character-source-links/{link_id}/picture",
+            json={"image_id": IMG_OK, **GOOD_CROP},
+            headers=headers,
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["link_id"] == link_id
+        assert body["image_id"] == IMG_OK
+        assert body["crop_w"] == GOOD_CROP["crop_w"]
+        assert body["set_by_user_id"] == tag_create_admin.user_id
+
+        row = (
+            await db_session.execute(
+                select(CharacterSourceLinkPictures).where(
+                    CharacterSourceLinkPictures.link_id == link_id  # type: ignore[arg-type]
+                )
+            )
+        ).scalar_one()
+        assert row.image_id == IMG_OK
+
+        audit = (
+            (
+                await db_session.execute(
+                    select(TagAuditLog).where(
+                        TagAuditLog.action_type == TagAuditActionType.PICTURE_SET  # type: ignore[arg-type]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(audit) == 1
+        assert audit[0].tag_id == CHAR_ID
+        assert audit[0].character_tag_id == CHAR_ID
+        assert audit[0].source_tag_id == SRC_ID
+
+    async def test_put_replaces_existing(
+        self, client: AsyncClient, db_session: AsyncSession, tag_create_admin: Users
+    ) -> None:
+        link_id = await _setup(db_session)
+        headers = await _login(client, "lp_admin", "AdminPassword123!")
+        first = await client.put(
+            f"/api/v1/character-source-links/{link_id}/picture",
+            json={"image_id": IMG_OK, **GOOD_CROP},
+            headers=headers,
+        )
+        assert first.status_code == 200, first.text
+        second = await client.put(
+            f"/api/v1/character-source-links/{link_id}/picture",
+            json={
+                "image_id": IMG_OK,
+                "crop_x": 0.2,
+                "crop_y": 0.2,
+                "crop_w": 0.2,
+                "crop_h": 0.25,
+            },
+            headers=headers,
+        )
+        assert second.status_code == 200, second.text
+        rows = (await db_session.execute(select(CharacterSourceLinkPictures))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].crop_x == 0.2
+
+    async def test_requires_auth_and_permission(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        link_id = await _setup(db_session)
+        payload = {"image_id": IMG_OK, **GOOD_CROP}
+        anon = await client.put(f"/api/v1/character-source-links/{link_id}/picture", json=payload)
+        assert anon.status_code == 401
+        regular = Users(
+            username="lp_regular",
+            password=get_password_hash("Password123!"),
+            password_type="bcrypt",
+            salt="",
+            email="lp_regular@example.com",
+            active=1,
+            admin=0,
+        )
+        db_session.add(regular)
+        await db_session.commit()
+        headers = await _login(client, "lp_regular", "Password123!")
+        denied = await client.put(
+            f"/api/v1/character-source-links/{link_id}/picture",
+            json=payload,
+            headers=headers,
+        )
+        assert denied.status_code == 403
+
+    @pytest.mark.parametrize(
+        ("image_id", "crop", "status", "detail_fragment"),
+        [
+            (99999, GOOD_CROP, 404, "Image not found"),
+            (IMG_HIDDEN, GOOD_CROP, 400, "not publicly visible"),
+            (IMG_MISSING_TAG, GOOD_CROP, 400, "must carry both"),
+            (  # x + w > 1
+                IMG_OK,
+                {"crop_x": 0.8, "crop_y": 0.1, "crop_w": 0.4, "crop_h": 0.5},
+                400,
+                "beyond the image",
+            ),
+            (  # 400x160px on 1000x800 — far from square
+                IMG_OK,
+                {"crop_x": 0.1, "crop_y": 0.1, "crop_w": 0.4, "crop_h": 0.2},
+                400,
+                "square",
+            ),
+        ],
+    )
+    async def test_validation_rejections(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        tag_create_admin: Users,
+        image_id: int,
+        crop: dict[str, float],
+        status: int,
+        detail_fragment: str,
+    ) -> None:
+        link_id = await _setup(db_session)
+        headers = await _login(client, "lp_admin", "AdminPassword123!")
+        response = await client.put(
+            f"/api/v1/character-source-links/{link_id}/picture",
+            json={"image_id": image_id, **crop},
+            headers=headers,
+        )
+        assert response.status_code == status, response.text
+        assert detail_fragment in response.json()["detail"]
+
+    async def test_per_field_range_is_pydantic_422(
+        self, client: AsyncClient, db_session: AsyncSession, tag_create_admin: Users
+    ) -> None:
+        link_id = await _setup(db_session)
+        headers = await _login(client, "lp_admin", "AdminPassword123!")
+        # crop_w = 0 violates the schema-level gt=0 -> FastAPI 422, list-shaped
+        # detail (distinct from the endpoint's 400 cross-field checks).
+        response = await client.put(
+            f"/api/v1/character-source-links/{link_id}/picture",
+            json={"image_id": IMG_OK, "crop_x": 0.1, "crop_y": 0.1, "crop_w": 0, "crop_h": 0.5},
+            headers=headers,
+        )
+        assert response.status_code == 422
+
+    async def test_missing_link_404(
+        self, client: AsyncClient, db_session: AsyncSession, tag_create_admin: Users
+    ) -> None:
+        await _setup(db_session)
+        headers = await _login(client, "lp_admin", "AdminPassword123!")
+        response = await client.put(
+            "/api/v1/character-source-links/999999/picture",
+            json={"image_id": IMG_OK, **GOOD_CROP},
+            headers=headers,
+        )
+        assert response.status_code == 404
+        assert "Link not found" in response.json()["detail"]
+
+    async def test_zero_dims_skips_aspect_check(
+        self, client: AsyncClient, db_session: AsyncSession, tag_create_admin: Users
+    ) -> None:
+        link_id = await _setup(db_session)
+        headers = await _login(client, "lp_admin", "AdminPassword123!")
+        # Wildly non-square crop is accepted when stored dims are 0 (legacy
+        # rows) — bounds still apply, aspect is unknowable.
+        response = await client.put(
+            f"/api/v1/character-source-links/{link_id}/picture",
+            json={
+                "image_id": IMG_NO_DIMS,
+                "crop_x": 0.0,
+                "crop_y": 0.0,
+                "crop_w": 0.9,
+                "crop_h": 0.1,
+            },
+            headers=headers,
+        )
+        assert response.status_code == 200, response.text
+
+
+class TestDeleteLinkPicture:
+    async def test_delete_removes_row_and_audits(
+        self, client: AsyncClient, db_session: AsyncSession, tag_create_admin: Users
+    ) -> None:
+        link_id = await _setup(db_session)
+        headers = await _login(client, "lp_admin", "AdminPassword123!")
+        put = await client.put(
+            f"/api/v1/character-source-links/{link_id}/picture",
+            json={"image_id": IMG_OK, **GOOD_CROP},
+            headers=headers,
+        )
+        assert put.status_code == 200, put.text
+        response = await client.delete(
+            f"/api/v1/character-source-links/{link_id}/picture", headers=headers
+        )
+        assert response.status_code == 204
+        rows = (await db_session.execute(select(CharacterSourceLinkPictures))).scalars().all()
+        assert rows == []
+        audit = (
+            (
+                await db_session.execute(
+                    select(TagAuditLog).where(
+                        TagAuditLog.action_type == TagAuditActionType.PICTURE_REMOVED  # type: ignore[arg-type]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(audit) == 1
+
+    async def test_delete_without_picture_404(
+        self, client: AsyncClient, db_session: AsyncSession, tag_create_admin: Users
+    ) -> None:
+        link_id = await _setup(db_session)
+        headers = await _login(client, "lp_admin", "AdminPassword123!")
+        response = await client.delete(
+            f"/api/v1/character-source-links/{link_id}/picture", headers=headers
+        )
+        assert response.status_code == 404

--- a/tests/api/v1/test_link_pictures.py
+++ b/tests/api/v1/test_link_pictures.py
@@ -346,3 +346,67 @@ class TestDeleteLinkPicture:
             f"/api/v1/character-source-links/{link_id}/picture", headers=headers
         )
         assert response.status_code == 404
+
+
+class TestTagDetailEmbed:
+    async def test_sources_carry_link_id_and_picture(
+        self, client: AsyncClient, db_session: AsyncSession, tag_create_admin: Users
+    ) -> None:
+        link_id = await _setup(db_session)
+        headers = await _login(client, "lp_admin", "AdminPassword123!")
+        put = await client.put(
+            f"/api/v1/character-source-links/{link_id}/picture",
+            json={"image_id": IMG_OK, **GOOD_CROP},
+            headers=headers,
+        )
+        assert put.status_code == 200, put.text
+
+        # Character page: sources[] carries link_id + picture
+        char_page = await client.get(f"/api/v1/tags/{CHAR_ID}")
+        assert char_page.status_code == 200
+        sources = char_page.json()["sources"]
+        assert len(sources) == 1
+        assert sources[0]["link_id"] == link_id
+        picture = sources[0]["picture"]
+        assert picture is not None
+        assert picture["image_id"] == IMG_OK
+        assert picture["crop_w"] == GOOD_CROP["crop_w"]
+        assert picture["thumbnail_url"].endswith(".webp")
+        assert "/thumbs/" in picture["thumbnail_url"]
+
+        # Source page: characters[] carries the same
+        src_page = await client.get(f"/api/v1/tags/{SRC_ID}")
+        characters = src_page.json()["characters"]
+        assert characters[0]["link_id"] == link_id
+        assert characters[0]["picture"]["image_id"] == IMG_OK
+
+    async def test_pictureless_link_has_null_picture(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        link_id = await _setup(db_session)
+        response = await client.get(f"/api/v1/tags/{CHAR_ID}")
+        sources = response.json()["sources"]
+        assert sources[0]["link_id"] == link_id
+        assert sources[0]["picture"] is None
+
+    async def test_picture_omitted_when_image_leaves_public_status(
+        self, client: AsyncClient, db_session: AsyncSession, tag_create_admin: Users
+    ) -> None:
+        link_id = await _setup(db_session)
+        headers = await _login(client, "lp_admin", "AdminPassword123!")
+        put = await client.put(
+            f"/api/v1/character-source-links/{link_id}/picture",
+            json={"image_id": IMG_OK, **GOOD_CROP},
+            headers=headers,
+        )
+        assert put.status_code == 200, put.text
+        image = (
+            await db_session.execute(
+                select(Images).where(Images.image_id == IMG_OK)  # type: ignore[arg-type]
+            )
+        ).scalar_one()
+        image.status = ImageStatus.DEACTIVATED  # deactivated after being chosen
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/tags/{CHAR_ID}")
+        assert response.json()["sources"][0]["picture"] is None


### PR DESCRIPTION
Chunk 4 of WhiteKitten's character↔source ideas (API side). Design + implementation plan live in the frontend repo: `docs/plans/2026-08-09-per-link-character-pictures-{design,impl}.md`.

## What

- New 1:1 table `character_source_link_pictures`: a representative picture per character-source link — an existing image reference plus a normalized square crop rect (`crop_x/y/w/h`, fractions of natural dimensions). CASCADE from both the link and the image; no half-null states.
- `PUT /character-source-links/{link_id}/picture` (upsert) and `DELETE .../picture`, both `TAG_CREATE`-gated, with audit rows (`picture_set` / `picture_removed`). PUT validates: image exists and is publicly visible, image carries BOTH linked tags, crop in bounds, crop pixel-square within 5% (skipped for legacy rows with zero stored dims).
- `GET /tags/{id}`: `sources[]`/`characters[]` entries now carry `link_id` and a nullable `picture {image_id, thumbnail_url, crop_*}`, with a read-time public-status re-check so a later-deactivated image degrades to no-picture. Thumbnail-URL logic extracted into shared `thumbnail_url_for()` — one implementation for the schema property and the embed.

## Notes

- **Carries a migration** (new table only, additive). Deploy order: this PR before the FE PR; on prod run `make prod-migrate` before rollout.
- Additive API surface — existing clients unaffected (`TagWithStats` keeps every existing key).
- The FE consumer (picture cards + crop dialog on tag pages) follows in a frontend PR.

## Testing

- 16 new tests in `tests/api/v1/test_link_pictures.py` (validation matrix, upsert, auth, audit, embed incl. deactivation degradation).
- Full `make pytest`: 2450 passed, 16 skipped, exit 0. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2rpFrURaJV8Ybv2mk1QLq