### PR TITLE
Bound the cost of unindexable comment searches (B + E)

### DIFF
--- a/app/api/v1/comments.py
+++ b/app/api/v1/comments.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import selectinload
 from app.api.dependencies import CommentSortParams, PaginationParams
 from app.config import AdminActionType, ReportStatus
 from app.core.auth import get_current_user
-from app.core.database import get_db
+from app.core.database import get_db, statement_timeout
 from app.core.permissions import Permission, has_permission
 from app.core.redis import get_redis
 from app.models import Comments, Images, Users
@@ -30,7 +30,11 @@ from app.schemas.comment import (
 )
 from app.schemas.comment_report import CommentReportCreate, CommentReportResponse
 from app.schemas.common import UserSummary
-from app.utils.comment_search import apply_comment_text_search
+from app.utils.comment_search import (
+    COMMENT_SEARCH_TIMEOUT_SECONDS,
+    apply_comment_text_search,
+    reject_unindexable_comment_search,
+)
 
 router = APIRouter(prefix="/comments", tags=["comments"])
 
@@ -119,8 +123,13 @@ async def list_comments(
     # Text search with mode selection. A blank/whitespace-only search_text means
     # "not searching," not "search for nothing" -- `if search_text:` alone would
     # still call apply_comment_text_search for e.g. "   ".
-    if search_text and search_text.strip():
-        query = apply_comment_text_search(query, search_text, search_mode)
+    searching = bool(search_text and search_text.strip())
+    if searching:
+        reject_unindexable_comment_search(search_text, search_mode)  # type: ignore[arg-type]
+        query = apply_comment_text_search(query, search_text, search_mode)  # type: ignore[arg-type]
+    # Only the text-search path can degrade to an unindexed scan; None makes the
+    # bound a no-op so plain image_ids/user_id listings are untouched.
+    search_timeout = COMMENT_SEARCH_TIMEOUT_SECONDS if searching else None
 
     # Date filtering
     if date_from:
@@ -130,7 +139,8 @@ async def list_comments(
 
     # Count total results
     count_query = select(func.count()).select_from(query.subquery())
-    total_result = await db.execute(count_query)
+    async with statement_timeout(db, search_timeout):
+        total_result = await db.execute(count_query)
     total = total_result.scalar()
 
     # Apply sorting
@@ -152,7 +162,8 @@ async def list_comments(
     )
 
     # Execute query
-    result = await db.execute(query)
+    async with statement_timeout(db, search_timeout):
+        result = await db.execute(query)
     comments = result.scalars().all()
 
     return CommentListResponse(

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -48,7 +48,7 @@ from app.config import (
     settings,
 )
 from app.core.auth import CurrentUser, VerifiedUser, get_current_user, get_optional_current_user
-from app.core.database import get_db
+from app.core.database import get_db, statement_timeout
 from app.core.db_retry import retry_on_snapshot_conflict
 from app.core.logging import get_logger
 from app.core.permission_deps import require_permission
@@ -136,7 +136,11 @@ from app.services.tag_context import stamp_context_sources
 from app.services.tag_type_flags import refresh_image_tag_type_flags
 from app.services.upload import check_upload_rate_limit, link_tags_to_image, save_uploaded_image
 from app.tasks.queue import enqueue_job
-from app.utils.comment_search import apply_comment_text_search
+from app.utils.comment_search import (
+    COMMENT_SEARCH_TIMEOUT_SECONDS,
+    apply_comment_text_search,
+    reject_unindexable_comment_search,
+)
 
 logger = get_logger(__name__)
 
@@ -559,6 +563,12 @@ async def list_images(
     # entry all key off `commentsearch is not None`.
     if commentsearch is not None and not commentsearch.strip():
         commentsearch = None
+    if commentsearch is not None:
+        reject_unindexable_comment_search(commentsearch, commentsearch_mode)
+    # Only the comment-text path can degrade to an unindexed scan, so only it
+    # carries the bound; every other filter here is index-backed. None elsewhere
+    # makes statement_timeout a no-op, leaving the fast paths untouched.
+    search_timeout = COMMENT_SEARCH_TIMEOUT_SECONDS if commentsearch is not None else None
 
     # Build base query
     query = select(Images)
@@ -876,7 +886,8 @@ async def list_images(
             count_query = select(func.count()).select_from(distinct_ids.subquery())
         else:
             count_query = select(func.count()).select_from(query.subquery())
-        total = (await db.execute(count_query)).scalar() or 0
+        async with statement_timeout(db, search_timeout):
+            total = (await db.execute(count_query)).scalar() or 0
 
     # Performance optimization: Two-stage query for fast filtering and sorting
     #
@@ -944,7 +955,8 @@ async def list_images(
     )
 
     # Execute query
-    result = await db.execute(final_query)
+    async with statement_timeout(db, search_timeout):
+        result = await db.execute(final_query)
     images = result.scalars().all()
 
     # Get favorite status for authenticated users (separate query for clean separation)

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -2,8 +2,10 @@
 Database configuration and session management
 """
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
 
+from sqlalchemy import text as sql_text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import declarative_base
 
@@ -65,3 +67,34 @@ def get_async_session() -> AsyncSession:
     Note: Caller is responsible for committing/rolling back.
     """
     return AsyncSessionLocal()
+
+
+@asynccontextmanager
+async def statement_timeout(db: AsyncSession, seconds: float | None) -> AsyncIterator[None]:
+    """Bound how long each statement inside the block may run.
+
+    A circuit breaker for query plans that go wrong, not a performance policy:
+    the limit should sit well clear of the slowest legitimate query so it never
+    fires on real traffic. MariaDB's `max_statement_time` is per *statement*, so
+    a request issuing several still has a total ceiling of the limit times the
+    statement count.
+
+    Restoring on exit is not optional. Connections are pooled and returned to the
+    pool without resetting session variables, so a limit left set would silently
+    apply to whatever request picks that connection up next. `DEFAULT` restores
+    the server's global value rather than assuming it is 0.
+
+    Passing `seconds=None` is a no-op, so callers can wrap a statement
+    unconditionally and decide per request whether the bound applies.
+    """
+    if seconds is None:
+        yield
+        return
+
+    # float() coerces the value: SET does not take bind parameters, so this is
+    # interpolated, and the coercion is what keeps that safe.
+    await db.execute(sql_text(f"SET SESSION max_statement_time = {float(seconds)}"))
+    try:
+        yield
+    finally:
+        await db.execute(sql_text("SET SESSION max_statement_time = DEFAULT"))

--- a/app/utils/comment_search.py
+++ b/app/utils/comment_search.py
@@ -214,10 +214,7 @@ def reject_unindexable_comment_search(raw: str, mode: str | None) -> None:
     if parse_comment_search(raw).is_too_short_to_index:
         raise HTTPException(
             status_code=400,
-            detail=(
-                f"Comment search terms must be at least {MIN_TOKEN_SIZE} characters. "
-                "Searching only very short words would scan every comment."
-            ),
+            detail=f"Comment search terms must be at least {MIN_TOKEN_SIZE} characters.",
         )
 
 

--- a/app/utils/comment_search.py
+++ b/app/utils/comment_search.py
@@ -133,8 +133,16 @@ class CommentSearchQuery:
         """
         if self.boolean_query or self.is_empty:
             return False
-        terms = self.like_terms + self.not_like_terms
-        return all(t.isascii() and len(t) < MIN_TOKEN_SIZE for t in terms)
+        # Split back into words rather than measuring the stored entry: a quoted
+        # phrase is kept as one joined string, so `"ab cd"` would otherwise
+        # measure five characters and slip past the guard that refuses the very
+        # same two words unquoted.
+        words = [
+            word
+            for term in self.like_terms + self.not_like_terms
+            for word in _WORD_RE.findall(term)
+        ]
+        return bool(words) and all(w.isascii() and len(w) < MIN_TOKEN_SIZE for w in words)
 
 
 def like_pattern(term: str) -> str:

--- a/app/utils/comment_search.py
+++ b/app/utils/comment_search.py
@@ -23,6 +23,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
+from fastapi import HTTPException
 from sqlalchemy import Select, false
 from sqlalchemy import text as sql_text
 
@@ -31,6 +32,21 @@ from app.models import Comments
 # Must match innodb_ft_min_token_size on the server. Anything shorter is
 # absent from the index, so `+ab` matches nothing at all.
 MIN_TOKEN_SIZE = 3
+
+# Ceiling on a single comment-search statement, in seconds.
+#
+# A circuit breaker, not a performance policy. The slowest legitimate search is
+# an all-unindexable one (CJK, or short/stopword-only terms), which falls back to
+# an unindexed LIKE scan. Measured warm on a 536k-comment corpus: ~0.5s for the
+# count and ~0.8s for the page query, and — importantly — flat regardless of how
+# many rows match, because the cost is the scan rather than the result set.
+#
+# 5s leaves roughly 6x headroom for a cold buffer pool, concurrency and corpus
+# growth. That margin is the point: if this ever fires on a real search it
+# becomes a hard failure for Japanese comment search, which has no indexed path
+# at all (MariaDB has no ngram parser). It exists to turn a plan regression from
+# minutes into an error, nothing more.
+COMMENT_SEARCH_TIMEOUT_SECONDS = 5.0
 
 # information_schema.INNODB_FT_DEFAULT_STOPWORD, verbatim. A stopword inside a
 # boolean conjunction is not ignored -- it makes the whole conjunction fail.
@@ -93,6 +109,32 @@ class CommentSearchQuery:
     @property
     def is_empty(self) -> bool:
         return not (self.boolean_query or self.like_terms or self.not_like_terms)
+
+    @property
+    def is_too_short_to_index(self) -> bool:
+        """Whether this query can only be served by an unindexed table scan
+        *and* is short enough that refusing it costs the user nothing.
+
+        The scan is a flat ~0.5s on the count and ~0.8s on the page query,
+        independent of how many rows match, so a search of nothing but one- and
+        two-character words buys a second of database time for a result nobody
+        wants. Callers refuse these with a 400.
+
+        Length-based and ASCII-only, deliberately:
+
+        * Non-ASCII is always allowed. MariaDB has no ngram parser, so the LIKE
+          fallback is the *only* path CJK has -- refusing it would break Japanese
+          comment search entirely, which is the opposite of the intent.
+        * Long-but-unindexable terms (stopwords like "the", "www", "com") are
+          allowed. They are wasteful but they are real words someone may mean.
+        * The threshold is MIN_TOKEN_SIZE, so lowering innodb_ft_min_token_size
+          and rebuilding the index automatically narrows this guard instead of
+          leaving it refusing terms the index can now see.
+        """
+        if self.boolean_query or self.is_empty:
+            return False
+        terms = self.like_terms + self.not_like_terms
+        return all(t.isascii() and len(t) < MIN_TOKEN_SIZE for t in terms)
 
 
 def like_pattern(term: str) -> str:
@@ -157,6 +199,26 @@ def parse_comment_search(raw: str) -> CommentSearchQuery:
         parsed.not_like_terms.extend(n.strip('"') for n in negatives)
 
     return parsed
+
+
+def reject_unindexable_comment_search(raw: str, mode: str | None) -> None:
+    """Raise 400 for a search of nothing but very short ASCII words.
+
+    Only applies to the parsed `all_words` path; the explicit legacy modes hand
+    their string straight to MySQL and are left alone. See
+    `CommentSearchQuery.is_too_short_to_index` for why the rule is length-based
+    and never touches non-ASCII.
+    """
+    if (mode or "all_words") != "all_words":
+        return
+    if parse_comment_search(raw).is_too_short_to_index:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Comment search terms must be at least {MIN_TOKEN_SIZE} characters. "
+                "Searching only very short words would scan every comment."
+            ),
+        )
 
 
 def apply_comment_text_search(query: Select[Any], raw: str, mode: str | None) -> Select[Any]:

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -3123,6 +3123,59 @@ class TestCommentFilters:
         assert match.image_id in returned
         assert no_match.image_id not in returned
 
+    async def test_commentsearch_rejects_only_short_ascii_terms(self, client: AsyncClient):
+        """A search of nothing but 1-2 character ASCII words is refused.
+
+        It can only be served by an unindexed scan (~0.5s on the count, ~0.8s on
+        the page, flat regardless of match count) for a result nobody wants.
+        """
+        response = await client.get("/api/v1/images?commentsearch=ab")
+        assert response.status_code == 400
+        assert "at least" in response.json()["detail"].lower()
+
+        response = await client.get("/api/v1/images?commentsearch=ab cd")
+        assert response.status_code == 400
+
+    @pytest.mark.needs_commit  # FULLTEXT search requires committed data
+    async def test_commentsearch_allows_short_non_ascii_terms(
+        self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
+    ):
+        """CJK must never be refused: LIKE is the only path it has.
+
+        MariaDB has no ngram parser, so a short Japanese term is unindexable by
+        definition. Refusing it would break Japanese comment search outright.
+        """
+        from app.models import Comments
+
+        user = Users(
+            username="cjk_user",
+            email="cjk@test.com",
+            password="testpass",
+            password_type="bcrypt",
+            salt="testsalt0000019",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        image = Images(**{**sample_image_data, "user_id": user.user_id})
+        db_session.add(image)
+        await db_session.flush()
+        db_session.add(
+            Comments(image_id=image.image_id, user_id=user.user_id, post_text="とても猫")
+        )
+        await db_session.commit()
+
+        response = await client.get("/api/v1/images?commentsearch=猫")
+        assert response.status_code == 200
+        assert image.image_id in {img["image_id"] for img in response.json()["images"]}
+
+    async def test_commentsearch_allows_a_short_term_beside_an_indexable_one(
+        self, client: AsyncClient
+    ):
+        """One indexable term is enough to keep the query index-backed."""
+        response = await client.get("/api/v1/images?commentsearch=happy bd")
+        assert response.status_code == 200
+
     @pytest.mark.needs_commit  # FULLTEXT search requires committed data
     async def test_commentsearch_boolean_mode_passes_operators_through(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict

--- a/tests/integration/test_statement_timeout.py
+++ b/tests/integration/test_statement_timeout.py
@@ -1,0 +1,64 @@
+"""Statement-timeout circuit breaker.
+
+These run against the real database because the whole point is what MariaDB does
+with `max_statement_time` -- a stub would prove nothing.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import statement_timeout
+
+
+async def _session_limit(db: AsyncSession) -> float:
+    result = await db.execute(text("SELECT @@SESSION.max_statement_time"))
+    return float(result.scalar() or 0)
+
+
+class TestStatementTimeout:
+    async def test_applies_the_limit_inside_the_block(self, db_session: AsyncSession):
+        async with statement_timeout(db_session, 5.0):
+            assert await _session_limit(db_session) == 5.0
+
+    async def test_restores_the_limit_afterwards(self, db_session: AsyncSession):
+        before = await _session_limit(db_session)
+        async with statement_timeout(db_session, 5.0):
+            pass
+        assert await _session_limit(db_session) == before
+
+    async def test_restores_the_limit_even_when_the_body_raises(self, db_session: AsyncSession):
+        """Connections are pooled, so a leaked limit would hit the next request."""
+        before = await _session_limit(db_session)
+        with pytest.raises(RuntimeError):
+            async with statement_timeout(db_session, 5.0):
+                raise RuntimeError("boom")
+        assert await _session_limit(db_session) == before
+
+    async def test_none_is_a_no_op(self, db_session: AsyncSession):
+        before = await _session_limit(db_session)
+        async with statement_timeout(db_session, None):
+            assert await _session_limit(db_session) == before
+        assert await _session_limit(db_session) == before
+
+    # MariaDB killing the statement aborts the transaction under SQLAlchemy, which
+    # emits this on the rollback below. It is the expected consequence of the
+    # breaker firing, not a defect -- named explicitly so the suite's output stays
+    # clean without hiding anything else.
+    @pytest.mark.filterwarnings(
+        "ignore:transaction already deassociated from connection:sqlalchemy.exc.SAWarning"
+    )
+    async def test_a_statement_over_the_limit_is_killed(self, db_session: AsyncSession):
+        """The breaker must actually break, not just set a variable.
+
+        A tiny limit is used deliberately: the real 5s ceiling is chosen to never
+        fire on legitimate traffic, so provoking it needs an artificial one.
+        """
+        with pytest.raises(OperationalError):
+            async with statement_timeout(db_session, 0.05):
+                await db_session.execute(text("SELECT SLEEP(2)"))
+
+        # The session is still usable afterwards, and unbounded again.
+        await db_session.rollback()
+        assert await _session_limit(db_session) == 0.0

--- a/tests/unit/test_comment_search.py
+++ b/tests/unit/test_comment_search.py
@@ -153,6 +153,25 @@ class TestIsTooShortToIndex:
     def test_short_ascii_alongside_non_ascii_is_allowed(self):
         assert not parse_comment_search("ab かわいい").is_too_short_to_index
 
+    def test_a_quoted_phrase_of_short_words_is_too_short(self):
+        """Quoting must not smuggle a short-word search past the guard.
+
+        A phrase is stored as one joined `like_terms` entry, so `"ab cd"` looks
+        five characters long even though it is the same two two-letter words that
+        `ab cd` is refused for. Both run the identical unindexed scan.
+        """
+        assert parse_comment_search('"ab cd"').is_too_short_to_index
+
+    def test_a_quoted_phrase_with_a_long_word_is_allowed(self):
+        assert not parse_comment_search('"ab happy"').is_too_short_to_index
+
+    def test_a_quoted_phrase_containing_non_ascii_is_allowed(self):
+        assert not parse_comment_search('"ab かわいい"').is_too_short_to_index
+
+    def test_a_quoted_phrase_of_long_stopwords_is_allowed(self):
+        # Same reasoning as the bare-word case: unindexable, but not short.
+        assert not parse_comment_search('"the cat"').is_too_short_to_index
+
     def test_a_long_stopword_is_not_too_short(self):
         # `the` is unindexable, but it is not *short*. This guard is about length
         # only -- widening it to stopwords would also refuse "www" and "com".

--- a/tests/unit/test_comment_search.py
+++ b/tests/unit/test_comment_search.py
@@ -126,3 +126,49 @@ class TestIsEmpty:
         assert not CommentSearchQuery(boolean_query="+cat").is_empty
         assert not CommentSearchQuery(like_terms=["ab"]).is_empty
         assert not CommentSearchQuery(not_like_terms=["ab"]).is_empty
+
+
+class TestIsTooShortToIndex:
+    """The guard for searches worth refusing rather than table-scanning for.
+
+    Deliberately length-based and ASCII-only. Non-ASCII must always be allowed
+    through: MariaDB has no ngram parser, so CJK can only ever be served by the
+    LIKE fallback, and refusing it would break Japanese comment search outright.
+    """
+
+    def test_single_short_ascii_term_is_too_short(self):
+        assert parse_comment_search("ab").is_too_short_to_index
+
+    def test_all_short_ascii_terms_are_too_short(self):
+        assert parse_comment_search("ab cd").is_too_short_to_index
+
+    def test_one_indexable_term_is_enough(self):
+        assert not parse_comment_search("ab happy").is_too_short_to_index
+
+    def test_non_ascii_is_never_too_short(self):
+        # LIKE is the only path CJK has; refusing it would break Japanese search.
+        assert not parse_comment_search("かわいい").is_too_short_to_index
+        assert not parse_comment_search("猫").is_too_short_to_index
+
+    def test_short_ascii_alongside_non_ascii_is_allowed(self):
+        assert not parse_comment_search("ab かわいい").is_too_short_to_index
+
+    def test_a_long_stopword_is_not_too_short(self):
+        # `the` is unindexable, but it is not *short*. This guard is about length
+        # only -- widening it to stopwords would also refuse "www" and "com".
+        assert not parse_comment_search("the").is_too_short_to_index
+
+    def test_nothing_searchable_is_not_reported_as_too_short(self):
+        # "!!!" has no terms at all; that is the zero-rows case, not this one.
+        assert not parse_comment_search("!!!").is_too_short_to_index
+        assert not parse_comment_search("").is_too_short_to_index
+
+    def test_threshold_follows_min_token_size(self):
+        # Tuning innodb_ft_min_token_size must not leave this guard refusing
+        # terms the index can now see.
+        from app.utils.comment_search import MIN_TOKEN_SIZE
+
+        just_short = "a" * (MIN_TOKEN_SIZE - 1)
+        just_long = "a" * MIN_TOKEN_SIZE
+        assert parse_comment_search(just_short).is_too_short_to_index
+        assert not parse_comment_search(just_long).is_too_short_to_index


### PR DESCRIPTION
Implements options **B** and **E** from the fe#351 discussion. Both target the one comment-search path that can degrade to an unindexed scan.

## The measurement this is built on

An all-unindexable search (every term short, a stopword, or non-ASCII) falls back to `LIKE`. Measured warm on the 536,865-comment dev corpus:

| Shape | Cost |
|---|---|
| Count statement | ~0.50 s |
| Page statement (`LIMIT 20`, with the `ORDER BY` sort) | ~0.82 s |
| Sensitivity to match count | **none** — flat |

The last row is the useful one. `の` matched 590 images and `ab` matched 31,101, and both cost ~0.5 s: the cost is the scan, not the result set. So there is no pathological *legitimate* query that balloons, which is what makes a fixed ceiling safe.

End-to-end, against the dev API:

| Search | Path | Time |
|---|---|---|
| `happy birthday` | index-backed | 59 ms |
| `猫` | pure LIKE (CJK) | 1166 ms |
| `the` | pure LIKE (stopword) | 1453 ms |

## B — refuse searches of only very short ASCII words

`?commentsearch=ab` and `?commentsearch=ab cd` now return 400. They can only be served by that scan, for a result nobody wants.

The rule is **length-based and ASCII-only**, deliberately:

- **Non-ASCII is never refused.** MariaDB has no ngram parser (verified: `WITH PARSER ngram` → `ERROR 1128: Function 'ngram' is not defined`), so `LIKE` is the *only* path CJK has. Refusing it would break Japanese comment search outright — the opposite of the intent. `?commentsearch=猫` still returns 200.
- **Long-but-unindexable terms are allowed.** `the`, `www`, `com` are stopwords and still scan. They are wasteful but they are words someone may mean, and widening the rule to stopwords would refuse `www`.
- **One indexable term is enough.** `happy bd` stays index-backed and fast.
- **The threshold follows `MIN_TOKEN_SIZE`**, so lowering `innodb_ft_min_token_size` and rebuilding narrows this guard automatically instead of leaving it refusing terms the index can now see.

## E — bound each comment-search statement at 5s

A circuit breaker for a plan regression, not a performance policy. The slowest real request measured is 1.45 s, so 5 s leaves ~3.4× headroom on the request and ~6× per statement — enough for a cold buffer pool, concurrency and corpus growth.

**The headroom is the point.** If this ever fires on a real search it becomes a hard failure for exactly the CJK searches B is written to protect. It exists to turn a plan regression from minutes into an error, nothing more.

- **Scoped to the search path.** A global `max_statement_time` would kill `ml_remap`, the co-occurrence materialisation, `prune_inactive_users` and `restore_prod_db`, all long-running by design.
- **Restored on exit, including on the exception path.** Connections are pooled and returned without resetting session variables, so a leaked limit would silently apply to whichever request picks that connection up next. `DEFAULT` restores the server global rather than assuming 0.
- `seconds=None` is a no-op, so the fast paths are wrapped without paying anything.

Note `max_statement_time` is **per statement**, and these endpoints issue two, so the request ceiling is ~10 s. A true request bound would be a different control.

## Testing

**2509 passed, 10 skipped** (up 16). mypy clean across 165 files; ruff clean apart from two pre-existing B007s in `test_images.py`.

The timeout tests run against the real database — a stub would prove nothing about what MariaDB does with `max_statement_time`. They cover that the limit applies, that it is restored normally *and* after an exception, that `None` is a no-op, and that the breaker genuinely kills an over-long statement rather than merely setting a variable.

## Not included

The remaining fe#351 items, and the InnoDB tuning discussion (`innodb_ft_min_token_size`, stopword table) — that would make the ASCII half of this problem largely disappear, and is worth doing on its own. Worth noting the slowest case above (`the`, 1.45 s) is a *stopword*, which B deliberately does not refuse and tuning would fix properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ysk73Y2HFf9dsQ1Lo7hU8