### PR TITLE
test(ratings): drop the anyio marker that breaks the suite in CI

### DIFF
--- a/tests/api/v1/test_user_ratings_endpoint.py
+++ b/tests/api/v1/test_user_ratings_endpoint.py
@@ -1,12 +1,19 @@
-"""Tests for GET /api/v1/users/{user_id}/ratings."""
+"""Tests for GET /api/v1/users/{user_id}/ratings.
 
-import pytest
+No `pytest.mark.anyio` here: the suite runs on pytest-asyncio
+(`asyncio_mode = "auto"`), and the anyio marker makes both plugins claim
+the same test. anyio then runs the test body in a runner of its own while
+pytest-asyncio sets up `engine`/`db_session` in the per-test asyncio loop --
+or the reverse, depending on which plugin registered first, which is not
+stable across environments. The loser's connection belongs to a dead loop
+and every test in the file dies on "got Future attached to a different
+loop" (see the `engine` fixture docstring in tests/conftest.py).
+"""
+
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Favorites, ImageRatings, Images, Users
-
-pytestmark = pytest.mark.anyio
 
 
 async def _make_user(db_session: AsyncSession, username: str) -> Users:


### PR DESCRIPTION
**main is red right now.** Re-running the last green CI run on main (`31598498388`, green 2026-08-12) fails today on the identical commit, so this is environment drift surfacing a latent fragility, not a regression from any recent PR. Every PR will fail CI until this lands.

## Symptom

All 13 tests in `tests/api/v1/test_user_ratings_endpoint.py` fail with:

```
RuntimeError: Task <Task pending coro=<...test_anonymous_is_rejected()>>
got Future <Future pending> attached to a different loop
```

They fail across all four xdist workers, so it is not a scheduling or pairing effect. The suite passes locally either way — which is exactly what a plugin-registration-order bug looks like.

## Cause

This file is the only one carrying `pytestmark = pytest.mark.anyio`, while the suite runs on pytest-asyncio with `asyncio_mode = "auto"`. Both plugins then claim the same items:

- anyio's `pytest_pycollect_makeitem` attaches the `anyio_backend` fixture, and its `pytest_pyfunc_call` (`tryfirst`) runs the coroutine in an anyio runner.
- pytest-asyncio's auto mode adds the `asyncio` marker to the same items and wraps the async fixtures in its own per-test loop.

Both hooks are `tryfirst`/`hookwrapper`, so which one wins is decided by plugin registration order — not stable across environments. When the test body lands in one loop and `engine`/`db_session` were set up in the other, the aiomysql connection belongs to a loop the test is not running in, and every DB call dies. The `engine` fixture in `tests/conftest.py` already documents this exact failure mode in its docstring.

## Fix

Drop the marker. The file then runs under pytest-asyncio like the other ~2,500 tests, so fixtures and test body share one loop by construction. Nothing else in the file used anyio, and the `anyio_backend` fixture in conftest stays for anything that genuinely wants it.

The comment block replacing the marker records why it must not come back.

## Verification

Passes locally (15 passed). Local runs were green before this change too, so **CI on this PR is the real check** — main being red on the same tests today is the control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHsrMknnDr4wWHnGFvBXWP