### PR TITLE
fix: retry MariaDB snapshot conflicts across every tag write path (#321)

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -34,6 +34,7 @@ from app.config import (
 )
 from app.core.auth import get_current_user
 from app.core.database import get_db
+from app.core.db_retry import retry_on_snapshot_conflict
 from app.core.permission_cache import invalidate_group_permissions, invalidate_user_permissions
 from app.core.permission_deps import require_all_permissions, require_permission
 from app.core.permissions import Permission
@@ -1503,139 +1504,163 @@ async def apply_tag_suggestions(
     if not has_report_manage and not has_tag_suggestion_apply:
         raise HTTPException(status_code=403, detail="Permission denied")
 
-    # Get the report
-    result = await db.execute(
-        select(ImageReports).where(ImageReports.report_id == report_id)  # type: ignore[arg-type]
-    )
-    report = result.scalar_one_or_none()
+    # Capture as a primitive: a snapshot-conflict retry below rolls back the
+    # transaction, which expires ORM instances (including current_user).
+    reviewer_id: int = current_user.user_id  # type: ignore[assignment]
 
-    if not report:
-        raise HTTPException(status_code=404, detail="Report not found")
-
-    if report.status != ReportStatus.PENDING:
-        raise HTTPException(status_code=400, detail="Report has already been processed")
-
-    # Validate this is a TAG_SUGGESTIONS report
-    if report.category != ReportCategory.TAG_SUGGESTIONS:
-        # Taggers can only apply to TAG_SUGGESTIONS
-        if has_tag_suggestion_apply and not has_report_manage:
-            raise HTTPException(status_code=403, detail="Permission denied")
-        raise HTTPException(
-            status_code=400, detail="Tag suggestions can only be applied to TAG_SUGGESTIONS reports"
+    # The TagLinks/TagHistory writes take locking reads on their FK parents
+    # (tags, images, users) and the usage_count triggers on tag_links keep those
+    # parent rows moving, so under innodb_snapshot_isolation a concurrent tag
+    # write aborts this one with ER_CHECKREAD (1020). Retry the whole
+    # fetch-through-commit unit on a fresh snapshot (see app/core/db_retry.py).
+    # Every row is re-fetched inside the unit — the rollback between attempts
+    # expires the report and suggestion instances this mutates — and the
+    # accumulators are rebuilt so a retry cannot report a tag once per attempt.
+    async def _apply() -> tuple[list[int], list[int], list[int], list[int]]:
+        # Get the report
+        result = await db.execute(
+            select(ImageReports).where(ImageReports.report_id == report_id)  # type: ignore[arg-type]
         )
+        report = result.scalar_one_or_none()
 
-    # Get all suggestions for this report
-    suggestions_result = await db.execute(
-        select(ImageReportTagSuggestions).where(
-            ImageReportTagSuggestions.report_id == report_id  # type: ignore[arg-type]
-        )
-    )
-    suggestions = list(suggestions_result.scalars().all())
+        if not report:
+            raise HTTPException(status_code=404, detail="Report not found")
 
-    if not suggestions:
-        raise HTTPException(status_code=400, detail="This report has no tag suggestions")
+        if report.status != ReportStatus.PENDING:
+            raise HTTPException(status_code=400, detail="Report has already been processed")
 
-    # Validate approved_suggestion_ids belong to this report
-    suggestion_ids = {s.suggestion_id for s in suggestions}
-    for sid in request_data.approved_suggestion_ids:
-        if sid not in suggestion_ids:
-            raise HTTPException(status_code=400, detail=f"Invalid suggestion ID: {sid}")
-
-    # Get existing tags on image
-    existing_tags_result = await db.execute(
-        select(TagLinks.tag_id).where(TagLinks.image_id == report.image_id)  # type: ignore[call-overload]
-    )
-    existing_tag_ids = set(existing_tags_result.scalars().all())
-
-    approved_ids = set(request_data.approved_suggestion_ids)
-    applied_tags: list[int] = []
-    removed_tags: list[int] = []
-    already_present: list[int] = []
-    already_absent: list[int] = []
-
-    for suggestion in suggestions:
-        if suggestion.suggestion_id in approved_ids:
-            suggestion.accepted = True
-
-            # Resolve alias to canonical tag
-            tag_result = await db.execute(
-                select(Tags).where(Tags.tag_id == suggestion.tag_id)  # type: ignore[arg-type]
+        # Validate this is a TAG_SUGGESTIONS report
+        if report.category != ReportCategory.TAG_SUGGESTIONS:
+            # Taggers can only apply to TAG_SUGGESTIONS
+            if has_tag_suggestion_apply and not has_report_manage:
+                raise HTTPException(status_code=403, detail="Permission denied")
+            raise HTTPException(
+                status_code=400,
+                detail="Tag suggestions can only be applied to TAG_SUGGESTIONS reports",
             )
-            tag = tag_result.scalar_one_or_none()
-            resolved_tag_id = tag.alias_of if tag and tag.alias_of else suggestion.tag_id
 
-            if suggestion.suggestion_type == 1:  # Add
-                if resolved_tag_id not in existing_tag_ids:
-                    tag_link = TagLinks(image_id=report.image_id, tag_id=resolved_tag_id)
-                    db.add(tag_link)
-                    db.add(
-                        TagHistory(
-                            image_id=report.image_id,
-                            tag_id=resolved_tag_id,
-                            action="a",
-                            user_id=current_user.user_id,
+        # Get all suggestions for this report
+        suggestions_result = await db.execute(
+            select(ImageReportTagSuggestions).where(
+                ImageReportTagSuggestions.report_id == report_id  # type: ignore[arg-type]
+            )
+        )
+        suggestions = list(suggestions_result.scalars().all())
+
+        if not suggestions:
+            raise HTTPException(status_code=400, detail="This report has no tag suggestions")
+
+        # Validate approved_suggestion_ids belong to this report
+        suggestion_ids = {s.suggestion_id for s in suggestions}
+        for sid in request_data.approved_suggestion_ids:
+            if sid not in suggestion_ids:
+                raise HTTPException(status_code=400, detail=f"Invalid suggestion ID: {sid}")
+
+        # Get existing tags on image
+        existing_tags_result = await db.execute(
+            select(TagLinks.tag_id).where(TagLinks.image_id == report.image_id)  # type: ignore[call-overload]
+        )
+        existing_tag_ids = set(existing_tags_result.scalars().all())
+
+        approved_ids = set(request_data.approved_suggestion_ids)
+        applied_tags: list[int] = []
+        removed_tags: list[int] = []
+        already_present: list[int] = []
+        already_absent: list[int] = []
+
+        for suggestion in suggestions:
+            if suggestion.suggestion_id in approved_ids:
+                suggestion.accepted = True
+
+                # Resolve alias to canonical tag
+                tag_result = await db.execute(
+                    select(Tags).where(Tags.tag_id == suggestion.tag_id)  # type: ignore[arg-type]
+                )
+                tag = tag_result.scalar_one_or_none()
+                resolved_tag_id = tag.alias_of if tag and tag.alias_of else suggestion.tag_id
+
+                if suggestion.suggestion_type == 1:  # Add
+                    if resolved_tag_id not in existing_tag_ids:
+                        tag_link = TagLinks(image_id=report.image_id, tag_id=resolved_tag_id)
+                        db.add(tag_link)
+                        db.add(
+                            TagHistory(
+                                image_id=report.image_id,
+                                tag_id=resolved_tag_id,
+                                action="a",
+                                user_id=reviewer_id,
+                            )
                         )
-                    )
-                    applied_tags.append(resolved_tag_id)
-                    existing_tag_ids.add(resolved_tag_id)
-                else:
-                    already_present.append(resolved_tag_id)
+                        applied_tags.append(resolved_tag_id)
+                        existing_tag_ids.add(resolved_tag_id)
+                    else:
+                        already_present.append(resolved_tag_id)
 
-            elif suggestion.suggestion_type == 2:  # Remove
-                if resolved_tag_id in existing_tag_ids:
-                    db.add(
-                        TagHistory(
-                            image_id=report.image_id,
-                            tag_id=resolved_tag_id,
-                            action="r",
-                            user_id=current_user.user_id,
+                elif suggestion.suggestion_type == 2:  # Remove
+                    if resolved_tag_id in existing_tag_ids:
+                        db.add(
+                            TagHistory(
+                                image_id=report.image_id,
+                                tag_id=resolved_tag_id,
+                                action="r",
+                                user_id=reviewer_id,
+                            )
                         )
-                    )
-                    await db.execute(
-                        delete(TagLinks).where(
-                            TagLinks.image_id == report.image_id,  # type: ignore[arg-type]
-                            TagLinks.tag_id == resolved_tag_id,  # type: ignore[arg-type]
+                        await db.execute(
+                            delete(TagLinks).where(
+                                TagLinks.image_id == report.image_id,  # type: ignore[arg-type]
+                                TagLinks.tag_id == resolved_tag_id,  # type: ignore[arg-type]
+                            )
                         )
-                    )
-                    removed_tags.append(resolved_tag_id)
-                    existing_tag_ids.discard(resolved_tag_id)
-                else:
-                    already_absent.append(resolved_tag_id)
-        else:
-            suggestion.accepted = False
+                        removed_tags.append(resolved_tag_id)
+                        existing_tag_ids.discard(resolved_tag_id)
+                    else:
+                        already_absent.append(resolved_tag_id)
+            else:
+                suggestion.accepted = False
 
-    # Resolve any matching pending ML suggestions (applying a tag out of band
-    # is an implicit approval; keeps the review queue's pending counts honest).
-    await approve_pending_suggestions_for_links(
-        db, [(report.image_id, tid) for tid in applied_tags], current_user.user_id
-    )
+        # Resolve any matching pending ML suggestions (applying a tag out of
+        # band is an implicit approval; keeps the review queue's pending counts
+        # honest).
+        await approve_pending_suggestions_for_links(
+            db, [(report.image_id, tid) for tid in applied_tags], reviewer_id
+        )
 
-    # Update report
-    report.status = ReportStatus.REVIEWED
-    report.reviewed_by = current_user.user_id
-    report.reviewed_at = datetime.now(UTC)
-    if request_data.admin_notes:
-        report.admin_notes = request_data.admin_notes
+        # Update report
+        report.status = ReportStatus.REVIEWED
+        report.reviewed_by = reviewer_id
+        report.reviewed_at = datetime.now(UTC)
+        if request_data.admin_notes:
+            report.admin_notes = request_data.admin_notes
 
-    # Log action
-    action = AdminActions(
-        user_id=current_user.user_id,
-        action_type=AdminActionType.REPORT_ACTION,
-        report_id=report_id,
-        image_id=report.image_id,
-        details={
-            "action": "apply_tag_suggestions",
-            "approved_count": len(approved_ids),
-            "rejected_count": len(suggestions) - len(approved_ids),
-            "applied_tags": applied_tags,
-            "removed_tags": removed_tags,
-        },
-    )
-    db.add(action)
+        # Log action
+        action = AdminActions(
+            user_id=reviewer_id,
+            action_type=AdminActionType.REPORT_ACTION,
+            report_id=report_id,
+            image_id=report.image_id,
+            details={
+                "action": "apply_tag_suggestions",
+                "approved_count": len(approved_ids),
+                "rejected_count": len(suggestions) - len(approved_ids),
+                "applied_tags": applied_tags,
+                "removed_tags": removed_tags,
+            },
+        )
+        db.add(action)
 
-    await refresh_image_tag_type_flags(db, report.image_id)
+        await refresh_image_tag_type_flags(db, report.image_id)
 
-    await db.commit()
+        await db.commit()
+
+        return applied_tags, removed_tags, already_present, already_absent
+
+    (
+        applied_tags,
+        removed_tags,
+        already_present,
+        already_absent,
+    ) = await retry_on_snapshot_conflict(db, _apply, what="apply_tag_suggestions")
 
     return ApplyTagSuggestionsResponse(
         message=f"Applied {len(applied_tags)} tags, removed {len(removed_tags)} tags",

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -2395,6 +2395,10 @@ async def add_tag_to_image(
     Returns:
         Success message
     """
+    # Capture as a primitive: a snapshot-conflict retry below rolls back the
+    # transaction, which expires ORM instances (including current_user).
+    user_id: int = current_user.id
+
     # Verify image exists
     image_result = await db.execute(select(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
     image = image_result.scalar_one_or_none()
@@ -2403,58 +2407,70 @@ async def add_tag_to_image(
         raise HTTPException(status_code=404, detail="Image not found")
 
     # Check ownership, admin, or permission
-    is_owner = image.user_id == current_user.id
+    is_owner = image.user_id == user_id
     is_admin = current_user.admin
-    has_edit_permission = await has_permission(
-        db, current_user.id, Permission.IMAGE_TAG_ADD, redis_client
-    )
+    has_edit_permission = await has_permission(db, user_id, Permission.IMAGE_TAG_ADD, redis_client)
 
     if not is_owner and not is_admin and not has_edit_permission:
         raise HTTPException(403, "Not authorized to edit this image")
 
-    # Verify tag exists and resolve aliases
-    tag_result = await db.execute(select(Tags).where(Tags.tag_id == tag_id))  # type: ignore[arg-type]
-    tag = tag_result.scalar_one_or_none()
+    # The TagLinks/TagHistory INSERTs take locking reads on their FK parents
+    # (tags, images, users) and the usage_count trigger on tag_links keeps those
+    # parent rows moving, so under innodb_snapshot_isolation a concurrent tag
+    # write aborts this one with ER_CHECKREAD (1020) — reported against the
+    # child table. Retry on a fresh snapshot instead of surfacing a 500 (see
+    # app/core/db_retry.py). The unit re-fetches its rows.
+    async def _apply_tag_add() -> int:
+        # Verify tag exists and resolve aliases
+        tag_result = await db.execute(select(Tags).where(Tags.tag_id == tag_id))  # type: ignore[arg-type]
+        tag = tag_result.scalar_one_or_none()
 
-    if not tag:
-        raise HTTPException(status_code=404, detail="Tag not found")
+        if not tag:
+            raise HTTPException(status_code=404, detail="Tag not found")
 
-    # Resolve alias tags to their actual tag (pass the already-fetched tag to avoid duplicate query)
-    _, resolved_tag_id = await resolve_tag_alias(db, tag_id, tag)
+        # Resolve alias tags to their actual tag (pass the already-fetched tag
+        # to avoid duplicate query)
+        _, resolved = await resolve_tag_alias(db, tag_id, tag)
 
-    # Check if tag link already exists (using resolved tag ID)
-    existing_link = await db.execute(
-        select(TagLinks).where(
-            TagLinks.image_id == image_id,  # type: ignore[arg-type]
-            TagLinks.tag_id == resolved_tag_id,  # type: ignore[arg-type]
+        # Check if tag link already exists (using resolved tag ID)
+        existing_link = await db.execute(
+            select(TagLinks).where(
+                TagLinks.image_id == image_id,  # type: ignore[arg-type]
+                TagLinks.tag_id == resolved,  # type: ignore[arg-type]
+            )
         )
-    )
-    if existing_link.scalar_one_or_none():
-        raise HTTPException(status_code=409, detail="Tag already linked to this image")
+        if existing_link.scalar_one_or_none():
+            raise HTTPException(status_code=409, detail="Tag already linked to this image")
 
-    # Create tag link (usage_count is maintained by database trigger)
-    tag_link = TagLinks(
-        image_id=image_id,
-        tag_id=resolved_tag_id,
-        user_id=current_user.id,
-    )
-    db.add(tag_link)
+        # Create tag link (usage_count is maintained by database trigger)
+        tag_link = TagLinks(
+            image_id=image_id,
+            tag_id=resolved,
+            user_id=user_id,
+        )
+        db.add(tag_link)
 
-    # Record in tag history
-    history_entry = TagHistory(
-        image_id=image_id,
-        tag_id=resolved_tag_id,
-        action="a",
-        user_id=current_user.id,
-    )
-    db.add(history_entry)
+        # Record in tag history
+        history_entry = TagHistory(
+            image_id=image_id,
+            tag_id=resolved,
+            action="a",
+            user_id=user_id,
+        )
+        db.add(history_entry)
 
-    # Resolve any matching pending ML suggestion (applying the tag out of band
-    # is an implicit approval; keeps the review queue's pending counts honest).
-    await approve_pending_suggestions_for_links(db, [(image_id, resolved_tag_id)], current_user.id)
+        # Resolve any matching pending ML suggestion (applying the tag out of
+        # band is an implicit approval; keeps the review queue's pending counts
+        # honest).
+        await approve_pending_suggestions_for_links(db, [(image_id, resolved)], user_id)
 
-    await refresh_image_tag_type_flags(db, image_id)
-    await db.commit()
+        await refresh_image_tag_type_flags(db, image_id)
+        await db.commit()
+        return resolved
+
+    # Non-DB side effect: the search sync stays outside the retried unit so a
+    # retry never repeats it.
+    resolved_tag_id = await retry_on_snapshot_conflict(db, _apply_tag_add, what="image_tag_add")
 
     # Re-fetch tag to get updated usage_count (maintained by DB trigger)
     tag_result = await db.execute(select(Tags).where(Tags.tag_id == resolved_tag_id))  # type: ignore[arg-type]
@@ -2481,6 +2497,10 @@ async def remove_tag_from_image(
     - The user has admin privileges
     - The user has the IMAGE_TAG_REMOVE permission
     """
+    # Capture as a primitive: a snapshot-conflict retry below rolls back the
+    # transaction, which expires ORM instances (including current_user).
+    user_id: int = current_user.id
+
     # Verify image exists
     image_result = await db.execute(select(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
     image = image_result.scalar_one_or_none()
@@ -2489,45 +2509,55 @@ async def remove_tag_from_image(
         raise HTTPException(status_code=404, detail="Image not found")
 
     # Check ownership, admin, or permission
-    is_owner = image.user_id == current_user.id
+    is_owner = image.user_id == user_id
     is_admin = current_user.admin
     has_edit_permission = await has_permission(
-        db, current_user.id, Permission.IMAGE_TAG_REMOVE, redis_client
+        db, user_id, Permission.IMAGE_TAG_REMOVE, redis_client
     )
 
     if not is_owner and not is_admin and not has_edit_permission:
         raise HTTPException(403, "Not authorized to edit this image")
 
-    # Check if tag link exists
-    link_result = await db.execute(
-        select(TagLinks).where(
-            TagLinks.image_id == image_id,  # type: ignore[arg-type]
-            TagLinks.tag_id == tag_id,  # type: ignore[arg-type]
+    # Same snapshot-conflict exposure as the add path: the TagHistory INSERT
+    # locking-reads its FK parents and the DELETE's usage_count trigger keeps
+    # the parent `tags` row moving, so a concurrent tag write can abort this one
+    # with ER_CHECKREAD (1020). Retry on a fresh snapshot (see
+    # app/core/db_retry.py). The unit re-fetches its rows.
+    async def _apply_tag_remove() -> None:
+        # Check if tag link exists
+        link_result = await db.execute(
+            select(TagLinks).where(
+                TagLinks.image_id == image_id,  # type: ignore[arg-type]
+                TagLinks.tag_id == tag_id,  # type: ignore[arg-type]
+            )
         )
-    )
-    tag_link = link_result.scalar_one_or_none()
+        tag_link = link_result.scalar_one_or_none()
 
-    if not tag_link:
-        raise HTTPException(status_code=404, detail="Tag not linked to this image")
+        if not tag_link:
+            raise HTTPException(status_code=404, detail="Tag not linked to this image")
 
-    # Record in tag history (before deleting the link)
-    history_entry = TagHistory(
-        image_id=image_id,
-        tag_id=tag_id,
-        action="r",
-        user_id=current_user.id,
-    )
-    db.add(history_entry)
-
-    # Delete tag link (usage_count is maintained by database trigger)
-    await db.execute(
-        delete(TagLinks).where(
-            TagLinks.image_id == image_id,  # type: ignore[arg-type]
-            TagLinks.tag_id == tag_id,  # type: ignore[arg-type]
+        # Record in tag history (before deleting the link)
+        history_entry = TagHistory(
+            image_id=image_id,
+            tag_id=tag_id,
+            action="r",
+            user_id=user_id,
         )
-    )
-    await refresh_image_tag_type_flags(db, image_id)
-    await db.commit()
+        db.add(history_entry)
+
+        # Delete tag link (usage_count is maintained by database trigger)
+        await db.execute(
+            delete(TagLinks).where(
+                TagLinks.image_id == image_id,  # type: ignore[arg-type]
+                TagLinks.tag_id == tag_id,  # type: ignore[arg-type]
+            )
+        )
+        await refresh_image_tag_type_flags(db, image_id)
+        await db.commit()
+
+    # Non-DB side effect: the search sync stays outside the retried unit so a
+    # retry never repeats it.
+    await retry_on_snapshot_conflict(db, _apply_tag_remove, what="image_tag_remove")
 
     # Re-fetch tag to get updated usage_count (maintained by DB trigger)
     tag_result = await db.execute(select(Tags).where(Tags.tag_id == tag_id))  # type: ignore[arg-type]

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -2817,6 +2817,18 @@ async def _discard_unfinished_upload(
         staged_path.unlink(missing_ok=True)
 
 
+async def _discard_finalized_upload(db: AsyncSession, image_id: int, staged_path: FilePath) -> None:
+    """Undo a committed upload whose file never reached its permanent name.
+
+    Deleting the row cascades its tag_links (fk_tag_links_image_id is ON DELETE
+    CASCADE) and reverses the same usage_count / image_posts triggers the insert
+    fired, so this leaves the counters where they started.
+    """
+    await db.execute(delete(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
+    await db.commit()
+    staged_path.unlink(missing_ok=True)
+
+
 @router.post(
     "/upload",
     response_model=ImageUploadResponse,
@@ -3038,9 +3050,24 @@ async def upload_image(
         filename = new_image.filename
 
         # Give the staged file its permanent name now that the row exists.
-        file_path = finalize_uploaded_image(
-            staged_path, settings.STORAGE_PATH, image_id, ext, date_prefix
-        )
+        try:
+            file_path = finalize_uploaded_image(
+                staged_path, settings.STORAGE_PATH, image_id, ext, date_prefix
+            )
+        except OSError:
+            # The row is committed, but its bytes never reached the name the row
+            # records — and the staging name is a uuid nothing can derive from
+            # the row, so leaving the pair in place strands both. Undo the row so
+            # the upload is still all-or-nothing, as it was when the rename
+            # happened before the commit.
+            logger.error(
+                "image_finalize_failed",
+                image_id=image_id,
+                staged_path=str(staged_path),
+                exc_info=True,
+            )
+            await _discard_finalized_upload(db, image_id, staged_path)
+            raise
         logger.info("image_saved", image_id=image_id, file_path=str(file_path))
 
         logger.info(

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -134,7 +134,12 @@ from app.services.recommendations import get_recommended_images
 from app.services.search import sync_tag_to_search
 from app.services.tag_context import stamp_context_sources
 from app.services.tag_type_flags import refresh_image_tag_type_flags
-from app.services.upload import check_upload_rate_limit, link_tags_to_image, save_uploaded_image
+from app.services.upload import (
+    check_upload_rate_limit,
+    finalize_uploaded_image,
+    link_tags_to_image,
+    stage_uploaded_image,
+)
 from app.tasks.queue import enqueue_job
 from app.utils.comment_search import (
     COMMENT_SEARCH_TIMEOUT_SECONDS,
@@ -2796,6 +2801,22 @@ async def unfavorite_image(
     }
 
 
+async def _discard_unfinished_upload(
+    db: AsyncSession, staged_path: FilePath | None, committed: bool
+) -> None:
+    """Undo an upload that failed before its row was committed.
+
+    Once the row is committed it owns the file, so a later failure (a job
+    enqueue, say) must leave both alone rather than delete a file the row
+    points at.
+    """
+    if committed:
+        return
+    await db.rollback()
+    if staged_path:
+        staged_path.unlink(missing_ok=True)
+
+
 @router.post(
     "/upload",
     response_model=ImageUploadResponse,
@@ -2872,33 +2893,11 @@ async def upload_image(
     # touching an expired attribute on an async session raises.
     uploader_id: int = current_user.id
 
-    # Concurrent uploads write identical placeholder values into the same
-    # index positions, so this INSERT can hit a snapshot conflict (see
-    # app/core/db_retry.py). A rolled-back attempt just burns an auto-inc id.
-    async def _insert_temp_image() -> Images:
-        temp = Images(
-            filename="temp",  # Will be updated after save
-            ext="tmp",
-            original_filename=file.filename or "unknown",
-            md5_hash="",  # Will be calculated during save
-            filesize=0,
-            width=0,
-            height=0,
-            user_id=uploader_id,
-            ip=client_ip,  # Log IP address
-            status=1,
-            locked=0,
-        )
-        db.add(temp)
-        await db.flush()  # Get image_id
-        return temp
-
-    temp_image = await retry_on_snapshot_conflict(db, _insert_temp_image, what="upload_temp_image")
-    image_id: int = temp_image.image_id  # type: ignore[assignment]
-
-    logger.info("image_record_created", image_id=image_id)
-
-    file_path: FilePath | None = None  # Initialize to track if file was saved
+    # The file write and both duplicate checks run BEFORE any database write, so
+    # the transaction that follows never holds a snapshot across the disk write
+    # or the IQDB network call. That is what makes it short enough to retry.
+    staged_path: FilePath | None = None
+    committed = False
     try:
         # Validate source_url before touching storage: only http(s) URLs are
         # accepted (blocks javascript:/data: schemes and similar).
@@ -2910,34 +2909,27 @@ async def upload_image(
                 detail="source_url must start with http:// or https://",
             )
 
-        # Save image to storage (validates and calculates hash)
-        # If validation fails, this will raise HTTPException
-        file_path, ext, md5_hash = await save_uploaded_image(file, settings.STORAGE_PATH, image_id)
-        logger.info("image_saved", image_id=image_id, file_path=str(file_path), md5_hash=md5_hash)
+        # Stage the file (validates and calculates hash) under a temporary name.
+        # If validation fails, this will raise HTTPException.
+        staged_path, ext, md5_hash = await stage_uploaded_image(file, settings.STORAGE_PATH)
+        logger.info("image_staged", file_path=str(staged_path), md5_hash=md5_hash)
 
         # Check for duplicate image (MD5)
         existing_result = await db.execute(
-            select(Images).where(
-                Images.md5_hash == md5_hash,  # type: ignore[arg-type]
-                Images.image_id != image_id,  # type: ignore[arg-type]
-            )
+            select(Images).where(Images.md5_hash == md5_hash)  # type: ignore[arg-type]
         )
         existing_image = existing_result.scalar_one_or_none()
 
         if existing_image:
-            # Capture the id before rollback expires the instance.
             existing_image_id: int = existing_image.image_id  # type: ignore[assignment]
             logger.warning(
                 "duplicate_image_detected",
-                image_id=image_id,
                 duplicate_of=existing_image_id,
                 md5_hash=md5_hash,
             )
-            # Clean up the temp record and saved file before returning 409,
-            # mirroring the IQDB near-duplicate path below.
-            await db.rollback()
-            if file_path:
-                file_path.unlink(missing_ok=True)
+            # Nothing was written to the database yet — only the staged file
+            # needs cleaning up, mirroring the IQDB near-duplicate path below.
+            staged_path.unlink(missing_ok=True)
             return JSONResponse(
                 status_code=status.HTTP_409_CONFLICT,
                 content=ImageUploadDuplicateResponse(
@@ -2946,30 +2938,22 @@ async def upload_image(
                 ).model_dump(mode="json"),
             )
 
-        # Get image dimensions and update record
-        width, height = get_image_dimensions(file_path)
-        filesize = file_path.stat().st_size
+        # Get image dimensions
+        width, height = get_image_dimensions(staged_path)
+        filesize = staged_path.stat().st_size
 
         # Calculate total pixels (in megapixels)
         total_pixels = Decimal((width * height) / 1_000_000)
 
-        # Derive from the actually-saved fullsize path so DB.filename matches
-        # the on-disk name even when upload straddles a local-midnight boundary
-        # (datetime.now() recomputed here can land on the next day).
-        filename = file_path.stem  # e.g. "2026-05-18-1116164"
-
         # Check IQDB for near-duplicate images unless user confirmed
         if not confirm_similar:
             iqdb_results = await check_iqdb_similarity(
-                file_path, db, threshold=settings.IQDB_UPLOAD_THRESHOLD
+                staged_path, db, threshold=settings.IQDB_UPLOAD_THRESHOLD
             )
             if iqdb_results:
                 # Hydrate IQDB results with full image data
                 similar = await _hydrate_similar_images(iqdb_results, db)
-                # Clean up temp record and file before returning 409
-                await db.rollback()
-                if file_path and file_path.exists():
-                    file_path.unlink()
+                staged_path.unlink(missing_ok=True)
                 return JSONResponse(
                     status_code=status.HTTP_409_CONFLICT,
                     content=ImageUploadSimilarResponse(
@@ -2990,34 +2974,74 @@ async def upload_image(
             else VariantStatus.NONE
         )
 
-        # Update temporary record with actual data
-        temp_image.filename = filename
-        temp_image.ext = ext
-        temp_image.md5_hash = md5_hash
-        temp_image.filesize = filesize
-        temp_image.width = width
-        temp_image.height = height
-        temp_image.total_pixels = total_pixels
-        temp_image.medium = medium_status
-        temp_image.large = large_status
-        temp_image.caption = caption
-        temp_image.miscmeta = miscmeta
-        temp_image.source_url = source_url
-
-        # Link tags if provided
+        # Parse tag ids before opening the transaction: a malformed list is a
+        # 400, not something to discover mid-write.
+        tag_id_list: list[int] = []
         if tag_ids.strip():
             try:
                 tag_id_list = [int(tid.strip()) for tid in tag_ids.split(",") if tid.strip()]
-                await link_tags_to_image(image_id, tag_id_list, uploader_id, db)
             except ValueError as e:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Invalid tag IDs format. Must be comma-separated integers.",
                 ) from e
 
-        # Commit all changes
-        await db.commit()
-        await db.refresh(temp_image)
+        # One date_prefix for both the recorded filename and the on-disk name,
+        # so the two agree even when the upload straddles a local-midnight
+        # boundary (a recomputed datetime.now() can land on the next day).
+        date_prefix = datetime.now().strftime("%Y-%m-%d")
+
+        # Everything above is non-DB work. What remains is a short,
+        # self-contained transaction: INSERT the row, name it from the id it
+        # just minted, link tags, commit. Its tag_links/tag_history INSERTs take
+        # locking reads on FK parents that other taggers keep moving, so under
+        # innodb_snapshot_isolation it can abort with ER_CHECKREAD (1020) —
+        # retry it on a fresh snapshot (see app/core/db_retry.py). A rolled-back
+        # attempt just burns an auto-inc id.
+        async def _insert_image() -> Images:
+            image = Images(
+                filename="",  # set below, from the id this INSERT mints
+                ext=ext,
+                original_filename=file.filename or "unknown",
+                md5_hash=md5_hash,
+                filesize=filesize,
+                width=width,
+                height=height,
+                total_pixels=total_pixels,
+                medium=medium_status,
+                large=large_status,
+                caption=caption,
+                miscmeta=miscmeta,
+                source_url=source_url,
+                user_id=uploader_id,
+                ip=client_ip,  # Log IP address
+                status=1,
+                locked=0,
+            )
+            db.add(image)
+            await db.flush()  # Get image_id
+            image.filename = f"{date_prefix}-{image.image_id}"
+            if tag_id_list:
+                await link_tags_to_image(
+                    image.image_id,  # type: ignore[arg-type]
+                    tag_id_list,
+                    uploader_id,
+                    db,
+                )
+            await db.commit()
+            return image
+
+        new_image = await retry_on_snapshot_conflict(db, _insert_image, what="upload_image")
+        committed = True
+        await db.refresh(new_image)
+        image_id: int = new_image.image_id  # type: ignore[assignment]
+        filename = new_image.filename
+
+        # Give the staged file its permanent name now that the row exists.
+        file_path = finalize_uploaded_image(
+            staged_path, settings.STORAGE_PATH, image_id, ext, date_prefix
+        )
+        logger.info("image_saved", image_id=image_id, file_path=str(file_path))
 
         logger.info(
             "image_upload_completed",
@@ -3102,51 +3126,46 @@ async def upload_image(
 
         # Build response
         image_response = ImageResponse(
-            image_id=temp_image.image_id or 0,  # image_id is guaranteed to exist after flush
-            filename=temp_image.filename,
-            ext=temp_image.ext,
-            original_filename=temp_image.original_filename,
-            md5_hash=temp_image.md5_hash,
-            filesize=temp_image.filesize,
-            width=temp_image.width,
-            height=temp_image.height,
-            caption=temp_image.caption,
-            miscmeta=temp_image.miscmeta,
-            source_url=temp_image.source_url,
-            rating=temp_image.rating,
-            user_id=temp_image.user_id,  # user_id is guaranteed from database
-            date_added=temp_image.date_added,
-            status=temp_image.status,
-            locked=temp_image.locked,
-            posts=temp_image.posts,
-            favorites=temp_image.favorites,
-            bayesian_rating=temp_image.bayesian_rating,
-            num_ratings=temp_image.num_ratings,
-            medium=temp_image.medium,
-            large=temp_image.large,
+            image_id=image_id,
+            filename=new_image.filename,
+            ext=new_image.ext,
+            original_filename=new_image.original_filename,
+            md5_hash=new_image.md5_hash,
+            filesize=new_image.filesize,
+            width=new_image.width,
+            height=new_image.height,
+            caption=new_image.caption,
+            miscmeta=new_image.miscmeta,
+            source_url=new_image.source_url,
+            rating=new_image.rating,
+            user_id=new_image.user_id,  # user_id is guaranteed from database
+            date_added=new_image.date_added,
+            status=new_image.status,
+            locked=new_image.locked,
+            posts=new_image.posts,
+            favorites=new_image.favorites,
+            bayesian_rating=new_image.bayesian_rating,
+            num_ratings=new_image.num_ratings,
+            medium=new_image.medium,
+            large=new_image.large,
         )
 
         return ImageUploadResponse(
             message="Image uploaded successfully",
-            image_id=temp_image.image_id or 0,  # image_id is guaranteed after flush
+            image_id=image_id,
             image=image_response,
         )
 
     except HTTPException as he:
-        # Clean up file and database record on validation error
         logger.warning(
             "image_upload_failed",
             image_id=image_id if "image_id" in locals() else None,
             error=he.detail,
             status_code=he.status_code,
         )
-        # Rollback database first, then delete file
-        await db.rollback()
-        if file_path and file_path.exists():
-            file_path.unlink()
+        await _discard_unfinished_upload(db, staged_path, committed)
         raise
     except Exception as e:
-        # Clean up file and database record on any error
         logger.error(
             "image_upload_error",
             image_id=image_id if "image_id" in locals() else None,
@@ -3154,10 +3173,7 @@ async def upload_image(
             error_type=type(e).__name__,
             exc_info=True,
         )
-        # Rollback database first, then delete file
-        await db.rollback()
-        if file_path and file_path.exists():
-            file_path.unlink()
+        await _discard_unfinished_upload(db, staged_path, committed)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to upload image",

--- a/app/services/batch_tag.py
+++ b/app/services/batch_tag.py
@@ -4,6 +4,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.db_retry import retry_on_snapshot_conflict
 from app.core.logging import get_logger
 from app.models.image import Images
 from app.models.tag import Tags
@@ -32,126 +33,141 @@ async def batch_add_tags(
 
     Returns a response listing which pairs were added and which were skipped.
     """
-    added: list[BatchTagResultItem] = []
-    skipped: list[BatchTagSkippedItem] = []
 
-    # 1. Resolve tags: fetch all, resolve aliases, collect missing
-    resolved_tags: dict[int, int | None] = {}  # original_tag_id -> resolved_tag_id or None
-    for tag_id in tag_ids:
-        tag_result = await db.execute(
-            select(Tags).where(Tags.tag_id == tag_id)  # type: ignore[arg-type]
-        )
-        tag = tag_result.scalar_one_or_none()
-        if not tag:
-            resolved_tags[tag_id] = None
-            continue
-        # Resolve alias inline (avoids importing from route layer)
-        resolved_tags[tag_id] = tag.alias_of if tag.alias_of else tag_id
+    # The TagLinks/TagHistory INSERTs take locking reads on their FK parents
+    # (tags, images, users) and the usage_count trigger on tag_links keeps those
+    # parent rows moving, so under innodb_snapshot_isolation a concurrent tag
+    # write aborts this batch with ER_CHECKREAD (1020). Retry the whole
+    # fetch-through-commit unit on a fresh snapshot (see app/core/db_retry.py).
+    # The accumulators are built inside the unit: reusing lists from a failed
+    # attempt would report every pair once per attempt.
+    async def _apply() -> tuple[list[BatchTagResultItem], list[BatchTagSkippedItem]]:
+        added: list[BatchTagResultItem] = []
+        skipped: list[BatchTagSkippedItem] = []
 
-    missing_tag_ids = {tid for tid, rid in resolved_tags.items() if rid is None}
+        # 1. Resolve tags: fetch all, resolve aliases, collect missing
+        resolved_tags: dict[int, int | None] = {}  # original_tag_id -> resolved_tag_id or None
+        for tag_id in tag_ids:
+            tag_result = await db.execute(
+                select(Tags).where(Tags.tag_id == tag_id)  # type: ignore[arg-type]
+            )
+            tag = tag_result.scalar_one_or_none()
+            if not tag:
+                resolved_tags[tag_id] = None
+                continue
+            # Resolve alias inline (avoids importing from route layer)
+            resolved_tags[tag_id] = tag.alias_of if tag.alias_of else tag_id
 
-    # 2. Fetch existing images in one query
-    valid_resolved_tag_ids = {rid for rid in resolved_tags.values() if rid is not None}
-    existing_image_result = await db.execute(
-        select(Images.image_id).where(  # type: ignore[call-overload]
-            Images.image_id.in_(image_ids)  # type: ignore[union-attr]
-        )
-    )
-    existing_image_ids = {row[0] for row in existing_image_result.all()}
+        missing_tag_ids = {tid for tid, rid in resolved_tags.items() if rid is None}
 
-    # 3. Fetch existing tag links in one query
-    existing_links: set[tuple[int, int]] = set()
-    if existing_image_ids and valid_resolved_tag_ids:
-        links_result = await db.execute(
-            select(TagLinks.image_id, TagLinks.tag_id).where(  # type: ignore[call-overload]
-                TagLinks.image_id.in_(existing_image_ids),  # type: ignore[attr-defined]
-                TagLinks.tag_id.in_(valid_resolved_tag_ids),  # type: ignore[attr-defined]
+        # 2. Fetch existing images in one query
+        valid_resolved_tag_ids = {rid for rid in resolved_tags.values() if rid is not None}
+        existing_image_result = await db.execute(
+            select(Images.image_id).where(  # type: ignore[call-overload]
+                Images.image_id.in_(image_ids)  # type: ignore[union-attr]
             )
         )
-        existing_links = {(row[0], row[1]) for row in links_result.all()}
+        existing_image_ids = {row[0] for row in existing_image_result.all()}
 
-    # 4. Process each image-tag pair
-    for image_id in image_ids:
-        for original_tag_id in tag_ids:
-            resolved_tag_id = resolved_tags[original_tag_id]
-
-            if original_tag_id in missing_tag_ids:
-                skipped.append(
-                    BatchTagSkippedItem(
-                        image_id=image_id,
-                        tag_id=original_tag_id,
-                        reason="tag_not_found",
-                    )
+        # 3. Fetch existing tag links in one query
+        existing_links: set[tuple[int, int]] = set()
+        if existing_image_ids and valid_resolved_tag_ids:
+            links_result = await db.execute(
+                select(TagLinks.image_id, TagLinks.tag_id).where(  # type: ignore[call-overload]
+                    TagLinks.image_id.in_(existing_image_ids),  # type: ignore[attr-defined]
+                    TagLinks.tag_id.in_(valid_resolved_tag_ids),  # type: ignore[attr-defined]
                 )
-                continue
+            )
+            existing_links = {(row[0], row[1]) for row in links_result.all()}
 
-            assert resolved_tag_id is not None  # guaranteed by missing_tag_ids check
+        # 4. Process each image-tag pair
+        for image_id in image_ids:
+            for original_tag_id in tag_ids:
+                resolved_tag_id = resolved_tags[original_tag_id]
 
-            if image_id not in existing_image_ids:
-                skipped.append(
-                    BatchTagSkippedItem(
+                if original_tag_id in missing_tag_ids:
+                    skipped.append(
+                        BatchTagSkippedItem(
+                            image_id=image_id,
+                            tag_id=original_tag_id,
+                            reason="tag_not_found",
+                        )
+                    )
+                    continue
+
+                assert resolved_tag_id is not None  # guaranteed by missing_tag_ids check
+
+                if image_id not in existing_image_ids:
+                    skipped.append(
+                        BatchTagSkippedItem(
+                            image_id=image_id,
+                            tag_id=resolved_tag_id,
+                            reason="image_not_found",
+                        )
+                    )
+                    continue
+
+                if (image_id, resolved_tag_id) in existing_links:
+                    skipped.append(
+                        BatchTagSkippedItem(
+                            image_id=image_id,
+                            tag_id=resolved_tag_id,
+                            reason="already_tagged",
+                        )
+                    )
+                    continue
+
+                db.add(
+                    TagLinks(
                         image_id=image_id,
                         tag_id=resolved_tag_id,
-                        reason="image_not_found",
+                        user_id=user_id,
                     )
                 )
-                continue
 
-            if (image_id, resolved_tag_id) in existing_links:
-                skipped.append(
-                    BatchTagSkippedItem(
+                db.add(
+                    TagHistory(
                         image_id=image_id,
                         tag_id=resolved_tag_id,
-                        reason="already_tagged",
+                        action="a",
+                        user_id=user_id,
                     )
                 )
-                continue
 
-            db.add(
-                TagLinks(
-                    image_id=image_id,
-                    tag_id=resolved_tag_id,
-                    user_id=user_id,
+                added.append(
+                    BatchTagResultItem(
+                        image_id=image_id,
+                        tag_id=resolved_tag_id,
+                    )
                 )
-            )
 
-            db.add(
-                TagHistory(
-                    image_id=image_id,
-                    tag_id=resolved_tag_id,
-                    action="a",
-                    user_id=user_id,
-                )
-            )
+                # Track as existing to prevent duplicates within same batch
+                existing_links.add((image_id, resolved_tag_id))
 
-            added.append(
-                BatchTagResultItem(
-                    image_id=image_id,
-                    tag_id=resolved_tag_id,
-                )
-            )
-
-            # Track as existing to prevent duplicates within same batch
-            existing_links.add((image_id, resolved_tag_id))
-
-    # Resolve any matching pending ML suggestions (applying a tag out of band
-    # is an implicit approval; keeps the review queue's pending counts honest).
-    await approve_pending_suggestions_for_links(
-        db, [(item.image_id, item.tag_id) for item in added], user_id
-    )
-
-    await refresh_images_tag_type_flags(db, {item.image_id for item in added})
-
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        logger.warning(
-            "batch_tag_integrity_error", user_id=user_id, tag_ids=tag_ids, image_ids=image_ids
+        # Resolve any matching pending ML suggestions (applying a tag out of
+        # band is an implicit approval; keeps the review queue's pending counts
+        # honest).
+        await approve_pending_suggestions_for_links(
+            db, [(item.image_id, item.tag_id) for item in added], user_id
         )
-        raise
 
-    # Sync affected tags to Meilisearch (usage_count updated by DB trigger)
+        await refresh_images_tag_type_flags(db, {item.image_id for item in added})
+
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            logger.warning(
+                "batch_tag_integrity_error", user_id=user_id, tag_ids=tag_ids, image_ids=image_ids
+            )
+            raise
+
+        return added, skipped
+
+    added, skipped = await retry_on_snapshot_conflict(db, _apply, what="batch_tag_add")
+
+    # Sync affected tags to Meilisearch (usage_count updated by DB trigger).
+    # Non-DB side effect: stays outside the retried unit so it never repeats.
     affected_tag_ids = {item.tag_id for item in added}
     if affected_tag_ids:
         tag_results = await db.execute(
@@ -173,130 +189,142 @@ async def batch_remove_tags(
 
     Returns a response listing which pairs were removed and which were skipped.
     """
-    removed: list[BatchTagResultItem] = []
-    skipped: list[BatchTagSkippedItem] = []
 
-    # 1. Resolve tags: fetch all, resolve aliases, collect missing
-    resolved_tags: dict[int, int | None] = {}  # original_tag_id -> resolved_tag_id or None
-    for tag_id in tag_ids:
-        tag_result = await db.execute(
-            select(Tags).where(Tags.tag_id == tag_id)  # type: ignore[arg-type]
-        )
-        tag = tag_result.scalar_one_or_none()
-        if not tag:
-            resolved_tags[tag_id] = None
-            continue
-        resolved_tags[tag_id] = tag.alias_of if tag.alias_of else tag_id
+    # Same snapshot-conflict exposure as the add path: the TagHistory INSERTs
+    # locking-read their FK parents and the DELETE's usage_count trigger keeps
+    # the parent `tags` rows moving. Retry the whole fetch-through-commit unit
+    # on a fresh snapshot (see app/core/db_retry.py). The accumulators are built
+    # inside the unit so a retry cannot report a pair once per attempt.
+    async def _apply() -> tuple[list[BatchTagResultItem], list[BatchTagSkippedItem]]:
+        removed: list[BatchTagResultItem] = []
+        skipped: list[BatchTagSkippedItem] = []
 
-    missing_tag_ids = {tid for tid, rid in resolved_tags.items() if rid is None}
+        # 1. Resolve tags: fetch all, resolve aliases, collect missing
+        resolved_tags: dict[int, int | None] = {}  # original_tag_id -> resolved_tag_id or None
+        for tag_id in tag_ids:
+            tag_result = await db.execute(
+                select(Tags).where(Tags.tag_id == tag_id)  # type: ignore[arg-type]
+            )
+            tag = tag_result.scalar_one_or_none()
+            if not tag:
+                resolved_tags[tag_id] = None
+                continue
+            resolved_tags[tag_id] = tag.alias_of if tag.alias_of else tag_id
 
-    # 2. Fetch existing images in one query
-    valid_resolved_tag_ids = {rid for rid in resolved_tags.values() if rid is not None}
-    existing_image_result = await db.execute(
-        select(Images.image_id).where(  # type: ignore[call-overload]
-            Images.image_id.in_(image_ids)  # type: ignore[union-attr]
-        )
-    )
-    existing_image_ids = {row[0] for row in existing_image_result.all()}
+        missing_tag_ids = {tid for tid, rid in resolved_tags.items() if rid is None}
 
-    # 3. Fetch existing tag links in one query
-    existing_links: set[tuple[int, int]] = set()
-    if existing_image_ids and valid_resolved_tag_ids:
-        links_result = await db.execute(
-            select(TagLinks.image_id, TagLinks.tag_id).where(  # type: ignore[call-overload]
-                TagLinks.image_id.in_(existing_image_ids),  # type: ignore[attr-defined]
-                TagLinks.tag_id.in_(valid_resolved_tag_ids),  # type: ignore[attr-defined]
+        # 2. Fetch existing images in one query
+        valid_resolved_tag_ids = {rid for rid in resolved_tags.values() if rid is not None}
+        existing_image_result = await db.execute(
+            select(Images.image_id).where(  # type: ignore[call-overload]
+                Images.image_id.in_(image_ids)  # type: ignore[union-attr]
             )
         )
-        existing_links = {(row[0], row[1]) for row in links_result.all()}
+        existing_image_ids = {row[0] for row in existing_image_result.all()}
 
-    # 4. Categorize each image-tag pair into removed/skipped
-    pairs_to_remove: list[tuple[int, int]] = []
-    for image_id in image_ids:
-        for original_tag_id in tag_ids:
-            resolved_tag_id = resolved_tags[original_tag_id]
-
-            if original_tag_id in missing_tag_ids:
-                skipped.append(
-                    BatchTagSkippedItem(
-                        image_id=image_id,
-                        tag_id=original_tag_id,
-                        reason="tag_not_found",
-                    )
+        # 3. Fetch existing tag links in one query
+        existing_links: set[tuple[int, int]] = set()
+        if existing_image_ids and valid_resolved_tag_ids:
+            links_result = await db.execute(
+                select(TagLinks.image_id, TagLinks.tag_id).where(  # type: ignore[call-overload]
+                    TagLinks.image_id.in_(existing_image_ids),  # type: ignore[attr-defined]
+                    TagLinks.tag_id.in_(valid_resolved_tag_ids),  # type: ignore[attr-defined]
                 )
-                continue
+            )
+            existing_links = {(row[0], row[1]) for row in links_result.all()}
 
-            assert resolved_tag_id is not None
+        # 4. Categorize each image-tag pair into removed/skipped
+        pairs_to_remove: list[tuple[int, int]] = []
+        for image_id in image_ids:
+            for original_tag_id in tag_ids:
+                resolved_tag_id = resolved_tags[original_tag_id]
 
-            if image_id not in existing_image_ids:
-                skipped.append(
-                    BatchTagSkippedItem(
+                if original_tag_id in missing_tag_ids:
+                    skipped.append(
+                        BatchTagSkippedItem(
+                            image_id=image_id,
+                            tag_id=original_tag_id,
+                            reason="tag_not_found",
+                        )
+                    )
+                    continue
+
+                assert resolved_tag_id is not None
+
+                if image_id not in existing_image_ids:
+                    skipped.append(
+                        BatchTagSkippedItem(
+                            image_id=image_id,
+                            tag_id=resolved_tag_id,
+                            reason="image_not_found",
+                        )
+                    )
+                    continue
+
+                if (image_id, resolved_tag_id) not in existing_links:
+                    skipped.append(
+                        BatchTagSkippedItem(
+                            image_id=image_id,
+                            tag_id=resolved_tag_id,
+                            reason="not_tagged",
+                        )
+                    )
+                    continue
+
+                pairs_to_remove.append((image_id, resolved_tag_id))
+                removed.append(
+                    BatchTagResultItem(
                         image_id=image_id,
                         tag_id=resolved_tag_id,
-                        reason="image_not_found",
                     )
                 )
-                continue
 
-            if (image_id, resolved_tag_id) not in existing_links:
-                skipped.append(
-                    BatchTagSkippedItem(
+                # Track as removed to prevent duplicate processing within same batch
+                existing_links.discard((image_id, resolved_tag_id))
+
+        # 5. Batch delete all tag links in a single statement
+        if pairs_to_remove:
+            from sqlalchemy import tuple_
+
+            await db.execute(
+                delete(TagLinks).where(
+                    tuple_(TagLinks.image_id, TagLinks.tag_id).in_(  # type: ignore[arg-type]
+                        pairs_to_remove
+                    )
+                )
+            )
+
+            # Record history for all removed pairs
+            for image_id, tag_id in pairs_to_remove:
+                db.add(
+                    TagHistory(
                         image_id=image_id,
-                        tag_id=resolved_tag_id,
-                        reason="not_tagged",
+                        tag_id=tag_id,
+                        action="r",
+                        user_id=user_id,
                     )
                 )
-                continue
 
-            pairs_to_remove.append((image_id, resolved_tag_id))
-            removed.append(
-                BatchTagResultItem(
-                    image_id=image_id,
-                    tag_id=resolved_tag_id,
-                )
+        await refresh_images_tag_type_flags(db, {item.image_id for item in removed})
+
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            logger.warning(
+                "batch_tag_remove_integrity_error",
+                user_id=user_id,
+                tag_ids=tag_ids,
+                image_ids=image_ids,
             )
+            raise
 
-            # Track as removed to prevent duplicate processing within same batch
-            existing_links.discard((image_id, resolved_tag_id))
+        return removed, skipped
 
-    # 5. Batch delete all tag links in a single statement
-    if pairs_to_remove:
-        from sqlalchemy import tuple_
+    removed, skipped = await retry_on_snapshot_conflict(db, _apply, what="batch_tag_remove")
 
-        await db.execute(
-            delete(TagLinks).where(
-                tuple_(TagLinks.image_id, TagLinks.tag_id).in_(  # type: ignore[arg-type]
-                    pairs_to_remove
-                )
-            )
-        )
-
-        # Record history for all removed pairs
-        for image_id, tag_id in pairs_to_remove:
-            db.add(
-                TagHistory(
-                    image_id=image_id,
-                    tag_id=tag_id,
-                    action="r",
-                    user_id=user_id,
-                )
-            )
-
-    await refresh_images_tag_type_flags(db, {item.image_id for item in removed})
-
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        logger.warning(
-            "batch_tag_remove_integrity_error",
-            user_id=user_id,
-            tag_ids=tag_ids,
-            image_ids=image_ids,
-        )
-        raise
-
-    # Sync affected tags to Meilisearch (usage_count updated by DB trigger)
+    # Sync affected tags to Meilisearch (usage_count updated by DB trigger).
+    # Non-DB side effect: stays outside the retried unit so it never repeats.
     affected_tag_ids = {item.tag_id for item in removed}
     if affected_tag_ids:
         tag_results = await db.execute(

--- a/app/services/upload.py
+++ b/app/services/upload.py
@@ -4,6 +4,7 @@ Image upload helpers for rate limiting, file saving, and tag linking.
 
 from datetime import UTC, datetime
 from pathlib import Path as FilePath
+from uuid import uuid4
 
 from fastapi import HTTPException, UploadFile, status
 from sqlalchemy import desc, func, select
@@ -69,14 +70,21 @@ async def check_upload_rate_limit(
             )
 
 
-async def save_uploaded_image(
-    file: UploadFile, storage_path: str, image_id: int
-) -> tuple[FilePath, str, str]:
+async def stage_uploaded_image(file: UploadFile, storage_path: str) -> tuple[FilePath, str, str]:
     """
-    Save uploaded image to storage with format: YYYY-MM-DD-{image_id}.{ext}
+    Write an upload to a staging path, validate it, and hash it.
 
     Returns:
-        Tuple of (file_path, extension, md5_hash)
+        Tuple of (staged_path, extension, md5_hash)
+
+    The file keeps its staging name until `finalize_uploaded_image` renames it:
+    the permanent name embeds the image_id, which does not exist until the row
+    is inserted. Splitting it this way keeps the file write and the duplicate
+    checks outside the database transaction, so that transaction stays short
+    enough to retry on a snapshot conflict (see app/core/db_retry.py).
+
+    The staging name is unique per upload — two users uploading files with the
+    same original name must not write to the same staging path.
     """
     # Get file extension
     if not file.filename:
@@ -91,10 +99,9 @@ async def save_uploaded_image(
     fullsize_dir = FilePath(storage_path) / "fullsize"
     fullsize_dir.mkdir(parents=True, exist_ok=True)
 
-    # Save file temporarily to validate and calculate hash
-    temp_path = fullsize_dir / f"temp_{file.filename}"
+    staged_path = fullsize_dir / f"staged_{uuid4().hex}"
     try:
-        with open(temp_path, "wb") as f:
+        with open(staged_path, "wb") as f:
             content = await file.read()
             if len(content) > settings.MAX_IMAGE_SIZE:
                 raise HTTPException(
@@ -104,33 +111,39 @@ async def save_uploaded_image(
             f.write(content)
 
         # Validate file is actually an image (security check)
-        validate_image_file(file, temp_path)
+        validate_image_file(file, staged_path)
 
         # Calculate MD5 hash
-        md5_hash = calculate_md5(temp_path)
+        md5_hash = calculate_md5(staged_path)
 
-        # Generate filename with date prefix and image_id
-        date_prefix = datetime.now().strftime("%Y-%m-%d")
-        final_filename = f"{date_prefix}-{image_id}.{ext}"
-        final_path = fullsize_dir / final_filename
-
-        # Move to final location
-        temp_path.rename(final_path)
-
-        return final_path, ext, md5_hash
+        return staged_path, ext, md5_hash
     except HTTPException:
-        # Clean up temp file on validation error
-        if temp_path.exists():
-            temp_path.unlink()
+        # Clean up staged file on validation error
+        staged_path.unlink(missing_ok=True)
         raise
     except Exception as e:
-        # Clean up temp file on any error
-        if temp_path.exists():
-            temp_path.unlink()
+        # Clean up staged file on any error
+        staged_path.unlink(missing_ok=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to save image",
         ) from e
+
+
+def finalize_uploaded_image(
+    staged_path: FilePath, storage_path: str, image_id: int, ext: str, date_prefix: str
+) -> FilePath:
+    """
+    Give a staged upload its permanent name: YYYY-MM-DD-{image_id}.{ext}
+
+    `date_prefix` is supplied by the caller rather than recomputed here so the
+    on-disk name always matches the filename recorded on the row, even when the
+    request straddles local midnight.
+    """
+    fullsize_dir = FilePath(storage_path) / "fullsize"
+    final_path = fullsize_dir / f"{date_prefix}-{image_id}.{ext}"
+    staged_path.rename(final_path)
+    return final_path
 
 
 async def link_tags_to_image(

--- a/tests/api/v1/test_batch_tag.py
+++ b/tests/api/v1/test_batch_tag.py
@@ -3,6 +3,7 @@
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import func, select
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import TagType
@@ -14,6 +15,7 @@ from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
 from app.services.tag_type_flags import refresh_image_tag_type_flags
+from tests.snapshot_conflict import _flaky_flush, _snapshot_conflict_error
 
 
 async def _create_user_with_tag_permission(
@@ -749,3 +751,118 @@ class TestBatchAddApprovesMlSuggestions:
             await db_session.refresh(s)
             assert s.status == "approved"
             assert s.reviewed_by_user_id == user.user_id
+
+
+@pytest.mark.api
+class TestBatchTagSnapshotConflictRetry:
+    """The batch paths INSERT into tag_links/tag_history, whose FK columns make
+    InnoDB locking-read the parent tags/images/users rows — and the usage_count
+    triggers on tag_links keep those parents moving. Under
+    innodb_snapshot_isolation a concurrent tag write aborts the batch with
+    ER_CHECKREAD (errno 1020), so it must retry on a fresh snapshot.
+
+    The added/removed accumulators must be rebuilt per attempt: a retry that
+    reuses lists from the failed attempt would report every pair twice.
+
+    ids are captured as ints before the request because the app under test
+    shares this session, so the retry's real rollback expires the fixtures.
+    """
+
+    @pytest.mark.needs_commit
+    async def test_batch_add_retries_snapshot_conflict_and_succeeds(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A transient 1020 is retried; each pair is added and reported once."""
+        user = await _create_user_with_tag_permission(db_session)
+        token = create_access_token(user.id)
+        images = await _create_test_images(db_session, user, 2)
+        tags = await _create_test_tags(db_session, 1)
+
+        image_ids = [img.image_id for img in images]
+        tag_id: int = tags[0].tag_id
+
+        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error("tag_history"))
+        with flush_patch:
+            response = await client.post(
+                "/api/v1/tags/batch",
+                json={"action": "add", "tag_ids": [tag_id], "image_ids": image_ids},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert response.status_code == 200, response.text
+        assert len(calls) >= 2  # failed attempt + successful retry
+
+        # Reported once per pair, not once per attempt.
+        data = response.json()
+        assert len(data["added"]) == 2
+        assert len(data["skipped"]) == 0
+
+        # ...and persisted once per pair.
+        link_count = await db_session.execute(
+            select(func.count())
+            .select_from(TagLinks)
+            .where(TagLinks.tag_id == tag_id, TagLinks.image_id.in_(image_ids))
+        )
+        assert link_count.scalar_one() == 2
+
+    @pytest.mark.needs_commit
+    async def test_batch_remove_retries_snapshot_conflict_and_succeeds(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A transient 1020 is retried; each pair is removed and reported once."""
+        user = await _create_user_with_tag_permission(db_session, ["image_tag_remove"])
+        token = create_access_token(user.id)
+        images = await _create_test_images(db_session, user, 2)
+        tags = await _create_test_tags(db_session, 1)
+
+        image_ids = [img.image_id for img in images]
+        tag_id: int = tags[0].tag_id
+
+        for image_id in image_ids:
+            db_session.add(TagLinks(image_id=image_id, tag_id=tag_id, user_id=user.user_id))
+        await db_session.commit()
+
+        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error("tag_history"))
+        with flush_patch:
+            response = await client.post(
+                "/api/v1/tags/batch",
+                json={"action": "remove", "tag_ids": [tag_id], "image_ids": image_ids},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert response.status_code == 200, response.text
+        assert len(calls) >= 2
+
+        data = response.json()
+        assert len(data["removed"]) == 2
+        assert len(data["skipped"]) == 0
+
+        link_count = await db_session.execute(
+            select(func.count())
+            .select_from(TagLinks)
+            .where(TagLinks.tag_id == tag_id, TagLinks.image_id.in_(image_ids))
+        )
+        assert link_count.scalar_one() == 0
+
+    @pytest.mark.needs_commit
+    async def test_batch_add_gives_up_after_bounded_retries(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A persistent 1020 propagates after a bounded number of attempts."""
+        user = await _create_user_with_tag_permission(db_session)
+        token = create_access_token(user.id)
+        images = await _create_test_images(db_session, user, 1)
+        tags = await _create_test_tags(db_session, 1)
+
+        image_ids = [img.image_id for img in images]
+        tag_id: int = tags[0].tag_id
+
+        flush_patch, calls = _flaky_flush(100, _snapshot_conflict_error("tag_history"))
+        with flush_patch, pytest.raises(OperationalError):
+            await client.post(
+                "/api/v1/tags/batch",
+                json={"action": "add", "tag_ids": [tag_id], "image_ids": image_ids},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert len(calls) == 3  # bounded: no infinite retry loop

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -8,9 +8,7 @@ These tests cover the /api/v1/images endpoints including:
 """
 
 from datetime import UTC, datetime
-from unittest.mock import patch
 
-import pymysql
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
@@ -21,7 +19,9 @@ from app.config import TagType, settings
 from app.models import Favorites, ImageRatings, Images, TagLinks, Tags, Users
 from app.models.ml_tag_suggestion import MlTagSuggestions
 from app.models.permissions import Groups, UserGroups
+from app.models.tag_history import TagHistory
 from app.services.tag_type_flags import refresh_image_tag_type_flags
+from tests.snapshot_conflict import _db_error, _flaky_flush, _snapshot_conflict_error
 
 
 @pytest.mark.api
@@ -4493,34 +4493,6 @@ class TestRateImage:
         assert data["num_ratings"] == 1
 
 
-def _db_error(errno: int, message: str) -> OperationalError:
-    """Build the sqlalchemy error the aiomysql/pymysql driver raises for `errno`."""
-    return OperationalError("UPDATE ...", None, pymysql.err.OperationalError(errno, message))
-
-
-def _snapshot_conflict_error() -> OperationalError:
-    """The error MariaDB raises under innodb_snapshot_isolation (ER_CHECKREAD)."""
-    return _db_error(1020, "Record has changed since last read in table 'images'")
-
-
-def _flaky_flush(fail_times: int, error: OperationalError):
-    """Patch AsyncSession.flush to raise `error` for the first `fail_times`
-    calls, then delegate to the real flush. Only a route's explicit
-    ``await db.flush()`` goes through AsyncSession.flush (autoflush runs inside
-    the sync Session), so the first intercepted call is the counter write.
-    Returns (patch_ctx, calls) where calls records each intercepted flush."""
-    real_flush = AsyncSession.flush
-    calls: list[int] = []
-
-    async def flush(self, *args, **kwargs):
-        calls.append(1)
-        if len(calls) <= fail_times:
-            raise error
-        await real_flush(self, *args, **kwargs)
-
-    return patch.object(AsyncSession, "flush", flush), calls
-
-
 @pytest.mark.api
 class TestFavoriteRatingSnapshotConflictRetry:
     """favorite/unfavorite/rate do read-modify-write UPDATEs on shared
@@ -4675,6 +4647,192 @@ class TestFavoriteRatingSnapshotConflictRetry:
         flush_patch, calls = _flaky_flush(100, _db_error(1213, "Deadlock found"))
         with flush_patch, pytest.raises(OperationalError):
             await authenticated_client.post(f"/api/v1/images/{image.image_id}/favorite")
+
+        assert len(calls) == 1  # not retried
+
+
+@pytest.mark.api
+class TestTagWriteSnapshotConflictRetry:
+    """Adding or removing a tag INSERTs into tag_history, whose tag_id/image_id/
+    user_id are FK columns — so InnoDB takes a locking read on each parent row.
+    The usage_count triggers on tag_links keep the parent `tags` row moving, and
+    the image_posts trigger does the same to `users`, so under
+    innodb_snapshot_isolation a concurrent tag write aborts this one with
+    ER_CHECKREAD (errno 1020). Two users tagging at the same moment is enough.
+
+    Both paths must retry on a fresh snapshot instead of surfacing a 500.
+
+    Each test captures image_id/tag_id as ints before calling the endpoint: the
+    app under test shares this session (conftest overrides get_db with
+    db_session), so the retry's real rollback expires the fixture instances.
+    Production never sees that — the request session is nobody else's.
+    """
+
+    @pytest.mark.needs_commit
+    async def test_add_tag_retries_snapshot_conflict_and_succeeds(
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
+        sample_user: Users,
+        sample_image_data: dict,
+    ):
+        """A transient 1020 during the tag add is retried and the tag lands once.
+
+        needs_commit: the retry performs a real session rollback to obtain a
+        fresh snapshot; under the default SAVEPOINT isolation that rollback
+        would unwind the fixture's committed image/tag rows too, which cannot
+        happen in production where they are durably committed.
+        """
+        image_data = sample_image_data.copy()
+        image_data["user_id"] = sample_user.user_id
+        image = Images(**image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        tag = Tags(title="snapshot_retry_add", type=1)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        image_id: int = image.image_id
+        tag_id: int = tag.tag_id
+
+        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error("tag_history"))
+        with flush_patch:
+            response = await authenticated_client.post(f"/api/v1/images/{image_id}/tags/{tag_id}")
+
+        assert response.status_code == 201, response.text
+        assert len(calls) >= 2  # failed attempt + successful retry
+
+        # The link landed exactly once despite the retry.
+        links = await db_session.execute(
+            select(TagLinks).where(
+                TagLinks.image_id == image_id,
+                TagLinks.tag_id == tag_id,
+            )
+        )
+        assert len(list(links.scalars().all())) == 1
+
+        # ...and so did its history row: a replayed unit must not double-log.
+        history = await db_session.execute(
+            select(TagHistory).where(
+                TagHistory.image_id == image_id,
+                TagHistory.tag_id == tag_id,
+                TagHistory.action == "a",
+            )
+        )
+        assert len(list(history.scalars().all())) == 1
+
+    @pytest.mark.needs_commit
+    async def test_remove_tag_retries_snapshot_conflict_and_succeeds(
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
+        sample_user: Users,
+        sample_image_data: dict,
+    ):
+        """A transient 1020 during the tag removal is retried and the link goes."""
+        image_data = sample_image_data.copy()
+        image_data["user_id"] = sample_user.user_id
+        image = Images(**image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        tag = Tags(title="snapshot_retry_remove", type=1)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        image_id: int = image.image_id
+        tag_id: int = tag.tag_id
+
+        db_session.add(TagLinks(image_id=image_id, tag_id=tag_id, user_id=sample_user.user_id))
+        await db_session.commit()
+
+        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error("tag_history"))
+        with flush_patch:
+            response = await authenticated_client.delete(
+                f"/api/v1/images/{image_id}/tags/{tag_id}"
+            )
+
+        assert response.status_code == 204, response.text
+        assert len(calls) >= 2
+
+        links = await db_session.execute(
+            select(TagLinks).where(
+                TagLinks.image_id == image_id,
+                TagLinks.tag_id == tag_id,
+            )
+        )
+        assert links.scalar_one_or_none() is None
+
+        history = await db_session.execute(
+            select(TagHistory).where(
+                TagHistory.image_id == image_id,
+                TagHistory.tag_id == tag_id,
+                TagHistory.action == "r",
+            )
+        )
+        assert len(list(history.scalars().all())) == 1
+
+    @pytest.mark.needs_commit
+    async def test_add_tag_gives_up_after_bounded_retries(
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
+        sample_user: Users,
+        sample_image_data: dict,
+    ):
+        """A persistent 1020 propagates after a bounded number of attempts."""
+        image_data = sample_image_data.copy()
+        image_data["user_id"] = sample_user.user_id
+        image = Images(**image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        tag = Tags(title="snapshot_retry_bounded", type=1)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        image_id: int = image.image_id
+        tag_id: int = tag.tag_id
+
+        flush_patch, calls = _flaky_flush(100, _snapshot_conflict_error("tag_history"))
+        with flush_patch, pytest.raises(OperationalError):
+            await authenticated_client.post(f"/api/v1/images/{image_id}/tags/{tag_id}")
+
+        assert len(calls) == 3  # bounded: no infinite retry loop
+
+    async def test_add_tag_does_not_retry_other_db_errors(
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
+        sample_user: Users,
+        sample_image_data: dict,
+    ):
+        """Non-1020 database errors propagate immediately with no retry."""
+        image_data = sample_image_data.copy()
+        image_data["user_id"] = sample_user.user_id
+        image = Images(**image_data)
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        tag = Tags(title="snapshot_retry_other_error", type=1)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+
+        image_id: int = image.image_id
+        tag_id: int = tag.tag_id
+
+        flush_patch, calls = _flaky_flush(100, _db_error(1213, "Deadlock found"))
+        with flush_patch, pytest.raises(OperationalError):
+            await authenticated_client.post(f"/api/v1/images/{image_id}/tags/{tag_id}")
 
         assert len(calls) == 1  # not retried
 

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -8,6 +8,7 @@ Tests cover:
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sqlalchemy import select
@@ -31,6 +32,7 @@ from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
 from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
+from tests.snapshot_conflict import _flaky_flush, _snapshot_conflict_error
 
 
 async def create_auth_user(
@@ -2473,3 +2475,113 @@ class TestAdminApplyTagSuggestions:
         assert tags[2].tag_id in added_tag_ids
         for h in additions:
             assert h.user_id == admin.user_id
+
+
+@pytest.mark.api
+class TestApplyTagSuggestionsSnapshotConflictRetry:
+    """apply_tag_suggestions INSERTs into tag_links/tag_history, whose FK columns
+    make InnoDB locking-read the parent tags/images/users rows, and the
+    usage_count trigger on tag_links keeps those parents moving. Under
+    innodb_snapshot_isolation a concurrent tag write aborts this one with
+    ER_CHECKREAD (errno 1020), so it must retry on a fresh snapshot.
+
+    The applied_tags/removed_tags accumulators must be rebuilt per attempt, or a
+    retry reports each tag once per attempt.
+    """
+
+    @pytest.mark.needs_commit
+    async def test_apply_retries_snapshot_conflict_and_succeeds(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A transient 1020 is retried; each tag is applied and reported once."""
+        admin, password = await create_auth_user(db_session, username="applyretry1", admin=True)
+        await grant_permission(db_session, admin.user_id, "report_manage")
+        image = await create_test_image(db_session, admin.user_id)
+        tags = await create_test_tags(db_session, count=2)
+        token = await login_user(client, admin.username, password)
+
+        report = ImageReports(
+            image_id=image.image_id,
+            user_id=admin.user_id,
+            category=4,
+            status=ReportStatus.PENDING,
+        )
+        db_session.add(report)
+        await db_session.flush()
+
+        suggestions = []
+        for tag in tags:
+            s = ImageReportTagSuggestions(report_id=report.report_id, tag_id=tag.tag_id)
+            db_session.add(s)
+            suggestions.append(s)
+        await db_session.commit()
+        for s in suggestions:
+            await db_session.refresh(s)
+
+        # Captured before the request: the app under test shares this session,
+        # so the retry's real rollback expires the fixture instances.
+        report_id: int = report.report_id
+        image_id: int = image.image_id
+        suggestion_ids = [s.suggestion_id for s in suggestions]
+
+        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error("tag_history"))
+        with flush_patch:
+            response = await client.post(
+                f"/api/v1/admin/reports/{report_id}/apply-tag-suggestions",
+                json={"approved_suggestion_ids": suggestion_ids},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert response.status_code == 200, response.text
+        assert len(calls) >= 2  # failed attempt + successful retry
+
+        # Reported once per tag, not once per attempt.
+        assert len(response.json()["applied_tags"]) == 2
+
+        # ...and linked once per tag.
+        tag_links = await db_session.execute(
+            select(TagLinks).where(TagLinks.image_id == image_id)
+        )
+        assert len(list(tag_links.scalars().all())) == 2
+
+        # The report transitioned exactly once.
+        await db_session.refresh(report)
+        assert report.status == ReportStatus.REVIEWED
+
+    @pytest.mark.needs_commit
+    async def test_apply_gives_up_after_bounded_retries(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A persistent 1020 propagates after a bounded number of attempts."""
+        admin, password = await create_auth_user(db_session, username="applyretry2", admin=True)
+        await grant_permission(db_session, admin.user_id, "report_manage")
+        image = await create_test_image(db_session, admin.user_id)
+        tags = await create_test_tags(db_session, count=1)
+        token = await login_user(client, admin.username, password)
+
+        report = ImageReports(
+            image_id=image.image_id,
+            user_id=admin.user_id,
+            category=4,
+            status=ReportStatus.PENDING,
+        )
+        db_session.add(report)
+        await db_session.flush()
+
+        suggestion = ImageReportTagSuggestions(report_id=report.report_id, tag_id=tags[0].tag_id)
+        db_session.add(suggestion)
+        await db_session.commit()
+        await db_session.refresh(suggestion)
+
+        report_id: int = report.report_id
+        suggestion_id: int = suggestion.suggestion_id
+
+        flush_patch, calls = _flaky_flush(100, _snapshot_conflict_error("tag_history"))
+        with flush_patch, pytest.raises(OperationalError):
+            await client.post(
+                f"/api/v1/admin/reports/{report_id}/apply-tag-suggestions",
+                json={"approved_suggestion_ids": [suggestion_id]},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert len(calls) == 3  # bounded: no infinite retry loop

--- a/tests/api/v1/test_upload.py
+++ b/tests/api/v1/test_upload.py
@@ -6,7 +6,6 @@ from io import BytesIO
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
-import pymysql
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.exc import OperationalError
@@ -15,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.security import create_access_token
 from app.models.user import Users
 from app.schemas.image import SimilarImageResult
+from tests.snapshot_conflict import _db_error, _flaky_flush, _snapshot_conflict_error
 
 
 @pytest.fixture
@@ -483,36 +483,6 @@ async def test_images_source_url_roundtrip(db_session: AsyncSession):
     await db_session.commit()
     await db_session.refresh(image)
     assert image.source_url == "https://www.pixiv.net/artworks/138823691"
-
-
-def _db_error(errno: int, message: str) -> OperationalError:
-    """Build the sqlalchemy error the aiomysql/pymysql driver raises for `errno`."""
-    return OperationalError(
-        "INSERT INTO images ...", None, pymysql.err.OperationalError(errno, message)
-    )
-
-
-def _snapshot_conflict_error() -> OperationalError:
-    """The error MariaDB raises under innodb_snapshot_isolation (ER_CHECKREAD)."""
-    return _db_error(1020, "Record has changed since last read in table 'images'")
-
-
-def _flaky_flush(fail_times: int, error: OperationalError):
-    """Patch AsyncSession.flush to raise `error` for the first `fail_times`
-    calls, then delegate to the real flush. Only the route's explicit
-    `await db.flush()` goes through AsyncSession.flush (autoflush runs inside
-    the sync Session), so the first intercepted call is the temp-row INSERT.
-    Returns (patch_ctx, calls) where calls records each intercepted flush."""
-    real_flush = AsyncSession.flush
-    calls: list[int] = []
-
-    async def flush(self, *args, **kwargs):
-        calls.append(1)
-        if len(calls) <= fail_times:
-            raise error
-        await real_flush(self, *args, **kwargs)
-
-    return patch.object(AsyncSession, "flush", flush), calls
 
 
 class TestUploadSnapshotConflictRetry:

--- a/tests/api/v1/test_upload.py
+++ b/tests/api/v1/test_upload.py
@@ -2,19 +2,24 @@
 
 import os
 import tempfile
+from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import create_access_token
 from app.models.user import Users
 from app.schemas.image import SimilarImageResult
-from tests.snapshot_conflict import _db_error, _flaky_flush, _snapshot_conflict_error
+from tests.snapshot_conflict import (
+    _db_error,
+    _flaky_flush,
+    _flaky_flush_nth,
+    _snapshot_conflict_error,
+)
 
 
 @pytest.fixture
@@ -78,22 +83,33 @@ def _make_similar_result(image_id: int, score: float) -> SimilarImageResult:
     )
 
 
-def _mock_save_uploaded_image(md5: str = "abc123unique"):
-    """Create an AsyncMock for save_uploaded_image that returns a fake path.
+@contextmanager
+def _mock_upload_storage(md5: str = "abc123unique"):
+    """Patch the upload route's two filesystem steps: stage, then finalize.
 
     Uses a per-xdist-worker temp path (not a single shared file) so parallel
     workers can't touch()/unlink() one another's file mid-request — the
     duplicate and IQDB 409 paths both unlink it, while the success path stats it.
+
+    finalize is a no-op: the staged path is already the final path here, so the
+    fake file survives for whatever the test asserts on afterwards.
     """
     worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
     fake_path = Path(tempfile.gettempdir()) / f"fake-upload-{worker}.jpg"
 
-    async def _save(file, storage_path, image_id):
+    async def _stage(file, storage_path):
         # Create the fake file so cleanup code (and stat()) don't error
         fake_path.touch()
         return fake_path, "jpg", md5
 
-    return patch("app.api.v1.images.save_uploaded_image", side_effect=_save)
+    def _finalize(staged_path, storage_path, image_id, ext, date_prefix):
+        return staged_path
+
+    with (
+        patch("app.api.v1.images.stage_uploaded_image", side_effect=_stage),
+        patch("app.api.v1.images.finalize_uploaded_image", side_effect=_finalize),
+    ):
+        yield
 
 
 class TestUploadIQDBDuplicateDetection:
@@ -110,7 +126,7 @@ class TestUploadIQDBDuplicateDetection:
         ]
 
         with (
-            _mock_save_uploaded_image(),
+            _mock_upload_storage(),
             patch(
                 "app.api.v1.images.check_iqdb_similarity",
                 new_callable=AsyncMock,
@@ -147,7 +163,7 @@ class TestUploadIQDBDuplicateDetection:
         mock_iqdb = AsyncMock(return_value=[])
 
         with (
-            _mock_save_uploaded_image("abc123unique2"),
+            _mock_upload_storage("abc123unique2"),
             patch("app.api.v1.images.check_iqdb_similarity", mock_iqdb),
             patch("app.api.v1.images.get_image_dimensions", return_value=(100, 100)),
             patch("app.api.v1.images.enqueue_job", new_callable=AsyncMock),
@@ -168,7 +184,7 @@ class TestUploadIQDBDuplicateDetection:
     ):
         """Upload succeeds normally when IQDB finds no near-duplicates."""
         with (
-            _mock_save_uploaded_image("abc123unique3"),
+            _mock_upload_storage("abc123unique3"),
             patch(
                 "app.api.v1.images.check_iqdb_similarity",
                 new_callable=AsyncMock,
@@ -193,7 +209,7 @@ class TestUploadIQDBDuplicateDetection:
     ):
         """Upload with miscmeta parameter stores it and returns it in the response."""
         with (
-            _mock_save_uploaded_image("abc123unique4"),
+            _mock_upload_storage("abc123unique4"),
             patch(
                 "app.api.v1.images.check_iqdb_similarity",
                 new_callable=AsyncMock,
@@ -218,7 +234,7 @@ class TestUploadIQDBDuplicateDetection:
     ):
         """Upload with source_url stores it and returns it in the response."""
         with (
-            _mock_save_uploaded_image("abc123unique5"),
+            _mock_upload_storage("abc123unique5"),
             patch(
                 "app.api.v1.images.check_iqdb_similarity",
                 new_callable=AsyncMock,
@@ -245,7 +261,7 @@ class TestUploadIQDBDuplicateDetection:
         self, upload_client: AsyncClient, verified_user: Users
     ):
         """Upload rejects a source_url that isn't http(s) with a 422."""
-        with _mock_save_uploaded_image():
+        with _mock_upload_storage():
             response = await upload_client.post(
                 "/api/v1/images/upload",
                 files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
@@ -260,7 +276,7 @@ class TestUploadIQDBDuplicateDetection:
     ):
         """Upload with whitespace-only source_url normalizes it to None."""
         with (
-            _mock_save_uploaded_image("abc123unique6"),
+            _mock_upload_storage("abc123unique6"),
             patch(
                 "app.api.v1.images.check_iqdb_similarity",
                 new_callable=AsyncMock,
@@ -295,7 +311,7 @@ class TestUploadMLTagSuggestions:
         enqueue_mock = AsyncMock()
 
         with (
-            _mock_save_uploaded_image("ml_enqueue_on"),
+            _mock_upload_storage("ml_enqueue_on"),
             patch(
                 "app.api.v1.images.check_iqdb_similarity",
                 new_callable=AsyncMock,
@@ -335,7 +351,7 @@ class TestUploadMLTagSuggestions:
         enqueue_mock = AsyncMock()
 
         with (
-            _mock_save_uploaded_image("ml_enqueue_off"),
+            _mock_upload_storage("ml_enqueue_off"),
             patch(
                 "app.api.v1.images.check_iqdb_similarity",
                 new_callable=AsyncMock,
@@ -375,7 +391,7 @@ class TestUploadMLTagSuggestions:
         enqueue_mock = AsyncMock(side_effect=_side_effect)
 
         with (
-            _mock_save_uploaded_image("ml_enqueue_fail"),
+            _mock_upload_storage("ml_enqueue_fail"),
             patch(
                 "app.api.v1.images.check_iqdb_similarity",
                 new_callable=AsyncMock,
@@ -417,7 +433,7 @@ class TestUploadMD5DuplicateDetection:
 
         # save_uploaded_image is mocked to yield the md5 of an image that already
         # exists in the DB (the test_image fixture), triggering the duplicate path.
-        with _mock_save_uploaded_image(existing_md5):
+        with _mock_upload_storage(existing_md5):
             response = await upload_client.post(
                 "/api/v1/images/upload",
                 files={"file": ("dup.jpg", _fake_image_bytes(), "image/jpeg")},
@@ -447,7 +463,7 @@ class TestUploadClientIPHandling:
         """
         ipv6 = "2600:6c63:ff0:6810:c042:21d5:bfed:9bae"
         with (
-            _mock_save_uploaded_image("ipv6upload01"),
+            _mock_upload_storage("ipv6upload01"),
             patch(
                 "app.api.v1.images.check_iqdb_similarity",
                 new_callable=AsyncMock,
@@ -508,7 +524,7 @@ class TestUploadSnapshotConflictRetry:
         """
         flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error())
         with (
-            _mock_save_uploaded_image("snapshotretry1"),
+            _mock_upload_storage("snapshotretry1"),
             patch(
                 "app.api.v1.images.check_iqdb_similarity",
                 new_callable=AsyncMock,
@@ -532,36 +548,178 @@ class TestUploadSnapshotConflictRetry:
     async def test_upload_gives_up_after_bounded_retries(
         self, upload_client: AsyncClient, verified_user: Users
     ):
-        """A persistent 1020 propagates after a bounded number of attempts."""
+        """A persistent 1020 gives up after a bounded number of attempts.
+
+        The exhausted error surfaces as the route's own 500 rather than a raw
+        OperationalError: the retried unit sits inside upload's try/except, so
+        the failure also rolls back and unlinks the staged file.
+        """
         flush_patch, calls = _flaky_flush(100, _snapshot_conflict_error())
         with (
-            _mock_save_uploaded_image("snapshotretry2"),
+            _mock_upload_storage("snapshotretry2"),
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("app.api.v1.images.get_image_dimensions", return_value=(100, 100)),
             flush_patch,
-            pytest.raises(OperationalError),
         ):
-            await upload_client.post(
+            response = await upload_client.post(
                 "/api/v1/images/upload",
                 files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
                 data={"tag_ids": "", "caption": ""},
             )
 
+        assert response.status_code == 500
         assert len(calls) == 3  # bounded: no infinite retry loop
 
     @pytest.mark.asyncio
     async def test_upload_does_not_retry_other_db_errors(
         self, upload_client: AsyncClient, verified_user: Users
     ):
-        """Non-1020 database errors propagate immediately with no retry."""
+        """Non-1020 database errors fail immediately with no retry."""
         flush_patch, calls = _flaky_flush(100, _db_error(1213, "Deadlock found"))
         with (
-            _mock_save_uploaded_image("snapshotretry3"),
+            _mock_upload_storage("snapshotretry3"),
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("app.api.v1.images.get_image_dimensions", return_value=(100, 100)),
             flush_patch,
-            pytest.raises(OperationalError),
         ):
-            await upload_client.post(
+            response = await upload_client.post(
                 "/api/v1/images/upload",
                 files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
                 data={"tag_ids": "", "caption": ""},
             )
 
+        assert response.status_code == 500
         assert len(calls) == 1  # not retried
+
+
+@pytest.mark.api
+class TestUploadTagLinkSnapshotConflictRetry:
+    """The upload's tag-link write is exposed to ER_CHECKREAD too, and for
+    longer than the temp-row INSERT: tag_links/tag_history INSERTs take locking
+    reads on their FK parents, and the usage_count trigger on tag_links keeps
+    the parent `tags` row moving whenever anyone else tags that tag.
+
+    The conflict is aimed at the second explicit flush (the tag-link write)
+    rather than the first (which mints the image_id), so this fails on any
+    implementation that only retries the id-minting INSERT.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.needs_commit
+    async def test_upload_with_tags_retries_snapshot_conflict_and_succeeds(
+        self,
+        upload_client: AsyncClient,
+        verified_user: Users,
+        db_session: AsyncSession,
+    ):
+        """A transient 1020 on the tag-link write is retried and the upload succeeds."""
+        from sqlalchemy import select
+
+        from app.models.image import Images
+        from app.models.tag import Tags
+        from app.models.tag_link import TagLinks
+
+        tag = Tags(title="upload_snapshot_retry", type=1)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(tag)
+        tag_id: int = tag.tag_id
+
+        flush_patch, calls = _flaky_flush_nth(2, _snapshot_conflict_error("tag_history"))
+        with (
+            _mock_upload_storage("tagsnapshotretry1"),
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("app.api.v1.images.get_image_dimensions", return_value=(100, 100)),
+            patch("app.api.v1.images.enqueue_job", new_callable=AsyncMock),
+            flush_patch,
+        ):
+            response = await upload_client.post(
+                "/api/v1/images/upload",
+                files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
+                data={"tag_ids": str(tag_id), "caption": ""},
+            )
+
+        assert response.status_code == 201, response.text
+        assert len(calls) >= 3  # id flush, failed tag flush, then the retry
+
+        image_id = response.json()["image"]["image_id"]
+        assert image_id > 0
+
+        # The tag landed exactly once on the surviving image.
+        links = await db_session.execute(
+            select(TagLinks).where(TagLinks.image_id == image_id, TagLinks.tag_id == tag_id)
+        )
+        assert len(list(links.scalars().all())) == 1
+
+        # The abandoned attempt left no image row behind.
+        images = await db_session.execute(
+            select(Images).where(Images.md5_hash == "tagsnapshotretry1")
+        )
+        assert len(list(images.scalars().all())) == 1
+
+
+@pytest.mark.api
+class TestUploadRealStorageRoundTrip:
+    """The route with its filesystem steps UNMOCKED, against a real temp dir.
+
+    Every other upload test replaces stage/finalize, so this is the only cover
+    for the seam between them: that the name the row records is the name the
+    file ends up with, and that no staged file is left behind.
+    """
+
+    @pytest.mark.asyncio
+    async def test_upload_names_the_file_to_match_the_row(
+        self,
+        upload_client: AsyncClient,
+        verified_user: Users,
+        db_session: AsyncSession,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        """The saved file is YYYY-MM-DD-{image_id}.jpg and the row agrees."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+
+        with (
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("app.api.v1.images.enqueue_job", new_callable=AsyncMock),
+        ):
+            response = await upload_client.post(
+                "/api/v1/images/upload",
+                files={"file": ("real_round_trip.jpg", _fake_image_bytes(), "image/jpeg")},
+                data={"tag_ids": "", "caption": ""},
+            )
+
+        assert response.status_code == 201, response.text
+        image = response.json()["image"]
+        image_id = image["image_id"]
+
+        # The row's filename embeds the id the INSERT minted...
+        assert image["filename"].endswith(f"-{image_id}")
+        assert image["ext"] == "jpg"
+        # ...and dimensions came from the real file, not a mock.
+        assert (image["width"], image["height"]) == (100, 100)
+
+        # ...and the file on disk carries exactly that name.
+        fullsize = tmp_path / "fullsize"
+        assert (fullsize / f"{image['filename']}.jpg").exists()
+
+        # Nothing was orphaned under a staging name.
+        assert list(fullsize.glob("staged_*")) == []

--- a/tests/api/v1/test_upload.py
+++ b/tests/api/v1/test_upload.py
@@ -723,3 +723,55 @@ class TestUploadRealStorageRoundTrip:
 
         # Nothing was orphaned under a staging name.
         assert list(fullsize.glob("staged_*")) == []
+
+    @pytest.mark.asyncio
+    async def test_finalize_failure_leaves_no_row_and_no_staged_file(
+        self,
+        upload_client: AsyncClient,
+        verified_user: Users,
+        db_session: AsyncSession,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        """A rename failure undoes the committed row instead of stranding it.
+
+        The row is committed before the staged file is renamed, so a failing
+        rename would otherwise leave a row naming a file that was never created
+        plus a staged file under a uuid name nothing can derive from the row.
+        An upload must still be all-or-nothing.
+        """
+        from sqlalchemy import select
+
+        from app.config import settings
+        from app.models.image import Images
+
+        monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
+
+        with (
+            patch(
+                "app.api.v1.images.check_iqdb_similarity",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("app.api.v1.images.enqueue_job", new_callable=AsyncMock),
+            patch(
+                "app.api.v1.images.finalize_uploaded_image",
+                side_effect=OSError("no space left on device"),
+            ),
+        ):
+            response = await upload_client.post(
+                "/api/v1/images/upload",
+                files={"file": ("finalize_fail.jpg", _fake_image_bytes(), "image/jpeg")},
+                data={"tag_ids": "", "caption": ""},
+            )
+
+        assert response.status_code == 500
+
+        # The committed row was undone.
+        rows = await db_session.execute(
+            select(Images).where(Images.original_filename == "finalize_fail.jpg")
+        )
+        assert list(rows.scalars().all()) == []
+
+        # And the staged bytes were not left behind under an unfindable name.
+        assert list((tmp_path / "fullsize").glob("staged_*")) == []

--- a/tests/services/test_upload_storage.py
+++ b/tests/services/test_upload_storage.py
@@ -1,0 +1,106 @@
+"""Tests for the upload's two filesystem steps against a real filesystem.
+
+The route tests mock both of these, so the naming contract they establish —
+staged file first, permanent YYYY-MM-DD-{image_id}.{ext} name only once the row
+exists — is only checked here.
+"""
+
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException, UploadFile
+from starlette.datastructures import Headers
+
+from app.services.upload import finalize_uploaded_image, stage_uploaded_image
+
+
+def _jpeg_bytes(color: str = "red") -> bytes:
+    from PIL import Image
+
+    img = Image.new("RGB", (64, 48), color=color)
+    buf = BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _upload(name: str = "photo.JPG", color: str = "red") -> UploadFile:
+    """A real multipart-style upload: staging validates content_type too."""
+    return UploadFile(
+        filename=name,
+        file=BytesIO(_jpeg_bytes(color)),
+        headers=Headers({"content-type": "image/jpeg"}),
+    )
+
+
+@pytest.mark.unit
+class TestStageUploadedImage:
+    async def test_stages_under_a_temporary_name_and_hashes(self, tmp_path: Path):
+        """The staged file exists, carries no permanent name, and is hashed."""
+        staged_path, ext, md5_hash = await stage_uploaded_image(_upload(), str(tmp_path))
+
+        assert staged_path.exists()
+        assert staged_path.parent == tmp_path / "fullsize"
+        assert staged_path.name.startswith("staged_")
+        assert ext == "jpg"  # lowercased from .JPG
+        assert len(md5_hash) == 32
+
+    async def test_concurrent_uploads_of_one_filename_get_distinct_paths(self, tmp_path: Path):
+        """Two uploads sharing an original filename must not share a staging path.
+
+        The staged file now outlives the duplicate and IQDB checks, so a shared
+        name would let one request overwrite or unlink another's bytes.
+        """
+        first, _, first_md5 = await stage_uploaded_image(_upload(color="red"), str(tmp_path))
+        second, _, second_md5 = await stage_uploaded_image(_upload(color="blue"), str(tmp_path))
+
+        assert first != second
+        assert first.exists() and second.exists()
+        assert first_md5 != second_md5  # neither clobbered the other
+
+    async def test_rejects_a_non_image_and_leaves_nothing_behind(self, tmp_path: Path):
+        """Bytes that aren't an image are refused and the staged file removed.
+
+        Content type and extension both claim JPEG, so this fails on PIL's
+        decode — the check that actually matters, since the other two are
+        user-controlled.
+        """
+        bogus = UploadFile(
+            filename="notreally.jpg",
+            file=BytesIO(b"this is not a jpeg"),
+            headers=Headers({"content-type": "image/jpeg"}),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await stage_uploaded_image(bogus, str(tmp_path))
+
+        assert exc_info.value.status_code == 400
+        assert list((tmp_path / "fullsize").glob("staged_*")) == []
+
+
+@pytest.mark.unit
+class TestFinalizeUploadedImage:
+    async def test_renames_to_the_permanent_name(self, tmp_path: Path):
+        """The staged file takes its YYYY-MM-DD-{image_id}.{ext} name in place."""
+        staged_path, ext, _ = await stage_uploaded_image(_upload(), str(tmp_path))
+
+        final_path = finalize_uploaded_image(staged_path, str(tmp_path), 1116164, ext, "2026-05-18")
+
+        assert final_path.name == "2026-05-18-1116164.jpg"
+        assert final_path.parent == tmp_path / "fullsize"
+        assert final_path.exists()
+        assert not staged_path.exists()
+
+    async def test_uses_the_caller_s_date_prefix(self, tmp_path: Path):
+        """The prefix comes from the caller so the name matches the DB filename.
+
+        The route records `{date_prefix}-{image_id}` on the row and passes the
+        same prefix here; recomputing the date inside would let an upload that
+        straddles local midnight write a name the row disagrees with.
+        """
+        staged_path, ext, _ = await stage_uploaded_image(_upload(), str(tmp_path))
+
+        final_path = finalize_uploaded_image(staged_path, str(tmp_path), 42, ext, "1999-12-31")
+
+        assert final_path.name == "1999-12-31-42.jpg"
+        assert final_path.stem == "1999-12-31-42"  # what the route stores as filename

--- a/tests/snapshot_conflict.py
+++ b/tests/snapshot_conflict.py
@@ -49,3 +49,22 @@ def _flaky_flush(fail_times: int, error: OperationalError):
         await real_flush(self, *args, **kwargs)
 
     return patch.object(AsyncSession, "flush", flush), calls
+
+
+def _flaky_flush_nth(n: int, error: OperationalError):
+    """Like `_flaky_flush`, but fails only the `n`th explicit flush (1-indexed).
+
+    Use this to aim the conflict at a specific write within a route that
+    flushes more than once — e.g. the upload's tag-link write rather than the
+    flush that mints its image_id. Returns (patch_ctx, calls).
+    """
+    real_flush = AsyncSession.flush
+    calls: list[int] = []
+
+    async def flush(self, *args, **kwargs):
+        calls.append(1)
+        if len(calls) == n:
+            raise error
+        await real_flush(self, *args, **kwargs)
+
+    return patch.object(AsyncSession, "flush", flush), calls

--- a/tests/snapshot_conflict.py
+++ b/tests/snapshot_conflict.py
@@ -1,0 +1,51 @@
+"""Helpers for testing the MariaDB snapshot-conflict retry (app/core/db_retry.py).
+
+Under ``innodb_snapshot_isolation=ON`` a locking statement that meets a row
+version committed after this transaction's snapshot aborts with ER_CHECKREAD
+(errno 1020) rather than reading the stale version. Write paths wrap their
+transactional unit in ``retry_on_snapshot_conflict`` so the conflict is retried
+on a fresh snapshot instead of surfacing a 500.
+
+These helpers inject that error into a route's explicit flush, which is what
+lets a test exercise the real helper without racing two live requests.
+"""
+
+from unittest.mock import patch
+
+import pymysql
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _db_error(errno: int, message: str) -> OperationalError:
+    """Build the sqlalchemy error the aiomysql/pymysql driver raises for `errno`."""
+    return OperationalError("UPDATE ...", None, pymysql.err.OperationalError(errno, message))
+
+
+def _snapshot_conflict_error(table: str = "images") -> OperationalError:
+    """The error MariaDB raises under innodb_snapshot_isolation (ER_CHECKREAD).
+
+    `table` is the table the conflict is reported against. For the tag write
+    paths that is `tag_history`: its INSERT takes a locking read on each FK
+    parent (tags/images/users), and ER_CHECKREAD names the child table's
+    handler, not the parent row that actually moved.
+    """
+    return _db_error(1020, f"Record has changed since last read in table '{table}'")
+
+
+def _flaky_flush(fail_times: int, error: OperationalError):
+    """Patch AsyncSession.flush to raise `error` for the first `fail_times`
+    calls, then delegate to the real flush. Only a route's explicit
+    ``await db.flush()`` goes through AsyncSession.flush (autoflush runs inside
+    the sync Session), so the first intercepted call is the route's own write.
+    Returns (patch_ctx, calls) where calls records each intercepted flush."""
+    real_flush = AsyncSession.flush
+    calls: list[int] = []
+
+    async def flush(self, *args, **kwargs):
+        calls.append(1)
+        if len(calls) <= fail_times:
+            raise error
+        await real_flush(self, *args, **kwargs)
+
+    return patch.object(AsyncSession, "flush", flush), calls


### PR DESCRIPTION
Fixes #321.

## The bug

`tag_history.tag_id` / `.image_id` / `.user_id` are FK columns, so inserting a history row makes InnoDB take a locking read on each **parent** row. Under `innodb_snapshot_isolation` a parent committed after this transaction's snapshot aborts that read with **ER_CHECKREAD (1020)** — and the error is reported against the **child** table's handler. That is why the reported traceback names `tag_history` even though nothing in the request read `tag_history`.

The parents keep moving on their own: the `usage_count` triggers on `tag_links` bump the parent `tags` row on every tag add/remove, and `users_image_posts_increment` bumps `users` on every upload. Two users tagging at the same moment is enough.

Reproduced in an isolated schema (MariaDB 11.8.8, `innodb_snapshot_isolation=1`) rather than reasoning from InnoDB internals:

| probe | result |
|---|---|
| INSERT `tag_history` (FK→tags), parent bumped by a `tag_links` INSERT trigger | `(1020, "Record has changed since last read in table 'tag_history'")` — the reported string, verbatim |
| INSERT `tag_history` (FK→tags), parent bumped by a direct UPDATE | same 1020 |
| INSERT into a child with **no FK**, same parent UPDATE | no conflict |
| INSERT `tag_history` with a **NULL** `tag_id` (no FK check), same parent UPDATE | no conflict |
| INSERT `tag_links` (FK→tags), parent bumped by another `tag_links` INSERT | 1020 against `tag_links` |

Rows 3 and 4 isolate it to the FK check. No tag write path wrapped its unit in `retry_on_snapshot_conflict`, and there is no global `OperationalError` handler, so the losing request surfaced a raw 500.

### One correction to the issue

The ML-suggestion cleanup in the traceback is incidental. `delete_pending_ancestor_suggestions`'s `db.flush()` is simply the first flush that pushes `add_tag_to_image`'s **own** two INSERTs to the server; the `db.commit()` two lines later raises the same 1020. It is also not a regression from the ML port (f8a63c1) — the exposure predates it, and the new frame just changed where the traceback points.

## The fix

Five paths were self-contained and take the #266 treatment directly:

- `add_tag_to_image`, `remove_tag_from_image`
- `batch_add_tags`, `batch_remove_tags`
- admin `apply_tag_suggestions`

Each hoists `current_user`'s id to a primitive (the rollback between attempts expires ORM instances), re-fetches its rows inside the unit, and keeps the Meilisearch sync outside so a retry never repeats it. The batch and admin paths build their `added`/`removed`/`skipped` accumulators **inside** the unit — reusing lists from a failed attempt would report every pair once per attempt, which the new tests assert against.

### Upload needed more than a wrapper

The upload held **one** transaction from the temp-row INSERT through the final commit, spanning a file write to disk *and* the IQDB network call. Its tag-link write could not be retried at all: a rollback would discard the uncommitted temp row whose `image_id` was already baked into the filename on disk. So the widest conflict window in the app was the one place that could not use the helper.

Reordered so no database write happens until every non-DB step is done:

```
stage file  ->  MD5 check  ->  IQDB check  ->  [ INSERT + tags + commit ]  ->  rename
```

`save_uploaded_image` splits into `stage_uploaded_image` (write, validate, hash) and `finalize_uploaded_image` (rename to `YYYY-MM-DD-{image_id}.{ext}`) — the same two steps it already did internally, except the row is now inserted in between, so the id it mints names the file. What remains in the transaction is an INSERT, a filename UPDATE, and the tag links.

Consequences worth reviewing:

- **The temp row is gone**, and with it both rollback-to-discard paths: the MD5 and IQDB 409s now just unlink the staged file, having written nothing.
- **`date_prefix` is computed once** and used for both the recorded filename and the on-disk name, so a midnight-straddling upload cannot disagree with itself. This replaces the old derive-the-filename-from-the-saved-path workaround.
- **Staging names are `uuid4`-based** instead of `temp_{original_filename}`. The staged file now outlives the duplicate checks, so two users uploading the same filename would otherwise clobber each other — a pre-existing race this reorder would have widened.
- **Post-commit failures no longer delete the image file.** Previously an enqueue error would unlink a file the committed row still pointed at.
- **Behavior change:** an exhausted retry on upload now returns the route's 500 with cleanup instead of an unhandled `OperationalError`, because the unit sits inside upload's `try/except`. Two existing tests assert on the response instead of a propagating exception.

## Tests

All TDD, red first. The upload's tag-link conflict is aimed at the **second** flush specifically, so it fails against any implementation that only retries the id-minting INSERT.

Every upload route test mocks the filesystem, so the real stage/finalize seam had no coverage at all. Added `tests/services/test_upload_storage.py` (real files, real PIL validation, the naming contract, and the distinct-staging-path race) plus a route-level round trip with the storage functions unmocked.

Test helpers deduplicated into `tests/snapshot_conflict.py` — `test_images.py` and `test_upload.py` had identical copies.

## Verification

- Full suite: **2536 passed, 10 skipped** (skips all pre-existing), ruff + mypy clean.
- No live upload was run against the dev stack: there is no dev credential in the repo and creating one would mutate the prod-scale restore. The unmocked round-trip test covers the same seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx4tX6zYZWuMu4EWHy6F6D