### PR TITLE
fix(users): default new accounts to grid and repair legacy thumb_layout=2

### DIFF
--- a/alembic/versions/0a2bc955ec55_default_thumb_layout_to_grid.py
+++ b/alembic/versions/0a2bc955ec55_default_thumb_layout_to_grid.py
@@ -1,0 +1,44 @@
+"""default thumb_layout to grid
+
+Revision ID: 0a2bc955ec55
+Revises: e380b541ec9f
+Create Date: 2026-08-14 08:21:24.412218
+
+"""
+from typing import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '0a2bc955ec55'
+down_revision: str | Sequence[str] | None = 'e380b541ec9f'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Point the column default at grid (1) to match the model default.
+
+    An anonymous visitor sees grid (the frontend resolves a missing
+    preference to grid), so a list default meant creating an account silently
+    switched the layout. Only new rows are affected: existing rows keep what
+    they hold, because among recently active users who have demonstrably
+    changed some other display preference, list is still the majority — the
+    stored 0s are not all inherited defaults (FE #309).
+
+    Metadata-only: SET DEFAULT rewrites the table definition, never the rows.
+    Stated explicitly so the migration fails loudly rather than silently
+    falling back to a locking rewrite of the users table.
+    """
+    op.execute(
+        "ALTER TABLE users ALTER COLUMN thumb_layout SET DEFAULT 1, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )
+
+
+def downgrade() -> None:
+    """Restore the legacy list default."""
+    op.execute(
+        "ALTER TABLE users ALTER COLUMN thumb_layout SET DEFAULT 0, "
+        "ALGORITHM=INSTANT, LOCK=NONE"
+    )

--- a/alembic/versions/e380b541ec9f_normalize_legacy_thumb_layout_2_to_grid.py
+++ b/alembic/versions/e380b541ec9f_normalize_legacy_thumb_layout_2_to_grid.py
@@ -1,0 +1,37 @@
+"""normalize legacy thumb_layout 2 to grid
+
+Revision ID: e380b541ec9f
+Revises: 40205fe4b1b6
+Create Date: 2026-08-14 08:21:22.950451
+
+"""
+from typing import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'e380b541ec9f'
+down_revision: str | Sequence[str] | None = '40205fe4b1b6'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Collapse legacy thumb_layout=2 rows onto grid (1).
+
+    thumb_layout is documented and validated as 0=list, 1=grid — the API
+    rejects anything else (app/schemas/user.py validate_boolean_prefs) — but
+    ~10% of rows carry a 2 inherited from the old site. The frontend's
+    view-mode store reads any non-zero value as grid, so those users already
+    see grid; the settings radios, however, test `=== 1` and `=== 0`, leaving
+    Display Preferences rendered with neither option selected and no way to
+    see the current state. Writing 1 preserves the layout they already get
+    and makes the stored value match the documented domain.
+    """
+    op.execute("UPDATE users SET thumb_layout = 1 WHERE thumb_layout = 2")
+
+
+def downgrade() -> None:
+    # Irreversible: a repaired row is indistinguishable from one that has
+    # always said 1. Intentionally a no-op.
+    pass

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -168,7 +168,9 @@ class Users(UserBase, table=True):
     # User preferences (private)
     email_pm_pref: int = Field(default=1)
     spoiler_warning_pref: int = Field(default=1)
-    thumb_layout: int = Field(default=0)
+    # 0=list, 1=grid. Grid matches what anonymous visitors see, so signing up
+    # no longer changes the layout out from under a new user (FE #309).
+    thumb_layout: int = Field(default=1)
     # Grid thumbnail size step in CSS pixels. Stored as the pixel value rather
     # than an ordinal so that adding steps stays additive — an ordinal would
     # silently change the meaning of existing rows. Validated against the

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -403,6 +403,27 @@ class TestCreateUser:
         response = await client.post("/api/v1/users", json=user_data)
         assert response.status_code == 400
 
+    async def test_create_user_defaults_to_grid_view(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """New accounts start in grid view, which is what anonymous visitors see.
+
+        The legacy default was list (0), so signing up silently changed the
+        layout out from under a visitor.
+        """
+        user_data = {
+            "username": "gridbydefault",
+            "email": "gridbydefault@example.com",
+            "password": "SecurePassword123!",
+            "turnstile_token": "test-token",
+        }
+
+        response = await client.post("/api/v1/users", json=user_data)
+        assert response.status_code == 200
+
+        result = await db_session.execute(select(Users).where(Users.username == "gridbydefault"))
+        assert result.scalar_one().thumb_layout == 1
+
 
 @pytest.mark.api
 class TestGetCurrentUserProfile:


### PR DESCRIPTION
Fixes anonymousobject/shuushuu-frontend#309.

## Grid is now the default for new accounts

An anonymous visitor sees grid — the frontend resolves a missing preference to grid (`viewMode.svelte.ts` treats anything non-zero as grid, and every server load defaults to `?? 1`). The column defaulted to `0` (list), so creating an account silently changed the layout out from under the new user.

`app/models/user.py` is what actually governs registration (`create_user` builds `Users(...)` and lets model defaults fill the rest); the migration keeps the column default in step for anything inserting outside the app.

**Existing rows are untouched.** Among users active since 2024 who have demonstrably changed some *other* display preference — a proxy for "expresses preferences" — the split is 195 list / 80 grid / 109 legacy-2. List is still ~51%, so the stored `0`s are not all inherited defaults, and flipping 15,895 rows would move the site under people who may well have chosen it.

## Legacy `thumb_layout = 2` repaired

`thumb_layout` is documented and validated as `0=list, 1=grid` (`validate_boolean_prefs` rejects anything else), but ~10% of rows carry a `2` inherited from the old site. The store reads non-zero as grid, so those users already see grid — but the settings radios test `=== 1` and `=== 0`, so **Display Preferences renders with neither option selected** and no way to see the current state.

Writing `1` preserves the layout they already get. Fixed in the data rather than in the frontend radios: the API rejects `2` on write, so once repaired the value is unreachable — tolerating it in the UI would be treating the symptom.

## Verification

TDD on the default: `test_create_user_defaults_to_grid_view` was watched failing (`assert 0 == 1`) before the model default flipped. Full suite after: **2514 passed, 10 skipped**.

The data repair follows the existing convention for data migrations (raw SQL in `op.execute`, as in `7d98087eabcb`, which likewise carries no test), so it is *not* covered by a test. Verified against the dev database instead:

```
before:  0 → 15,895   1 →   232   2 → 1,837    DEFAULT 0
after:   0 → 15,895   1 → 2,069                DEFAULT 1
```

`downgrade -2` → `upgrade head` round-trips cleanly: the default reverts, and the data repair is deliberately a no-op on downgrade, since a repaired row is indistinguishable from one that always said `1`.

The default migration is metadata-only (`ALTER COLUMN ... SET DEFAULT` with `ALGORITHM=INSTANT, LOCK=NONE`) — no rewrite of the users table.

## Deploy

Needs `make prod-migrate` before the deploy. No frontend change accompanies this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHsrMknnDr4wWHnGFvBXWP