### PR TITLE
chore(scripts): resolve mypy errors across 21 tooling scripts

### DIFF
--- a/scripts/analyze_character_sources.py
+++ b/scripts/analyze_character_sources.py
@@ -24,14 +24,14 @@ import asyncio
 import csv
 import sys
 from pathlib import Path
+from typing import Any
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import TagType, settings
 from app.models.character_source_link import CharacterSourceLinks
@@ -43,19 +43,19 @@ async def analyze_character_sources(
     threshold: float = 0.8,
     min_images: int = 5,
     output_file: str | None = None,
-) -> list[dict]:
+) -> list[dict[str, Any]]:
     """
     Analyze co-occurrence patterns between character and source tags.
     """
     engine = create_async_engine(settings.DATABASE_URL, echo=False)
-    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     results = []
 
     async with async_session() as db:
         # Get all character tags with usage >= min_images
         char_result = await db.execute(
-            select(Tags.tag_id, Tags.title)
+            select(Tags.tag_id, Tags.title)  # type: ignore[call-overload]
             .where(Tags.type == TagType.CHARACTER)
             .where(Tags.usage_count >= min_images)
             .order_by(Tags.title)
@@ -67,7 +67,9 @@ async def analyze_character_sources(
         for char_id, char_title in character_tags:
             # Get count of images with this character
             count_result = await db.execute(
-                select(func.count(TagLinks.image_id)).where(TagLinks.tag_id == char_id)
+                select(func.count(TagLinks.image_id)).where(  # type: ignore[arg-type]
+                    TagLinks.tag_id == char_id
+                )
             )
             total_images = count_result.scalar() or 0
 
@@ -75,16 +77,20 @@ async def analyze_character_sources(
                 continue
 
             # Use subquery for image_ids instead of loading into Python memory
-            image_subquery = select(TagLinks.image_id).where(TagLinks.tag_id == char_id).subquery()
+            image_subquery = (
+                select(TagLinks.image_id)  # type: ignore[call-overload]
+                .where(TagLinks.tag_id == char_id)
+                .subquery()
+            )
 
             # Count source tags that co-occur
             source_counts_result = await db.execute(
-                select(Tags.tag_id, Tags.title, func.count(TagLinks.image_id).label("count"))
+                select(Tags.tag_id, Tags.title, func.count(TagLinks.image_id).label("count"))  # type: ignore[call-overload, arg-type]
                 .join(TagLinks, Tags.tag_id == TagLinks.tag_id)
                 .where(Tags.type == TagType.SOURCE)
-                .where(TagLinks.image_id.in_(select(image_subquery)))
+                .where(TagLinks.image_id.in_(select(image_subquery)))  # type: ignore[attr-defined]
                 .group_by(Tags.tag_id, Tags.title)
-                .order_by(func.count(TagLinks.image_id).desc())
+                .order_by(func.count(TagLinks.image_id).desc())  # type: ignore[arg-type]
             )
 
             for source_id, source_title, count in source_counts_result.all():
@@ -129,7 +135,7 @@ async def analyze_character_sources(
 
 
 async def create_links_from_results(
-    results: list[dict],
+    results: list[dict[str, Any]],
     user_id: int | None = None,
     batch_size: int = 100,
 ) -> tuple[int, int]:
@@ -142,7 +148,7 @@ async def create_links_from_results(
     Returns (created_count, skipped_count).
     """
     engine = create_async_engine(settings.DATABASE_URL, echo=False)
-    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     created = 0
     skipped = 0
@@ -202,7 +208,7 @@ async def find_conflated_characters(
     min_usage: int = 20,
     min_images: int = 5,
     min_share: float = 0.05,
-) -> list[dict]:
+) -> list[dict[str, Any]]:
     """
     Report character tags whose images split across >= 2 dominant sources.
 
@@ -214,7 +220,7 @@ async def find_conflated_characters(
     """
     char_rows = (
         await db.execute(
-            select(Tags.tag_id, Tags.title)
+            select(Tags.tag_id, Tags.title)  # type: ignore[call-overload]
             .where(Tags.type == TagType.CHARACTER)
             .where(Tags.usage_count >= min_usage)
             .order_by(Tags.tag_id)
@@ -223,20 +229,26 @@ async def find_conflated_characters(
 
     link_count_rows = (
         await db.execute(
-            select(CharacterSourceLinks.character_tag_id, func.count()).group_by(
-                CharacterSourceLinks.character_tag_id
-            )
+            select(  # type: ignore[call-overload]
+                CharacterSourceLinks.character_tag_id, func.count()
+            ).group_by(CharacterSourceLinks.character_tag_id)
         )
     ).all()
-    link_counts = dict(link_count_rows)
+    link_counts: dict[int, int] = dict(link_count_rows)  # type: ignore[arg-type]
 
-    results: list[dict] = []
+    results: list[dict[str, Any]] = []
     for char_id, char_title in char_rows:
-        image_subquery = select(TagLinks.image_id).where(TagLinks.tag_id == char_id).subquery()
+        image_subquery = (
+            select(TagLinks.image_id)  # type: ignore[call-overload]
+            .where(TagLinks.tag_id == char_id)
+            .subquery()
+        )
 
         total_images = (
             await db.execute(
-                select(func.count(TagLinks.image_id)).where(TagLinks.tag_id == char_id)
+                select(func.count(TagLinks.image_id)).where(  # type: ignore[arg-type]
+                    TagLinks.tag_id == char_id
+                )
             )
         ).scalar() or 0
         # usage_count is denormalized and can drift; re-check against live links
@@ -247,9 +259,9 @@ async def find_conflated_characters(
         source_rows = (
             await db.execute(
                 select(canonical_id, func.count(func.distinct(TagLinks.image_id)).label("count"))
-                .join(TagLinks, Tags.tag_id == TagLinks.tag_id)
-                .where(Tags.type == TagType.SOURCE)
-                .where(TagLinks.image_id.in_(select(image_subquery)))
+                .join(TagLinks, Tags.tag_id == TagLinks.tag_id)  # type: ignore[arg-type]
+                .where(Tags.type == TagType.SOURCE)  # type: ignore[arg-type]
+                .where(TagLinks.image_id.in_(select(image_subquery)))  # type: ignore[attr-defined]
                 .group_by(canonical_id)
             )
         ).all()
@@ -257,9 +269,9 @@ async def find_conflated_characters(
         source_tagged = (
             await db.execute(
                 select(func.count(func.distinct(TagLinks.image_id)))
-                .join(Tags, Tags.tag_id == TagLinks.tag_id)
-                .where(Tags.type == TagType.SOURCE)
-                .where(TagLinks.image_id.in_(select(image_subquery)))
+                .join(Tags, Tags.tag_id == TagLinks.tag_id)  # type: ignore[arg-type]
+                .where(Tags.type == TagType.SOURCE)  # type: ignore[arg-type]
+                .where(TagLinks.image_id.in_(select(image_subquery)))  # type: ignore[attr-defined]
             )
         ).scalar() or 0
         if source_tagged == 0:
@@ -295,9 +307,11 @@ async def find_conflated_characters(
     source_ids = {s["source_tag_id"] for r in results for s in r["sources"]}
     if source_ids:
         title_rows = (
-            await db.execute(select(Tags.tag_id, Tags.title).where(Tags.tag_id.in_(source_ids)))
+            await db.execute(
+                select(Tags.tag_id, Tags.title).where(Tags.tag_id.in_(source_ids))  # type: ignore[call-overload, union-attr]
+            )
         ).all()
-        titles = dict(title_rows)
+        titles: dict[int, str | None] = dict(title_rows)  # type: ignore[arg-type]
         for r in results:
             for s in r["sources"]:
                 s["source_title"] = titles.get(s["source_tag_id"])
@@ -308,10 +322,10 @@ async def find_conflated_characters(
 
 async def run_conflated(
     min_usage: int, min_images: int, min_share: float, output_file: str | None
-) -> list[dict]:
+) -> list[dict[str, Any]]:
     """CLI wrapper: open a session, run the report, print, optionally CSV."""
     engine = create_async_engine(settings.DATABASE_URL, echo=False)
-    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     async with async_session() as db:
         results = await find_conflated_characters(
             db, min_usage=min_usage, min_images=min_images, min_share=min_share

--- a/scripts/audit_alias_parent_violations.py
+++ b/scripts/audit_alias_parent_violations.py
@@ -12,8 +12,7 @@ Usage: uv run python scripts/audit_alias_parent_violations.py
 import asyncio
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import settings
 from app.models.tag import Tags
@@ -21,13 +20,13 @@ from app.models.tag import Tags
 
 async def audit() -> None:
     engine = create_async_engine(settings.DATABASE_URL, echo=False)
-    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False, future=True)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with async_session() as db:
         # Violation 1: Tags whose parent is an alias
-        parent_alias = Tags.__table__.alias("parent")
+        parent_alias = Tags.__table__.alias("parent")  # type: ignore[attr-defined]
         result = await db.execute(
-            select(
+            select(  # type: ignore[call-overload]
                 Tags.tag_id,
                 Tags.title,
                 Tags.inheritedfrom_id,
@@ -51,12 +50,12 @@ async def audit() -> None:
             print("\n=== Violation 1: No tags with alias parents ===")
 
         # Violation 2: Tags that are aliases AND have children
-        child_alias = Tags.__table__.alias("child")
+        child_alias = Tags.__table__.alias("child")  # type: ignore[attr-defined]
         result = await db.execute(
-            select(Tags.tag_id, Tags.title, Tags.alias_of)
-            .where(Tags.alias_of.isnot(None))
+            select(Tags.tag_id, Tags.title, Tags.alias_of)  # type: ignore[call-overload]
+            .where(Tags.alias_of.isnot(None))  # type: ignore[union-attr]
             .where(
-                Tags.tag_id.in_(
+                Tags.tag_id.in_(  # type: ignore[union-attr]
                     select(child_alias.c.inheritedfrom_id).where(
                         child_alias.c.inheritedfrom_id.isnot(None)
                     )
@@ -71,7 +70,9 @@ async def audit() -> None:
             )
             for row in alias_with_children:
                 children_result = await db.execute(
-                    select(Tags.tag_id, Tags.title).where(Tags.inheritedfrom_id == row.tag_id)
+                    select(Tags.tag_id, Tags.title).where(  # type: ignore[call-overload]
+                        Tags.inheritedfrom_id == row.tag_id
+                    )
                 )
                 children = children_result.all()
                 child_list = ", ".join(f"'{t}' (id: {i})" for i, t in children)

--- a/scripts/backfill_tag_usage_counts.py
+++ b/scripts/backfill_tag_usage_counts.py
@@ -12,8 +12,7 @@ The triggers will maintain these counts going forward automatically.
 import asyncio
 
 from sqlalchemy import func, select, text
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import settings
 from app.models import TagLinks, Tags
@@ -23,14 +22,16 @@ async def backfill_usage_counts() -> None:
     """Calculate usage_count for all tags based on tag_links."""
     engine = create_async_engine(settings.DATABASE_URL, echo=False)
 
-    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False, future=True)
+    async_session = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False, future=True
+    )
 
     async with async_session() as db:
         print("Backfilling tag usage_count from tag_links...")
 
         # Get count of how many images have each tag
         # Count DISTINCT image_ids per tag_id to handle if the same image has the same tag multiple times
-        stmt = select(
+        stmt = select(  # type: ignore[call-overload]
             TagLinks.tag_id, func.count(func.distinct(TagLinks.image_id)).label("count")
         ).group_by(TagLinks.tag_id)
         result = await db.execute(stmt)
@@ -56,13 +57,17 @@ async def backfill_usage_counts() -> None:
         # Show statistics
         stats_result = await db.execute(
             select(
-                func.count(Tags.tag_id).label("total_tags"),
+                func.count(Tags.tag_id).label("total_tags"),  # type: ignore[arg-type]
                 func.sum(Tags.usage_count).label("total_usage"),
                 func.avg(Tags.usage_count).label("avg_usage"),
                 func.max(Tags.usage_count).label("max_usage"),
             )
         )
         stats = stats_result.first()
+        # An aggregate SELECT with no GROUP BY always returns exactly one row
+        # (COUNT/SUM/AVG/MAX over zero rows still produce a row of
+        # zeros/NULLs), so this can't actually be None.
+        assert stats is not None
         print("\nStatistics:")
         print(f"  Total tags: {stats[0]}")
         print(f"  Total usage count: {stats[1]}")

--- a/scripts/bench_feed_count.py
+++ b/scripts/bench_feed_count.py
@@ -10,13 +10,14 @@ Quantifies the list_images count optimization (hidden-complement instead of the
 import time
 
 from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Connection
 
 from app.config import settings
 
 VISIBLE = "(-1, 1, 2)"  # PUBLIC_IMAGE_STATUSES: REPOST, ACTIVE, SPOILER
 
 
-def _time_ms(conn, sql: str, runs: int = 3) -> float:
+def _time_ms(conn: Connection, sql: str, runs: int = 3) -> float:
     conn.execute(text(sql)).scalar()  # warm
     best = float("inf")
     for _ in range(runs):
@@ -26,7 +27,7 @@ def _time_ms(conn, sql: str, runs: int = 3) -> float:
     return best
 
 
-def _explain_type(conn, sql: str) -> str:
+def _explain_type(conn: Connection, sql: str) -> str:
     row = conn.execute(text("EXPLAIN " + sql)).mappings().first()
     return f"{row['type']}/{row['key']}/{row['rows']} rows" if row else "?"
 

--- a/scripts/compare_schemas.py
+++ b/scripts/compare_schemas.py
@@ -15,14 +15,15 @@ import os
 import sys
 from collections import defaultdict
 from pathlib import Path
+from typing import Any
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import Engine, create_engine, text
 
 
-def get_table_schema(engine, db_name: str) -> dict:
+def get_table_schema(engine: Engine, db_name: str) -> dict[str, Any]:
     """Get schema information for all tables in a database."""
     schema = {}
 
@@ -60,7 +61,7 @@ def get_table_schema(engine, db_name: str) -> dict:
     return schema
 
 
-def compare_tables(test_schema: dict, dev_schema: dict) -> None:
+def compare_tables(test_schema: dict[str, Any], dev_schema: dict[str, Any]) -> None:
     """Compare tables between two schemas."""
     test_tables = set(test_schema.keys())
     dev_tables = set(dev_schema.keys())
@@ -88,7 +89,12 @@ def compare_tables(test_schema: dict, dev_schema: dict) -> None:
         print()
 
 
-def compare_columns(table: str, test_cols: list, dev_cols: list, show_all: bool = False) -> None:
+def compare_columns(
+    table: str,
+    test_cols: list[dict[str, Any]],
+    dev_cols: list[dict[str, Any]],
+    show_all: bool = False,
+) -> None:
     """Compare columns for a specific table."""
     test_fields = {col["field"]: col for col in test_cols}
     dev_fields = {col["field"]: col for col in dev_cols}

--- a/scripts/convert_bbcode_to_markdown.py
+++ b/scripts/convert_bbcode_to_markdown.py
@@ -149,7 +149,10 @@ async def migrate_comments(db: AsyncSession, batch_size: int, dry_run: bool) -> 
 
         # Fetch one batch at a time
         result = await db.execute(
-            select(Comments).order_by(Comments.post_id).limit(batch_size).offset(offset)
+            select(Comments)
+            .order_by(Comments.post_id)  # type: ignore[arg-type]
+            .limit(batch_size)
+            .offset(offset)
         )
         comments = result.scalars().all()
 
@@ -196,7 +199,7 @@ async def migrate_comments(db: AsyncSession, batch_size: int, dry_run: bool) -> 
     return counts
 
 
-async def main(dry_run: bool = False, batch_size: int = 1000, auto_confirm: bool = False):
+async def main(dry_run: bool = False, batch_size: int = 1000, auto_confirm: bool = False) -> None:
     """Run BBCode to Markdown conversion."""
     print("=" * 80)
     print("BBCode to Markdown Conversion Script")

--- a/scripts/generate_character_mappings.py
+++ b/scripts/generate_character_mappings.py
@@ -257,7 +257,9 @@ async def load_internal_characters() -> list[tuple[int, str]]:
     async with get_async_session() as db:
         rows = (
             await db.execute(
-                select(Tags.tag_id, Tags.title).where(Tags.type == CHARACTER_TYPE)  # type: ignore[arg-type]
+                select(Tags.tag_id, Tags.title).where(  # type: ignore[call-overload]
+                    Tags.type == CHARACTER_TYPE
+                )
             )
         ).all()
     return [(tag_id, title) for tag_id, title in rows]
@@ -330,11 +332,10 @@ async def main() -> None:
 
     if args.linked_only:
         async with get_async_session() as db:
-            linked_ids = set(
-                (await db.execute(select(CharacterSourceLinks.character_tag_id).distinct()))
-                .scalars()
-                .all()
-            )
+            linked_stmt = select(  # type: ignore[call-overload]
+                CharacterSourceLinks.character_tag_id
+            ).distinct()
+            linked_ids = set((await db.execute(linked_stmt)).scalars().all())
         results = apply_linked_only(results, linked_ids)
         print(
             f"linked-only: restricted auto-map to {len(linked_ids)} source-linked internal characters"

--- a/scripts/generate_thumbnails.py
+++ b/scripts/generate_thumbnails.py
@@ -144,7 +144,7 @@ def get_images_streaming(
                     while True:
                         result = await conn.execute(
                             select(Images.image_id, Images.filename, Images.ext)  # type: ignore[call-overload]
-                            .where(Images.image_id < last_id)  # type: ignore[arg-type,operator]
+                            .where(Images.image_id < last_id)  # type: ignore[operator]
                             .order_by(Images.image_id.desc())  # type: ignore[union-attr]
                             .limit(batch_size)
                         )

--- a/scripts/generate_variants.py
+++ b/scripts/generate_variants.py
@@ -83,20 +83,20 @@ def process_variant_worker(
                 if icc_profile:
                     input_profile = ImageCms.ImageCmsProfile(ImageCms.getOpenProfile(icc_profile))
                     if img.mode == "L":
-                        img = ImageCms.profileToProfile(img, input_profile, srgb_profile)
+                        img = ImageCms.profileToProfile(img, input_profile, srgb_profile)  # type: ignore[assignment]
                     else:
-                        img = ImageCms.profileToProfile(
+                        img = ImageCms.profileToProfile(  # type: ignore[assignment]
                             img, input_profile, srgb_profile, outputMode="RGB"
                         )
             except PyCMSError, OSError, TypeError:
                 if img.mode not in ("RGB", "L"):
-                    img = img.convert("RGB")
+                    img = img.convert("RGB")  # type: ignore[assignment]
 
             # Convert RGBA to RGB for JPEG
             if img.mode in ("RGBA", "LA") and ext.lower() in ("jpg", "jpeg"):
                 background = Image.new("RGB", img.size, (255, 255, 255))
                 background.paste(img, mask=img.split()[-1] if img.mode == "RGBA" else None)
-                img = background
+                img = background  # type: ignore[assignment]
 
             img.thumbnail((threshold, threshold), Image.Resampling.LANCZOS)
 
@@ -107,7 +107,7 @@ def process_variant_worker(
             elif ext.lower() == "webp":
                 save_kwargs["quality"] = settings.LARGE_QUALITY
 
-            img.save(variant_path, **save_kwargs)
+            img.save(variant_path, **save_kwargs)  # type: ignore[arg-type]
 
             # Delete if variant is larger than original
             original_size = source_path.stat().st_size

--- a/scripts/import_tag_mappings.py
+++ b/scripts/import_tag_mappings.py
@@ -47,7 +47,7 @@ async def import_mappings(db: AsyncSession, csv_path: Path) -> dict[str, object]
     external_tag rows are skipped). Returns a summary dict of counts."""
     # Pre-load mappable internal tags for case-insensitive title lookup.
     result = await db.execute(
-        select(Tags.tag_id, Tags.title).where(Tags.type.in_(MAPPABLE_TAG_TYPES))  # type: ignore[attr-defined]
+        select(Tags.tag_id, Tags.title).where(Tags.type.in_(MAPPABLE_TAG_TYPES))  # type: ignore[call-overload,attr-defined]
     )
     internal_tags: dict[str, int] = {}
     ambiguous_titles: set[str] = set()
@@ -80,9 +80,9 @@ async def import_mappings(db: AsyncSession, csv_path: Path) -> dict[str, object]
     id_to_title: dict[int, str | None] = {}
     if explicit_ids:
         res = await db.execute(
-            select(Tags.tag_id, Tags.title).where(Tags.tag_id.in_(explicit_ids))  # type: ignore[attr-defined]
+            select(Tags.tag_id, Tags.title).where(Tags.tag_id.in_(explicit_ids))  # type: ignore[call-overload,union-attr]
         )
-        id_to_title = dict(res.all())
+        id_to_title = dict(res.all())  # type: ignore[arg-type]
 
     created = 0
     updated = 0

--- a/scripts/migrate_legacy_db.py
+++ b/scripts/migrate_legacy_db.py
@@ -40,8 +40,15 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
-from db_utils import (
+# mypy resolves this file as `scripts.migrate_legacy_db` (mypy_path = "." +
+# explicit_package_bases in pyproject.toml), so it looks for a top-level
+# `db_utils` module and can't find one. At runtime this import works because
+# `python scripts/migrate_legacy_db.py` puts scripts/ (not the repo root) at
+# sys.path[0], making db_utils importable as a top-level module. Not a real
+# bug, just a static/runtime resolution mismatch.
+from db_utils import (  # type: ignore[import-not-found]
     DEV_TEST_DATABASES,
     create_test_user,
     drop_and_create_database,
@@ -55,7 +62,7 @@ from db_utils import (
     stop_docker_services,
 )
 
-MIGRATION_STEPS = [
+MIGRATION_STEPS: list[dict[str, Any]] = [
     {
         "number": 1,
         "name": "convert_bbcode_to_markdown",
@@ -99,7 +106,7 @@ MIGRATION_STEPS = [
 INITIAL_MIGRATION_REVISION = "8d66158eb568"
 
 
-def print_step(step_num: int, step: dict):
+def print_step(step_num: int, step: dict[str, Any]) -> None:
     """Print step information."""
     print(f"Step {step_num}: {step['name']}")
     print(f"  Script: {step['script']}")
@@ -115,7 +122,10 @@ def find_script(script_name: str) -> Path | None:
 
 
 async def run_step(
-    step: dict, dry_run: bool = False, auto_confirm: bool = False, database_url: str | None = None
+    step: dict[str, Any],
+    dry_run: bool = False,
+    auto_confirm: bool = False,
+    database_url: str | None = None,
 ) -> bool:
     """
     Run a migration step script.
@@ -398,7 +408,7 @@ async def run_migration(
     return all_succeeded
 
 
-async def main():
+async def main() -> None:
     """Main entry point."""
     parser = argparse.ArgumentParser(
         description="Orchestrate complete legacy database migration",

--- a/scripts/migrate_quoted_comments.py
+++ b/scripts/migrate_quoted_comments.py
@@ -176,7 +176,7 @@ async def find_parent_comment(
     # Find exact text match on this image
     result = await db.execute(
         select(Comments).where(
-            (Comments.image_id == image_id)
+            (Comments.image_id == image_id)  # type: ignore[arg-type]
             & (Comments.post_id != current_comment_id)
             & (Comments.post_text == quoted_text)
         )
@@ -219,9 +219,9 @@ async def migrate_quoted_comments(
         logger.info("migration_step", step="1_load_quoted_comments")
         result = await db.execute(
             select(Comments).where(
-                (Comments.post_text.like("%[quote=%"))
-                | (Comments.post_text.like("%[quote]%"))
-                | (Comments.post_text.like(">%"))
+                (Comments.post_text.like("%[quote=%"))  # type: ignore[attr-defined]
+                | (Comments.post_text.like("%[quote]%"))  # type: ignore[attr-defined]
+                | (Comments.post_text.like(">%"))  # type: ignore[attr-defined]
             )
         )
         quoted_comments = result.scalars().all()
@@ -239,11 +239,13 @@ async def migrate_quoted_comments(
 
         # Fetch only necessary fields for matching (reduces memory)
         result = await db.execute(
-            select(Comments.post_id, Comments.image_id, Comments.post_text).where(
-                Comments.image_id.in_(image_ids)
+            select(  # type: ignore[call-overload]
+                Comments.post_id, Comments.image_id, Comments.post_text
+            ).where(
+                Comments.image_id.in_(image_ids)  # type: ignore[union-attr]
             )
         )
-        comments_by_image: dict[int, list] = {}
+        comments_by_image: dict[int | None, list[tuple[int | None, str]]] = {}
         for row in result.all():
             if row.image_id not in comments_by_image:
                 comments_by_image[row.image_id] = []

--- a/scripts/ml_bulk_approve_skirt.py
+++ b/scripts/ml_bulk_approve_skirt.py
@@ -27,7 +27,7 @@ SCOPE_TAG_ID = 16  # school uniform
 async def run(args: argparse.Namespace) -> None:
     async with get_async_session() as db:
         query = (
-            select(MlTagSuggestions.suggestion_id)
+            select(MlTagSuggestions.suggestion_id)  # type: ignore[call-overload]
             .join(TagLinks, TagLinks.image_id == MlTagSuggestions.image_id)
             .where(
                 MlTagSuggestions.tag_id == SKIRT_TAG_ID,

--- a/scripts/ml_remap.py
+++ b/scripts/ml_remap.py
@@ -57,7 +57,7 @@ async def run(args: argparse.Namespace) -> None:
         else:
             # Fetch distinct image IDs for this model, ordered for resumable checkpointing.
             stmt = (
-                select(MlRawPredictions.image_id)
+                select(MlRawPredictions.image_id)  # type: ignore[call-overload]
                 .join(MlModels, MlModels.id == MlRawPredictions.model_id)
                 .where(MlModels.name == model_name)
                 .distinct()

--- a/scripts/normalize_db_text.py
+++ b/scripts/normalize_db_text.py
@@ -59,7 +59,7 @@ async def normalize_users(db: AsyncSession, batch_size: int, dry_run: bool) -> d
     # Fetch all users
     result = await db.execute(
         select(Users).where(
-            Users.active == 1  # Only normalize active users
+            Users.active == 1  # type: ignore[arg-type]  # Only normalize active users
         )
     )
     users = result.scalars().all()
@@ -76,6 +76,8 @@ async def normalize_users(db: AsyncSession, batch_size: int, dry_run: bool) -> d
             original = getattr(user, field)
             if original and isinstance(original, str):
                 normalized = normalize_text(original)
+                # normalize_text only returns None for falsy input, and original is truthy here
+                assert normalized is not None
                 if normalized != original:
                     if not dry_run:
                         setattr(user, field, normalized)
@@ -127,6 +129,8 @@ async def normalize_privmsgs(db: AsyncSession, batch_size: int, dry_run: bool) -
         # Normalize subject
         if msg.subject:
             normalized_subject = normalize_text(msg.subject)
+            # normalize_text only returns None for falsy input, and msg.subject is truthy here
+            assert normalized_subject is not None
             if normalized_subject != msg.subject:
                 if not dry_run:
                     msg.subject = normalized_subject
@@ -139,15 +143,18 @@ async def normalize_privmsgs(db: AsyncSession, batch_size: int, dry_run: bool) -
 
         # Normalize text
         if msg.text:
-            normalized_text = normalize_text(msg.text)
-            if normalized_text != msg.text:
+            original_text = msg.text
+            normalized_text = normalize_text(original_text)
+            # normalize_text only returns None for falsy input, and original_text is truthy here
+            assert normalized_text is not None
+            if normalized_text != original_text:
                 if not dry_run:
                     msg.text = normalized_text
                 counts["text"] += 1
                 needs_update = True
                 if total_updated < 10:  # Only show first 10
                     print(f"  PM {msg.privmsg_id} - text:")
-                    print(f"    Before: {msg.text[:100]}")
+                    print(f"    Before: {original_text[:100]}")
                     print(f"    After:  {normalized_text[:100]}")
 
         if needs_update:
@@ -191,6 +198,8 @@ async def normalize_comments(db: AsyncSession, batch_size: int, dry_run: bool) -
         # Normalize post_text
         if comment.post_text:
             normalized_text = normalize_text(comment.post_text)
+            # normalize_text only returns None for falsy input, and comment.post_text is truthy here
+            assert normalized_text is not None
             if normalized_text != comment.post_text:
                 if not dry_run:
                     comment.post_text = normalized_text
@@ -241,28 +250,34 @@ async def normalize_tags(db: AsyncSession, batch_size: int, dry_run: bool) -> di
 
         # Normalize title
         if tag.title:
-            normalized_title = normalize_text(tag.title)
-            if normalized_title != tag.title:
+            original_title = tag.title
+            normalized_title = normalize_text(original_title)
+            # normalize_text only returns None for falsy input, and original_title is truthy here
+            assert normalized_title is not None
+            if normalized_title != original_title:
                 if not dry_run:
                     tag.title = normalized_title
                 counts["title"] += 1
                 needs_update = True
                 if total_updated < 10:  # Only show first 10
                     print(f"  Tag {tag.tag_id} - title:")
-                    print(f"    Before: {tag.title[:100]}")
+                    print(f"    Before: {original_title[:100]}")
                     print(f"    After:  {normalized_title[:100]}")
 
         # Normalize desc
         if tag.desc:
-            normalized_desc = normalize_text(tag.desc)
-            if normalized_desc != tag.desc:
+            original_desc = tag.desc
+            normalized_desc = normalize_text(original_desc)
+            # normalize_text only returns None for falsy input, and original_desc is truthy here
+            assert normalized_desc is not None
+            if normalized_desc != original_desc:
                 if not dry_run:
                     tag.desc = normalized_desc
                 counts["desc"] += 1
                 needs_update = True
                 if total_updated < 10:  # Only show first 10
                     print(f"  Tag {tag.tag_id} - desc:")
-                    print(f"    Before: {tag.desc[:100]}")
+                    print(f"    Before: {original_desc[:100]}")
                     print(f"    After:  {normalized_desc[:100]}")
 
         if needs_update:
@@ -283,7 +298,7 @@ async def normalize_tags(db: AsyncSession, batch_size: int, dry_run: bool) -> di
     return counts
 
 
-async def main(dry_run: bool = False, batch_size: int = 1000, auto_confirm: bool = False):
+async def main(dry_run: bool = False, batch_size: int = 1000, auto_confirm: bool = False) -> None:
     """Run normalization on all relevant tables."""
     print("=" * 80)
     print("Database Text Normalization Script")

--- a/scripts/populate_iqdb.py
+++ b/scripts/populate_iqdb.py
@@ -28,11 +28,18 @@ import argparse
 import asyncio
 import sys
 import time
+from collections.abc import AsyncIterator, Sequence
 from pathlib import Path
+from typing import Any
 
 import httpx
-from sqlalchemy import func, select, update
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy import Row, func, select, update
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 # Add parent directory to path so we can import app modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -129,19 +136,21 @@ def _get_thumbnail_path(image_id: int, filename: str) -> Path:
     return thumbs_dir / f"{filename}.webp" if filename else thumbs_dir / f"{image_id}.webp"
 
 
-async def iter_image_batches(engine, batch_size: int, start_from: int, *, only_missing_hash: bool):
+async def iter_image_batches(
+    engine: AsyncEngine, batch_size: int, start_from: int, *, only_missing_hash: bool
+) -> AsyncIterator[Sequence[Row[Any]]]:
     """Yield batches of (image_id, filename, iqdb_hash) using keyset pagination."""
     last_id = start_from
     while True:
         async with engine.connect() as conn:
             query = (
-                select(Images.image_id, Images.filename, Images.iqdb_hash)
-                .where(Images.image_id > last_id)
+                select(Images.image_id, Images.filename, Images.iqdb_hash)  # type: ignore[call-overload]
+                .where(Images.image_id > last_id)  # type: ignore[operator]
                 .order_by(Images.image_id)
                 .limit(batch_size)
             )
             if only_missing_hash:
-                query = query.where(Images.iqdb_hash.is_(None))
+                query = query.where(Images.iqdb_hash.is_(None))  # type: ignore[union-attr]
             result = await conn.execute(query)
             rows = result.fetchall()
 
@@ -151,20 +160,24 @@ async def iter_image_batches(engine, batch_size: int, start_from: int, *, only_m
         last_id = rows[-1][0]
 
 
-async def get_image_count(engine, start_from: int, *, only_missing_hash: bool) -> int:
+async def get_image_count(engine: AsyncEngine, start_from: int, *, only_missing_hash: bool) -> int:
     """Return the count of images to process."""
     async with engine.connect() as conn:
-        query = select(func.count()).select_from(Images).where(Images.image_id > start_from)
+        query = (
+            select(func.count()).select_from(Images).where(Images.image_id > start_from)  # type: ignore[operator, arg-type]
+        )
         if only_missing_hash:
-            query = query.where(Images.iqdb_hash.is_(None))
+            query = query.where(Images.iqdb_hash.is_(None))  # type: ignore[union-attr]
         result = await conn.execute(query)
-        return result.scalar_one()
+        count = result.scalar_one()
+        assert isinstance(count, int)
+        return count
 
 
 async def _process_one(
     semaphore: asyncio.Semaphore,
     http_client: httpx.Client,
-    session_factory,
+    session_factory: async_sessionmaker[AsyncSession],
     image_id: int,
     filename: str,
     dry_run: bool,
@@ -195,7 +208,7 @@ async def _process_one(
                 async with session_factory() as session, session.begin():
                     await session.execute(
                         update(Images)
-                        .where(Images.image_id == image_id)
+                        .where(Images.image_id == image_id)  # type: ignore[arg-type]
                         .values(iqdb_hash=iqdb_hash)
                     )
             except Exception as e:

--- a/scripts/r2_sync.py
+++ b/scripts/r2_sync.py
@@ -553,9 +553,9 @@ async def cmd_avatars_backfill(*, dry_run: bool = False, concurrency: int = 8) -
     async with r2.bulk_session():
         async with get_async_session() as db:
             result = await db.execute(
-                select(Users.user_id, Users.avatar).where(
-                    Users.avatar != "",  # type: ignore[arg-type]
-                    Users.avatar_in_r2 == False,  # type: ignore[arg-type]  # noqa: E712
+                select(Users.user_id, Users.avatar).where(  # type: ignore[call-overload]
+                    Users.avatar != "",
+                    Users.avatar_in_r2 == False,  # noqa: E712
                 )
             )
             rows = result.all()

--- a/scripts/refresh_user_tag_affinity.py
+++ b/scripts/refresh_user_tag_affinity.py
@@ -13,8 +13,7 @@ from pathlib import Path
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import settings
 from app.services.user_tag_affinity import refresh_user_tag_affinity
@@ -22,7 +21,7 @@ from app.services.user_tag_affinity import refresh_user_tag_affinity
 
 async def main() -> None:
     engine = create_async_engine(settings.DATABASE_URL, echo=False)
-    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with async_session() as db:
         n = await refresh_user_tag_affinity(

--- a/scripts/reindex_search.py
+++ b/scripts/reindex_search.py
@@ -49,7 +49,7 @@ async def reindex_tags(batch_size: int = 1000) -> None:
             while True:
                 result = await db.execute(
                     select(Tags)
-                    .where(Tags.tag_id > last_id)  # type: ignore[arg-type]
+                    .where(Tags.tag_id > last_id)  # type: ignore[arg-type,operator]
                     .order_by(Tags.tag_id)  # type: ignore[arg-type]
                     .limit(batch_size)
                 )
@@ -60,7 +60,9 @@ async def reindex_tags(batch_size: int = 1000) -> None:
 
                 await service.index_tags_from_db(db, tags)
                 indexed += len(tags)
-                last_id = tags[-1].tag_id  # type: ignore[assignment]
+                new_last_id = tags[-1].tag_id
+                assert new_last_id is not None, "persisted tags always have a tag_id"
+                last_id = new_last_id
                 print(f"  Indexed {indexed} tags...")
 
             elapsed = time.monotonic() - start

--- a/scripts/repair_alias_chains.py
+++ b/scripts/repair_alias_chains.py
@@ -33,8 +33,7 @@ import argparse
 import asyncio
 
 from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import TagAuditActionType, settings
 from app.models.tag import Tags
@@ -62,11 +61,13 @@ def resolve_terminal(tag_id: int, alias_map: dict[int, int | None]) -> int | Non
 
 async def repair(*, apply: bool) -> None:
     engine = create_async_engine(settings.DATABASE_URL, echo=False)
-    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False, future=True)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     try:
         async with async_session() as db:
-            rows = (await db.execute(select(Tags.tag_id, Tags.title, Tags.alias_of))).all()
+            rows = (
+                await db.execute(select(Tags.tag_id, Tags.title, Tags.alias_of))  # type: ignore[call-overload]
+            ).all()
             alias_map: dict[int, int | None] = {row.tag_id: row.alias_of for row in rows}
             titles: dict[int, str] = {row.tag_id: row.title for row in rows}
 

--- a/scripts/seed_test_account_activity.py
+++ b/scripts/seed_test_account_activity.py
@@ -34,8 +34,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.engine import CursorResult
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import settings
 
@@ -97,9 +97,17 @@ async def seed_activity(db: AsyncSession, username: str, tag_title: str, favorit
 
     await db.commit()
 
+    # db.execute() is typed as returning the generic Result[Any], but a raw
+    # INSERT executed via text() always comes back as a CursorResult, which
+    # is what actually carries .rowcount.
+    assert isinstance(fav_result, CursorResult)
     fav_inserted = fav_result.rowcount or 0
     fav_skipped = len(image_ids) - fav_inserted
-    rating_inserted = rating_result.rowcount if rating_result is not None else 0
+    if rating_result is not None:
+        assert isinstance(rating_result, CursorResult)
+        rating_inserted = rating_result.rowcount
+    else:
+        rating_inserted = 0
     rating_skipped = len(rated_ids) - rating_inserted
 
     print(
@@ -119,7 +127,7 @@ async def main() -> None:
     args = parser.parse_args()
 
     engine = create_async_engine(settings.DATABASE_URL, echo=False)
-    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with async_session() as db:
         await seed_activity(db, args.username, args.tag, args.favorites)


### PR DESCRIPTION
Second of a four-PR stack. Base is `docs/plans-reorg` (#327) — **merge that first**. It carries the `mypy_path` / `explicit_package_bases` fix these changes depend on; without it, one suppression here becomes an `Unused "type: ignore"` error under `strict`.

## Why

Making `mypy scripts/` work in #327 revealed 142 errors that had been invisible while the directory-level run aborted on a module-name collision. This clears 123 of them across 21 files. The remaining 19 were in files with uncommitted work at the time and land in PR 3.

## What

Most of this is real typing rather than suppression: missing parameter and return annotations, bare `dict`/`list` given type parameters, and the legacy `sessionmaker(engine, class_=AsyncSession)` spelling replaced with `async_sessionmaker` in five scripts — same call, correctly typed, and already what `app/core/database.py` uses.

The rest are `# type: ignore` with specific codes, all tracing to one pre-existing condition: the pydantic/SQLModel mypy plugin is disabled, so SQLModel columns type as their plain Python type instead of `InstrumentedAttribute`, and every `select()`, `.in_()`, `func.count()` and `.where()` fails overload resolution. `app/` already carries **1030** such suppressions in the same distribution, so these match an established convention rather than inventing one. Two stale ignores in `r2_sync.py` were removed and one over-broad one in `generate_thumbnails.py` narrowed.

Where a value is provably non-None, narrowing is used instead of suppression — `assert stats is not None` on an unconditional aggregate SELECT, and asserts after `normalize_text()` calls that sit inside a truthy guard where the single None-returning path is unreachable.

## Known, not fixed

`migrate_quoted_comments.py` builds `image_ids` from a nullable column, and SQL `IN (..., NULL)` never matches, so a comment with a NULL `image_id` would be silently skipped for parent matching. I checked the database: the column is nullable but currently holds zero NULL rows. Latent, not active.

## Verification

`mypy scripts/` down to 19 errors, all in files excluded from this PR. `mypy app/` unchanged at zero across 165 files. 102 script tests and 314 unit tests passing. Ruff clean, no format drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx4tX6zYZWuMu4EWHy6F6D