### PR TITLE
fix(tags): guard type changes against character-source links and alias canonicals

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -420,6 +420,70 @@ async def validate_tag_relationships(
             )
 
 
+# A source can carry hundreds of characters, so the error names a sample
+# rather than every counterpart.
+_LINKED_TAG_SAMPLE_SIZE = 5
+
+
+def _linked_tag_sample(titles: list[str]) -> str:
+    """Render counterpart titles for an error message, capped in length."""
+    sample = ", ".join(f"'{title}'" for title in titles[:_LINKED_TAG_SAMPLE_SIZE])
+    remaining = len(titles) - _LINKED_TAG_SAMPLE_SIZE
+    return f"{sample} and {remaining} more" if remaining > 0 else sample
+
+
+async def validate_character_source_links_for_type(
+    db: AsyncSession, *, tag_id: int, new_type: int
+) -> None:
+    """Reject a type change that would orphan the tag's character-source links.
+
+    Links are only reachable from a CHARACTER tag's page (its sources) and a
+    SOURCE tag's page (its characters), and both sides are type-checked when a
+    link is created. A tag retyped out of either role therefore leaves its rows
+    behind as orphans: invisible on its own page, still listed on the
+    counterpart's. Blocking keeps the link (and its picture crop) intact and
+    puts the delete in the moderator's hands.
+
+    Raises HTTPException(400) on validation failure.
+    """
+    if new_type != TagType.CHARACTER:
+        linked_sources = await db.execute(
+            select(Tags.title)  # type: ignore[call-overload]
+            .join(CharacterSourceLinks, Tags.tag_id == CharacterSourceLinks.source_tag_id)
+            .where(CharacterSourceLinks.character_tag_id == tag_id)
+            .order_by(Tags.title)
+        )
+        source_titles = [row[0] for row in linked_sources]
+        if source_titles:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Cannot change tag type: this tag is linked as a character to "
+                    f"{len(source_titles)} source tag(s): {_linked_tag_sample(source_titles)}. "
+                    f"Remove the character-source link(s) first."
+                ),
+            )
+
+    if new_type != TagType.SOURCE:
+        linked_characters = await db.execute(
+            select(Tags.title)  # type: ignore[call-overload]
+            .join(CharacterSourceLinks, Tags.tag_id == CharacterSourceLinks.character_tag_id)
+            .where(CharacterSourceLinks.source_tag_id == tag_id)
+            .order_by(Tags.title)
+        )
+        character_titles = [row[0] for row in linked_characters]
+        if character_titles:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Cannot change tag type: this tag is linked as a source to "
+                    f"{len(character_titles)} character tag(s): "
+                    f"{_linked_tag_sample(character_titles)}. "
+                    f"Remove the character-source link(s) first."
+                ),
+            )
+
+
 @router.get("/suggestion-stats", response_model=TagSuggestionStatsResponse)
 async def get_tag_suggestion_stats(
     pagination: Annotated[PaginationParams, Depends()],
@@ -1713,6 +1777,32 @@ async def update_tag(
         inheritedfrom_id=inheritedfrom_id,
         alias_of=alias_id,
     )
+
+    if new_type != tag.type:
+        # An alias is a synonym of its canonical -- same concept, same type. A
+        # request that edits the type without touching alias_of never reaches
+        # the check above, so re-validate against the existing canonical here.
+        # Only the type match is re-run: feeding the existing target through
+        # validate_tag_relationships would also re-run the chain and children
+        # checks and 400 unrelated edits on legacy rows.
+        if "alias_of" not in update_data and tag.alias_of is not None:
+            canonical_result = await db.execute(
+                select(Tags).where(Tags.tag_id == tag.alias_of)  # type: ignore[arg-type]
+            )
+            canonical_tag = canonical_result.scalar_one_or_none()
+            if canonical_tag is not None and canonical_tag.type != new_type:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Cannot give an alias a different type than its canonical. "
+                        f"This tag is an alias of '{canonical_tag.title}' "
+                        f"(id: {tag.alias_of}), which has type {canonical_tag.type}, "
+                        f"not {new_type}. Retype the canonical instead: the change "
+                        f"cascades to its aliases."
+                    ),
+                )
+
+        await validate_character_source_links_for_type(db, tag_id=tag_id, new_type=new_type)
 
     # Update fields
     for key, value in update_data.items():

--- a/scripts/repair_character_source_link_aliases.sql
+++ b/scripts/repair_character_source_link_aliases.sql
@@ -1,0 +1,120 @@
+-- Repair character_source_links rows whose character or source side is an alias.
+--
+-- Links are created against canonical tags only (the API rejects aliases on
+-- both sides), and aliasing a linked tag migrates its links to the canonical.
+-- Rows that still point at an alias predate those guards -- legacy imports and
+-- alias edits made outside the API. They duplicate the canonical tag's links
+-- and are invisible to any lookup that resolves aliases first.
+--
+-- Re-pointing follows alias_of ONE hop, and only when the canonical can legally
+-- hold the row: character side type=4, source side type=2, neither itself an
+-- alias. Rows whose canonical fails that test, and rows whose canonical pair is
+-- already taken, are left untouched and reported instead -- deleting either one
+-- is a judgment call (it can drop a curated link picture), so it stays manual.
+--
+-- Nothing here deletes. Run 1 (preview) -> 2 (re-point) -> 3 (verify):
+--
+--   docker exec -i shuushuu-mariadb-dev mariadb -uroot -p<pw> shuushuu_dev \
+--     < scripts/repair_character_source_link_aliases.sql
+--
+-- Statement 2 is idempotent; a second run finds nothing to do. No tag_audit_log
+-- rows are written: the API's own alias-migration path (update_tag) doesn't
+-- audit character-source link moves either.
+
+
+-- 1. Preview. `action` says what statement 2 will do with each row.
+-- The taken-pair test resolves other rows' targets without the type guard, so
+-- it errs toward flagging: a row marked SKIP-taken is worth eyeballing, not
+-- necessarily broken.
+-- START TRANSACTION;
+SELECT csl.id,
+       csl.character_tag_id,
+       ct.title AS character_title,
+       COALESCE(cc.tag_id, csl.character_tag_id) AS target_character_tag_id,
+       csl.source_tag_id,
+       st.title AS source_title,
+       COALESCE(cs.tag_id, csl.source_tag_id) AS target_source_tag_id,
+       (SELECT COUNT(*) FROM character_source_link_pictures p WHERE p.link_id = csl.id) AS has_picture,
+       CASE
+           WHEN (ct.alias_of IS NOT NULL AND (cc.tag_id IS NULL OR cc.type <> 4 OR cc.alias_of IS NOT NULL))
+             OR (st.alias_of IS NOT NULL AND (cs.tag_id IS NULL OR cs.type <> 2 OR cs.alias_of IS NOT NULL))
+               THEN 'SKIP - canonical cannot hold this row, review by hand'
+           WHEN EXISTS (
+               SELECT 1
+               FROM character_source_links other
+               JOIN tags other_ct ON other_ct.tag_id = other.character_tag_id
+               JOIN tags other_st ON other_st.tag_id = other.source_tag_id
+               WHERE other.id <> csl.id
+                 AND COALESCE(other_ct.alias_of, other.character_tag_id)
+                     = COALESCE(cc.tag_id, csl.character_tag_id)
+                 AND COALESCE(other_st.alias_of, other.source_tag_id)
+                     = COALESCE(cs.tag_id, csl.source_tag_id)
+           ) THEN 'SKIP - canonical pair already taken, review by hand'
+           ELSE 'REPOINT'
+       END AS action
+FROM character_source_links csl
+JOIN tags ct ON ct.tag_id = csl.character_tag_id
+JOIN tags st ON st.tag_id = csl.source_tag_id
+LEFT JOIN tags cc ON cc.tag_id = ct.alias_of
+LEFT JOIN tags cs ON cs.tag_id = st.alias_of
+WHERE ct.alias_of IS NOT NULL
+   OR st.alias_of IS NOT NULL
+ORDER BY csl.id;
+
+
+-- 2. Re-point onto the canonical tags. `taken` holds every link's resolved
+-- target pair, so a row is skipped both when another row already sits at its
+-- target and when another alias row is heading for the same pair -- the update
+-- can't trip unique_character_source.
+UPDATE character_source_links csl
+JOIN tags ct ON ct.tag_id = csl.character_tag_id
+JOIN tags st ON st.tag_id = csl.source_tag_id
+LEFT JOIN tags cc ON cc.tag_id = ct.alias_of
+LEFT JOIN tags cs ON cs.tag_id = st.alias_of
+LEFT JOIN (
+    SELECT other.id,
+           COALESCE(other_ct.alias_of, other.character_tag_id) AS target_character_tag_id,
+           COALESCE(other_st.alias_of, other.source_tag_id) AS target_source_tag_id
+    FROM character_source_links other
+    JOIN tags other_ct ON other_ct.tag_id = other.character_tag_id
+    JOIN tags other_st ON other_st.tag_id = other.source_tag_id
+) taken
+  ON taken.id <> csl.id
+ AND taken.target_character_tag_id = COALESCE(cc.tag_id, csl.character_tag_id)
+ AND taken.target_source_tag_id = COALESCE(cs.tag_id, csl.source_tag_id)
+SET csl.character_tag_id = COALESCE(cc.tag_id, csl.character_tag_id),
+    csl.source_tag_id = COALESCE(cs.tag_id, csl.source_tag_id)
+WHERE (ct.alias_of IS NOT NULL OR st.alias_of IS NOT NULL)
+  AND (ct.alias_of IS NULL OR (cc.tag_id IS NOT NULL AND cc.type = 4 AND cc.alias_of IS NULL))
+  AND (st.alias_of IS NULL OR (cs.tag_id IS NOT NULL AND cs.type = 2 AND cs.alias_of IS NULL))
+  AND taken.id IS NULL;
+
+
+-- 3. Verify. `repairable_remaining` must be 0; whatever is left in
+-- `alias_side_rows_remaining` is the manual-review pile, listed by statement 1.
+SELECT
+    SUM(CASE
+            WHEN (ct.alias_of IS NULL OR (cc.tag_id IS NOT NULL AND cc.type = 4 AND cc.alias_of IS NULL))
+             AND (st.alias_of IS NULL OR (cs.tag_id IS NOT NULL AND cs.type = 2 AND cs.alias_of IS NULL))
+             AND NOT EXISTS (
+                 SELECT 1
+                 FROM character_source_links other
+                 JOIN tags other_ct ON other_ct.tag_id = other.character_tag_id
+                 JOIN tags other_st ON other_st.tag_id = other.source_tag_id
+                 WHERE other.id <> csl.id
+                   AND COALESCE(other_ct.alias_of, other.character_tag_id)
+                       = COALESCE(cc.tag_id, csl.character_tag_id)
+                   AND COALESCE(other_st.alias_of, other.source_tag_id)
+                       = COALESCE(cs.tag_id, csl.source_tag_id)
+             )
+                THEN 1 ELSE 0
+        END) AS repairable_remaining,
+    COUNT(*) AS alias_side_rows_remaining
+FROM character_source_links csl
+JOIN tags ct ON ct.tag_id = csl.character_tag_id
+JOIN tags st ON st.tag_id = csl.source_tag_id
+LEFT JOIN tags cc ON cc.tag_id = ct.alias_of
+LEFT JOIN tags cs ON cs.tag_id = st.alias_of
+WHERE ct.alias_of IS NOT NULL
+   OR st.alias_of IS NOT NULL;
+-- ROLLBACK;

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -4272,6 +4272,231 @@ class TestUpdateTag:
         assert tag_p.type == TagType.ARTIST
         assert tag_p.alias_of == tag_b.tag_id
 
+    async def _admin_token(
+        self, client: AsyncClient, db_session: AsyncSession, username: str
+    ) -> str:
+        """Create an admin with TAG_UPDATE and return their access token."""
+        perm = Perms(title="tag_update", desc="Update tags")
+        db_session.add(perm)
+        await db_session.commit()
+        await db_session.refresh(perm)
+
+        admin = Users(
+            username=username,
+            password=get_password_hash("AdminPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email=f"{username}@example.com",
+            active=1,
+            admin=1,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+
+        db_session.add(UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1))
+        await db_session.commit()
+
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": username, "password": "AdminPassword123!"},
+        )
+        return str(login_response.json()["access_token"])
+
+    async def test_type_change_blocked_while_linked_as_character(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A character tag that holds character-source links can't be retyped:
+        the link rows would survive as orphans, invisible on the retyped tag's
+        own page but still listed on the source it points at."""
+        access_token = await self._admin_token(client, db_session, "adminretypechar")
+
+        char_tag = Tags(title="Retype Char", desc="", type=TagType.CHARACTER)
+        source_tag = Tags(title="Retype Char Source", desc="", type=TagType.SOURCE)
+        db_session.add_all([char_tag, source_tag])
+        await db_session.commit()
+        await db_session.refresh(char_tag)
+        await db_session.refresh(source_tag)
+
+        db_session.add(
+            CharacterSourceLinks(
+                character_tag_id=char_tag.tag_id, source_tag_id=source_tag.tag_id
+            )
+        )
+        await db_session.commit()
+
+        response = await client.put(
+            f"/api/v1/tags/{char_tag.tag_id}",
+            json={"title": "Retype Char", "type": TagType.SOURCE},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 400
+        assert "character-source link" in response.json()["detail"]
+
+        # The tag keeps its type and the link survives untouched
+        await db_session.refresh(char_tag)
+        assert char_tag.type == TagType.CHARACTER
+        links_result = await db_session.execute(
+            select(CharacterSourceLinks).where(
+                CharacterSourceLinks.character_tag_id == char_tag.tag_id
+            )
+        )
+        assert len(links_result.scalars().all()) == 1
+
+    async def test_type_change_blocked_while_linked_as_source(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Mirror case: a source tag with characters linked to it can't be
+        retyped out of SOURCE."""
+        access_token = await self._admin_token(client, db_session, "adminretypesource")
+
+        char_tag = Tags(title="Retype Source Char", desc="", type=TagType.CHARACTER)
+        source_tag = Tags(title="Retype Source", desc="", type=TagType.SOURCE)
+        db_session.add_all([char_tag, source_tag])
+        await db_session.commit()
+        await db_session.refresh(char_tag)
+        await db_session.refresh(source_tag)
+
+        db_session.add(
+            CharacterSourceLinks(
+                character_tag_id=char_tag.tag_id, source_tag_id=source_tag.tag_id
+            )
+        )
+        await db_session.commit()
+
+        response = await client.put(
+            f"/api/v1/tags/{source_tag.tag_id}",
+            json={"title": "Retype Source", "type": TagType.THEME},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 400
+        assert "character-source link" in response.json()["detail"]
+
+        await db_session.refresh(source_tag)
+        assert source_tag.type == TagType.SOURCE
+
+    async def test_unrelated_edit_allowed_while_linked_as_character(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """The link guard is scoped to type changes: a description edit on a
+        linked character tag must still go through."""
+        access_token = await self._admin_token(client, db_session, "admindesclinked")
+
+        char_tag = Tags(title="Linked Char Desc", desc="old", type=TagType.CHARACTER)
+        source_tag = Tags(title="Linked Char Desc Source", desc="", type=TagType.SOURCE)
+        db_session.add_all([char_tag, source_tag])
+        await db_session.commit()
+        await db_session.refresh(char_tag)
+        await db_session.refresh(source_tag)
+
+        db_session.add(
+            CharacterSourceLinks(
+                character_tag_id=char_tag.tag_id, source_tag_id=source_tag.tag_id
+            )
+        )
+        await db_session.commit()
+
+        response = await client.put(
+            f"/api/v1/tags/{char_tag.tag_id}",
+            json={"title": "Linked Char Desc", "desc": "new"},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+
+        await db_session.refresh(char_tag)
+        assert char_tag.desc == "new"
+
+    async def test_retyping_alias_rejects_mismatch_with_canonical(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Issue #307: editing an alias's own type -- without touching
+        alias_of -- must still be validated against its existing canonical."""
+        access_token = await self._admin_token(client, db_session, "adminaliasretype")
+
+        canonical = Tags(title="Alias Retype Canonical", desc="", type=TagType.THEME)
+        db_session.add(canonical)
+        await db_session.commit()
+        await db_session.refresh(canonical)
+
+        alias = Tags(
+            title="Alias Retype Alias", desc="", type=TagType.THEME, alias_of=canonical.tag_id
+        )
+        db_session.add(alias)
+        await db_session.commit()
+        await db_session.refresh(alias)
+
+        response = await client.put(
+            f"/api/v1/tags/{alias.tag_id}",
+            json={"title": "Alias Retype Alias", "type": TagType.ARTIST},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "different type than its canonical" in detail
+        assert "Alias Retype Canonical" in detail
+
+        await db_session.refresh(alias)
+        assert alias.type == TagType.THEME
+
+    async def test_retyping_alias_to_match_canonical_repairs_row(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """The type-match check still allows repairing an already-mismatched
+        alias by setting it to its canonical's type."""
+        access_token = await self._admin_token(client, db_session, "adminaliasrepair")
+
+        canonical = Tags(title="Alias Repair Canonical", desc="", type=TagType.ARTIST)
+        db_session.add(canonical)
+        await db_session.commit()
+        await db_session.refresh(canonical)
+
+        # Legacy mismatched row, written directly to bypass API validation
+        alias = Tags(
+            title="Alias Repair Alias", desc="", type=TagType.THEME, alias_of=canonical.tag_id
+        )
+        db_session.add(alias)
+        await db_session.commit()
+        await db_session.refresh(alias)
+
+        response = await client.put(
+            f"/api/v1/tags/{alias.tag_id}",
+            json={"title": "Alias Repair Alias", "type": TagType.ARTIST},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+
+        await db_session.refresh(alias)
+        assert alias.type == TagType.ARTIST
+
+    async def test_editing_mismatched_alias_description_still_allowed(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """The #307 check is scoped to type edits: an unrelated description
+        edit on an already-mismatched alias must not 400."""
+        access_token = await self._admin_token(client, db_session, "adminaliasdesc")
+
+        canonical = Tags(title="Alias Desc Canonical", desc="", type=TagType.ARTIST)
+        db_session.add(canonical)
+        await db_session.commit()
+        await db_session.refresh(canonical)
+
+        alias = Tags(
+            title="Alias Desc Alias", desc="old", type=TagType.THEME, alias_of=canonical.tag_id
+        )
+        db_session.add(alias)
+        await db_session.commit()
+        await db_session.refresh(alias)
+
+        response = await client.put(
+            f"/api/v1/tags/{alias.tag_id}",
+            json={"title": "Alias Desc Alias", "desc": "new"},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == 200
+
+        await db_session.refresh(alias)
+        assert alias.desc == "new"
+
 
 @pytest.mark.api
 class TestDeleteTag:


### PR DESCRIPTION
Closes #324. Closes #307.

Two holes in `PUT /api/v1/tags/{tag_id}`: a type change went through with no regard for the relationships that depend on that type.

## Character-source links (#324, reported by WhiteKitten)

> it lets you swap a tag type from character to something (e.g. source) else even if the character tag is linked to a source--the link disappears from the changed tag page but still exists on the page the tag was linked to

`update_tag` recomputed image tag-type flags and cascaded the type to incoming aliases, but never touched `character_source_links`. Both sides of a link are strictly type-checked at creation, and `get_tag` branches its link query on `tag.type` — a CHARACTER tag reads "sources where `character_tag_id` = me", a SOURCE tag reads "characters where `source_tag_id` = me". So a retyped tag's rows survive but get read from the wrong side: gone from its own page, still listed on the counterpart's (that join has no type filter on the other side). Mirror hole for retyping a SOURCE with characters linked to it.

`validate_character_source_links_for_type()` now blocks the change while the tag holds links in a role its new type can't fill, naming up to five counterparts plus a count — one source in prod carries 984 characters, so listing them all was out.

**Why block instead of cascade-delete.** A link can carry a curated picture crop; destroying that silently on a type edit isn't recoverable. This follows the existing precedent for `Cannot make a tag with children into an alias... Reassign or remove child tags first`.

## Alias canonicals (#307)

`validate_tag_relationships` only runs its alias-type check when `alias_of` is in the payload, so a type-only edit on an alias never saw its canonical. The fix is the issue's option 1: re-check the existing canonical on type edits, comparing **types only**. Feeding the existing target through the full validation would re-run the chain and children checks and 400 unrelated edits on legacy rows. An already-mismatched alias stays repairable by setting it to its canonical's type, and the error points at the canonical-retype path that cascades.

Both guards are gated on the type actually changing — that's what keeps them from blocking description edits on rows that are already corrupt.

## Data repair

`scripts/repair_character_source_link_aliases.sql` handles pre-existing rows whose character or source side is an alias (12 in the prod restore). It previews, re-points onto the canonical **only when the canonical can legally hold the row** (character side type 4, source side type 2, neither itself an alias), and reports the rest. It deletes nothing — a colliding or type-invalid row can carry a picture crop, so that call stays manual.

Already run on dev: 11 rows re-pointed (8 → `Ar Tonelico`, 3 → `Takopi's Original Sin`), total link count unchanged. One row is left for manual deletion — id 10891, `Pixiv 3510686` (ARTIST) linked to `Vocaloid`, which has no legitimate re-point since its own canonical is an ARTIST too. **Prod still needs both the script and that hand-fix**, along with the 2 type-mismatched aliases from #307 (`yrafy`, `Pixiv 68298330`), which the new code makes repairable through the API.

## Tests

6 new tests in `TestUpdateTag`. Three reproduce the bugs (confirmed failing first — the retype returned 200 before the fix); three pin the absence of over-validation, since both guards' main risk is blocking edits they shouldn't:

- `test_type_change_blocked_while_linked_as_character` / `..._as_source`
- `test_unrelated_edit_allowed_while_linked_as_character`
- `test_retyping_alias_rejects_mismatch_with_canonical`
- `test_retyping_alias_to_match_canonical_repairs_row`
- `test_editing_mismatched_alias_description_still_allowed`

Full suite: 2520 passed, 10 skipped. mypy clean. The repair SQL was verified against the prod-scale dev restore in rolled-back transactions across three scenarios: clean data, an injected canonical-pair collision, and two alias rows converging on one pair (the last two both leave rows untouched rather than tripping `unique_character_source`).

## Scoping note

The link guard checks the edited tag only, not the aliases that the #306 type cascade will retype. In healthy data an alias can't hold links — creation rejects aliases, and aliasing a linked tag migrates its links to the canonical — so the only case is legacy row 10891, and blocking there would 400 unrelated edits on the canonical, exactly the trap #307 warns about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx4tX6zYZWuMu4EWHy6F6D