### PR TITLE
Comment search: require all words instead of any

### DIFF
--- a/app/api/v1/comments.py
+++ b/app/api/v1/comments.py
@@ -71,15 +71,18 @@ async def list_comments(
     - Sorting by date, post_id, or update_count
     - Filter by image, user, or text search
     - Date range filtering
-    - Multiple search modes (LIKE, natural fulltext, boolean fulltext)
+    - Multiple search modes (all_words, natural fulltext, boolean fulltext, LIKE)
 
     **Search Modes:**
     - `all_words` (default): every term must appear. Index-backed where the
       fulltext index can see the term, LIKE where it cannot (short words,
-      stopwords, non-ASCII). Supports `"exact phrase"` and `-excluded`.
+      stopwords, non-ASCII). Supports `"exact phrase"` and `-excluded`. A blank
+      or whitespace-only `search_text` applies no filter at all; a non-blank
+      value with nothing searchable in it (e.g. `!!!`) matches zero comments.
     - `natural`: MySQL fulltext natural language search — matches ANY term
     - `boolean`: MySQL fulltext boolean search with raw operators
-    - `like`: Simple pattern matching, works anywhere. Example: `?search_text=awesome`
+    - `like`: Simple pattern matching, works anywhere. Example: `?search_text=awesome`.
+      `%` and `_` in the query are escaped to literals, not treated as wildcards.
 
     **Boolean Mode Examples:**
     - `+awesome -terrible`: Must contain "awesome", must not contain "terrible"
@@ -113,8 +116,10 @@ async def list_comments(
     if user_id is not None:
         query = query.where(Comments.user_id == user_id)  # type: ignore[arg-type]
 
-    # Text search with mode selection
-    if search_text:
+    # Text search with mode selection. A blank/whitespace-only search_text means
+    # "not searching," not "search for nothing" -- `if search_text:` alone would
+    # still call apply_comment_text_search for e.g. "   ".
+    if search_text and search_text.strip():
         query = apply_comment_text_search(query, search_text, search_mode)
 
     # Date filtering

--- a/app/api/v1/comments.py
+++ b/app/api/v1/comments.py
@@ -30,6 +30,7 @@ from app.schemas.comment import (
 )
 from app.schemas.comment_report import CommentReportCreate, CommentReportResponse
 from app.schemas.common import UserSummary
+from app.utils.comment_search import apply_comment_text_search
 
 router = APIRouter(prefix="/comments", tags=["comments"])
 
@@ -49,8 +50,11 @@ async def list_comments(
     search_mode: Annotated[
         str | None,
         Query(
-            pattern="^(natural|boolean|like)$",
-            description="Search mode: natural (default), boolean fulltext, or LIKE",
+            pattern="^(all_words|natural|boolean|like)$",
+            description=(
+                "Search mode: all_words (default, every term required), "
+                "natural language fulltext (any term), boolean fulltext, or LIKE"
+            ),
         ),
     ] = None,
     # Date filtering
@@ -70,8 +74,11 @@ async def list_comments(
     - Multiple search modes (LIKE, natural fulltext, boolean fulltext)
 
     **Search Modes:**
-    - `natural` (default): MySQL fulltext natural language search (10-100x faster, relevance ranking)
-    - `boolean`: MySQL fulltext boolean search with operators
+    - `all_words` (default): every term must appear. Index-backed where the
+      fulltext index can see the term, LIKE where it cannot (short words,
+      stopwords, non-ASCII). Supports `"exact phrase"` and `-excluded`.
+    - `natural`: MySQL fulltext natural language search — matches ANY term
+    - `boolean`: MySQL fulltext boolean search with raw operators
     - `like`: Simple pattern matching, works anywhere. Example: `?search_text=awesome`
 
     **Boolean Mode Examples:**
@@ -83,14 +90,12 @@ async def list_comments(
     - `/comments?image_id=123` - All comments on image 123
     - `/comments?image_ids=123,456,789` - All comments on multiple images (efficient for N images)
     - `/comments?user_id=5` - All comments by user 5
-    - `/comments?search_text=awesome` - Fast fulltext search
+    - `/comments?search_text=happy birthday` - Comments containing BOTH words
     - `/comments?search_text=awesome&search_mode=like` - Simple search using LIKE
-    - `/comments?search_text=awesome&search_mode=natural` - Fast fulltext search, same as default
+    - `/comments?search_text=awesome&search_mode=natural` - Any-term match
     - `/comments?search_text=+great -bad&search_mode=boolean` - Boolean fulltext
     - `/comments?date_from=2024-01-01` - Comments from 2024 onwards
     """
-    from sqlalchemy import text as sql_text
-
     # Build base query - exclude deleted comments
     query = select(Comments).where(Comments.deleted == False)  # type: ignore[arg-type]  # noqa: E712
 
@@ -110,20 +115,7 @@ async def list_comments(
 
     # Text search with mode selection
     if search_text:
-        # Default to natural if no mode specified
-        effective_mode = search_mode or "natural"
-
-        if effective_mode == "boolean":
-            # Boolean fulltext: supports +word, -word, "phrase", word*
-            match_expr = sql_text("MATCH(post_text) AGAINST(:query IN BOOLEAN MODE)")
-            query = query.where(match_expr).params(query=search_text)
-        elif effective_mode == "natural":
-            # Natural language fulltext: ranks by relevance
-            match_expr = sql_text("MATCH(post_text) AGAINST(:query IN NATURAL LANGUAGE MODE)")
-            query = query.where(match_expr).params(query=search_text)
-        else:  # like
-            # Simple pattern matching (slowest but works everywhere)
-            query = query.where(Comments.post_text.like(f"%{search_text}%"))  # type: ignore
+        query = apply_comment_text_search(query, search_text, search_mode)
 
     # Date filtering
     if date_from:

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -27,7 +27,6 @@ from fastapi import (
 )
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy import and_, asc, delete, desc, func, or_, select
-from sqlalchemy import text as sql_text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
@@ -137,6 +136,7 @@ from app.services.tag_context import stamp_context_sources
 from app.services.tag_type_flags import refresh_image_tag_type_flags
 from app.services.upload import check_upload_rate_limit, link_tags_to_image, save_uploaded_image
 from app.tasks.queue import enqueue_job
+from app.utils.comment_search import apply_comment_text_search
 
 logger = get_logger(__name__)
 
@@ -482,8 +482,11 @@ async def list_images(
     commentsearch_mode: Annotated[
         str | None,
         Query(
-            pattern="^(natural|boolean|like)$",
-            description="Search mode: natural (default), boolean fulltext, or LIKE",
+            pattern="^(all_words|natural|boolean|like)$",
+            description=(
+                "Search mode: all_words (default, every term required), "
+                "natural language fulltext (any term), boolean fulltext, or LIKE"
+            ),
         ),
     ] = None,
     hascomments: Annotated[
@@ -514,8 +517,11 @@ async def list_images(
     - Comment filtering (by commenter user ID, text search, or presence)
 
     **Comment Search Modes:**
-    - `natural` (default): MySQL fulltext natural language search (10-100x faster, relevance ranking)
-    - `boolean`: MySQL fulltext boolean search with operators
+    - `all_words` (default): every term must appear. Index-backed where the
+      fulltext index can see the term, LIKE where it cannot (short words,
+      stopwords, non-ASCII). Supports `"exact phrase"` and `-excluded`.
+    - `natural`: MySQL fulltext natural language search — matches ANY term
+    - `boolean`: MySQL fulltext boolean search with raw operators
     - `like`: Simple pattern matching, works anywhere
 
     **Boolean Mode Examples:**
@@ -530,9 +536,10 @@ async def list_images(
     - `/images?date_from=2024-01-01&sort_by=favorites` - Images from 2024, sorted by popularity
     - `/images?user_id=5&min_rating=4.0` - High-rated images by user 5
     - `/images?commenter=10` - Images commented on by user 10
-    - `/images?commentsearch=awesome` - Images with "awesome" in comments (natural fulltext)
-    - `/images?commentsearch=awesome&commentsearch_mode=like` - Simple search using LIKE
-    - `/images?commentsearch=+great -bad&commentsearch_mode=boolean` - Boolean fulltext
+    - `/images?commentsearch=happy birthday` - Comments containing BOTH words
+    - `/images?commentsearch="happy birthday"` - Comments containing the phrase
+    - `/images?commentsearch=happy -sad` - Has "happy", not "sad"
+    - `/images?commentsearch=awesome&commentsearch_mode=natural` - Any-term match
     - `/images?hascomments=true` - Images that have comments
     - `/images?hascomments=false` - Images with no comments
     - `/images?exclude_user_id=5,6` - Hide uploads by users 5 and 6
@@ -760,21 +767,7 @@ async def list_images(
         if commenter is not None:
             query = query.where(Comments.user_id == commenter)  # type: ignore[arg-type]
         if commentsearch is not None:
-            # Text search with mode selection (default to natural language fulltext)
-            effective_mode = commentsearch_mode or "natural"
-
-            if effective_mode == "boolean":
-                # Boolean fulltext: supports +word, -word, "phrase", word*
-                match_expr = sql_text("MATCH(post_text) AGAINST(:query IN BOOLEAN MODE)")
-                query = query.where(match_expr).params(query=commentsearch)
-            elif effective_mode == "natural":
-                # Natural language fulltext: ranks by relevance (default, fastest)
-                match_expr = sql_text("MATCH(post_text) AGAINST(:query IN NATURAL LANGUAGE MODE)")
-                query = query.where(match_expr).params(query=commentsearch)
-            else:  # like
-                # Simple pattern matching (slowest but works everywhere)
-                search_pattern = f"%{commentsearch}%"
-                query = query.where(Comments.post_text.like(search_pattern))  # type: ignore[attr-defined]
+            query = apply_comment_text_search(query, commentsearch, commentsearch_mode)
     elif hascomments is True:
         # Use posts counter field (fast indexed lookup)
         query = query.where(Images.posts > 0)  # type: ignore[arg-type]

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -519,10 +519,13 @@ async def list_images(
     **Comment Search Modes:**
     - `all_words` (default): every term must appear. Index-backed where the
       fulltext index can see the term, LIKE where it cannot (short words,
-      stopwords, non-ASCII). Supports `"exact phrase"` and `-excluded`.
+      stopwords, non-ASCII). Supports `"exact phrase"` and `-excluded`. A blank
+      or whitespace-only `commentsearch` applies no filter at all; a non-blank
+      value with nothing searchable in it (e.g. `!!!`) matches zero comments.
     - `natural`: MySQL fulltext natural language search — matches ANY term
     - `boolean`: MySQL fulltext boolean search with raw operators
-    - `like`: Simple pattern matching, works anywhere
+    - `like`: Simple pattern matching, works anywhere. `%` and `_` in the query
+      are escaped to literals, not treated as wildcards.
 
     **Boolean Mode Examples:**
     - `+awesome -terrible`: Must contain "awesome", must not contain "terrible"
@@ -546,6 +549,13 @@ async def list_images(
     - `/images?exclude_commenter=10` - Hide images user 10 commented on
     - `/images?exclude_favorited_by_user_id=7` - Hide images user 7 favorited
     """
+    # A blank/whitespace-only commentsearch means "not searching," not "search for
+    # nothing" -- normalize it to None up front so it reads as absent everywhere
+    # below: the Comments JOIN guard, the count's JOIN guard, and the _FeedFilters
+    # entry all key off `commentsearch is not None`.
+    if commentsearch is not None and not commentsearch.strip():
+        commentsearch = None
+
     # Build base query
     query = select(Images)
 

--- a/app/utils/comment_search.py
+++ b/app/utils/comment_search.py
@@ -1,0 +1,153 @@
+"""Translate a user's comment-search string into SQL predicates.
+
+InnoDB fulltext offers two modes and both are wrong as a default:
+
+* NATURAL LANGUAGE MODE ORs its terms. On the dev corpus `happy birthday`
+  matched 9,671 comments, of which only 2,059 contain the phrase.
+* BOOLEAN MODE ANDs correctly with `+term`, but returns *zero* rows for any
+  term the index cannot see. `+happy +bd` and `+the +cat` both match nothing.
+
+So we split the query across both mechanisms: terms the index can see go into
+a BOOLEAN MODE conjunction (fast, index-backed), and everything else falls
+back to LIKE. Every term is ANDed either way, and no single term can zero out
+the result set.
+
+Only `\\w+` runs ever reach the boolean string. That is a hard requirement,
+not a stylistic one: a stray `@` makes MySQL raise ERROR 1064, which would
+surface as a 500 on the default search path.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# Must match innodb_ft_min_token_size on the server. Anything shorter is
+# absent from the index, so `+ab` matches nothing at all.
+MIN_TOKEN_SIZE = 3
+
+# information_schema.INNODB_FT_DEFAULT_STOPWORD, verbatim. A stopword inside a
+# boolean conjunction is not ignored -- it makes the whole conjunction fail.
+STOPWORDS = frozenset(
+    {
+        "a",
+        "about",
+        "an",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "com",
+        "de",
+        "en",
+        "for",
+        "from",
+        "how",
+        "i",
+        "in",
+        "is",
+        "it",
+        "la",
+        "of",
+        "on",
+        "or",
+        "that",
+        "the",
+        "this",
+        "to",
+        "und",
+        "was",
+        "what",
+        "when",
+        "where",
+        "who",
+        "will",
+        "with",
+        "www",
+    }
+)
+
+# A quoted phrase (optionally negated), or a bare run of non-space characters.
+_TERM_RE = re.compile(r'-?"[^"]*"|\S+')
+
+# Word characters only. The fulltext parser breaks on everything else, so
+# "well-known" is two tokens to the index and must be two tokens to us.
+_WORD_RE = re.compile(r"\w+", re.UNICODE)
+
+
+@dataclass
+class CommentSearchQuery:
+    """The predicates a parsed search string maps onto."""
+
+    boolean_query: str = ""
+    like_terms: list[str] = field(default_factory=list)
+    not_like_terms: list[str] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.boolean_query or self.like_terms or self.not_like_terms)
+
+
+def like_pattern(term: str) -> str:
+    """Build a contains-pattern, escaping LIKE metacharacters.
+
+    Without this a search for `100%` degrades into "match anything". Backslash
+    is escaped first so it cannot double-escape the wildcards added after it.
+    """
+    escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{escaped}%"
+
+
+def _is_indexable(token: str) -> bool:
+    """Whether the fulltext index can actually see this token.
+
+    Non-ASCII is excluded deliberately. With the default parser a whitespace-
+    free run of Japanese is a single token, so a substring search for it misses
+    rows LIKE finds -- measured at 33 vs 52 for one common term, across the
+    19,200 comments that contain non-ASCII text.
+    """
+    return len(token) >= MIN_TOKEN_SIZE and token.isascii() and token.lower() not in STOPWORDS
+
+
+def parse_comment_search(raw: str) -> CommentSearchQuery:
+    """Split a user's search string into fulltext and LIKE predicates."""
+    parsed = CommentSearchQuery()
+    positives: list[str] = []
+    negatives: list[str] = []
+
+    for match in _TERM_RE.finditer(raw or ""):
+        term = match.group(0)
+        negated = term.startswith("-")
+        if negated:
+            term = term[1:]
+
+        if term.startswith('"') and term.endswith('"') and len(term) >= 2:
+            phrase = term[1:-1].strip()
+            if not phrase:
+                continue
+            tokens = _WORD_RE.findall(phrase)
+            if tokens and all(_is_indexable(t) for t in tokens):
+                # Phrase search stays token-based, matching fulltext semantics
+                # (punctuation and repeated spaces are not significant).
+                quoted = '"' + " ".join(tokens) + '"'
+                (negatives if negated else positives).append(quoted)
+            else:
+                (parsed.not_like_terms if negated else parsed.like_terms).append(phrase)
+            continue
+
+        for token in _WORD_RE.findall(term):
+            if _is_indexable(token):
+                (negatives if negated else positives).append(token)
+            else:
+                (parsed.not_like_terms if negated else parsed.like_terms).append(token)
+
+    if positives:
+        parsed.boolean_query = " ".join([f"+{p}" for p in positives] + [f"-{n}" for n in negatives])
+    else:
+        # A boolean query of only negative terms matches nothing in InnoDB, so
+        # the exclusions have to ride on NOT LIKE when there is no positive
+        # term to anchor them.
+        parsed.not_like_terms.extend(n.strip('"') for n in negatives)
+
+    return parsed

--- a/app/utils/comment_search.py
+++ b/app/utils/comment_search.py
@@ -23,7 +23,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-from sqlalchemy import Select
+from sqlalchemy import Select, false
 from sqlalchemy import text as sql_text
 
 from app.models import Comments
@@ -165,6 +165,13 @@ def apply_comment_text_search(query: Select[Any], raw: str, mode: str | None) ->
     `query` must already select from / join the Comments table. The bind
     parameter is named `comment_q` so it cannot collide with a caller's own
     parameters.
+
+    Callers are expected to skip calling this at all for a blank/whitespace-only
+    `raw` -- that means "not searching," not "search for nothing" (see the
+    `commentsearch`/`search_text` guards in images.py/comments.py). A non-blank
+    `raw` that still has nothing searchable (e.g. "!!!") is a query the user typed
+    that can never match a comment, so it returns zero rows rather than silently
+    falling back to "no filter."
     """
     effective_mode = mode or "all_words"
 
@@ -183,9 +190,11 @@ def apply_comment_text_search(query: Select[Any], raw: str, mode: str | None) ->
 
     parsed = parse_comment_search(raw)
     if parsed.is_empty:
-        # Nothing searchable in the input (e.g. "!!!"). The caller has already
-        # joined Comments, so this degrades to "images that have comments".
-        return query
+        # Nothing searchable in a non-blank input (e.g. "!!!"): no comment can
+        # ever match, so this must return zero rows. A blank/whitespace-only
+        # `raw` is also is_empty here, but callers guard against calling this
+        # helper with one at all (blank means "no filter", not "zero rows").
+        return query.where(false())
 
     if parsed.boolean_query:
         query = query.where(

--- a/app/utils/comment_search.py
+++ b/app/utils/comment_search.py
@@ -21,6 +21,12 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy import Select
+from sqlalchemy import text as sql_text
+
+from app.models import Comments
 
 # Must match innodb_ft_min_token_size on the server. Anything shorter is
 # absent from the index, so `+ab` matches nothing at all.
@@ -151,3 +157,43 @@ def parse_comment_search(raw: str) -> CommentSearchQuery:
         parsed.not_like_terms.extend(n.strip('"') for n in negatives)
 
     return parsed
+
+
+def apply_comment_text_search(query: Select[Any], raw: str, mode: str | None) -> Select[Any]:
+    """Add comment-text predicates to `query`.
+
+    `query` must already select from / join the Comments table. The bind
+    parameter is named `comment_q` so it cannot collide with a caller's own
+    parameters.
+    """
+    effective_mode = mode or "all_words"
+
+    if effective_mode == "boolean":
+        return query.where(sql_text("MATCH(post_text) AGAINST(:comment_q IN BOOLEAN MODE)")).params(
+            comment_q=raw
+        )
+
+    if effective_mode == "natural":
+        return query.where(
+            sql_text("MATCH(post_text) AGAINST(:comment_q IN NATURAL LANGUAGE MODE)")
+        ).params(comment_q=raw)
+
+    if effective_mode == "like":
+        return query.where(Comments.post_text.like(like_pattern(raw), escape="\\"))  # type: ignore[attr-defined]
+
+    parsed = parse_comment_search(raw)
+    if parsed.is_empty:
+        # Nothing searchable in the input (e.g. "!!!"). The caller has already
+        # joined Comments, so this degrades to "images that have comments".
+        return query
+
+    if parsed.boolean_query:
+        query = query.where(
+            sql_text("MATCH(post_text) AGAINST(:comment_q IN BOOLEAN MODE)")
+        ).params(comment_q=parsed.boolean_query)
+    for term in parsed.like_terms:
+        query = query.where(Comments.post_text.like(like_pattern(term), escape="\\"))  # type: ignore[attr-defined]
+    for term in parsed.not_like_terms:
+        # post_text is NOT NULL (verified), so NOT LIKE needs no NULL guard.
+        query = query.where(~Comments.post_text.like(like_pattern(term), escape="\\"))  # type: ignore[attr-defined]
+    return query

--- a/tests/api/v1/test_comments.py
+++ b/tests/api/v1/test_comments.py
@@ -152,6 +152,34 @@ class TestListComments:
         assert data["total"] == 1
         assert "awesome" in data["comments"][0]["post_text"].lower()
 
+    @pytest.mark.needs_commit  # FULLTEXT search requires committed data
+    async def test_search_text_defaults_to_all_words(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """/comments text search requires all words too."""
+        from app.models import Comments
+
+        user = Users(
+            username="csearch_user",
+            email="csearch@test.com",
+            password="testpass",
+            password_type="bcrypt",
+            salt="testsalt0000014",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        both = Comments(user_id=user.user_id, post_text="happy birthday to you")
+        one = Comments(user_id=user.user_id, post_text="such a happy picture")
+        db_session.add_all([both, one])
+        await db_session.commit()
+
+        response = await client.get("/api/v1/comments?search_text=happy birthday")
+        assert response.status_code == 200
+        returned = {c["post_id"] for c in response.json()["comments"]}
+        assert both.post_id in returned
+        assert one.post_id not in returned
+
 
 @pytest.mark.api
 class TestGetComment:

--- a/tests/api/v1/test_comments.py
+++ b/tests/api/v1/test_comments.py
@@ -180,6 +180,59 @@ class TestListComments:
         assert both.post_id in returned
         assert one.post_id not in returned
 
+    async def test_search_text_unsearchable_query_returns_zero_rows(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A non-blank query with nothing indexable or LIKE-able (e.g. "!!!") must
+        match nothing -- not silently degrade to "no filter"."""
+        from app.models import Comments
+
+        user = Users(
+            username="unsearch_user",
+            email="unsearch@test.com",
+            password="testpass",
+            password_type="bcrypt",
+            salt="testsalt0000017",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        db_session.add(Comments(user_id=user.user_id, post_text="happy birthday"))
+        await db_session.commit()
+
+        response = await client.get("/api/v1/comments?search_text=!!!")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["comments"] == []
+        assert data["total"] == 0
+
+    async def test_search_text_blank_applies_no_filter(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A blank/whitespace-only query means "not searching"."""
+        from app.models import Comments
+
+        user = Users(
+            username="blanktxt_user",
+            email="blanktxt@test.com",
+            password="testpass",
+            password_type="bcrypt",
+            salt="testsalt0000018",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        comment = Comments(user_id=user.user_id, post_text="anything at all")
+        db_session.add(comment)
+        await db_session.commit()
+
+        response = await client.get("/api/v1/comments", params={"search_text": "   "})
+        assert response.status_code == 200
+        data = response.json()
+        returned = {c["post_id"] for c in data["comments"]}
+        assert comment.post_id in returned
+        assert data["total"] == 1
+
 
 @pytest.mark.api
 class TestGetComment:

--- a/tests/api/v1/test_comments.py
+++ b/tests/api/v1/test_comments.py
@@ -180,6 +180,22 @@ class TestListComments:
         assert both.post_id in returned
         assert one.post_id not in returned
 
+        # Pin the literal mode string the frontend sends explicitly
+        # (+page.server.ts) -- it must be accepted and behave like the
+        # implicit default, or the two repos silently drift apart.
+        response = await client.get(
+            "/api/v1/comments?search_text=happy birthday&search_mode=all_words"
+        )
+        assert response.status_code == 200
+        returned = {c["post_id"] for c in response.json()["comments"]}
+        assert both.post_id in returned
+        assert one.post_id not in returned
+
+    async def test_search_mode_rejects_unknown_value(self, client: AsyncClient):
+        """A typo'd mode must 422, not silently fall through to the default."""
+        response = await client.get("/api/v1/comments?search_text=happy&search_mode=bogus")
+        assert response.status_code == 422
+
     async def test_search_text_unsearchable_query_returns_zero_rows(
         self, client: AsyncClient, db_session: AsyncSession
     ):

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -3060,6 +3060,22 @@ class TestCommentFilters:
         assert both.image_id in returned
         assert happy_only.image_id not in returned
 
+        # Pin the literal mode string the frontend sends explicitly
+        # (+page.server.ts) -- it must be accepted and behave like the
+        # implicit default, or the two repos silently drift apart.
+        response = await client.get(
+            "/api/v1/images?commentsearch=happy birthday&commentsearch_mode=all_words"
+        )
+        assert response.status_code == 200
+        returned = {img["image_id"] for img in response.json()["images"]}
+        assert both.image_id in returned
+        assert happy_only.image_id not in returned
+
+    async def test_commentsearch_mode_rejects_unknown_value(self, client: AsyncClient):
+        """A typo'd mode must 422, not silently fall through to the default."""
+        response = await client.get("/api/v1/images?commentsearch=happy&commentsearch_mode=bogus")
+        assert response.status_code == 422
+
     @pytest.mark.needs_commit  # FULLTEXT search requires committed data
     async def test_commentsearch_short_token_does_not_zero_results(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -3016,16 +3016,173 @@ class TestCommentFilters:
         assert data["total"] == 1
         assert data["images"][0]["filename"] == "img1"
 
-    async def test_commentsearch_boolean_mode(
+    @pytest.mark.needs_commit  # FULLTEXT search requires committed data
+    async def test_commentsearch_defaults_to_all_words(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
     ):
-        """Test comment search with boolean fulltext mode (requires FULLTEXT index)."""
-        import pytest
+        """Multi-word search requires ALL words, not any of them."""
+        from app.models import Comments
 
-        # Skip this test if running in environment without FULLTEXT index
-        # In production, the fulltext index is created by Alembic migration
-        # This test is primarily for documenting the feature
-        pytest.skip("Requires FULLTEXT index on posts.post_text - test in production environment")
+        user = Users(
+            username="allwords_user",
+            email="allwords@test.com",
+            password="testpass",
+            password_type="bcrypt",
+            salt="testsalt0000010",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        both = Images(**{**sample_image_data, "user_id": user.user_id})
+        happy_only = Images(**{**sample_image_data, "user_id": user.user_id})
+        db_session.add_all([both, happy_only])
+        await db_session.flush()
+
+        db_session.add_all(
+            [
+                Comments(
+                    image_id=both.image_id,
+                    user_id=user.user_id,
+                    post_text="happy birthday to you",
+                ),
+                Comments(
+                    image_id=happy_only.image_id,
+                    user_id=user.user_id,
+                    post_text="such a happy picture",
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get("/api/v1/images?commentsearch=happy birthday")
+        assert response.status_code == 200
+        returned = {img["image_id"] for img in response.json()["images"]}
+        assert both.image_id in returned
+        assert happy_only.image_id not in returned
+
+    @pytest.mark.needs_commit  # FULLTEXT search requires committed data
+    async def test_commentsearch_short_token_does_not_zero_results(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """A sub-min-token-size word must narrow via LIKE, not wipe the results.
+
+        `MATCH(...) AGAINST('+happy +bd' IN BOOLEAN MODE)` returns 0 rows.
+        """
+        from app.models import Comments
+
+        user = Users(
+            username="shorttok_user",
+            email="shorttok@test.com",
+            password="testpass",
+            password_type="bcrypt",
+            salt="testsalt0000011",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        match = Images(**{**sample_image_data, "user_id": user.user_id})
+        no_match = Images(**{**sample_image_data, "user_id": user.user_id})
+        db_session.add_all([match, no_match])
+        await db_session.flush()
+
+        db_session.add_all(
+            [
+                Comments(
+                    image_id=match.image_id,
+                    user_id=user.user_id,
+                    post_text="happy bd friend",
+                ),
+                Comments(
+                    image_id=no_match.image_id,
+                    user_id=user.user_id,
+                    post_text="happy day friend",
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get("/api/v1/images?commentsearch=happy bd")
+        assert response.status_code == 200
+        returned = {img["image_id"] for img in response.json()["images"]}
+        assert match.image_id in returned
+        assert no_match.image_id not in returned
+
+    @pytest.mark.needs_commit  # FULLTEXT search requires committed data
+    async def test_commentsearch_stopword_does_not_zero_results(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """`the` is an InnoDB stopword; `+the +cat` returns 0 rows."""
+        from app.models import Comments
+
+        user = Users(
+            username="stopword_user",
+            email="stopword@test.com",
+            password="testpass",
+            password_type="bcrypt",
+            salt="testsalt0000012",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        image = Images(**{**sample_image_data, "user_id": user.user_id})
+        db_session.add(image)
+        await db_session.flush()
+        db_session.add(
+            Comments(
+                image_id=image.image_id,
+                user_id=user.user_id,
+                post_text="the cat is sitting",
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get("/api/v1/images?commentsearch=the cat")
+        assert response.status_code == 200
+        returned = {img["image_id"] for img in response.json()["images"]}
+        assert image.image_id in returned
+
+    async def test_commentsearch_special_characters_do_not_500(
+        self, client: AsyncClient, sample_image_data: dict
+    ):
+        """`@` and `)` are ERROR 1064 in boolean mode if passed through raw."""
+        response = await client.get("/api/v1/images?commentsearch=happy@birthday)")
+        assert response.status_code == 200
+
+    @pytest.mark.needs_commit  # FULLTEXT search requires committed data
+    async def test_commentsearch_natural_mode_still_available(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """The old OR behaviour remains reachable via an explicit mode."""
+        from app.models import Comments
+
+        user = Users(
+            username="natural_user",
+            email="natural@test.com",
+            password="testpass",
+            password_type="bcrypt",
+            salt="testsalt0000013",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        image = Images(**{**sample_image_data, "user_id": user.user_id})
+        db_session.add(image)
+        await db_session.flush()
+        db_session.add(
+            Comments(
+                image_id=image.image_id,
+                user_id=user.user_id,
+                post_text="such a happy picture",
+            )
+        )
+        await db_session.commit()
+
+        response = await client.get(
+            "/api/v1/images?commentsearch=happy birthday&commentsearch_mode=natural"
+        )
+        assert response.status_code == 200
+        returned = {img["image_id"] for img in response.json()["images"]}
+        assert image.image_id in returned
 
     async def test_commentsearch_like_mode(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -3184,6 +3184,68 @@ class TestCommentFilters:
         returned = {img["image_id"] for img in response.json()["images"]}
         assert image.image_id in returned
 
+    async def test_commentsearch_unsearchable_query_returns_zero_rows(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """A non-blank query with nothing indexable or LIKE-able (e.g. "!!!") must
+        match nothing -- not silently degrade to "images that have comments"."""
+        from app.models import Comments
+
+        user = Users(
+            username="unsearchable_user",
+            email="unsearchable@test.com",
+            password="testpass",
+            password_type="bcrypt",
+            salt="testsalt0000015",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        image = Images(**{**sample_image_data, "user_id": user.user_id})
+        db_session.add(image)
+        await db_session.flush()
+        db_session.add(
+            Comments(image_id=image.image_id, user_id=user.user_id, post_text="happy birthday")
+        )
+        await db_session.commit()
+
+        response = await client.get("/api/v1/images?commentsearch=!!!")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["images"] == []
+        # The count and the page must agree, or pagination lies.
+        assert data["total"] == 0
+
+    async def test_commentsearch_blank_applies_no_filter(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """A blank/whitespace-only query means "not searching" -- an image with no
+        comments at all must still be returned, unlike a real comment filter (which
+        would exclude it via the Comments JOIN)."""
+        user = Users(
+            username="blanksearch_user",
+            email="blanksearch@test.com",
+            password="testpass",
+            password_type="bcrypt",
+            salt="testsalt0000016",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        no_comments = Images(**{**sample_image_data, "user_id": user.user_id})
+        db_session.add(no_comments)
+        await db_session.commit()
+
+        response = await client.get("/api/v1/images", params={"commentsearch": "   "})
+        assert response.status_code == 200
+        data = response.json()
+        returned = {img["image_id"] for img in data["images"]}
+        assert no_comments.image_id in returned
+        # A blank commentsearch must also fall into the bare-default-feed fast
+        # count path (no JOIN), not the exact-subquery count -- both must agree
+        # with the page, or pagination lies.
+        assert data["total"] == 1
+
     async def test_commentsearch_like_mode(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
     ):

--- a/tests/unit/test_comment_search.py
+++ b/tests/unit/test_comment_search.py
@@ -1,0 +1,128 @@
+"""Unit tests for the comment-search query parser.
+
+Every case here maps to a behaviour measured against the live corpus and
+recorded in docs/plans/2026-08-10-comment-search-and-semantics-impl.md.
+"""
+
+from app.utils.comment_search import (
+    CommentSearchQuery,
+    like_pattern,
+    parse_comment_search,
+)
+
+
+class TestParseCommentSearch:
+    def test_multiple_words_are_anded(self):
+        parsed = parse_comment_search("happy birthday")
+        assert parsed.boolean_query == "+happy +birthday"
+        assert parsed.like_terms == []
+        assert parsed.not_like_terms == []
+
+    def test_single_word(self):
+        parsed = parse_comment_search("birthday")
+        assert parsed.boolean_query == "+birthday"
+
+    def test_short_token_falls_back_to_like(self):
+        # `+happy +bd` returns 0 rows: `bd` is below innodb_ft_min_token_size.
+        parsed = parse_comment_search("happy bd")
+        assert parsed.boolean_query == "+happy"
+        assert parsed.like_terms == ["bd"]
+
+    def test_stopword_falls_back_to_like(self):
+        # `+the +cat` returns 0 rows: `the` is on the InnoDB stopword list.
+        parsed = parse_comment_search("the cat")
+        assert parsed.boolean_query == "+cat"
+        assert parsed.like_terms == ["the"]
+
+    def test_all_terms_unindexable_produces_no_boolean_query(self):
+        parsed = parse_comment_search("the of")
+        assert parsed.boolean_query == ""
+        assert parsed.like_terms == ["the", "of"]
+
+    def test_non_ascii_falls_back_to_like(self):
+        # The default parser cannot see inside a whitespace-free CJK run.
+        parsed = parse_comment_search("かわいい")
+        assert parsed.boolean_query == ""
+        assert parsed.like_terms == ["かわいい"]
+
+    def test_mixed_ascii_and_cjk(self):
+        parsed = parse_comment_search("cute かわいい")
+        assert parsed.boolean_query == "+cute"
+        assert parsed.like_terms == ["かわいい"]
+
+    def test_quoted_phrase_uses_boolean_phrase_syntax(self):
+        parsed = parse_comment_search('"happy birthday"')
+        assert parsed.boolean_query == '+"happy birthday"'
+        assert parsed.like_terms == []
+
+    def test_quoted_phrase_with_unindexable_token_falls_back_to_like(self):
+        parsed = parse_comment_search('"the cat"')
+        assert parsed.boolean_query == ""
+        assert parsed.like_terms == ["the cat"]
+
+    def test_phrase_and_bare_word_combine(self):
+        parsed = parse_comment_search('"happy birthday" yui')
+        assert parsed.boolean_query == '+"happy birthday" +yui'
+
+    def test_negated_term_excludes(self):
+        parsed = parse_comment_search("happy -sad")
+        assert parsed.boolean_query == "+happy -sad"
+        assert parsed.not_like_terms == []
+
+    def test_only_negative_terms_fall_back_to_not_like(self):
+        # A boolean query with no positive term matches nothing in InnoDB.
+        parsed = parse_comment_search("-sad")
+        assert parsed.boolean_query == ""
+        assert parsed.not_like_terms == ["sad"]
+
+    def test_negated_unindexable_term_uses_not_like(self):
+        parsed = parse_comment_search("happy -ab")
+        assert parsed.boolean_query == "+happy"
+        assert parsed.not_like_terms == ["ab"]
+
+    def test_boolean_operators_in_input_cannot_reach_the_query(self):
+        # `+happy@birthday)` is ERROR 1064 if passed through verbatim.
+        parsed = parse_comment_search("happy@birthday)")
+        assert parsed.boolean_query == "+happy +birthday"
+        assert "@" not in parsed.boolean_query
+        assert ")" not in parsed.boolean_query
+
+    def test_hyphenated_word_splits_into_tokens(self):
+        # The fulltext parser breaks on `-`, so we must too.
+        parsed = parse_comment_search("well-known")
+        assert parsed.boolean_query == "+well +known"
+
+    def test_unbalanced_quote_does_not_crash(self):
+        parsed = parse_comment_search('happy "birthday')
+        assert parsed.boolean_query == "+happy +birthday"
+
+    def test_empty_input_is_empty(self):
+        assert parse_comment_search("").is_empty
+        assert parse_comment_search("   ").is_empty
+        assert parse_comment_search("!!!").is_empty
+
+    def test_case_is_preserved_but_stopwords_match_case_insensitively(self):
+        parsed = parse_comment_search("The Cat")
+        assert parsed.boolean_query == "+Cat"
+        assert parsed.like_terms == ["The"]
+
+
+class TestLikePattern:
+    def test_wraps_in_wildcards(self):
+        assert like_pattern("cat") == "%cat%"
+
+    def test_escapes_like_metacharacters(self):
+        # `100%` must search for a literal percent, not "anything".
+        assert like_pattern("100%") == "%100\\%%"
+        assert like_pattern("a_b") == "%a\\_b%"
+
+    def test_escapes_backslash_first(self):
+        assert like_pattern("a\\b") == "%a\\\\b%"
+
+
+class TestIsEmpty:
+    def test_is_empty_only_when_nothing_parsed(self):
+        assert CommentSearchQuery().is_empty
+        assert not CommentSearchQuery(boolean_query="+cat").is_empty
+        assert not CommentSearchQuery(like_terms=["ab"]).is_empty
+        assert not CommentSearchQuery(not_like_terms=["ab"]).is_empty


### PR DESCRIPTION
## Problem

Comment text search used MySQL fulltext **NATURAL LANGUAGE MODE**, which ORs its terms. Searching `happy birthday` returned comments containing only "happy". On the dev corpus (536,865 comments):

| Query for `happy birthday` | Comments matched |
|---|---|
| `NATURAL LANGUAGE MODE` (the old default) | 9,671 |
| both words anywhere | 2,214 |
| the literal phrase | 2,059 |

So ~79% of results contained only one of the two words. The relevance ranking that would justify OR-semantics was also discarded — `MATCH` appeared only in `WHERE`, never in `ORDER BY`.

## What this does

Adds an `all_words` mode and makes it the default for `commentsearch_mode` (`/images`) and `search_mode` (`/comments`). Every term is required. `"exact phrase"` and `-excluded` work.

The naive fix — prefixing every token with `+` — is badly broken, and `app/utils/comment_search.py` documents each failure mode with the measurement behind it:

- **Sub-minimum tokens.** `+happy +bd` → **0 rows** (`bd` is below `innodb_ft_min_token_size`), where natural mode returned 9,095.
- **Stopwords.** `+the +cat` → **0 rows**; `+cat` alone returns 1,612. A stopword in a boolean conjunction doesn't get ignored, it fails the whole query.
- **Only-negative queries.** `-sad` → 0 rows; InnoDB boolean mode needs a positive term.
- **Operator characters.** `+happy@birthday)` is **ERROR 1064**, not an empty result — a 500 on what would become the default path.
- **CJK.** The default parser treats a whitespace-free Japanese run as one token: `+かわいい` finds 33 rows where `LIKE` finds 52. 19,200 comments contain non-ASCII text.

So terms the index can see go into a `BOOLEAN MODE` conjunction; everything else falls back to `LIKE`. Both are ANDed, and no single term can zero the result set. Verified equivalent: `MATCH('+happy') AND LIKE '%bd%'` returns 47 rows, identical to pure `LIKE`, but index-backed on the selective term. Only `\w+` runs ever reach the boolean string, which is what makes the 1064 crash unreachable.

An unsearchable query (`!!!`) returns **zero rows**, matching the old behaviour; a blank parameter means **no filter** on both endpoints, which also fixes a pre-existing disagreement between them.

`natural`, `boolean` and `like` remain available explicitly.

## Notes for review

- **Merge this before the frontend PR.** The frontend sends `search_mode=all_words`; a pre-change API rejects it with 422.
- No migration. The fulltext index already exists everywhere.
- `test_commentsearch_boolean_mode` was a permanently-skipped stub claiming fulltext is unavailable in tests. That was false — conftest applies the full alembic chain and the pytest worker DBs do have `idx_post_text_fulltext`. It's replaced with tests that actually run.
- Several tests need `@pytest.mark.needs_commit`: the default `db_session` fixture uses SAVEPOINT-only commits that InnoDB FULLTEXT cannot see.
- `like` mode now escapes `%` and `_` to literals (previously they leaked through as wildcards). Documented in both docstrings.

## Testing

Full suite: **2489 passed, 10 skipped** (all pre-existing).

The OR→AND change was verified to be genuinely covered, not just asserted: reverting the default to `natural` makes `test_commentsearch_defaults_to_all_words` and its `/comments` twin fail with `assert 2 not in {1, 2}`. The `all_words` string itself is pinned by explicit-mode tests, and a bogus mode is pinned to 422, so a rename can't pass CI silently.

## Known limitations

A search whose terms are *all* unindexable degrades to pure `LIKE` — measured at 0.4–0.8s, ~1.4s including the count query. The hybrid path stays at 0.07s. Tracked with the other deferred items in frontend issue #351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ysk73Y2HFf9dsQ1Lo7hU8