### PR TITLE
chore: actually enforce ruff on scripts/ and tests/

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,11 @@ repos:
       - id: ruff-check
         args: [--fix]
         types_or: [python, pyi]
-        exclude: ^(tests|docs)/|^test_.*\.py$
+        exclude: ^docs/
       # Run the formatter
       - id: ruff-format
         types_or: [python, pyi]
-        exclude: ^(tests|docs)/|^test_.*\.py$
+        exclude: ^docs/
 
   # Standard pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,10 +87,7 @@ exclude = [
     "*.md",
 ]
 extend-exclude = [
-    "tests",
     "docs",
-    "scripts",
-    "test_*.py",
 ]
 
 [tool.ruff.lint]
@@ -112,6 +109,16 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # unused imports
+# Test fixtures are frequently bound to a name only to keep the row alive for
+# the assertions below; the value itself is never read. Deleting the binding
+# would delete the row the test depends on.
+"tests/**" = ["F841"]
+# A couple of test modules import helpers from sibling test modules partway
+# down the file to avoid an import cycle at module load.
+"tests/api/v1/test_user_ratings_endpoint.py" = ["E402"]
+# %-formatting is the subject of these assertions, not an accident: they prove
+# a RedactedStr survives the %r path arq uses when logging job kwargs.
+"tests/unit/test_redacted_str.py" = ["UP031"]
 
 [tool.ruff.lint.pyupgrade]
 # Enforce Python 3.10+ type hints (use | instead of Optional)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,15 @@ markers = [
 # warn_unused_ignores = true
 # warn_no_return = true
 # follow_imports = "normal"
-# Disable pydantic plugin due to typing_extensions conflict in VS Code extension
+# The pydantic mypy plugin is off deliberately, and not because it fails to
+# load: CLI mypy runs it fine (checked on mypy 1.19 / pydantic 2.12). It is off
+# because it synthesises __init__ from field names and so misreports
+# alias-based construction — TagSummary(title=..., type=...) is correct at
+# runtime under populate_by_name but reads as a missing argument. Enabling it
+# trades ~11 removable ignores for new false positives, and does nothing for
+# the SQLAlchemy column-expression errors that are most of the ignores here.
+# (A direct `import pydantic.mypy` raises ImportError because mypy ships
+# compiled modules; that does not affect mypy's own plugin loading.)
 # plugins = ["pydantic.mypy"]
 # namespace_packages = true
 # Strict mode settings

--- a/tests/README.md
+++ b/tests/README.md
@@ -148,10 +148,12 @@ Use markers to categorize tests:
 ```python
 import pytest
 
+
 @pytest.mark.unit
 def test_something_fast():
     """Unit test - no database or external dependencies."""
     pass
+
 
 @pytest.mark.api
 async def test_api_endpoint(client):
@@ -159,10 +161,12 @@ async def test_api_endpoint(client):
     response = await client.get("/api/v1/images")
     assert response.status_code == 200
 
+
 @pytest.mark.integration
 async def test_database_operation(db_session):
     """Integration test - tests database operations."""
     pass
+
 
 @pytest.mark.slow
 async def test_slow_operation():
@@ -198,10 +202,12 @@ async def test_with_client(client: AsyncClient):
     response = await client.get("/api/v1/images")
     assert response.status_code == 200
 
+
 async def test_with_fixtures(test_user, test_image, db_session):
     """Use data fixtures - they're already created in the DB."""
     # test_user and test_image are already committed
     assert test_image.user_id == test_user.user_id
+
 
 async def test_create_custom_data(test_user, db_session):
     """Create custom test data for this specific test."""

--- a/tests/api/v1/test_admin_actions.py
+++ b/tests/api/v1/test_admin_actions.py
@@ -79,9 +79,7 @@ async def create_test_image(db_session: AsyncSession, user_id: int) -> Images:
     return image
 
 
-async def grant_permissions(
-    db_session: AsyncSession, user_id: int, perm_titles: list[str]
-):
+async def grant_permissions(db_session: AsyncSession, user_id: int, perm_titles: list[str]):
     """Grant multiple permissions to a user via a group."""
     # Get or create a test group
     result = await db_session.execute(select(Groups).where(Groups.title == "audit_test_admin"))
@@ -129,9 +127,7 @@ async def grant_permissions(
 class TestReportDismissAuditLog:
     """Tests for audit logging when dismissing reports."""
 
-    async def test_dismiss_creates_audit_entry(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_dismiss_creates_audit_entry(self, client: AsyncClient, db_session: AsyncSession):
         """Dismissing a report creates REPORT_DISMISS audit entry."""
         admin, password = await create_admin_user(db_session, "dismissadmin1")
         await grant_permissions(db_session, admin.user_id, ["report_manage"])
@@ -174,9 +170,7 @@ class TestReportDismissAuditLog:
 class TestReportActionAuditLog:
     """Tests for audit logging when taking action on reports."""
 
-    async def test_action_creates_audit_entry(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_action_creates_audit_entry(self, client: AsyncClient, db_session: AsyncSession):
         """Taking action on a report creates REPORT_ACTION audit entry."""
         admin, password = await create_admin_user(db_session, "actionadmin1")
         await grant_permissions(db_session, admin.user_id, ["report_manage"])
@@ -265,9 +259,7 @@ class TestReviewStartAuditLog:
     ):
         """Escalating a report creates REVIEW_START audit entry."""
         admin, password = await create_admin_user(db_session, "escadmin1")
-        await grant_permissions(
-            db_session, admin.user_id, ["report_manage", "review_start"]
-        )
+        await grant_permissions(db_session, admin.user_id, ["report_manage", "review_start"])
         token = await login_user(client, admin.username, password)
 
         image = await create_test_image(db_session, admin.user_id)
@@ -311,9 +303,7 @@ class TestReviewStartAuditLog:
 class TestReviewVoteAuditLog:
     """Tests for audit logging when voting on reviews."""
 
-    async def test_vote_creates_audit_entry(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_vote_creates_audit_entry(self, client: AsyncClient, db_session: AsyncSession):
         """Casting a vote creates REVIEW_VOTE audit entry."""
         admin, password = await create_admin_user(db_session, "voteadmin1")
         await grant_permissions(db_session, admin.user_id, ["review_vote"])
@@ -361,9 +351,7 @@ class TestReviewVoteAuditLog:
 class TestReviewCloseAuditLog:
     """Tests for audit logging when closing reviews."""
 
-    async def test_close_creates_audit_entry(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_close_creates_audit_entry(self, client: AsyncClient, db_session: AsyncSession):
         """Closing a review creates REVIEW_CLOSE audit entry."""
         admin, password = await create_admin_user(db_session, "closeadmin1")
         await grant_permissions(db_session, admin.user_id, ["review_close_early"])
@@ -411,9 +399,7 @@ class TestReviewCloseAuditLog:
 class TestReviewExtendAuditLog:
     """Tests for audit logging when extending reviews."""
 
-    async def test_extend_creates_audit_entry(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_extend_creates_audit_entry(self, client: AsyncClient, db_session: AsyncSession):
         """Extending a review creates REVIEW_EXTEND audit entry."""
         admin, password = await create_admin_user(db_session, "extendadmin1")
         await grant_permissions(db_session, admin.user_id, ["review_start"])

--- a/tests/api/v1/test_admin_images.py
+++ b/tests/api/v1/test_admin_images.py
@@ -75,9 +75,7 @@ async def grant_permission(db_session: AsyncSession, user_id: int, perm_title: s
         db_session.add(perm)
         await db_session.flush()
 
-    result = await db_session.execute(
-        select(Groups).where(Groups.title == "image_test_admin")
-    )
+    result = await db_session.execute(select(Groups).where(Groups.title == "image_test_admin"))
     group = result.scalar_one_or_none()
     if not group:
         group = Groups(title="image_test_admin", desc="Image test admin group")
@@ -135,9 +133,7 @@ async def create_test_image(db_session: AsyncSession, user_id: int) -> Images:
 class TestImageStatusChange:
     """Tests for PATCH /api/v1/admin/images/{image_id} endpoint."""
 
-    async def test_mark_image_as_spoiler(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_mark_image_as_spoiler(self, client: AsyncClient, db_session: AsyncSession):
         """Test marking an image as spoiler."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "image_edit")
@@ -265,9 +261,7 @@ class TestImageStatusChange:
         assert response.status_code == 400
         assert "replacement_id" in response.json()["detail"].lower()
 
-    async def test_cannot_repost_self(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_cannot_repost_self(self, client: AsyncClient, db_session: AsyncSession):
         """Test that an image cannot be marked as a repost of itself."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "image_edit")
@@ -287,9 +281,7 @@ class TestImageStatusChange:
         assert response.status_code == 400
         assert "itself" in response.json()["detail"].lower()
 
-    async def test_invalid_replacement_id(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_invalid_replacement_id(self, client: AsyncClient, db_session: AsyncSession):
         """Test that invalid replacement_id fails."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "image_edit")
@@ -359,9 +351,7 @@ class TestImageStatusChange:
 
         assert response.status_code == 403
 
-    async def test_image_not_found(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_image_not_found(self, client: AsyncClient, db_session: AsyncSession):
         """Test 404 for non-existent image."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "image_edit")
@@ -376,9 +366,7 @@ class TestImageStatusChange:
 
         assert response.status_code == 404
 
-    async def test_invalid_status_value(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_invalid_status_value(self, client: AsyncClient, db_session: AsyncSession):
         """Test validation error for invalid status value."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "image_edit")
@@ -520,15 +508,13 @@ class TestImageStatusChangeAuditLog:
 
         # Add data to repost
         db_session.add(Favorites(user_id=user.user_id, image_id=repost_image.image_id))
-        db_session.add(ImageRatings(
-            user_id=user.user_id, image_id=repost_image.image_id, rating=8
-        ))
+        db_session.add(ImageRatings(user_id=user.user_id, image_id=repost_image.image_id, rating=8))
         tag = Tags(title="repost test tag", type=1)
         db_session.add(tag)
         await db_session.flush()
-        db_session.add(TagLinks(
-            tag_id=tag.tag_id, image_id=repost_image.image_id, user_id=user.user_id
-        ))
+        db_session.add(
+            TagLinks(tag_id=tag.tag_id, image_id=repost_image.image_id, user_id=user.user_id)
+        )
         repost_image.favorites = 1
         await db_session.commit()
 
@@ -547,31 +533,31 @@ class TestImageStatusChangeAuditLog:
 
         # Verify data migrated to original
         fav_result = await db_session.execute(
-            select(func.count()).select_from(Favorites).where(
-                Favorites.image_id == original_image.image_id
-            )
+            select(func.count())
+            .select_from(Favorites)
+            .where(Favorites.image_id == original_image.image_id)
         )
         assert fav_result.scalar() == 1
 
         rating_result = await db_session.execute(
-            select(func.count()).select_from(ImageRatings).where(
-                ImageRatings.image_id == original_image.image_id
-            )
+            select(func.count())
+            .select_from(ImageRatings)
+            .where(ImageRatings.image_id == original_image.image_id)
         )
         assert rating_result.scalar() == 1
 
         tag_result = await db_session.execute(
-            select(func.count()).select_from(TagLinks).where(
-                TagLinks.image_id == original_image.image_id
-            )
+            select(func.count())
+            .select_from(TagLinks)
+            .where(TagLinks.image_id == original_image.image_id)
         )
         assert tag_result.scalar() == 1
 
         # Verify repost is cleaned up
         fav_result = await db_session.execute(
-            select(func.count()).select_from(Favorites).where(
-                Favorites.image_id == repost_image.image_id
-            )
+            select(func.count())
+            .select_from(Favorites)
+            .where(Favorites.image_id == repost_image.image_id)
         )
         assert fav_result.scalar() == 0
 
@@ -621,12 +607,14 @@ class TestImageStatusChangeAuditLog:
         assert response.status_code == 200
 
         rows = (
-            await db_session.execute(
-                select(MlTagSuggestions).where(
-                    MlTagSuggestions.image_id == repost.image_id
+            (
+                await db_session.execute(
+                    select(MlTagSuggestions).where(MlTagSuggestions.image_id == repost.image_id)
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         assert rows == []
 
 
@@ -634,9 +622,7 @@ class TestImageStatusChangeAuditLog:
 class TestImageLocked:
     """Tests for locking/unlocking image comments."""
 
-    async def test_lock_image_comments(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_lock_image_comments(self, client: AsyncClient, db_session: AsyncSession):
         """Test locking comments on an image."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "image_edit")
@@ -661,9 +647,7 @@ class TestImageLocked:
         await db_session.refresh(image)
         assert image.locked == 1
 
-    async def test_unlock_image_comments(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_unlock_image_comments(self, client: AsyncClient, db_session: AsyncSession):
         """Test unlocking comments on an image."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "image_edit")
@@ -711,9 +695,7 @@ class TestImageLocked:
         assert data["status"] == ImageStatus.SPOILER
         assert data["locked"] == 1
 
-    async def test_locked_only_without_status(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_locked_only_without_status(self, client: AsyncClient, db_session: AsyncSession):
         """Test that locked can be changed without providing status."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "image_edit")
@@ -734,9 +716,7 @@ class TestImageLocked:
         assert data["locked"] == 1
         assert data["status"] == original_status  # Status unchanged
 
-    async def test_locked_audit_log(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_locked_audit_log(self, client: AsyncClient, db_session: AsyncSession):
         """Test that locking an image creates an audit log entry."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "image_edit")

--- a/tests/api/v1/test_admin_suspensions.py
+++ b/tests/api/v1/test_admin_suspensions.py
@@ -77,9 +77,7 @@ async def grant_permission(db_session: AsyncSession, user_id: int, perm_title: s
         await db_session.flush()
 
     # Get or create a test group
-    result = await db_session.execute(
-        select(Groups).where(Groups.title == "suspension_test_admin")
-    )
+    result = await db_session.execute(select(Groups).where(Groups.title == "suspension_test_admin"))
     group = result.scalar_one_or_none()
     if not group:
         group = Groups(title="suspension_test_admin", desc="Suspension test admin group")
@@ -124,9 +122,7 @@ async def login_user(client: AsyncClient, username: str, password: str) -> str:
 class TestSuspendUser:
     """Tests for POST /api/v1/admin/users/{user_id}/suspend endpoint."""
 
-    async def test_suspend_user_temporary(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_suspend_user_temporary(self, client: AsyncClient, db_session: AsyncSession):
         """Test suspending a user with expiration date."""
         # Create admin and regular users
         admin, admin_password = await create_admin_user(db_session)
@@ -171,9 +167,7 @@ class TestSuspendUser:
         )
         assert result.scalar_one_or_none() is None
 
-    async def test_suspend_user_permanent(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_suspend_user_permanent(self, client: AsyncClient, db_session: AsyncSession):
         """Test permanent suspension (no expiration)."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")
@@ -239,9 +233,7 @@ class TestSuspendUser:
         assert response.status_code == 400
         assert "already suspended" in response.json()["detail"].lower()
 
-    async def test_suspend_nonexistent_user(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_suspend_nonexistent_user(self, client: AsyncClient, db_session: AsyncSession):
         """Test suspending a user that doesn't exist."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")
@@ -259,9 +251,7 @@ class TestSuspendUser:
 
         assert response.status_code == 404
 
-    async def test_suspend_self_prevention(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_suspend_self_prevention(self, client: AsyncClient, db_session: AsyncSession):
         """Test that admins cannot suspend themselves."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")
@@ -280,9 +270,7 @@ class TestSuspendUser:
         assert response.status_code == 400
         assert "yourself" in response.json()["detail"].lower()
 
-    async def test_suspend_without_permission(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_suspend_without_permission(self, client: AsyncClient, db_session: AsyncSession):
         """Test suspending without USER_BAN permission."""
         admin, admin_password = await create_admin_user(db_session, username="nopermadmin")
         # Don't grant USER_BAN permission
@@ -301,9 +289,7 @@ class TestSuspendUser:
 
         assert response.status_code == 403
 
-    async def test_suspend_reason_too_short(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_suspend_reason_too_short(self, client: AsyncClient, db_session: AsyncSession):
         """Test that suspension reason must be at least 3 characters."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")
@@ -417,15 +403,11 @@ class TestSuspendUser:
 class TestReactivateUser:
     """Tests for POST /api/v1/admin/users/{user_id}/reactivate endpoint."""
 
-    async def test_reactivate_suspended_user(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_reactivate_suspended_user(self, client: AsyncClient, db_session: AsyncSession):
         """Test reactivating a suspended user."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")
-        target_user = await create_regular_user(
-            db_session, username="reactivateme", active=0
-        )
+        target_user = await create_regular_user(db_session, username="reactivateme", active=0)
 
         # Create suspension record
         suspend_until = datetime.now(UTC) + timedelta(days=1)
@@ -469,9 +451,7 @@ class TestReactivateUser:
         """Test reactivating a user who is already active without suspension record."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")
-        target_user = await create_regular_user(
-            db_session, username="alreadyactive", active=1
-        )
+        target_user = await create_regular_user(db_session, username="alreadyactive", active=1)
         # No suspension record - user was never suspended
 
         token = await login_user(client, admin.username, admin_password)
@@ -491,9 +471,7 @@ class TestReactivateUser:
         """Test reactivating an inactive user with no suspension record."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")
-        target_user = await create_regular_user(
-            db_session, username="nosuspension", active=0
-        )
+        target_user = await create_regular_user(db_session, username="nosuspension", active=0)
         # No suspension record created
 
         token = await login_user(client, admin.username, admin_password)
@@ -512,9 +490,7 @@ class TestReactivateUser:
         """Test reactivating a user who was already reactivated."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")
-        target_user = await create_regular_user(
-            db_session, username="wasreactivated", active=0
-        )
+        target_user = await create_regular_user(db_session, username="wasreactivated", active=0)
 
         # Create suspension and reactivation records
         now = datetime.now(UTC)
@@ -550,9 +526,7 @@ class TestReactivateUser:
         self, client: AsyncClient, db_session: AsyncSession
     ):
         """Test reactivating without USER_BAN permission."""
-        admin, admin_password = await create_admin_user(
-            db_session, username="nopermreactivate"
-        )
+        admin, admin_password = await create_admin_user(db_session, username="nopermreactivate")
         target_user = await create_regular_user(db_session, username="target", active=0)
 
         token = await login_user(client, admin.username, admin_password)
@@ -569,9 +543,7 @@ class TestReactivateUser:
 class TestUserSuspensionHistory:
     """Tests for GET /api/v1/admin/users/{user_id}/suspensions endpoint."""
 
-    async def test_get_suspension_history(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_suspension_history(self, client: AsyncClient, db_session: AsyncSession):
         """Test retrieving user suspension history."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")
@@ -671,9 +643,7 @@ class TestUserSuspensionHistory:
         self, client: AsyncClient, db_session: AsyncSession
     ):
         """Test getting history without USER_BAN permission."""
-        admin, admin_password = await create_admin_user(
-            db_session, username="nopermhistory"
-        )
+        admin, admin_password = await create_admin_user(db_session, username="nopermhistory")
         target_user = await create_regular_user(db_session, username="someuser")
 
         token = await login_user(client, admin.username, admin_password)
@@ -690,9 +660,7 @@ class TestUserSuspensionHistory:
 class TestUserWarningAcknowledgement:
     """Tests for GET/POST /api/v1/users/me/warnings endpoints."""
 
-    async def test_get_unacknowledged_warnings(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_unacknowledged_warnings(self, client: AsyncClient, db_session: AsyncSession):
         """Test getting unacknowledged warnings for current user."""
         user = await create_regular_user(db_session, username="warneduser")
         admin, _ = await create_admin_user(db_session)
@@ -822,9 +790,7 @@ class TestUserWarningAcknowledgement:
         assert data["items"][0]["action"] == "suspended"
         assert data["items"][0]["reason"] == "You have been suspended"
 
-    async def test_acknowledge_warnings(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_acknowledge_warnings(self, client: AsyncClient, db_session: AsyncSession):
         """Test acknowledging all warnings."""
         user = await create_regular_user(db_session, username="ackuser")
         admin, _ = await create_admin_user(db_session)
@@ -871,9 +837,7 @@ class TestUserWarningAcknowledgement:
         )
         assert response.json()["count"] == 0
 
-    async def test_acknowledge_no_warnings(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_acknowledge_no_warnings(self, client: AsyncClient, db_session: AsyncSession):
         """Test acknowledging when there are no warnings."""
         user = await create_regular_user(db_session, username="nowarningsuser")
 
@@ -904,9 +868,7 @@ class TestUserWarningAcknowledgement:
 class TestAdminSuspensionList:
     """Tests for GET /api/v1/admin/suspensions endpoint."""
 
-    async def test_list_all_suspensions(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_list_all_suspensions(self, client: AsyncClient, db_session: AsyncSession):
         """Test listing all suspension records across all users."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")
@@ -1062,9 +1024,7 @@ class TestAdminSuspensionList:
         assert data["total"] == 1
         assert data["items"][0]["action"] == "warning"
 
-    async def test_filter_by_days_back(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_filter_by_days_back(self, client: AsyncClient, db_session: AsyncSession):
         """Test filtering by days_back."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")
@@ -1155,9 +1115,7 @@ class TestAdminSuspensionList:
         data = response.json()
         assert len(data["items"]) == 2
 
-    async def test_is_active_calculation(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_is_active_calculation(self, client: AsyncClient, db_session: AsyncSession):
         """Test that is_active correctly identifies active suspensions."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")
@@ -1231,13 +1189,9 @@ class TestAdminSuspensionList:
         # active_count should be 1
         assert data["active_count"] == 1
 
-    async def test_without_permission(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_without_permission(self, client: AsyncClient, db_session: AsyncSession):
         """Test listing suspensions without USER_BAN permission."""
-        admin, admin_password = await create_admin_user(
-            db_session, username="nopermsusplist"
-        )
+        admin, admin_password = await create_admin_user(db_session, username="nopermsusplist")
         # Don't grant USER_BAN permission
 
         token = await login_user(client, admin.username, admin_password)
@@ -1249,9 +1203,7 @@ class TestAdminSuspensionList:
 
         assert response.status_code == 403
 
-    async def test_excludes_reactivated_action(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_excludes_reactivated_action(self, client: AsyncClient, db_session: AsyncSession):
         """Test that reactivated action records are excluded from the list."""
         admin, admin_password = await create_admin_user(db_session)
         await grant_permission(db_session, admin.user_id, "user_ban")

--- a/tests/api/v1/test_backfill_tag_type_flags.py
+++ b/tests/api/v1/test_backfill_tag_type_flags.py
@@ -105,7 +105,9 @@ class TestBackfillTagTypeFlags:
         assert fresh_a.has_artist is True, "image A should have has_artist=True after backfill"
         assert fresh_a.has_theme is False, "image A should have has_theme=False (no theme tag)"
         assert fresh_a.has_source is False, "image A should have has_source=False (no source tag)"
-        assert fresh_a.has_character is False, "image A should have has_character=False (no character tag)"
+        assert fresh_a.has_character is False, (
+            "image A should have has_character=False (no character tag)"
+        )
 
         # Fresh-read image B — all flags should remain False
         fresh_b = (
@@ -120,9 +122,7 @@ class TestBackfillTagTypeFlags:
         assert fresh_b.has_source is False, "image B should have has_source=False (no tags)"
         assert fresh_b.has_character is False, "image B should have has_character=False (no tags)"
 
-    async def test_backfill_sets_all_four_flag_types(
-        self, db_session: AsyncSession
-    ):
+    async def test_backfill_sets_all_four_flag_types(self, db_session: AsyncSession):
         """Image with tags of all four types gets all four flags set after backfill."""
         user = await _create_user(db_session)
         image = await _create_image(db_session, user.user_id, "backfillAll1")
@@ -133,7 +133,9 @@ class TestBackfillTagTypeFlags:
             db_session.add(tag)
             await db_session.flush()
             await db_session.refresh(tag)
-            db_session.add(TagLinks(tag_id=tag.tag_id, image_id=image.image_id, user_id=user.user_id))
+            db_session.add(
+                TagLinks(tag_id=tag.tag_id, image_id=image.image_id, user_id=user.user_id)
+            )
         await db_session.flush()
 
         await backfill_range(db_session, lo=image.image_id, hi=image.image_id + 1)
@@ -151,9 +153,7 @@ class TestBackfillTagTypeFlags:
         assert fresh.has_artist is True
         assert fresh.has_character is True
 
-    async def test_backfill_is_idempotent(
-        self, db_session: AsyncSession
-    ):
+    async def test_backfill_is_idempotent(self, db_session: AsyncSession):
         """Running backfill_range twice produces the same result."""
         user = await _create_user(db_session)
         image = await _create_image(db_session, user.user_id, "backfillIdem1")
@@ -162,7 +162,9 @@ class TestBackfillTagTypeFlags:
         db_session.add(source_tag)
         await db_session.flush()
         await db_session.refresh(source_tag)
-        db_session.add(TagLinks(tag_id=source_tag.tag_id, image_id=image.image_id, user_id=user.user_id))
+        db_session.add(
+            TagLinks(tag_id=source_tag.tag_id, image_id=image.image_id, user_id=user.user_id)
+        )
         await db_session.flush()
 
         # Run twice

--- a/tests/api/v1/test_banner_preferences.py
+++ b/tests/api/v1/test_banner_preferences.py
@@ -21,7 +21,10 @@ class TestGetPreferences:
         assert data["pins"] == []
 
     async def test_returns_stored_preferences(
-        self, authenticated_client: AsyncClient, db_session: AsyncSession, sample_user,
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
+        sample_user,
     ):
         prefs = UserBannerPreferences(user_id=sample_user.user_id, preferred_size=BannerSize.large)
         db_session.add(prefs)
@@ -32,19 +35,28 @@ class TestGetPreferences:
         assert response.json()["preferred_size"] == "large"
 
     async def test_returns_pins_with_banner_data(
-        self, authenticated_client: AsyncClient, db_session: AsyncSession, sample_user,
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
+        sample_user,
     ):
         banner = Banners(
-            name="pinned", size=BannerSize.small, supports_dark=True,
-            supports_light=True, full_image="pin.png", active=True,
+            name="pinned",
+            size=BannerSize.small,
+            supports_dark=True,
+            supports_light=True,
+            full_image="pin.png",
+            active=True,
         )
         db_session.add(banner)
         await db_session.commit()
         await db_session.refresh(banner)
 
         pin = UserBannerPins(
-            user_id=sample_user.user_id, size=BannerSize.small,
-            theme=BannerTheme.dark, banner_id=banner.banner_id,
+            user_id=sample_user.user_id,
+            size=BannerSize.small,
+            theme=BannerTheme.dark,
+            banner_id=banner.banner_id,
         )
         db_session.add(pin)
         await db_session.commit()
@@ -60,20 +72,23 @@ class TestGetPreferences:
 class TestUpdatePreferences:
     async def test_requires_auth(self, client: AsyncClient):
         response = await client.patch(
-            "/api/v1/banners/preferences", json={"preferred_size": "large"},
+            "/api/v1/banners/preferences",
+            json={"preferred_size": "large"},
         )
         assert response.status_code == 401
 
     async def test_updates_size(self, authenticated_client: AsyncClient):
         response = await authenticated_client.patch(
-            "/api/v1/banners/preferences", json={"preferred_size": "large"},
+            "/api/v1/banners/preferences",
+            json={"preferred_size": "large"},
         )
         assert response.status_code == 200
         assert response.json()["preferred_size"] == "large"
 
     async def test_rejects_invalid_size(self, authenticated_client: AsyncClient):
         response = await authenticated_client.patch(
-            "/api/v1/banners/preferences", json={"preferred_size": "huge"},
+            "/api/v1/banners/preferences",
+            json={"preferred_size": "huge"},
         )
         assert response.status_code == 422
 
@@ -88,11 +103,17 @@ class TestPinBanner:
         assert response.status_code == 401
 
     async def test_pins_banner(
-        self, authenticated_client: AsyncClient, db_session: AsyncSession,
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
     ):
         banner = Banners(
-            name="to_pin", size=BannerSize.small, supports_dark=True,
-            supports_light=True, full_image="pin.png", active=True,
+            name="to_pin",
+            size=BannerSize.small,
+            supports_dark=True,
+            supports_light=True,
+            full_image="pin.png",
+            active=True,
         )
         db_session.add(banner)
         await db_session.commit()
@@ -112,11 +133,17 @@ class TestPinBanner:
         assert response.status_code == 404
 
     async def test_rejects_size_mismatch(
-        self, authenticated_client: AsyncClient, db_session: AsyncSession,
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
     ):
         banner = Banners(
-            name="large_b", size=BannerSize.large, supports_dark=True,
-            supports_light=True, full_image="lg.png", active=True,
+            name="large_b",
+            size=BannerSize.large,
+            supports_dark=True,
+            supports_light=True,
+            full_image="lg.png",
+            active=True,
         )
         db_session.add(banner)
         await db_session.commit()
@@ -150,19 +177,28 @@ class TestUnpinBanner:
         assert response.status_code == 401
 
     async def test_removes_pin(
-        self, authenticated_client: AsyncClient, db_session: AsyncSession, sample_user,
+        self,
+        authenticated_client: AsyncClient,
+        db_session: AsyncSession,
+        sample_user,
     ):
         banner = Banners(
-            name="unpin_me", size=BannerSize.small, supports_dark=True,
-            supports_light=True, full_image="u.png", active=True,
+            name="unpin_me",
+            size=BannerSize.small,
+            supports_dark=True,
+            supports_light=True,
+            full_image="u.png",
+            active=True,
         )
         db_session.add(banner)
         await db_session.commit()
         await db_session.refresh(banner)
 
         pin = UserBannerPins(
-            user_id=sample_user.user_id, size=BannerSize.small,
-            theme=BannerTheme.dark, banner_id=banner.banner_id,
+            user_id=sample_user.user_id,
+            size=BannerSize.small,
+            theme=BannerTheme.dark,
+            banner_id=banner.banner_id,
         )
         db_session.add(pin)
         await db_session.commit()
@@ -182,17 +218,24 @@ class TestUnpinBanner:
 @pytest.mark.api
 class TestCurrentBannerWithAuth:
     async def test_anonymous_still_works(
-        self, client_real_redis: AsyncClient, db_session: AsyncSession,
+        self,
+        client_real_redis: AsyncClient,
+        db_session: AsyncSession,
     ):
         """Anonymous request without auth works as before."""
         banner = Banners(
-            name="anon", size=BannerSize.small, supports_dark=True,
-            supports_light=True, full_image="anon.png", active=True,
+            name="anon",
+            size=BannerSize.small,
+            supports_dark=True,
+            supports_light=True,
+            full_image="anon.png",
+            active=True,
         )
         db_session.add(banner)
         await db_session.commit()
 
         response = await client_real_redis.get(
-            "/api/v1/banners/current", params={"theme": "dark", "size": "small"},
+            "/api/v1/banners/current",
+            params={"theme": "dark", "size": "small"},
         )
         assert response.status_code == 200

--- a/tests/api/v1/test_banners.py
+++ b/tests/api/v1/test_banners.py
@@ -1,13 +1,13 @@
 """Tests for banners API endpoints."""
 
 import json
-from httpx import AsyncClient
 
 import pytest
 import redis.asyncio as redis
+from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.misc import BannerSize, Banners
+from app.models.misc import Banners, BannerSize
 
 
 @pytest.mark.api

--- a/tests/api/v1/test_batch_tag.py
+++ b/tests/api/v1/test_batch_tag.py
@@ -108,9 +108,7 @@ class TestBatchTagValidation:
         )
         assert response.status_code == 401
 
-    async def test_rejects_empty_tag_ids(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_rejects_empty_tag_ids(self, client: AsyncClient, db_session: AsyncSession):
         """tag_ids must have at least 1 item."""
         user = await _create_user_with_tag_permission(db_session)
         token = create_access_token(user.id)
@@ -121,9 +119,7 @@ class TestBatchTagValidation:
         )
         assert response.status_code == 422
 
-    async def test_rejects_too_many_tag_ids(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_rejects_too_many_tag_ids(self, client: AsyncClient, db_session: AsyncSession):
         """tag_ids must have at most 5 items."""
         user = await _create_user_with_tag_permission(db_session)
         token = create_access_token(user.id)
@@ -134,9 +130,7 @@ class TestBatchTagValidation:
         )
         assert response.status_code == 422
 
-    async def test_rejects_empty_image_ids(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_rejects_empty_image_ids(self, client: AsyncClient, db_session: AsyncSession):
         """image_ids must have at least 1 item."""
         user = await _create_user_with_tag_permission(db_session)
         token = create_access_token(user.id)
@@ -147,9 +141,7 @@ class TestBatchTagValidation:
         )
         assert response.status_code == 422
 
-    async def test_rejects_too_many_image_ids(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_rejects_too_many_image_ids(self, client: AsyncClient, db_session: AsyncSession):
         """image_ids must have at most 100 items."""
         user = await _create_user_with_tag_permission(db_session)
         token = create_access_token(user.id)
@@ -160,9 +152,7 @@ class TestBatchTagValidation:
         )
         assert response.status_code == 422
 
-    async def test_rejects_invalid_action(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_rejects_invalid_action(self, client: AsyncClient, db_session: AsyncSession):
         """Only 'add' and 'remove' actions are supported."""
         user = await _create_user_with_tag_permission(db_session)
         token = create_access_token(user.id)
@@ -178,9 +168,7 @@ class TestBatchTagValidation:
 class TestBatchTagAdd:
     """Tests for the happy path and skip-and-report behavior."""
 
-    async def test_add_tags_to_images(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_add_tags_to_images(self, client: AsyncClient, db_session: AsyncSession):
         """Successfully add multiple tags to multiple images."""
         user = await _create_user_with_tag_permission(db_session)
         token = create_access_token(user.id)
@@ -201,9 +189,7 @@ class TestBatchTagAdd:
         assert len(data["added"]) == 6  # 3 images * 2 tags
         assert len(data["skipped"]) == 0
 
-    async def test_skips_nonexistent_images(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_skips_nonexistent_images(self, client: AsyncClient, db_session: AsyncSession):
         """Missing image IDs are reported as skipped."""
         user = await _create_user_with_tag_permission(db_session)
         token = create_access_token(user.id)
@@ -227,9 +213,7 @@ class TestBatchTagAdd:
         assert skipped[0]["image_id"] == 999999
         assert skipped[0]["reason"] == "image_not_found"
 
-    async def test_skips_nonexistent_tags(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_skips_nonexistent_tags(self, client: AsyncClient, db_session: AsyncSession):
         """Missing tag IDs are reported as skipped."""
         user = await _create_user_with_tag_permission(db_session)
         token = create_access_token(user.id)
@@ -251,9 +235,7 @@ class TestBatchTagAdd:
         assert len(skipped) == 1
         assert skipped[0]["reason"] == "tag_not_found"
 
-    async def test_skips_already_tagged(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_skips_already_tagged(self, client: AsyncClient, db_session: AsyncSession):
         """Already-existing tag links are reported as skipped."""
         user = await _create_user_with_tag_permission(db_session)
         token = create_access_token(user.id)
@@ -284,9 +266,7 @@ class TestBatchTagAdd:
         assert len(data["skipped"]) == 1
         assert data["skipped"][0]["reason"] == "already_tagged"
 
-    async def test_resolves_alias_tags(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_resolves_alias_tags(self, client: AsyncClient, db_session: AsyncSession):
         """Alias tags resolve to their canonical tag."""
         user = await _create_user_with_tag_permission(db_session)
         token = create_access_token(user.id)
@@ -318,9 +298,7 @@ class TestBatchTagAdd:
         # The added pair should use the canonical tag_id
         assert data["added"][0]["tag_id"] == canonical.tag_id
 
-    async def test_creates_tag_history(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_creates_tag_history(self, client: AsyncClient, db_session: AsyncSession):
         """Each new tag link creates a tag history entry."""
         from app.models.tag_history import TagHistory
 
@@ -350,9 +328,7 @@ class TestBatchTagAdd:
         count = result.scalar()
         assert count == 2
 
-    async def test_requires_permission(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_requires_permission(self, client: AsyncClient, db_session: AsyncSession):
         """Users without IMAGE_TAG_ADD permission get 403."""
         # Create user WITHOUT the permission
         user = Users(
@@ -380,9 +356,7 @@ class TestBatchTagAdd:
 class TestBatchTagRemove:
     """Tests for batch tag removal."""
 
-    async def test_remove_tags_from_images(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_remove_tags_from_images(self, client: AsyncClient, db_session: AsyncSession):
         """Successfully remove multiple tags from multiple images."""
         user = await _create_user_with_tag_permission(db_session, ["image_tag_remove"])
         token = create_access_token(user.id)
@@ -411,9 +385,7 @@ class TestBatchTagRemove:
         assert len(data["removed"]) == 4  # 2 images * 2 tags
         assert len(data["skipped"]) == 0
 
-    async def test_skips_not_tagged(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_skips_not_tagged(self, client: AsyncClient, db_session: AsyncSession):
         """Tags not linked to images are reported as skipped."""
         user = await _create_user_with_tag_permission(db_session, ["image_tag_remove"])
         token = create_access_token(user.id)
@@ -435,9 +407,7 @@ class TestBatchTagRemove:
         assert len(data["skipped"]) == 1
         assert data["skipped"][0]["reason"] == "not_tagged"
 
-    async def test_skips_nonexistent_images(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_skips_nonexistent_images(self, client: AsyncClient, db_session: AsyncSession):
         """Missing image IDs are reported as skipped."""
         user = await _create_user_with_tag_permission(db_session, ["image_tag_remove"])
         token = create_access_token(user.id)
@@ -458,9 +428,7 @@ class TestBatchTagRemove:
         assert len(data["skipped"]) == 1
         assert data["skipped"][0]["reason"] == "image_not_found"
 
-    async def test_skips_nonexistent_tags(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_skips_nonexistent_tags(self, client: AsyncClient, db_session: AsyncSession):
         """Missing tag IDs are reported as skipped."""
         user = await _create_user_with_tag_permission(db_session, ["image_tag_remove"])
         token = create_access_token(user.id)
@@ -481,9 +449,7 @@ class TestBatchTagRemove:
         assert len(data["skipped"]) == 1
         assert data["skipped"][0]["reason"] == "tag_not_found"
 
-    async def test_creates_removal_history(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_creates_removal_history(self, client: AsyncClient, db_session: AsyncSession):
         """Each removed tag link creates a tag history entry with action 'r'."""
         from app.models.tag_history import TagHistory
 
@@ -517,9 +483,7 @@ class TestBatchTagRemove:
         )
         assert result.scalar() == 1
 
-    async def test_resolves_alias_tags(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_resolves_alias_tags(self, client: AsyncClient, db_session: AsyncSession):
         """Alias tags resolve to their canonical tag for removal."""
         user = await _create_user_with_tag_permission(db_session, ["image_tag_remove"])
         token = create_access_token(user.id)
@@ -538,9 +502,7 @@ class TestBatchTagRemove:
 
         # Link canonical tag to image
         db_session.add(
-            TagLinks(
-                image_id=images[0].image_id, tag_id=canonical.tag_id, user_id=user.user_id
-            )
+            TagLinks(image_id=images[0].image_id, tag_id=canonical.tag_id, user_id=user.user_id)
         )
         await db_session.commit()
 
@@ -580,9 +542,7 @@ class TestBatchTagRemove:
         )
         assert history_result.scalar_one_or_none() is not None
 
-    async def test_requires_remove_permission(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_requires_remove_permission(self, client: AsyncClient, db_session: AsyncSession):
         """Users without IMAGE_TAG_REMOVE permission get 403."""
         # User with only ADD permission, not REMOVE
         user = await _create_user_with_tag_permission(db_session, ["image_tag_add"])

--- a/tests/api/v1/test_character_source_links.py
+++ b/tests/api/v1/test_character_source_links.py
@@ -21,7 +21,6 @@ from app.models.permissions import Perms, UserPerms
 from app.models.tag import Tags
 from app.models.user import Users
 
-
 # =============================================================================
 # Fixtures
 # =============================================================================

--- a/tests/api/v1/test_comment_reports.py
+++ b/tests/api/v1/test_comment_reports.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import CommentReportCategory, ImageStatus, ReportCategory, ReportStatus
 from app.core.security import get_password_hash
-from app.models import Comments, CommentReports, ImageReports, Images, Users
+from app.models import CommentReports, Comments, ImageReports, Images, Users
 from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
 
 
@@ -128,9 +128,7 @@ async def grant_permission(db_session: AsyncSession, user_id: int, perm_title: s
 class TestUserCommentReportEndpoint:
     """Tests for POST /api/v1/comments/{comment_id}/report endpoint."""
 
-    async def test_report_comment_success(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_report_comment_success(self, client: AsyncClient, db_session: AsyncSession):
         """Test successfully reporting a comment."""
         user, password = await create_auth_user(db_session)
         image = await create_test_image(db_session, user.user_id)
@@ -167,9 +165,7 @@ class TestUserCommentReportEndpoint:
 
         assert response.status_code == 401
 
-    async def test_report_nonexistent_comment(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_report_nonexistent_comment(self, client: AsyncClient, db_session: AsyncSession):
         """Test reporting a comment that doesn't exist."""
         user, password = await create_auth_user(db_session)
         token = await login_user(client, user.username, password)
@@ -183,9 +179,7 @@ class TestUserCommentReportEndpoint:
         assert response.status_code == 404
         assert "not found" in response.json()["detail"].lower()
 
-    async def test_report_deleted_comment(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_report_deleted_comment(self, client: AsyncClient, db_session: AsyncSession):
         """Test that deleted comments cannot be reported."""
         user, password = await create_auth_user(db_session)
         image = await create_test_image(db_session, user.user_id)
@@ -204,9 +198,7 @@ class TestUserCommentReportEndpoint:
         assert response.status_code == 400
         assert "deleted" in response.json()["detail"].lower()
 
-    async def test_duplicate_pending_report(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_duplicate_pending_report(self, client: AsyncClient, db_session: AsyncSession):
         """Test that a user cannot have multiple pending reports on the same comment."""
         user, password = await create_auth_user(db_session)
         image = await create_test_image(db_session, user.user_id)
@@ -230,9 +222,7 @@ class TestUserCommentReportEndpoint:
         assert response.status_code == 409
         assert "pending report" in response.json()["detail"].lower()
 
-    async def test_invalid_category(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_invalid_category(self, client: AsyncClient, db_session: AsyncSession):
         """Test that invalid categories are rejected."""
         user, password = await create_auth_user(db_session)
         image = await create_test_image(db_session, user.user_id)
@@ -252,9 +242,7 @@ class TestUserCommentReportEndpoint:
 class TestAdminCommentReportEndpoints:
     """Tests for admin comment report endpoints."""
 
-    async def test_list_comment_reports(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_list_comment_reports(self, client: AsyncClient, db_session: AsyncSession):
         """Test listing comment reports with report_type=comment filter."""
         user, password = await create_auth_user(db_session, "admin1", "admin1@test.com")
         await grant_permission(db_session, user.user_id, "report_view")
@@ -283,9 +271,7 @@ class TestAdminCommentReportEndpoints:
         assert "comment_reports" in data
         assert len(data["comment_reports"]) == 1
 
-    async def test_list_unified_reports(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_list_unified_reports(self, client: AsyncClient, db_session: AsyncSession):
         """Test listing combined image and comment reports."""
         user, password = await create_auth_user(db_session, "admin_uni", "admin_uni@test.com")
         await grant_permission(db_session, user.user_id, "report_view")
@@ -373,9 +359,7 @@ class TestAdminCommentReportEndpoints:
         assert len(data["comment_reports"]) == 1
         assert data["comment_reports"][0]["category"] == CommentReportCategory.RULE_VIOLATION
 
-    async def test_list_report_deleted_comment(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_list_report_deleted_comment(self, client: AsyncClient, db_session: AsyncSession):
         """Test listing a report for a deleted comment."""
         user, password = await create_auth_user(db_session, "admin_del", "admin_del@test.com")
         await grant_permission(db_session, user.user_id, "report_view")
@@ -417,7 +401,6 @@ class TestAdminCommentReportEndpoints:
         # Usually reports cascade on delete, so if comment is gone, report is gone.
         # But if we rely on OUTER JOIN, we are prepared for it.
         # I'll just skip hard delete test for now to avoid complexity with DB constraints in test.
-
 
     async def test_list_comment_reports_includes_reviewed_by_username(
         self, client: AsyncClient, db_session: AsyncSession
@@ -461,9 +444,7 @@ class TestAdminCommentReportEndpoints:
         assert data["comment_reports"][0]["reviewed_by_user"]["user_id"] == user.user_id
         assert data["comment_reports"][0]["reviewed_by_user"]["username"] == user.username
 
-    async def test_dismiss_comment_report(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_dismiss_comment_report(self, client: AsyncClient, db_session: AsyncSession):
         """Test dismissing a comment report."""
         user, password = await create_auth_user(db_session, "admin2", "admin2@test.com")
         await grant_permission(db_session, user.user_id, "report_manage")
@@ -494,9 +475,7 @@ class TestAdminCommentReportEndpoints:
         await db_session.refresh(report)
         assert report.status == ReportStatus.DISMISSED
 
-    async def test_delete_comment_via_report(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_delete_comment_via_report(self, client: AsyncClient, db_session: AsyncSession):
         """Test deleting a comment via the report action."""
         user, password = await create_auth_user(db_session, "admin3", "admin3@test.com")
         await grant_permission(db_session, user.user_id, "report_manage")
@@ -531,9 +510,7 @@ class TestAdminCommentReportEndpoints:
         await db_session.refresh(report)
         assert report.status == ReportStatus.REVIEWED
 
-    async def test_action_on_processed_report(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_action_on_processed_report(self, client: AsyncClient, db_session: AsyncSession):
         """Test that actions cannot be taken on already processed reports."""
         user, password = await create_auth_user(db_session, "admin4", "admin4@test.com")
         await grant_permission(db_session, user.user_id, "report_manage")
@@ -568,9 +545,7 @@ class TestAdminCommentReportEndpoints:
         assert response.status_code == 400
         assert "already been processed" in response.json()["detail"]
 
-    async def test_dismiss_requires_permission(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_dismiss_requires_permission(self, client: AsyncClient, db_session: AsyncSession):
         """Test that dismiss requires REPORT_MANAGE permission."""
         user, password = await create_auth_user(db_session, "nonadmin", "nonadmin@test.com")
         # No permission granted
@@ -636,17 +611,25 @@ class TestAdminCommentReportEndpoints:
         c1 = await create_test_comment(db_session, user.user_id, image.image_id, "c1")
         c2 = await create_test_comment(db_session, user.user_id, image.image_id, "c2")
 
-        cr1 = CommentReports(comment_id=c1.post_id, user_id=user.user_id, status=ReportStatus.PENDING)
-        cr2 = CommentReports(comment_id=c2.post_id, user_id=user.user_id, status=ReportStatus.PENDING)
+        cr1 = CommentReports(
+            comment_id=c1.post_id, user_id=user.user_id, status=ReportStatus.PENDING
+        )
+        cr2 = CommentReports(
+            comment_id=c2.post_id, user_id=user.user_id, status=ReportStatus.PENDING
+        )
         db_session.add(cr1)
         db_session.add(cr2)
 
         # Create 2 image reports
         user2, _ = await create_auth_user(db_session, "u2", "u2@test.com")
 
-        ir1 = ImageReports(image_id=image.image_id, user_id=user.user_id, status=ReportStatus.PENDING)
+        ir1 = ImageReports(
+            image_id=image.image_id, user_id=user.user_id, status=ReportStatus.PENDING
+        )
         image2 = await create_test_image(db_session, user2.user_id)
-        ir2 = ImageReports(image_id=image2.image_id, user_id=user2.user_id, status=ReportStatus.PENDING)
+        ir2 = ImageReports(
+            image_id=image2.image_id, user_id=user2.user_id, status=ReportStatus.PENDING
+        )
 
         db_session.add(ir1)
         db_session.add(ir2)
@@ -682,9 +665,7 @@ class TestAdminCommentReportEndpoints:
 class TestAdminGetCommentReport:
     """Tests for GET /api/v1/admin/reports/comments/{report_id} endpoint."""
 
-    async def test_get_comment_report_success(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_comment_report_success(self, client: AsyncClient, db_session: AsyncSession):
         """Test fetching a single comment report by ID."""
         user, password = await create_auth_user(db_session, "admin_get", "admin_get@test.com")
         await grant_permission(db_session, user.user_id, "report_view")

--- a/tests/api/v1/test_comments.py
+++ b/tests/api/v1/test_comments.py
@@ -413,6 +413,7 @@ class TestGetCommentStats:
         assert data["total_comments"] >= 4
         assert data["total_images_with_comments"] >= 2
 
+
 @pytest.mark.api
 class TestCreateComment:
     """Tests for POST /api/v1/comments endpoint."""
@@ -498,9 +499,7 @@ class TestCreateComment:
         )
         assert response.status_code == 401
 
-    async def test_create_comment_image_not_found(
-        self, authenticated_client: AsyncClient
-    ):
+    async def test_create_comment_image_not_found(self, authenticated_client: AsyncClient):
         """Test creating a comment on non-existent image."""
         response = await authenticated_client.post(
             "/api/v1/comments",
@@ -823,17 +822,13 @@ class TestDeleteComment:
         comment_id = comment.post_id
 
         # Delete
-        response = await authenticated_client.delete(
-            f"/api/v1/comments/{comment_id}"
-        )
+        response = await authenticated_client.delete(f"/api/v1/comments/{comment_id}")
         assert response.status_code == 200
         assert response.json()["post_text"] == "[deleted]"
         assert response.json()["deleted"] is True
 
         # Verify soft deleted (text set to "[deleted]", deleted flag set to True)
-        result = await db_session.execute(
-            select(Comments).where(Comments.post_id == comment_id)
-        )
+        result = await db_session.execute(select(Comments).where(Comments.post_id == comment_id))
         deleted_comment = result.scalar_one_or_none()
         assert deleted_comment is not None
         assert deleted_comment.post_text == "[deleted]"
@@ -879,9 +874,7 @@ class TestDeleteComment:
         reply_id = reply.post_id
 
         # Delete parent
-        response = await authenticated_client.delete(
-            f"/api/v1/comments/{parent.post_id}"
-        )
+        response = await authenticated_client.delete(f"/api/v1/comments/{parent.post_id}")
         assert response.status_code == 200
         assert response.json()["post_text"] == "[deleted]"
         assert response.json()["deleted"] is True
@@ -896,9 +889,7 @@ class TestDeleteComment:
         assert deleted_parent.deleted is True
 
         # Verify reply preserved with parent_comment_id set to NULL (SET NULL cascade)
-        result = await db_session.execute(
-            select(Comments).where(Comments.post_id == reply_id)
-        )
+        result = await db_session.execute(select(Comments).where(Comments.post_id == reply_id))
         preserved_reply = result.scalar_one_or_none()
         assert preserved_reply is not None
         assert preserved_reply.post_text == "Reply"  # Original text preserved
@@ -964,9 +955,7 @@ async def grant_mod_permission(db_session: AsyncSession, user_id: int, perm_titl
         db_session.add(perm)
         await db_session.flush()
 
-    result = await db_session.execute(
-        select(Groups).where(Groups.title == "comment_mod_group")
-    )
+    result = await db_session.execute(select(Groups).where(Groups.title == "comment_mod_group"))
     group = result.scalar_one_or_none()
     if not group:
         group = Groups(title="comment_mod_group", desc="Comment mod group")

--- a/tests/api/v1/test_daily_upload_limit.py
+++ b/tests/api/v1/test_daily_upload_limit.py
@@ -1,9 +1,6 @@
 """API tests for daily upload limit: uploads_remaining_today and 429 enforcement."""
 
 from datetime import UTC, datetime
-from io import BytesIO
-from pathlib import Path
-from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -16,14 +13,14 @@ from app.models.user import Users
 
 def _make_user(**overrides) -> Users:
     """Create a Users instance with sensible defaults."""
-    defaults = dict(
-        password="hashed_password_here",
-        password_type="bcrypt",
-        salt="saltsalt12345678",
-        active=1,
-        email_verified=True,
-        maximgperday=15,
-    )
+    defaults = {
+        "password": "hashed_password_here",
+        "password_type": "bcrypt",
+        "salt": "saltsalt12345678",
+        "active": 1,
+        "email_verified": True,
+        "maximgperday": 15,
+    }
     defaults.update(overrides)
     return Users(**defaults)
 
@@ -66,13 +63,9 @@ class TestUploadsRemainingToday:
         data = response.json()
         assert data["uploads_remaining_today"] == 15
 
-    async def test_decrements_after_uploads(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_decrements_after_uploads(self, client: AsyncClient, db_session: AsyncSession):
         """uploads_remaining_today should decrease with each upload."""
-        user = _make_user(
-            username="remaindecr", email="remaindecr@example.com", maximgperday=10
-        )
+        user = _make_user(username="remaindecr", email="remaindecr@example.com", maximgperday=10)
         db_session.add(user)
         await db_session.commit()
         await db_session.refresh(user)
@@ -90,13 +83,9 @@ class TestUploadsRemainingToday:
         assert response.status_code == 200
         assert response.json()["uploads_remaining_today"] == 7  # 10 - 3
 
-    async def test_floors_at_zero(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_floors_at_zero(self, client: AsyncClient, db_session: AsyncSession):
         """uploads_remaining_today should never go negative."""
-        user = _make_user(
-            username="remainzero", email="remainzero@example.com", maximgperday=2
-        )
+        user = _make_user(username="remainzero", email="remainzero@example.com", maximgperday=2)
         db_session.add(user)
         await db_session.commit()
         await db_session.refresh(user)

--- a/tests/api/v1/test_donations.py
+++ b/tests/api/v1/test_donations.py
@@ -80,9 +80,7 @@ class TestListDonations:
         response = await client.get("/api/v1/donations?limit=0")
         assert response.status_code == 422
 
-    async def test_response_shape(
-        self, client: AsyncClient, sample_donations: list[Donations]
-    ):
+    async def test_response_shape(self, client: AsyncClient, sample_donations: list[Donations]):
         """Each donation has the expected fields."""
         response = await client.get("/api/v1/donations?limit=1")
         data = response.json()
@@ -107,9 +105,7 @@ class TestListDonations:
         data = response.json()
         assert data["donations"][0]["username"] == "testuser"
 
-    async def test_username_null_when_no_user(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_username_null_when_no_user(self, client: AsyncClient, db_session: AsyncSession):
         """Username is null when user_id has no matching user."""
         db_session.add(Donations(amount=10, user_id=0, nick="Anonymous"))
         await db_session.commit()
@@ -167,9 +163,7 @@ class TestMonthlyDonations:
         data = response.json()
         assert data["monthly_totals"] == []
 
-    async def test_monthly_returns_totals(
-        self, client: AsyncClient, monthly_donations: None
-    ):
+    async def test_monthly_returns_totals(self, client: AsyncClient, monthly_donations: None):
         """Returns monthly totals grouped correctly."""
         response = await client.get("/api/v1/donations/monthly?months=12")
         assert response.status_code == 200
@@ -192,9 +186,7 @@ class TestMonthlyDonations:
         # Should only include current month and last month, not 3 months ago
         assert len(totals) == 2
 
-    async def test_monthly_default_6_months(
-        self, client: AsyncClient, monthly_donations: None
-    ):
+    async def test_monthly_default_6_months(self, client: AsyncClient, monthly_donations: None):
         """Default months is 6."""
         response = await client.get("/api/v1/donations/monthly")
         data = response.json()
@@ -211,9 +203,7 @@ class TestMonthlyDonations:
         response = await client.get("/api/v1/donations/monthly?months=0")
         assert response.status_code == 422
 
-    async def test_monthly_response_shape(
-        self, client: AsyncClient, monthly_donations: None
-    ):
+    async def test_monthly_response_shape(self, client: AsyncClient, monthly_donations: None):
         """Each entry has year, month, total fields."""
         response = await client.get("/api/v1/donations/monthly")
         data = response.json()
@@ -259,14 +249,10 @@ class TestCreateDonation:
 
     async def test_create_requires_auth(self, client: AsyncClient):
         """Returns 401 without authentication."""
-        response = await client.post(
-            "/api/v1/donations", json={"amount": 10}
-        )
+        response = await client.post("/api/v1/donations", json={"amount": 10})
         assert response.status_code == 401
 
-    async def test_create_requires_permission(
-        self, client: AsyncClient, unprivileged_token: str
-    ):
+    async def test_create_requires_permission(self, client: AsyncClient, unprivileged_token: str):
         """Returns 403 without DONATIONS_CREATE permission."""
         response = await client.post(
             "/api/v1/donations",

--- a/tests/api/v1/test_favorites.py
+++ b/tests/api/v1/test_favorites.py
@@ -53,9 +53,7 @@ class TestGetFavoriteImages:
         response = await client.get("/api/v1/favorites/user/999999")
         assert response.status_code == 404
 
-    async def test_get_favorite_images_empty(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_favorite_images_empty(self, client: AsyncClient, db_session: AsyncSession):
         """Test getting favorites when user has no favorites."""
         response = await client.get("/api/v1/favorites/user/1")
         assert response.status_code == 200

--- a/tests/api/v1/test_feed_count.py
+++ b/tests/api/v1/test_feed_count.py
@@ -57,7 +57,9 @@ async def _img(db, owner, md5, status):
 
 
 async def _login(client, username):
-    r = await client.post("/api/v1/auth/login", json={"username": username, "password": "TestPassword123!"})
+    r = await client.post(
+        "/api/v1/auth/login", json={"username": username, "password": "TestPassword123!"}
+    )
     assert r.status_code == 200
     return r.json()["access_token"]
 
@@ -101,7 +103,9 @@ class TestFastFeedCount:
             db_session, or_(Images.status.in_(VISIBLE), Images.user_id == a.user_id)
         )
         token = await _login(client, a.username)
-        r = await client.get("/api/v1/images/?per_page=1", headers={"Authorization": f"Bearer {token}"})
+        r = await client.get(
+            "/api/v1/images/?per_page=1", headers={"Authorization": f"Bearer {token}"}
+        )
         assert r.json()["total"] == expected_a
         # sanity: a has hidden images, so this strictly exceeds the anon total
         assert expected_a > expected_anon
@@ -115,7 +119,9 @@ class TestFastFeedCount:
 
         expected_all = await _ground_truth(db_session)
         token = await _login(client, a.username)
-        r = await client.get("/api/v1/images/?per_page=1", headers={"Authorization": f"Bearer {token}"})
+        r = await client.get(
+            "/api/v1/images/?per_page=1", headers={"Authorization": f"Bearer {token}"}
+        )
         assert r.json()["total"] == expected_all
 
     async def test_explicit_filters_fall_back_to_exact_count(
@@ -140,7 +146,6 @@ class TestFastFeedCount:
         r = await client.get(f"/api/v1/images/?user_id={b.user_id}&per_page=1", headers=h)
         assert r.json()["total"] == expected_b
 
-
     async def test_bare_feed_total_excludes_reposts_for_hide_reposts_viewer(
         self, client: AsyncClient, db_session: AsyncSession
     ):
@@ -157,7 +162,9 @@ class TestFastFeedCount:
             ),
         )
         token = await _login(client, viewer.username)
-        r = await client.get("/api/v1/images/?per_page=1", headers={"Authorization": f"Bearer {token}"})
+        r = await client.get(
+            "/api/v1/images/?per_page=1", headers={"Authorization": f"Bearer {token}"}
+        )
         assert r.json()["total"] == expected
 
         # Sanity: hiding reposts strictly reduces the total (the seed has a repost).
@@ -170,9 +177,11 @@ class TestFastFeedCount:
         self, client: AsyncClient, db_session: AsyncSession
     ):
         owner = await _user(db_session, "fcOwnRep", show_all=0, hide_reposts=1)
-        await _img(db_session, owner, "or0" + "0" * 29, 1)   # own active (visible)
+        await _img(db_session, owner, "or0" + "0" * 29, 1)  # own active (visible)
         await _img(db_session, owner, "or1" + "1" * 29, -1)  # own repost (public, hidden by pref)
-        await _img(db_session, owner, "or2" + "2" * 29, 0)   # own deactivated (hidden, but own -> visible)
+        await _img(
+            db_session, owner, "or2" + "2" * 29, 0
+        )  # own deactivated (hidden, but own -> visible)
 
         expected = await _ground_truth(
             db_session,
@@ -182,7 +191,9 @@ class TestFastFeedCount:
             ),
         )
         token = await _login(client, owner.username)
-        r = await client.get("/api/v1/images/?per_page=1", headers={"Authorization": f"Bearer {token}"})
+        r = await client.get(
+            "/api/v1/images/?per_page=1", headers={"Authorization": f"Bearer {token}"}
+        )
         assert r.json()["total"] == expected
 
 
@@ -192,7 +203,12 @@ class TestFeedCountCache:
         """The three global counts are TTL-cached (no per-mutation invalidation): a new
         image isn't reflected until the entry expires or is cleared. Also guards the
         str<->int round-trip through Redis."""
-        from app.services.feed_count_cache import _KEY_HIDDEN, _KEY_REPOST, _KEY_TOTAL, get_feed_counts
+        from app.services.feed_count_cache import (
+            _KEY_HIDDEN,
+            _KEY_REPOST,
+            _KEY_TOTAL,
+            get_feed_counts,
+        )
 
         await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN, _KEY_REPOST)
         try:
@@ -201,7 +217,9 @@ class TestFeedCountCache:
             await _img(db_session, a, "c1" + "0" * 30, 0)
 
             total1, hidden1, repost1 = await get_feed_counts(db_session, redis_client)
-            assert isinstance(total1, int) and isinstance(hidden1, int) and isinstance(repost1, int)  # parsed back from str
+            assert (
+                isinstance(total1, int) and isinstance(hidden1, int) and isinstance(repost1, int)
+            )  # parsed back from str
 
             # New image is NOT reflected while the cache is warm (TTL, no invalidation).
             await _img(db_session, a, "c2" + "0" * 30, 1)
@@ -215,12 +233,17 @@ class TestFeedCountCache:
             await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN, _KEY_REPOST)
 
     async def test_feed_counts_include_repost_count(self, db_session: AsyncSession, redis_client):
-        from app.services.feed_count_cache import _KEY_HIDDEN, _KEY_REPOST, _KEY_TOTAL, get_feed_counts
+        from app.services.feed_count_cache import (
+            _KEY_HIDDEN,
+            _KEY_REPOST,
+            _KEY_TOTAL,
+            get_feed_counts,
+        )
 
         await redis_client.delete(_KEY_TOTAL, _KEY_HIDDEN, _KEY_REPOST)
         try:
             u = await _user(db_session, "fcRepost", show_all=0)
-            await _img(db_session, u, "fr0" + "0" * 29, 1)   # active
+            await _img(db_session, u, "fr0" + "0" * 29, 1)  # active
             await _img(db_session, u, "fr1" + "1" * 29, -1)  # repost
             total, hidden, repost = await get_feed_counts(db_session, redis_client)
             assert isinstance(repost, int) and repost >= 1

--- a/tests/api/v1/test_image_delete_r2.py
+++ b/tests/api/v1/test_image_delete_r2.py
@@ -65,10 +65,9 @@ class TestDeleteEnqueuesR2:
         await db_session.refresh(image)
         image_id = image.image_id
 
-        with patch(
-            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue, patch(
-            "app.api.v1.images.remove_from_iqdb", return_value=True
+        with (
+            patch("app.api.v1.images.enqueue_job", new_callable=AsyncMock) as mock_enqueue,
+            patch("app.api.v1.images.remove_from_iqdb", return_value=True),
         ):
             response = await client.delete(
                 f"/api/v1/images/{image_id}?reason=test",
@@ -76,9 +75,7 @@ class TestDeleteEnqueuesR2:
             )
         assert response.status_code == 204
         delete_calls = [
-            c
-            for c in mock_enqueue.await_args_list
-            if c.args[0] == "r2_delete_image_job"
+            c for c in mock_enqueue.await_args_list if c.args[0] == "r2_delete_image_job"
         ]
         assert len(delete_calls) == 1
         assert delete_calls[0].kwargs["r2_location"] == int(R2Location.PUBLIC)
@@ -108,18 +105,15 @@ class TestDeleteEnqueuesR2:
         await db_session.commit()
         await db_session.refresh(image)
 
-        with patch(
-            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue, patch(
-            "app.api.v1.images.remove_from_iqdb", return_value=True
+        with (
+            patch("app.api.v1.images.enqueue_job", new_callable=AsyncMock) as mock_enqueue,
+            patch("app.api.v1.images.remove_from_iqdb", return_value=True),
         ):
             await client.delete(
                 f"/api/v1/images/{image.image_id}?reason=test",
                 headers={"Authorization": f"Bearer {token}"},
             )
         delete_calls = [
-            c
-            for c in mock_enqueue.await_args_list
-            if c.args[0] == "r2_delete_image_job"
+            c for c in mock_enqueue.await_args_list if c.args[0] == "r2_delete_image_job"
         ]
         assert delete_calls == []

--- a/tests/api/v1/test_image_edit.py
+++ b/tests/api/v1/test_image_edit.py
@@ -68,9 +68,7 @@ async def grant_permission(db_session: AsyncSession, user_id: int, perm_title: s
         db_session.add(perm)
         await db_session.flush()
 
-    result = await db_session.execute(
-        select(Groups).where(Groups.title == "edit_test_group")
-    )
+    result = await db_session.execute(select(Groups).where(Groups.title == "edit_test_group"))
     group = result.scalar_one_or_none()
     if not group:
         group = Groups(title="edit_test_group", desc="Image edit test group")
@@ -109,9 +107,7 @@ class TestImageEdit:
     """Tests for PATCH /api/v1/images/{image_id}."""
 
     @pytest.mark.asyncio
-    async def test_owner_can_update_caption(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_owner_can_update_caption(self, client: AsyncClient, db_session: AsyncSession):
         """Image owner can update their image's caption."""
         owner = await create_user(db_session)
         image = await create_image(db_session, owner.user_id)
@@ -126,9 +122,7 @@ class TestImageEdit:
         assert response.json()["caption"] == "new caption"
 
     @pytest.mark.asyncio
-    async def test_owner_can_update_miscmeta(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_owner_can_update_miscmeta(self, client: AsyncClient, db_session: AsyncSession):
         """Image owner can update their image's miscmeta."""
         owner = await create_user(db_session)
         image = await create_image(db_session, owner.user_id)
@@ -180,14 +174,10 @@ class TestImageEdit:
         assert response.json()["caption"] == "mod edited"
 
     @pytest.mark.asyncio
-    async def test_admin_can_edit_any_image(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_admin_can_edit_any_image(self, client: AsyncClient, db_session: AsyncSession):
         """Admin users can edit any image."""
         owner = await create_user(db_session, username="owner3", email="owner3@test.com")
-        admin = await create_user(
-            db_session, username="admin", email="admin@test.com", admin=1
-        )
+        admin = await create_user(db_session, username="admin", email="admin@test.com", admin=1)
         image = await create_image(db_session, owner.user_id, caption="before")
 
         response = await client.patch(
@@ -200,9 +190,7 @@ class TestImageEdit:
         assert response.json()["caption"] == "admin edited"
 
     @pytest.mark.asyncio
-    async def test_empty_update_returns_400(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_empty_update_returns_400(self, client: AsyncClient, db_session: AsyncSession):
         """Empty update body (no fields set) returns 400."""
         owner = await create_user(db_session)
         image = await create_image(db_session, owner.user_id)
@@ -216,9 +204,7 @@ class TestImageEdit:
         assert response.status_code == 400
 
     @pytest.mark.asyncio
-    async def test_image_not_found_returns_404(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_image_not_found_returns_404(self, client: AsyncClient, db_session: AsyncSession):
         """Editing a nonexistent image returns 404."""
         user = await create_user(db_session)
 
@@ -280,7 +266,9 @@ class TestImageOwnerStatusChange:
         owner = await create_user(db_session, username="repost1", email="rp1@test.com")
         original = await create_image(db_session, owner.user_id)
         repost = await create_image(
-            db_session, owner.user_id, caption="repost img",
+            db_session,
+            owner.user_id,
+            caption="repost img",
         )
         # Use a different md5 hash for the second image to keep test data distinct
         repost.md5_hash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -350,9 +338,7 @@ class TestImageOwnerStatusChange:
         assert "replacement_id" in response.json()["detail"]
 
     @pytest.mark.asyncio
-    async def test_repost_of_self_fails(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_repost_of_self_fails(self, client: AsyncClient, db_session: AsyncSession):
         """Cannot mark an image as a repost of itself."""
         owner = await create_user(db_session, username="selfr1", email="sr1@test.com")
         image = await create_image(db_session, owner.user_id)
@@ -384,9 +370,7 @@ class TestImageOwnerStatusChange:
         assert "original" in response.json()["detail"].lower()
 
     @pytest.mark.asyncio
-    async def test_non_owner_cannot_set_status(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_non_owner_cannot_set_status(self, client: AsyncClient, db_session: AsyncSession):
         """Non-owner without admin/permissions cannot change image status."""
         owner = await create_user(db_session, username="statusown1", email="so1@test.com")
         other = await create_user(db_session, username="statusoth1", email="so2@test.com")
@@ -438,9 +422,7 @@ class TestImageOwnerStatusChange:
         assert response.status_code == 200
 
         result = await db_session.execute(
-            select(ImageStatusHistory).where(
-                ImageStatusHistory.image_id == image.image_id
-            )
+            select(ImageStatusHistory).where(ImageStatusHistory.image_id == image.image_id)
         )
         history = result.scalar_one()
         assert history.old_status == 1  # ACTIVE

--- a/tests/api/v1/test_image_jobs.py
+++ b/tests/api/v1/test_image_jobs.py
@@ -91,9 +91,7 @@ class TestAddToIqdbJob:
             patch("builtins.open", create=True),
             patch("app.tasks.image_jobs.AsyncSessionLocal", test_session_factory),
         ):
-            result = await add_to_iqdb_job(
-                ctx, indexed_image.image_id, "/fake/path/thumb.webp"
-            )
+            result = await add_to_iqdb_job(ctx, indexed_image.image_id, "/fake/path/thumb.webp")
 
         assert result == {"success": True}
 
@@ -102,9 +100,7 @@ class TestAddToIqdbJob:
         image_id = indexed_image.image_id
         async with test_session_factory() as verify_session:
             refetched = (
-                await verify_session.execute(
-                    select(Images).where(Images.image_id == image_id)
-                )
+                await verify_session.execute(select(Images).where(Images.image_id == image_id))
             ).scalar_one()
         assert refetched.iqdb_hash == fake_hash
 
@@ -126,9 +122,7 @@ class TestAddToIqdbJob:
                 side_effect=RuntimeError("simulated db outage"),
             ),
         ):
-            result = await add_to_iqdb_job(
-                ctx, indexed_image.image_id, "/fake/path/thumb.webp"
-            )
+            result = await add_to_iqdb_job(ctx, indexed_image.image_id, "/fake/path/thumb.webp")
 
         assert result == {"success": True}
         assert any(

--- a/tests/api/v1/test_image_reports_endpoint.py
+++ b/tests/api/v1/test_image_reports_endpoint.py
@@ -14,8 +14,14 @@ from app.models.user import Users
 
 
 async def _make_user(db, username, password="TestPassword123!"):
-    user = Users(username=username, password=get_password_hash(password),
-                 password_type="bcrypt", salt="", email=f"{username}@example.com", active=1)
+    user = Users(
+        username=username,
+        password=get_password_hash(password),
+        password_type="bcrypt",
+        salt="",
+        email=f"{username}@example.com",
+        active=1,
+    )
     db.add(user)
     await db.commit()
     await db.refresh(user)
@@ -43,13 +49,26 @@ async def _login(client, username, password="TestPassword123!"):
 
 
 async def _img_with_report(db, owner, md5):
-    img = Images(filename="rep", ext="jpg", md5_hash=md5, user_id=owner.user_id,
-                 width=10, height=10, filesize=100, status=1)
+    img = Images(
+        filename="rep",
+        ext="jpg",
+        md5_hash=md5,
+        user_id=owner.user_id,
+        width=10,
+        height=10,
+        filesize=100,
+        status=1,
+    )
     db.add(img)
     await db.commit()
     await db.refresh(img)
-    report = ImageReports(image_id=img.image_id, user_id=owner.user_id, category=2,
-                          reason_text="looks AI", status=ReportStatus.PENDING)
+    report = ImageReports(
+        image_id=img.image_id,
+        user_id=owner.user_id,
+        category=2,
+        reason_text="looks AI",
+        status=ReportStatus.PENDING,
+    )
     db.add(report)
     await db.commit()
     await db.refresh(report)

--- a/tests/api/v1/test_image_reviews_endpoint.py
+++ b/tests/api/v1/test_image_reviews_endpoint.py
@@ -334,9 +334,7 @@ class TestGetImageReviews:
         assert "created_at" in item
         assert "closed_at" in item
 
-    async def test_pagination_works(
-        self, client: AsyncClient, db_session: AsyncSession
-    ) -> None:
+    async def test_pagination_works(self, client: AsyncClient, db_session: AsyncSession) -> None:
         """Should support pagination."""
         # Create a user
         user = Users(
@@ -379,9 +377,7 @@ class TestGetImageReviews:
         await db_session.commit()
 
         # Get first page with per_page=2
-        response = await client.get(
-            f"/api/v1/images/{image.image_id}/reviews?page=1&per_page=2"
-        )
+        response = await client.get(f"/api/v1/images/{image.image_id}/reviews?page=1&per_page=2")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 1
@@ -390,18 +386,14 @@ class TestGetImageReviews:
         assert data["total"] == 5
 
         # Get second page
-        response = await client.get(
-            f"/api/v1/images/{image.image_id}/reviews?page=2&per_page=2"
-        )
+        response = await client.get(f"/api/v1/images/{image.image_id}/reviews?page=2&per_page=2")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 2
         assert len(data["items"]) == 2
 
         # Get third page
-        response = await client.get(
-            f"/api/v1/images/{image.image_id}/reviews?page=3&per_page=2"
-        )
+        response = await client.get(f"/api/v1/images/{image.image_id}/reviews?page=3&per_page=2")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 3

--- a/tests/api/v1/test_image_status_history.py
+++ b/tests/api/v1/test_image_status_history.py
@@ -229,9 +229,7 @@ class TestImageStatusHistoryOnStatusChange:
 class TestImageStatusHistoryOnReviewClose:
     """Tests that ImageStatusHistory is written when reviews are closed."""
 
-    async def test_review_close_creates_history_entry_keep(
-        self, db_session: AsyncSession
-    ) -> None:
+    async def test_review_close_creates_history_entry_keep(self, db_session: AsyncSession) -> None:
         """Closing a review with KEEP outcome should create ImageStatusHistory entry."""
         from app.models.review_vote import ReviewVotes
 

--- a/tests/api/v1/test_image_status_history_endpoint.py
+++ b/tests/api/v1/test_image_status_history_endpoint.py
@@ -296,9 +296,7 @@ class TestGetImageStatusHistory:
         response = await client.get("/api/v1/images/99999999/status-history")
         assert response.status_code == 404
 
-    async def test_pagination_works(
-        self, client: AsyncClient, db_session: AsyncSession
-    ) -> None:
+    async def test_pagination_works(self, client: AsyncClient, db_session: AsyncSession) -> None:
         """Should support pagination."""
         # Create a user
         user = Users(
@@ -329,7 +327,7 @@ class TestGetImageStatusHistory:
         await db_session.refresh(image)
 
         # Create 5 status history entries
-        for i in range(5):
+        for _i in range(5):
             history = ImageStatusHistory(
                 image_id=image.image_id,
                 old_status=ImageStatus.ACTIVE,
@@ -444,9 +442,7 @@ class TestGetImageStatusHistory:
         assert data["items"][1]["id"] == history2.id
         assert data["items"][2]["id"] == history1.id
 
-    async def test_handles_null_user(
-        self, client: AsyncClient, db_session: AsyncSession
-    ) -> None:
+    async def test_handles_null_user(self, client: AsyncClient, db_session: AsyncSession) -> None:
         """Should handle history entries with null user_id gracefully."""
         # Create a user for image ownership
         user = Users(
@@ -569,8 +565,14 @@ class TestGetImageStatusHistory:
 
 
 async def _make_user(db_session, username, password="TestPassword123!"):
-    user = Users(username=username, password=get_password_hash(password),
-                 password_type="bcrypt", salt="", email=f"{username}@example.com", active=1)
+    user = Users(
+        username=username,
+        password=get_password_hash(password),
+        password_type="bcrypt",
+        salt="",
+        email=f"{username}@example.com",
+        active=1,
+    )
     db_session.add(user)
     await db_session.commit()
     await db_session.refresh(user)
@@ -578,7 +580,9 @@ async def _make_user(db_session, username, password="TestPassword123!"):
 
 
 async def _grant_image_edit(db_session, user_id):
-    perm = (await db_session.execute(select(Perms).where(Perms.title == "image_edit"))).scalar_one_or_none()
+    perm = (
+        await db_session.execute(select(Perms).where(Perms.title == "image_edit"))
+    ).scalar_one_or_none()
     if not perm:
         perm = Perms(title="image_edit", desc="edit images")
         db_session.add(perm)
@@ -592,7 +596,9 @@ async def _grant_image_edit(db_session, user_id):
 
 
 async def _grant_report_view(db_session, user_id):
-    perm = (await db_session.execute(select(Perms).where(Perms.title == "report_view"))).scalar_one_or_none()
+    perm = (
+        await db_session.execute(select(Perms).where(Perms.title == "report_view"))
+    ).scalar_one_or_none()
     if not perm:
         perm = Perms(title="report_view", desc="view reports")
         db_session.add(perm)
@@ -612,18 +618,31 @@ async def _login(client, username, password="TestPassword123!"):
 
 
 async def _seed_deactivation(db_session, owner):
-    image = Images(filename="histvis", ext="jpg", md5_hash="a" * 32,
-                   user_id=owner.user_id, width=100, height=100, filesize=1000,
-                   status=ImageStatus.DEACTIVATED,
-                   reason_category=DeactivationReason.LOW_QUALITY,
-                   status_reason="blurry and low res")
+    image = Images(
+        filename="histvis",
+        ext="jpg",
+        md5_hash="a" * 32,
+        user_id=owner.user_id,
+        width=100,
+        height=100,
+        filesize=1000,
+        status=ImageStatus.DEACTIVATED,
+        reason_category=DeactivationReason.LOW_QUALITY,
+        status_reason="blurry and low res",
+    )
     db_session.add(image)
     await db_session.commit()
     await db_session.refresh(image)
-    db_session.add(ImageStatusHistory(
-        image_id=image.image_id, old_status=ImageStatus.ACTIVE,
-        new_status=ImageStatus.DEACTIVATED, user_id=owner.user_id,
-        reason_category=DeactivationReason.LOW_QUALITY, reason="blurry and low res"))
+    db_session.add(
+        ImageStatusHistory(
+            image_id=image.image_id,
+            old_status=ImageStatus.ACTIVE,
+            new_status=ImageStatus.DEACTIVATED,
+            user_id=owner.user_id,
+            reason_category=DeactivationReason.LOW_QUALITY,
+            reason="blurry and low res",
+        )
+    )
     await db_session.commit()
     return image
 
@@ -640,35 +659,55 @@ class TestStatusHistoryReasonVisibility:
         assert r.status_code == 200
         row = r.json()["items"][0]
         assert row["reason_category"] == DeactivationReason.LOW_QUALITY  # category always shown
-        assert row["reason"] is None  # free-text hidden from anonymous on a hidden-status transition
+        assert (
+            row["reason"] is None
+        )  # free-text hidden from anonymous on a hidden-status transition
 
     async def test_reason_visible_to_owner_and_mod(self, client, db_session):
         owner = await _make_user(db_session, "histowner2")
         image = await _seed_deactivation(db_session, owner)
 
         owner_token = await _login(client, owner.username)
-        r = await client.get(f"/api/v1/images/{image.image_id}/status-history",
-                             headers={"Authorization": f"Bearer {owner_token}"})
+        r = await client.get(
+            f"/api/v1/images/{image.image_id}/status-history",
+            headers={"Authorization": f"Bearer {owner_token}"},
+        )
         assert r.json()["items"][0]["reason"] == "blurry and low res"
 
         mod = await _make_user(db_session, "histmod2")
         await _grant_image_edit(db_session, mod.user_id)
         mod_token = await _login(client, mod.username)
-        r = await client.get(f"/api/v1/images/{image.image_id}/status-history",
-                             headers={"Authorization": f"Bearer {mod_token}"})
+        r = await client.get(
+            f"/api/v1/images/{image.image_id}/status-history",
+            headers={"Authorization": f"Bearer {mod_token}"},
+        )
         assert r.json()["items"][0]["reason"] == "blurry and low res"
 
     async def test_reason_public_for_spoiler_transition(self, client, db_session):
         owner = await _make_user(db_session, "histowner3")
-        image = Images(filename="histspoil", ext="jpg", md5_hash="b" * 32,
-                       user_id=owner.user_id, width=100, height=100, filesize=1000,
-                       status=ImageStatus.SPOILER, status_reason="mild nudity")
+        image = Images(
+            filename="histspoil",
+            ext="jpg",
+            md5_hash="b" * 32,
+            user_id=owner.user_id,
+            width=100,
+            height=100,
+            filesize=1000,
+            status=ImageStatus.SPOILER,
+            status_reason="mild nudity",
+        )
         db_session.add(image)
         await db_session.commit()
         await db_session.refresh(image)
-        db_session.add(ImageStatusHistory(
-            image_id=image.image_id, old_status=ImageStatus.ACTIVE,
-            new_status=ImageStatus.SPOILER, user_id=owner.user_id, reason="mild nudity"))
+        db_session.add(
+            ImageStatusHistory(
+                image_id=image.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.SPOILER,
+                user_id=owner.user_id,
+                reason="mild nudity",
+            )
+        )
         await db_session.commit()
 
         r = await client.get(f"/api/v1/images/{image.image_id}/status-history")
@@ -680,15 +719,29 @@ class TestStatusHistoryReasonVisibility:
     async def test_restore_reason_hidden_from_anonymous(self, client, db_session):
         """Un-hiding from a hidden state carries moderation rationale -> owner/mod only."""
         owner = await _make_user(db_session, "histowner4")
-        image = Images(filename="histrestore", ext="jpg", md5_hash="d" * 32,
-                       user_id=owner.user_id, width=100, height=100, filesize=1000,
-                       status=ImageStatus.ACTIVE, status_reason="appeal granted")
+        image = Images(
+            filename="histrestore",
+            ext="jpg",
+            md5_hash="d" * 32,
+            user_id=owner.user_id,
+            width=100,
+            height=100,
+            filesize=1000,
+            status=ImageStatus.ACTIVE,
+            status_reason="appeal granted",
+        )
         db_session.add(image)
         await db_session.commit()
         await db_session.refresh(image)
-        db_session.add(ImageStatusHistory(
-            image_id=image.image_id, old_status=ImageStatus.DEACTIVATED,
-            new_status=ImageStatus.ACTIVE, user_id=owner.user_id, reason="appeal granted"))
+        db_session.add(
+            ImageStatusHistory(
+                image_id=image.image_id,
+                old_status=ImageStatus.DEACTIVATED,
+                new_status=ImageStatus.ACTIVE,
+                user_id=owner.user_id,
+                reason="appeal granted",
+            )
+        )
         await db_session.commit()
 
         r = await client.get(f"/api/v1/images/{image.image_id}/status-history")
@@ -698,15 +751,29 @@ class TestStatusHistoryReasonVisibility:
     async def test_unspoiler_reason_public(self, client, db_session):
         """SPOILER -> ACTIVE is visible -> visible: the reason stays public."""
         owner = await _make_user(db_session, "histowner5")
-        image = Images(filename="histunspoil", ext="jpg", md5_hash="e" * 32,
-                       user_id=owner.user_id, width=100, height=100, filesize=1000,
-                       status=ImageStatus.ACTIVE, status_reason="not actually a spoiler")
+        image = Images(
+            filename="histunspoil",
+            ext="jpg",
+            md5_hash="e" * 32,
+            user_id=owner.user_id,
+            width=100,
+            height=100,
+            filesize=1000,
+            status=ImageStatus.ACTIVE,
+            status_reason="not actually a spoiler",
+        )
         db_session.add(image)
         await db_session.commit()
         await db_session.refresh(image)
-        db_session.add(ImageStatusHistory(
-            image_id=image.image_id, old_status=ImageStatus.SPOILER,
-            new_status=ImageStatus.ACTIVE, user_id=owner.user_id, reason="not actually a spoiler"))
+        db_session.add(
+            ImageStatusHistory(
+                image_id=image.image_id,
+                old_status=ImageStatus.SPOILER,
+                new_status=ImageStatus.ACTIVE,
+                user_id=owner.user_id,
+                reason="not actually a spoiler",
+            )
+        )
         await db_session.commit()
 
         r = await client.get(f"/api/v1/images/{image.image_id}/status-history")
@@ -716,9 +783,16 @@ class TestStatusHistoryReasonVisibility:
     async def test_report_id_visible_to_mod_hidden_from_anon(self, client, db_session):
         """The originating report_id is exposed to REPORT_VIEW mods, NULL to others."""
         owner = await _make_user(db_session, "histreport1")
-        image = Images(filename="histrep", ext="jpg", md5_hash="f" * 32,
-                       user_id=owner.user_id, width=100, height=100, filesize=1000,
-                       status=ImageStatus.DEACTIVATED)
+        image = Images(
+            filename="histrep",
+            ext="jpg",
+            md5_hash="f" * 32,
+            user_id=owner.user_id,
+            width=100,
+            height=100,
+            filesize=1000,
+            status=ImageStatus.DEACTIVATED,
+        )
         db_session.add(image)
         await db_session.commit()
         await db_session.refresh(image)
@@ -726,11 +800,17 @@ class TestStatusHistoryReasonVisibility:
         db_session.add(report)
         await db_session.commit()
         await db_session.refresh(report)
-        db_session.add(ImageStatusHistory(
-            image_id=image.image_id, old_status=ImageStatus.ACTIVE,
-            new_status=ImageStatus.DEACTIVATED, user_id=owner.user_id,
-            reason_category=DeactivationReason.INAPPROPRIATE, reason="x",
-            report_id=report.report_id))
+        db_session.add(
+            ImageStatusHistory(
+                image_id=image.image_id,
+                old_status=ImageStatus.ACTIVE,
+                new_status=ImageStatus.DEACTIVATED,
+                user_id=owner.user_id,
+                reason_category=DeactivationReason.INAPPROPRIATE,
+                reason="x",
+                report_id=report.report_id,
+            )
+        )
         await db_session.commit()
 
         # Anonymous: report_id hidden.

--- a/tests/api/v1/test_image_status_r2.py
+++ b/tests/api/v1/test_image_status_r2.py
@@ -41,9 +41,7 @@ async def _grant_permission(db_session: AsyncSession, user_id: int, perm_title: 
         db_session.add(perm)
         await db_session.flush()
 
-    result = await db_session.execute(
-        select(Groups).where(Groups.title == "r2_status_test_group")
-    )
+    result = await db_session.execute(select(Groups).where(Groups.title == "r2_status_test_group"))
     group = result.scalar_one_or_none()
     if not group:
         group = Groups(title="r2_status_test_group", desc="R2 status test group")
@@ -93,9 +91,7 @@ class TestStatusChangeEnqueuesSync:
         await db_session.commit()
         await db_session.refresh(image)
 
-        with patch(
-            "app.services.image_status.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue:
+        with patch("app.services.image_status.enqueue_job", new_callable=AsyncMock) as mock_enqueue:
             response = await client.patch(
                 f"/api/v1/admin/images/{image.image_id}",
                 json={
@@ -107,9 +103,7 @@ class TestStatusChangeEnqueuesSync:
             )
         assert response.status_code == 200
         sync_calls = [
-            c
-            for c in mock_enqueue.await_args_list
-            if c.args[0] == "sync_image_status_job"
+            c for c in mock_enqueue.await_args_list if c.args[0] == "sync_image_status_job"
         ]
         assert len(sync_calls) == 1
         assert sync_calls[0].kwargs["image_id"] == image.image_id
@@ -135,9 +129,7 @@ class TestStatusChangeEnqueuesSync:
         await db_session.commit()
         await db_session.refresh(image)
 
-        with patch(
-            "app.services.image_status.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue:
+        with patch("app.services.image_status.enqueue_job", new_callable=AsyncMock) as mock_enqueue:
             response = await client.patch(
                 f"/api/v1/admin/images/{image.image_id}",
                 json={"locked": True},
@@ -145,9 +137,7 @@ class TestStatusChangeEnqueuesSync:
             )
         assert response.status_code == 200
         sync_calls = [
-            c
-            for c in mock_enqueue.await_args_list
-            if c.args[0] == "sync_image_status_job"
+            c for c in mock_enqueue.await_args_list if c.args[0] == "sync_image_status_job"
         ]
         assert sync_calls == []
 
@@ -170,9 +160,7 @@ class TestStatusChangeEnqueuesSync:
         await db_session.commit()
         await db_session.refresh(image)
 
-        with patch(
-            "app.services.image_status.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue:
+        with patch("app.services.image_status.enqueue_job", new_callable=AsyncMock) as mock_enqueue:
             response = await client.patch(
                 f"/api/v1/admin/images/{image.image_id}",
                 json={
@@ -184,9 +172,7 @@ class TestStatusChangeEnqueuesSync:
             )
         assert response.status_code == 200
         sync_calls = [
-            c
-            for c in mock_enqueue.await_args_list
-            if c.args[0] == "sync_image_status_job"
+            c for c in mock_enqueue.await_args_list if c.args[0] == "sync_image_status_job"
         ]
         assert sync_calls == []
 
@@ -215,9 +201,7 @@ class TestStatusChangeEnqueuesSync:
         await db_session.commit()
         await db_session.refresh(image)
 
-        with patch(
-            "app.services.image_status.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue:
+        with patch("app.services.image_status.enqueue_job", new_callable=AsyncMock) as mock_enqueue:
             response = await client.patch(
                 f"/api/v1/images/{image.image_id}",
                 json={"status": ImageStatus.SPOILER},
@@ -225,8 +209,6 @@ class TestStatusChangeEnqueuesSync:
             )
         assert response.status_code == 200
         sync_calls = [
-            c
-            for c in mock_enqueue.await_args_list
-            if c.args[0] == "sync_image_status_job"
+            c for c in mock_enqueue.await_args_list if c.args[0] == "sync_image_status_job"
         ]
         assert sync_calls == []

--- a/tests/api/v1/test_image_tag_history.py
+++ b/tests/api/v1/test_image_tag_history.py
@@ -150,4 +150,6 @@ class TestTagHistoryOnImageTagging:
         )
         history = result.scalar_one_or_none()
         assert history is not None
-        assert history.user_id == sample_user.user_id, "TagHistory should record the user who added the tag"
+        assert history.user_id == sample_user.user_id, (
+            "TagHistory should record the user who added the tag"
+        )

--- a/tests/api/v1/test_image_tag_history_endpoint.py
+++ b/tests/api/v1/test_image_tag_history_endpoint.py
@@ -205,9 +205,7 @@ class TestGetImageTagHistory:
         # Added later via add_tag_to_image: both a tag_link AND a tag_history 'a' exist.
         db_session.add(TagLinks(tag_id=tag.tag_id, image_id=image.image_id, user_id=user.user_id))
         db_session.add(
-            TagHistory(
-                image_id=image.image_id, tag_id=tag.tag_id, action="a", user_id=user.user_id
-            )
+            TagHistory(image_id=image.image_id, tag_id=tag.tag_id, action="a", user_id=user.user_id)
         )
         await db_session.commit()
 
@@ -273,9 +271,7 @@ class TestGetImageTagHistory:
         assert data["total"] == 2
         assert sorted(item["action"] for item in data["items"]) == ["added", "removed"]
 
-    async def test_includes_tag_info(
-        self, client: AsyncClient, db_session: AsyncSession
-    ) -> None:
+    async def test_includes_tag_info(self, client: AsyncClient, db_session: AsyncSession) -> None:
         """History entries should include tag info (LinkedTag)."""
         # Create a user
         user = Users(
@@ -334,9 +330,7 @@ class TestGetImageTagHistory:
         assert item["tag"]["tag_id"] == tag.tag_id
         assert item["tag"]["title"] == "included tag info"
 
-    async def test_includes_user_info(
-        self, client: AsyncClient, db_session: AsyncSession
-    ) -> None:
+    async def test_includes_user_info(self, client: AsyncClient, db_session: AsyncSession) -> None:
         """History entries should include user info."""
         # Create a user
         user = Users(
@@ -402,9 +396,7 @@ class TestGetImageTagHistory:
         response = await client.get("/api/v1/images/99999999/tag-history")
         assert response.status_code == 404
 
-    async def test_pagination_works(
-        self, client: AsyncClient, db_session: AsyncSession
-    ) -> None:
+    async def test_pagination_works(self, client: AsyncClient, db_session: AsyncSession) -> None:
         """Should support pagination."""
         # Create a user
         user = Users(
@@ -640,9 +632,7 @@ class TestGetImageTagHistory:
         assert "avatar_in_r2" not in item_user
         assert item_user["avatar_url"] == "https://cdn.test/avatars/abc.png"
 
-    async def test_handles_null_user(
-        self, client: AsyncClient, db_session: AsyncSession
-    ) -> None:
+    async def test_handles_null_user(self, client: AsyncClient, db_session: AsyncSession) -> None:
         """Should handle history entries with null user_id gracefully."""
         # Create a user for image ownership
         user = Users(

--- a/tests/api/v1/test_image_upload_r2.py
+++ b/tests/api/v1/test_image_upload_r2.py
@@ -48,9 +48,7 @@ class TestUploadEnqueuesR2Finalize:
         monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
         token = create_access_token(uploader.user_id)
 
-        with patch(
-            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue:
+        with patch("app.api.v1.images.enqueue_job", new_callable=AsyncMock) as mock_enqueue:
             response = await client.post(
                 "/api/v1/images/upload",
                 files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
@@ -58,9 +56,7 @@ class TestUploadEnqueuesR2Finalize:
             )
         assert response.status_code in (200, 201)
         finalize_calls = [
-            c
-            for c in mock_enqueue.await_args_list
-            if c.args[0] == "r2_finalize_upload_job"
+            c for c in mock_enqueue.await_args_list if c.args[0] == "r2_finalize_upload_job"
         ]
         assert len(finalize_calls) == 1
         assert finalize_calls[0].kwargs.get("_defer_by", 0) >= 60
@@ -72,17 +68,13 @@ class TestUploadEnqueuesR2Finalize:
         monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
         token = create_access_token(uploader.user_id)
 
-        with patch(
-            "app.api.v1.images.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue:
+        with patch("app.api.v1.images.enqueue_job", new_callable=AsyncMock) as mock_enqueue:
             await client.post(
                 "/api/v1/images/upload",
                 files={"file": ("test.jpg", _fake_image_bytes(), "image/jpeg")},
                 headers={"Authorization": f"Bearer {token}"},
             )
         finalize_calls = [
-            c
-            for c in mock_enqueue.await_args_list
-            if c.args[0] == "r2_finalize_upload_job"
+            c for c in mock_enqueue.await_args_list if c.args[0] == "r2_finalize_upload_job"
         ]
         assert finalize_calls == []

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -2625,7 +2625,7 @@ class TestTagUsageCount:
         """Test that usage_count tracks multiple images with the same tag."""
         # Create multiple images
         images = []
-        for i in range(3):
+        for _i in range(3):
             image_data = sample_image_data.copy()
             image_data["user_id"] = sample_user.user_id
             image = Images(**image_data)
@@ -4753,9 +4753,7 @@ class TestTagWriteSnapshotConflictRetry:
 
         flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error("tag_history"))
         with flush_patch:
-            response = await authenticated_client.delete(
-                f"/api/v1/images/{image_id}/tags/{tag_id}"
-            )
+            response = await authenticated_client.delete(f"/api/v1/images/{image_id}/tags/{tag_id}")
 
         assert response.status_code == 204, response.text
         assert len(calls) >= 2
@@ -4852,7 +4850,7 @@ class TestGetImageRatings:
 
         # Create ratings from multiple users
         users = []
-        for i, rating_value in enumerate([5, 8, 10]):
+        for i in range(3):
             user = Users(
                 username=f"rater_{i}",
                 password="hashed",

--- a/tests/api/v1/test_images_groups.py
+++ b/tests/api/v1/test_images_groups.py
@@ -9,9 +9,7 @@ from app.models.permissions import Groups, UserGroups
 
 
 @pytest.mark.asyncio
-async def test_list_images_includes_empty_groups(
-    client: AsyncClient, db_session: AsyncSession
-):
+async def test_list_images_includes_empty_groups(client: AsyncClient, db_session: AsyncSession):
     """Images endpoint returns empty groups array for users without groups."""
     # Create an image (user 1 exists from fixture, has no groups)
     image = Images(
@@ -36,17 +34,13 @@ async def test_list_images_includes_empty_groups(
     assert len(data["images"]) >= 1
 
     # Find our image
-    test_image = next(
-        (img for img in data["images"] if img["filename"] == "test-groups-001"), None
-    )
+    test_image = next((img for img in data["images"] if img["filename"] == "test-groups-001"), None)
     assert test_image is not None
     assert test_image["user"]["groups"] == []
 
 
 @pytest.mark.asyncio
-async def test_list_images_includes_user_groups(
-    client: AsyncClient, db_session: AsyncSession
-):
+async def test_list_images_includes_user_groups(client: AsyncClient, db_session: AsyncSession):
     """Images endpoint returns user's groups in response."""
     # Create a group and add user 1 to it
     group = Groups(title="mods", desc="Moderators")
@@ -76,17 +70,13 @@ async def test_list_images_includes_user_groups(
     assert response.status_code == 200
 
     data = response.json()
-    test_image = next(
-        (img for img in data["images"] if img["filename"] == "test-groups-002"), None
-    )
+    test_image = next((img for img in data["images"] if img["filename"] == "test-groups-002"), None)
     assert test_image is not None
     assert test_image["user"]["groups"] == ["mods"]
 
 
 @pytest.mark.asyncio
-async def test_get_image_includes_user_groups(
-    client: AsyncClient, db_session: AsyncSession
-):
+async def test_get_image_includes_user_groups(client: AsyncClient, db_session: AsyncSession):
     """Single image endpoint returns user's groups."""
     # Create a group and add user 1 to it
     group = Groups(title="testers", desc="Testers")

--- a/tests/api/v1/test_images_suggestion_count.py
+++ b/tests/api/v1/test_images_suggestion_count.py
@@ -19,7 +19,6 @@ from app.models.permissions import Perms, UserPerms
 from app.models.tag import Tags
 from app.models.user import Users
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -118,9 +117,7 @@ class TestMlSuggestionCountOnImageList:
     def _enable_badge(self, monkeypatch):
         monkeypatch.setattr(settings, "ML_SUGGESTION_BADGE_ENABLED", True)
 
-    async def test_tagger_sees_pending_count(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_tagger_sees_pending_count(self, client: AsyncClient, db_session: AsyncSession):
         """A user with IMAGE_TAG_ADD sees ml_suggestion_count == N for their image."""
         owner = await _make_user(db_session, "tc_tagger_owner")
         tagger = await _make_user(db_session, "tc_tagger")
@@ -144,9 +141,7 @@ class TestMlSuggestionCountOnImageList:
         assert matching, "Seeded image not found in list"
         assert matching[0]["ml_suggestion_count"] == 2
 
-    async def test_plain_user_sees_none(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_plain_user_sees_none(self, client: AsyncClient, db_session: AsyncSession):
         """A user without IMAGE_TAG_ADD (and not admin) gets ml_suggestion_count=None."""
         owner = await _make_user(db_session, "tc_plain_owner")
         plain = await _make_user(db_session, "tc_plain")

--- a/tests/api/v1/test_iqdb_feed.py
+++ b/tests/api/v1/test_iqdb_feed.py
@@ -32,9 +32,7 @@ class TestIqdbFeed:
         assert root.tag == "images"
         assert len(root) == 0
 
-    async def test_returns_active_images(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_returns_active_images(self, client: AsyncClient, db_session: AsyncSession):
         """Should return active images with correct XML attributes."""
         image = Images(
             filename="2026-01-15-12345",
@@ -68,9 +66,7 @@ class TestIqdbFeed:
         assert elem.get("submitted_on") is not None
         assert "2026-01-15-12345.webp" in elem.get("preview_url")
 
-    async def test_excludes_non_active_images(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_excludes_non_active_images(self, client: AsyncClient, db_session: AsyncSession):
         """Should only return images with status == ACTIVE."""
         # Create one active and one inactive image
         active = Images(
@@ -103,9 +99,7 @@ class TestIqdbFeed:
         assert len(root) == 1
         assert root[0].get("id") == str(active.image_id)
 
-    async def test_limit_parameter(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_limit_parameter(self, client: AsyncClient, db_session: AsyncSession):
         """Should respect the limit parameter."""
         for i in range(5):
             image = Images(
@@ -126,9 +120,7 @@ class TestIqdbFeed:
         root = ET.fromstring(response.text)
         assert len(root) == 3
 
-    async def test_default_limit_is_16(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_default_limit_is_16(self, client: AsyncClient, db_session: AsyncSession):
         """Default limit should be 16."""
         for i in range(20):
             image = Images(
@@ -155,9 +147,7 @@ class TestIqdbFeed:
 
         assert response.status_code == 422
 
-    async def test_after_id_ascending_order(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_after_id_ascending_order(self, client: AsyncClient, db_session: AsyncSession):
         """With after_id, should return images with id > after_id in ASC order."""
         images = []
         for i in range(5):
@@ -212,9 +202,7 @@ class TestIqdbFeed:
         ids = [int(elem.get("id")) for elem in root]
         assert ids == sorted(ids, reverse=True)
 
-    async def test_tags_grouped_by_type(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_tags_grouped_by_type(self, client: AsyncClient, db_session: AsyncSession):
         """Tags should be grouped by type in the XML attributes."""
         image = Images(
             filename="tagged-image",

--- a/tests/api/v1/test_media.py
+++ b/tests/api/v1/test_media.py
@@ -295,7 +295,10 @@ class TestServeMediumEndpoint:
         response = await client.get(f"/medium/2026-01-02-{image_with_medium.image_id}.png")
         assert response.status_code == 200
         assert "X-Accel-Redirect" in response.headers
-        assert f"/internal/medium/{image_with_medium.filename}.png" in response.headers["X-Accel-Redirect"]
+        assert (
+            f"/internal/medium/{image_with_medium.filename}.png"
+            in response.headers["X-Accel-Redirect"]
+        )
 
     async def test_medium_returns_404_when_variant_missing(
         self, client: AsyncClient, image_without_medium: Images
@@ -439,7 +442,10 @@ class TestServeLargeEndpoint:
         response = await client.get(f"/large/2026-01-02-{image_with_large.image_id}.jpeg")
         assert response.status_code == 200
         assert "X-Accel-Redirect" in response.headers
-        assert f"/internal/large/{image_with_large.filename}.jpeg" in response.headers["X-Accel-Redirect"]
+        assert (
+            f"/internal/large/{image_with_large.filename}.jpeg"
+            in response.headers["X-Accel-Redirect"]
+        )
 
     async def test_large_returns_404_when_variant_missing(
         self, client: AsyncClient, image_without_large: Images
@@ -472,9 +478,7 @@ class TestServeLargeEndpoint:
         self, client: AsyncClient, protected_image_with_large: Images
     ):
         """Protected large variant returns 404 for anonymous user."""
-        response = await client.get(
-            f"/large/2026-01-02-{protected_image_with_large.image_id}.jpeg"
-        )
+        response = await client.get(f"/large/2026-01-02-{protected_image_with_large.image_id}.jpeg")
         assert response.status_code == 404
 
     async def test_protected_large_owner_returns_xaccel(

--- a/tests/api/v1/test_ml_analyze.py
+++ b/tests/api/v1/test_ml_analyze.py
@@ -243,7 +243,12 @@ async def test_analyze_character_child_does_not_supersede_theme_parent_when_flag
     await db_session.refresh(character_child)
 
     raw_preds = [
-        {"external_tag": "vocaloid_outfit", "confidence": 0.7, "category": 0, "model_version": "v1"},
+        {
+            "external_tag": "vocaloid_outfit",
+            "confidence": 0.7,
+            "category": 0,
+            "model_version": "v1",
+        },
         {"external_tag": "hatsune_miku", "confidence": 0.95, "category": 4, "model_version": "v1"},
     ]
     resolved = [
@@ -323,9 +328,14 @@ async def test_analyze_small_image_not_recompressed(
             return []
 
     with (
-        patch("app.api.v1.ml_analyze.get_ml_service", new_callable=AsyncMock,
-              return_value=_CapturingService()),
-        patch("app.api.v1.ml_analyze.resolve_external_tags", new_callable=AsyncMock, return_value=[]),
+        patch(
+            "app.api.v1.ml_analyze.get_ml_service",
+            new_callable=AsyncMock,
+            return_value=_CapturingService(),
+        ),
+        patch(
+            "app.api.v1.ml_analyze.resolve_external_tags", new_callable=AsyncMock, return_value=[]
+        ),
     ):
         response = await analyze_client.post(
             "/api/v1/ml-tag-suggestions/analyze",

--- a/tests/api/v1/test_ml_suggestion_queue.py
+++ b/tests/api/v1/test_ml_suggestion_queue.py
@@ -554,7 +554,7 @@ class TestWorklistPagination:
         await _grant_image_tag_add(db_session, user)
         images = [await _make_image(db_session, user, f"wpag1_{i}") for i in range(8)]
         tags = [await _make_tag(db_session, user, f"wpag1_t{i}") for i in range(8)]
-        for img, tag in zip(images, tags):
+        for img, tag in zip(images, tags, strict=False):
             await _make_suggestion(db_session, img, tag)
         await db_session.commit()
 
@@ -582,7 +582,7 @@ class TestWorklistPagination:
         await _grant_image_tag_add(db_session, user)
         images = [await _make_image(db_session, user, f"wpag2_{i}") for i in range(8)]
         tags = [await _make_tag(db_session, user, f"wpag2_t{i}") for i in range(8)]
-        for img, tag in zip(images, tags):
+        for img, tag in zip(images, tags, strict=False):
             await _make_suggestion(db_session, img, tag)
         await db_session.commit()
 
@@ -630,7 +630,7 @@ class TestWorklistPagination:
         await _grant_image_tag_add(db_session, user)
         images = [await _make_image(db_session, user, f"wpag4_{i}") for i in range(6)]
         tags = [await _make_tag(db_session, user, f"wpag4_t{i}") for i in range(6)]
-        for img, tag in zip(images, tags):
+        for img, tag in zip(images, tags, strict=False):
             await _make_suggestion(db_session, img, tag)
         await db_session.commit()
 

--- a/tests/api/v1/test_ml_suggestion_queue.py
+++ b/tests/api/v1/test_ml_suggestion_queue.py
@@ -554,7 +554,7 @@ class TestWorklistPagination:
         await _grant_image_tag_add(db_session, user)
         images = [await _make_image(db_session, user, f"wpag1_{i}") for i in range(8)]
         tags = [await _make_tag(db_session, user, f"wpag1_t{i}") for i in range(8)]
-        for img, tag in zip(images, tags, strict=False):
+        for img, tag in zip(images, tags, strict=True):
             await _make_suggestion(db_session, img, tag)
         await db_session.commit()
 
@@ -582,7 +582,7 @@ class TestWorklistPagination:
         await _grant_image_tag_add(db_session, user)
         images = [await _make_image(db_session, user, f"wpag2_{i}") for i in range(8)]
         tags = [await _make_tag(db_session, user, f"wpag2_t{i}") for i in range(8)]
-        for img, tag in zip(images, tags, strict=False):
+        for img, tag in zip(images, tags, strict=True):
             await _make_suggestion(db_session, img, tag)
         await db_session.commit()
 
@@ -630,7 +630,7 @@ class TestWorklistPagination:
         await _grant_image_tag_add(db_session, user)
         images = [await _make_image(db_session, user, f"wpag4_{i}") for i in range(6)]
         tags = [await _make_tag(db_session, user, f"wpag4_t{i}") for i in range(6)]
-        for img, tag in zip(images, tags, strict=False):
+        for img, tag in zip(images, tags, strict=True):
             await _make_suggestion(db_session, img, tag)
         await db_session.commit()
 

--- a/tests/api/v1/test_ml_tag_suggestions.py
+++ b/tests/api/v1/test_ml_tag_suggestions.py
@@ -404,9 +404,7 @@ class TestGetMlTagSuggestions:
         )
         assert response.status_code == 200
 
-    async def test_admin_can_view_others_image(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_admin_can_view_others_image(self, client: AsyncClient, db_session: AsyncSession):
         """An admin (admin=True, no IMAGE_TAG_ADD perm) can view suggestions on any image."""
         owner = Users(
             username="admin_view_owner",
@@ -1114,9 +1112,7 @@ class TestReviewMlTagSuggestions:
         tag_links = result.scalars().all()
         assert len(tag_links) == 1
 
-    async def test_approve_creates_tag_history(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_approve_creates_tag_history(self, client: AsyncClient, db_session: AsyncSession):
         """Approving a suggestion records a TagHistory add row (action='a')."""
         user = Users(
             username="test_history",
@@ -1207,9 +1203,7 @@ class TestReviewMlTagSuggestions:
         db_session.add(tag)
         await db_session.flush()
 
-        db_session.add(
-            TagLinks(image_id=image.image_id, tag_id=tag.tag_id, user_id=user.user_id)
-        )
+        db_session.add(TagLinks(image_id=image.image_id, tag_id=tag.tag_id, user_id=user.user_id))
         suggestion = MlTagSuggestions(
             image_id=image.image_id,
             tag_id=tag.tag_id,
@@ -1326,9 +1320,7 @@ class TestReviewMlTagSuggestions:
         db_session.add(canonical)
         await db_session.flush()
 
-        alias = Tags(
-            title="alias", type=1, user_id=user.user_id, alias_of=canonical.tag_id
-        )
+        alias = Tags(title="alias", type=1, user_id=user.user_id, alias_of=canonical.tag_id)
         db_session.add(alias)
         await db_session.flush()
 
@@ -1398,9 +1390,7 @@ class TestReviewMlTagSuggestions:
         db_session.add(canonical)
         await db_session.flush()
 
-        alias = Tags(
-            title="alias", type=1, user_id=user.user_id, alias_of=canonical.tag_id
-        )
+        alias = Tags(title="alias", type=1, user_id=user.user_id, alias_of=canonical.tag_id)
         db_session.add(alias)
         await db_session.flush()
 
@@ -1517,9 +1507,7 @@ class TestReviewMlTagSuggestions:
         db_session.add(owner)
         await db_session.flush()
 
-        moderator = await _create_moderator(
-            db_session, "review_mod", "review_mod@example.com"
-        )
+        moderator = await _create_moderator(db_session, "review_mod", "review_mod@example.com")
 
         image = Images(
             filename="test",

--- a/tests/api/v1/test_news.py
+++ b/tests/api/v1/test_news.py
@@ -79,9 +79,7 @@ class TestListNews:
         assert data["total"] == 0
         assert data["news"] == []
 
-    async def test_list_returns_news_with_username(
-        self, client: AsyncClient, news_item: News
-    ):
+    async def test_list_returns_news_with_username(self, client: AsyncClient, news_item: News):
         """List returns news items with username from user join."""
         response = await client.get("/api/v1/news")
         assert response.status_code == 200
@@ -104,9 +102,7 @@ class TestListNews:
         assert data["page"] == 1
         assert data["per_page"] == 2
 
-    async def test_list_ordered_newest_first(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_list_ordered_newest_first(self, client: AsyncClient, db_session: AsyncSession):
         """List returns news ordered by news_id DESC (newest first)."""
         for i in range(3):
             db_session.add(News(user_id=1, title=f"News {i}", news_text=f"Content {i}"))
@@ -140,14 +136,10 @@ class TestCreateNews:
 
     async def test_create_requires_auth(self, client: AsyncClient):
         """Create returns 401 without authentication."""
-        response = await client.post(
-            "/api/v1/news", json={"title": "Test", "news_text": "Content"}
-        )
+        response = await client.post("/api/v1/news", json={"title": "Test", "news_text": "Content"})
         assert response.status_code == 401
 
-    async def test_create_requires_permission(
-        self, client: AsyncClient, unprivileged_token: str
-    ):
+    async def test_create_requires_permission(self, client: AsyncClient, unprivileged_token: str):
         """Create returns 403 without NEWS_CREATE permission."""
         response = await client.post(
             "/api/v1/news",
@@ -192,9 +184,7 @@ class TestUpdateNews:
 
     async def test_update_requires_auth(self, client: AsyncClient, news_item: News):
         """Update returns 401 without authentication."""
-        response = await client.put(
-            f"/api/v1/news/{news_item.news_id}", json={"title": "Updated"}
-        )
+        response = await client.put(f"/api/v1/news/{news_item.news_id}", json={"title": "Updated"})
         assert response.status_code == 401
 
     async def test_update_requires_permission(

--- a/tests/api/v1/test_open_report_flag.py
+++ b/tests/api/v1/test_open_report_flag.py
@@ -14,8 +14,14 @@ from app.models.user import Users
 
 
 async def _make_user(db, username, password="TestPassword123!"):
-    user = Users(username=username, password=get_password_hash(password),
-                 password_type="bcrypt", salt="", email=f"{username}@example.com", active=1)
+    user = Users(
+        username=username,
+        password=get_password_hash(password),
+        password_type="bcrypt",
+        salt="",
+        email=f"{username}@example.com",
+        active=1,
+    )
     db.add(user)
     await db.commit()
     await db.refresh(user)
@@ -43,8 +49,16 @@ async def _login(client, username, password="TestPassword123!"):
 
 
 async def _image(db, owner, md5):
-    img = Images(filename="orf", ext="jpg", md5_hash=md5, user_id=owner.user_id,
-                 width=10, height=10, filesize=100, status=1)
+    img = Images(
+        filename="orf",
+        ext="jpg",
+        md5_hash=md5,
+        user_id=owner.user_id,
+        width=10,
+        height=10,
+        filesize=100,
+        status=1,
+    )
     db.add(img)
     await db.commit()
     await db.refresh(img)
@@ -59,8 +73,14 @@ class TestHasOpenReportFlag:
         owner = await _make_user(db_session, "orfowner")
         reported = await _image(db_session, owner, "a" * 32)
         clean = await _image(db_session, owner, "b" * 32)
-        db_session.add(ImageReports(image_id=reported.image_id, user_id=owner.user_id,
-                                    category=2, status=ReportStatus.PENDING))
+        db_session.add(
+            ImageReports(
+                image_id=reported.image_id,
+                user_id=owner.user_id,
+                category=2,
+                status=ReportStatus.PENDING,
+            )
+        )
         await db_session.commit()
 
         mod = await _make_user(db_session, "orfmod")
@@ -87,8 +107,14 @@ class TestHasOpenReportFlag:
     async def test_list_flag_for_mod(self, client: AsyncClient, db_session: AsyncSession):
         owner = await _make_user(db_session, "orflistowner")
         reported = await _image(db_session, owner, "c" * 32)
-        db_session.add(ImageReports(image_id=reported.image_id, user_id=owner.user_id,
-                                    category=2, status=ReportStatus.PENDING))
+        db_session.add(
+            ImageReports(
+                image_id=reported.image_id,
+                user_id=owner.user_id,
+                category=2,
+                status=ReportStatus.PENDING,
+            )
+        )
         await db_session.commit()
 
         mod = await _make_user(db_session, "orflistmod")

--- a/tests/api/v1/test_pm_notifications.py
+++ b/tests/api/v1/test_pm_notifications.py
@@ -10,8 +10,8 @@ from unittest.mock import patch
 
 import pytest
 
-from app.services.email import send_pm_notification_email
 from app.models.user import Users
+from app.services.email import send_pm_notification_email
 
 
 @pytest.mark.asyncio

--- a/tests/api/v1/test_privmsg_threads.py
+++ b/tests/api/v1/test_privmsg_threads.py
@@ -95,15 +95,25 @@ class TestGetThreads:
 
         t1 = str(uuid.uuid4())
         msg1 = Privmsgs(
-            from_user_id=user_b.user_id, to_user_id=user_a.user_id,
-            subject="Read thread", text="Hi", thread_id=t1, date=now, viewed=1,
+            from_user_id=user_b.user_id,
+            to_user_id=user_a.user_id,
+            subject="Read thread",
+            text="Hi",
+            thread_id=t1,
+            date=now,
+            viewed=1,
         )
         db_session.add(msg1)
 
         t2 = str(uuid.uuid4())
         msg2 = Privmsgs(
-            from_user_id=user_c.user_id, to_user_id=user_a.user_id,
-            subject="Unread thread", text="Hey", thread_id=t2, date=now, viewed=0,
+            from_user_id=user_c.user_id,
+            to_user_id=user_a.user_id,
+            subject="Unread thread",
+            text="Hey",
+            thread_id=t2,
+            date=now,
+            viewed=0,
         )
         db_session.add(msg2)
         await db_session.commit()
@@ -119,15 +129,20 @@ class TestGetThreads:
         assert t2 in thread_ids
         assert t1 not in thread_ids
 
-    async def test_threads_exclude_left_conversations(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_threads_exclude_left_conversations(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Test that left (soft-deleted) conversations don't appear."""
         user_a = await create_user(db_session, "left_a")
         user_b = await create_user(db_session, "left_b")
 
         thread_id = str(uuid.uuid4())
         msg = Privmsgs(
-            from_user_id=user_b.user_id, to_user_id=user_a.user_id,
-            subject="Left thread", text="Bye", thread_id=thread_id,
+            from_user_id=user_b.user_id,
+            to_user_id=user_a.user_id,
+            subject="Left thread",
+            text="Bye",
+            thread_id=thread_id,
             to_del=1,
         )
         db_session.add(msg)
@@ -142,7 +157,9 @@ class TestGetThreads:
         thread_ids = [t["thread_id"] for t in response.json()["threads"]]
         assert thread_id not in thread_ids
 
-    async def test_threads_sorted_by_latest_message(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_threads_sorted_by_latest_message(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Test threads are sorted by most recent message date."""
         user_a = await create_user(db_session, "sort_a")
         user_b = await create_user(db_session, "sort_b")
@@ -151,16 +168,28 @@ class TestGetThreads:
         now = datetime.now(UTC)
 
         t1 = str(uuid.uuid4())
-        db_session.add(Privmsgs(
-            from_user_id=user_b.user_id, to_user_id=user_a.user_id,
-            subject="Old", text="Old msg", thread_id=t1, date=now - timedelta(hours=1),
-        ))
+        db_session.add(
+            Privmsgs(
+                from_user_id=user_b.user_id,
+                to_user_id=user_a.user_id,
+                subject="Old",
+                text="Old msg",
+                thread_id=t1,
+                date=now - timedelta(hours=1),
+            )
+        )
 
         t2 = str(uuid.uuid4())
-        db_session.add(Privmsgs(
-            from_user_id=user_c.user_id, to_user_id=user_a.user_id,
-            subject="New", text="New msg", thread_id=t2, date=now,
-        ))
+        db_session.add(
+            Privmsgs(
+                from_user_id=user_c.user_id,
+                to_user_id=user_a.user_id,
+                subject="New",
+                text="New msg",
+                thread_id=t2,
+                date=now,
+            )
+        )
         await db_session.commit()
 
         token = await login(client, "sort_a")
@@ -178,7 +207,9 @@ class TestGetThreads:
 class TestSendThreadedMessage:
     """Tests for POST /api/v1/privmsgs with thread_id."""
 
-    async def test_send_new_message_creates_thread(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_send_new_message_creates_thread(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Test sending a new message generates a thread_id."""
         user_a = await create_user(db_session, "send_a", email_verified=True)
         user_b = await create_user(db_session, "send_b", email_verified=True)
@@ -202,8 +233,11 @@ class TestSendThreadedMessage:
 
         thread_id = str(uuid.uuid4())
         msg = Privmsgs(
-            from_user_id=user_a.user_id, to_user_id=user_b.user_id,
-            subject="Original", text="First msg", thread_id=thread_id,
+            from_user_id=user_a.user_id,
+            to_user_id=user_b.user_id,
+            subject="Original",
+            text="First msg",
+            thread_id=thread_id,
         )
         db_session.add(msg)
         await db_session.commit()
@@ -223,15 +257,20 @@ class TestSendThreadedMessage:
         data = response.json()
         assert data["thread_id"] == thread_id
 
-    async def test_reply_resets_recipient_del_flag(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_reply_resets_recipient_del_flag(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Test that replying to a left thread resets the recipient's del flag."""
         user_a = await create_user(db_session, "reset_a", email_verified=True)
         user_b = await create_user(db_session, "reset_b", email_verified=True)
 
         thread_id = str(uuid.uuid4())
         msg = Privmsgs(
-            from_user_id=user_a.user_id, to_user_id=user_b.user_id,
-            subject="Left", text="Old msg", thread_id=thread_id,
+            from_user_id=user_a.user_id,
+            to_user_id=user_b.user_id,
+            subject="Left",
+            text="Old msg",
+            thread_id=thread_id,
             to_del=1,  # user_b left the thread
         )
         db_session.add(msg)
@@ -301,8 +340,12 @@ class TestGetThreadMessages:
 
         thread_id = str(uuid.uuid4())
         msg = Privmsgs(
-            from_user_id=user_b.user_id, to_user_id=user_a.user_id,
-            subject="Unread", text="Please read", thread_id=thread_id, viewed=0,
+            from_user_id=user_b.user_id,
+            to_user_id=user_a.user_id,
+            subject="Unread",
+            text="Please read",
+            thread_id=thread_id,
+            viewed=0,
         )
         db_session.add(msg)
         await db_session.commit()
@@ -327,8 +370,11 @@ class TestGetThreadMessages:
 
         thread_id = str(uuid.uuid4())
         msg = Privmsgs(
-            from_user_id=user_a.user_id, to_user_id=user_b.user_id,
-            subject="Private", text="Secret", thread_id=thread_id,
+            from_user_id=user_a.user_id,
+            to_user_id=user_b.user_id,
+            subject="Private",
+            text="Secret",
+            thread_id=thread_id,
         )
         db_session.add(msg)
         await db_session.commit()
@@ -364,8 +410,11 @@ class TestLeaveThread:
         msgs = []
         for i in range(2):
             msg = Privmsgs(
-                from_user_id=user_a.user_id, to_user_id=user_b.user_id,
-                subject="Leave test", text=f"Msg {i}", thread_id=thread_id,
+                from_user_id=user_a.user_id,
+                to_user_id=user_b.user_id,
+                subject="Leave test",
+                text=f"Msg {i}",
+                thread_id=thread_id,
             )
             db_session.add(msg)
             msgs.append(msg)
@@ -392,8 +441,11 @@ class TestLeaveThread:
 
         thread_id = str(uuid.uuid4())
         msg = Privmsgs(
-            from_user_id=user_a.user_id, to_user_id=user_b.user_id,
-            subject="Leave send", text="Msg", thread_id=thread_id,
+            from_user_id=user_a.user_id,
+            to_user_id=user_b.user_id,
+            subject="Leave send",
+            text="Msg",
+            thread_id=thread_id,
         )
         db_session.add(msg)
         await db_session.commit()
@@ -417,8 +469,11 @@ class TestLeaveThread:
 
         thread_id = str(uuid.uuid4())
         msg = Privmsgs(
-            from_user_id=user_a.user_id, to_user_id=user_b.user_id,
-            subject="Private", text="Secret", thread_id=thread_id,
+            from_user_id=user_a.user_id,
+            to_user_id=user_b.user_id,
+            subject="Private",
+            text="Secret",
+            thread_id=thread_id,
         )
         db_session.add(msg)
         await db_session.commit()

--- a/tests/api/v1/test_privmsgs.py
+++ b/tests/api/v1/test_privmsgs.py
@@ -12,23 +12,21 @@ from datetime import UTC, datetime
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.core.security import get_password_hash
 from app.models.permissions import Groups, Perms, UserGroups, UserPerms
 from app.models.privmsg import Privmsgs
 from app.models.user import Users
-from app.config import settings
 
 
 @pytest.mark.api
 class TestGetReceivedPrivmsgs:
     """Tests for GET /api/v1/privmsgs/received endpoint."""
 
-    async def test_get_own_received_messages(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_own_received_messages(self, client: AsyncClient, db_session: AsyncSession):
         """Test user getting their own received messages."""
         # Create user
         user = Users(
@@ -97,7 +95,9 @@ class TestGetReceivedPrivmsgs:
         for msg in data["messages"]:
             assert msg["to_user_id"] == user.user_id
             # Avatar URL should be present and correctly generated
-            assert msg.get("from_avatar_url") == f"{settings.IMAGE_BASE_URL}/images/avatars/sender.png"
+            assert (
+                msg.get("from_avatar_url") == f"{settings.IMAGE_BASE_URL}/images/avatars/sender.png"
+            )
 
     async def test_get_received_messages_unauthenticated(self, client: AsyncClient):
         """Test getting received messages without authentication."""
@@ -195,7 +195,9 @@ class TestGetReceivedPrivmsgs:
         )
         assert response.status_code == 403
 
-    async def test_delete_privmsg_marks_to_del_for_recipient(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_delete_privmsg_marks_to_del_for_recipient(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Test recipient deleting a message marks to_del and preserves row if sender hasn't deleted."""
         # Create recipient
         recipient = Users(
@@ -224,14 +226,19 @@ class TestGetReceivedPrivmsgs:
         access_token = login_response.json()["access_token"]
 
         # Delete message
-        response = await client.delete(f"/api/v1/privmsgs/{msg.privmsg_id}", headers={"Authorization": f"Bearer {access_token}"})
+        response = await client.delete(
+            f"/api/v1/privmsgs/{msg.privmsg_id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
         assert response.status_code == 204
 
         # Refresh from DB
         await db_session.refresh(msg)
         assert msg.to_del == 1
 
-    async def test_delete_privmsg_deleted_when_both_deleted(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_delete_privmsg_deleted_when_both_deleted(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Test that message row is removed when both parties have deleted it."""
         # Create sender and recipient
         sender = Users(
@@ -257,7 +264,9 @@ class TestGetReceivedPrivmsgs:
         await db_session.refresh(recipient)
 
         # Create message
-        msg = Privmsgs(from_user_id=sender.user_id, to_user_id=recipient.user_id, text="Temp message")
+        msg = Privmsgs(
+            from_user_id=sender.user_id, to_user_id=recipient.user_id, text="Temp message"
+        )
         db_session.add(msg)
         await db_session.commit()
         await db_session.refresh(msg)
@@ -268,7 +277,10 @@ class TestGetReceivedPrivmsgs:
             json={"username": "delsender", "password": "TestPassword123!"},
         )
         access_token_sender = login_response.json()["access_token"]
-        response = await client.delete(f"/api/v1/privmsgs/{msg.privmsg_id}", headers={"Authorization": f"Bearer {access_token_sender}"})
+        response = await client.delete(
+            f"/api/v1/privmsgs/{msg.privmsg_id}",
+            headers={"Authorization": f"Bearer {access_token_sender}"},
+        )
         assert response.status_code == 204
 
         # Recipient deletes, should remove row
@@ -277,11 +289,16 @@ class TestGetReceivedPrivmsgs:
             json={"username": "delrecipient2", "password": "TestPassword123!"},
         )
         access_token_recipient = login_response.json()["access_token"]
-        response = await client.delete(f"/api/v1/privmsgs/{msg.privmsg_id}", headers={"Authorization": f"Bearer {access_token_recipient}"})
+        response = await client.delete(
+            f"/api/v1/privmsgs/{msg.privmsg_id}",
+            headers={"Authorization": f"Bearer {access_token_recipient}"},
+        )
         assert response.status_code == 204
 
         # Check that message no longer exists
-        result = await db_session.execute(select(Privmsgs).where(Privmsgs.privmsg_id == msg.privmsg_id))
+        result = await db_session.execute(
+            select(Privmsgs).where(Privmsgs.privmsg_id == msg.privmsg_id)
+        )
         assert result.scalar_one_or_none() is None
 
 
@@ -289,9 +306,7 @@ class TestGetReceivedPrivmsgs:
 class TestGetSentPrivmsgs:
     """Tests for GET /api/v1/privmsgs/sent endpoint."""
 
-    async def test_get_own_sent_messages(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_own_sent_messages(self, client: AsyncClient, db_session: AsyncSession):
         """Test user getting their own sent messages."""
         # Create user
         user = Users(
@@ -459,7 +474,9 @@ class TestGetSentPrivmsgs:
         )
         assert response.status_code == 403
 
-    async def test_get_privmsg_details_and_mark_viewed(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_get_privmsg_details_and_mark_viewed(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Recipient should be able to fetch a single privmsg and it should be marked viewed."""
         # Create sender and recipient
         sender = Users(
@@ -485,7 +502,9 @@ class TestGetSentPrivmsgs:
         await db_session.refresh(recipient)
 
         # Create message from sender to recipient (unviewed)
-        msg = Privmsgs(from_user_id=sender.user_id, to_user_id=recipient.user_id, text="Hello there", viewed=0)
+        msg = Privmsgs(
+            from_user_id=sender.user_id, to_user_id=recipient.user_id, text="Hello there", viewed=0
+        )
         db_session.add(msg)
         await db_session.commit()
         await db_session.refresh(msg)
@@ -498,7 +517,10 @@ class TestGetSentPrivmsgs:
         access_token = login_response.json()["access_token"]
 
         # Fetch single message
-        response = await client.get(f"/api/v1/privmsgs/{msg.privmsg_id}", headers={"Authorization": f"Bearer {access_token}"})
+        response = await client.get(
+            f"/api/v1/privmsgs/{msg.privmsg_id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
         assert response.status_code == 200
         data = response.json()
         assert data["privmsg_id"] == msg.privmsg_id
@@ -508,7 +530,9 @@ class TestGetSentPrivmsgs:
         await db_session.refresh(msg)
         assert msg.viewed == 1
 
-    async def test_privmsg_handles_html_entities_in_text(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_privmsg_handles_html_entities_in_text(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Ensure messages stored with HTML entities don't double-encode when rendered."""
         sender = Users(
             username="entity_sender",
@@ -533,7 +557,13 @@ class TestGetSentPrivmsgs:
         await db_session.refresh(recipient)
 
         problematic = 'So I want my title to be &quot;Alpha &amp; Omega&quot; or Alpha N&#039; Omega" if the &amp; character is illegal'
-        msg = Privmsgs(from_user_id=sender.user_id, to_user_id=recipient.user_id, subject='i&#039;m sad', text=problematic, viewed=0)
+        msg = Privmsgs(
+            from_user_id=sender.user_id,
+            to_user_id=recipient.user_id,
+            subject="i&#039;m sad",
+            text=problematic,
+            viewed=0,
+        )
         db_session.add(msg)
         await db_session.commit()
         await db_session.refresh(msg)
@@ -545,20 +575,25 @@ class TestGetSentPrivmsgs:
         )
         access_token = login_response.json()["access_token"]
 
-        response = await client.get(f"/api/v1/privmsgs/{msg.privmsg_id}", headers={"Authorization": f"Bearer {access_token}"})
+        response = await client.get(
+            f"/api/v1/privmsgs/{msg.privmsg_id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
         assert response.status_code == 200
         data = response.json()
 
         # The rendered HTML should not contain double-encoded &amp;quot; sequences
         assert "&amp;quot;" not in data["text_html"]
         # It should contain a properly encoded quote entity for HTML output
-        assert "&quot;Alpha" in data["text_html"] or 'Alpha' in data["text_html"]
+        assert "&quot;Alpha" in data["text_html"] or "Alpha" in data["text_html"]
 
         # Subject should be normalized and should not contain HTML entity for apostrophe
         assert "&#039;" not in data["subject"]
         assert "'" in data["subject"]
 
-    async def test_get_privmsg_details_sender_can_view_without_marking_viewed(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_get_privmsg_details_sender_can_view_without_marking_viewed(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Sender should be able to fetch their sent message and it should not mark viewed."""
         sender = Users(
             username="pm_sender2",
@@ -582,7 +617,9 @@ class TestGetSentPrivmsgs:
         await db_session.refresh(sender)
         await db_session.refresh(recipient)
 
-        msg = Privmsgs(from_user_id=sender.user_id, to_user_id=recipient.user_id, text="Hi there", viewed=0)
+        msg = Privmsgs(
+            from_user_id=sender.user_id, to_user_id=recipient.user_id, text="Hi there", viewed=0
+        )
         db_session.add(msg)
         await db_session.commit()
         await db_session.refresh(msg)
@@ -594,7 +631,10 @@ class TestGetSentPrivmsgs:
         )
         access_token = login_response.json()["access_token"]
 
-        response = await client.get(f"/api/v1/privmsgs/{msg.privmsg_id}", headers={"Authorization": f"Bearer {access_token}"})
+        response = await client.get(
+            f"/api/v1/privmsgs/{msg.privmsg_id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
         assert response.status_code == 200
         data = response.json()
         assert data["privmsg_id"] == msg.privmsg_id
@@ -603,7 +643,9 @@ class TestGetSentPrivmsgs:
         await db_session.refresh(msg)
         assert msg.viewed == 0
 
-    async def test_get_privmsg_details_unauthorized(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_get_privmsg_details_unauthorized(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """A random third party should not be able to view someone else's message."""
         sender = Users(
             username="pm_sender3",
@@ -637,7 +679,9 @@ class TestGetSentPrivmsgs:
         await db_session.refresh(recipient)
         await db_session.refresh(outsider)
 
-        msg = Privmsgs(from_user_id=sender.user_id, to_user_id=recipient.user_id, text="Secret", viewed=0)
+        msg = Privmsgs(
+            from_user_id=sender.user_id, to_user_id=recipient.user_id, text="Secret", viewed=0
+        )
         db_session.add(msg)
         await db_session.commit()
         await db_session.refresh(msg)
@@ -648,7 +692,10 @@ class TestGetSentPrivmsgs:
         )
         access_token = login_response.json()["access_token"]
 
-        response = await client.get(f"/api/v1/privmsgs/{msg.privmsg_id}", headers={"Authorization": f"Bearer {access_token}"})
+        response = await client.get(
+            f"/api/v1/privmsgs/{msg.privmsg_id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
         assert response.status_code == 403
 
 

--- a/tests/api/v1/test_random_images.py
+++ b/tests/api/v1/test_random_images.py
@@ -62,9 +62,7 @@ class TestRandomImagesRedirect:
             db_session.add(img)
         await db_session.commit()
 
-        response = await client.get(
-            "/api/v1/images/random?per_page=5", follow_redirects=False
-        )
+        response = await client.get("/api/v1/images/random?per_page=5", follow_redirects=False)
 
         assert response.status_code == 302
         location = response.headers["location"]

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -8,10 +8,9 @@ Tests cover:
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
-
-from sqlalchemy import select
 
 from app.config import (
     AdminActionType,
@@ -160,9 +159,7 @@ async def add_tag_to_image(db_session: AsyncSession, image_id: int, tag_id: int)
 class TestUserReportEndpoint:
     """Tests for POST /api/v1/images/{image_id}/report endpoint."""
 
-    async def test_report_image_success(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_report_image_success(self, client: AsyncClient, db_session: AsyncSession):
         """Test successful image report by authenticated user."""
         user, password = await create_auth_user(db_session)
         image = await create_test_image(db_session, user.user_id)
@@ -184,9 +181,7 @@ class TestUserReportEndpoint:
         assert data["status_label"] == "Pending"
         assert data["category_label"] == "Inappropriate Image"
 
-    async def test_report_image_category_only(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_report_image_category_only(self, client: AsyncClient, db_session: AsyncSession):
         """Test report with category only, no reason_text."""
         user, password = await create_auth_user(db_session)
         image = await create_test_image(db_session, user.user_id)
@@ -217,9 +212,7 @@ class TestUserReportEndpoint:
 
         assert response.status_code == 401
 
-    async def test_report_nonexistent_image(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_report_nonexistent_image(self, client: AsyncClient, db_session: AsyncSession):
         """Test reporting non-existent image returns 404."""
         user, password = await create_auth_user(db_session)
         token = await login_user(client, user.username, password)
@@ -529,7 +522,6 @@ class TestAdminReportsList:
         assert 1 in categories  # REPOST
         assert 4 in categories  # TAG_SUGGESTIONS
 
-
     async def test_list_reports_includes_reviewed_by_username(
         self, client: AsyncClient, db_session: AsyncSession
     ):
@@ -634,9 +626,7 @@ class TestAdminReportsList:
 class TestAdminGetReport:
     """Tests for GET /api/v1/admin/reports/{report_id} endpoint."""
 
-    async def test_get_report_success(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_report_success(self, client: AsyncClient, db_session: AsyncSession):
         """Test fetching a single image report by ID."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "report_view")
@@ -712,9 +702,7 @@ class TestAdminGetReport:
         assert data["suggested_tags"] is not None
         assert len(data["suggested_tags"]) == 2
 
-    async def test_get_report_not_found(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_report_not_found(self, client: AsyncClient, db_session: AsyncSession):
         """Test 404 for nonexistent report."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "report_view")
@@ -727,9 +715,7 @@ class TestAdminGetReport:
 
         assert response.status_code == 404
 
-    async def test_get_report_no_permission(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_report_no_permission(self, client: AsyncClient, db_session: AsyncSession):
         """Test 403 when user lacks permission."""
         user, password = await create_auth_user(db_session)
         token = await login_user(client, user.username, password)
@@ -749,9 +735,7 @@ class TestAdminGetReport:
         await grant_permission(db_session, tagger.user_id, "tag_suggestion_apply")
         token = await login_user(client, tagger.username, password)
 
-        admin, _ = await create_auth_user(
-            db_session, username="admin", email="admin@example.com"
-        )
+        admin, _ = await create_auth_user(db_session, username="admin", email="admin@example.com")
         image = await create_test_image(db_session, admin.user_id)
         report = ImageReports(
             image_id=image.image_id,
@@ -779,9 +763,7 @@ class TestAdminGetReport:
         await grant_permission(db_session, tagger.user_id, "tag_suggestion_apply")
         token = await login_user(client, tagger.username, password)
 
-        admin, _ = await create_auth_user(
-            db_session, username="admin", email="admin@example.com"
-        )
+        admin, _ = await create_auth_user(db_session, username="admin", email="admin@example.com")
         image = await create_test_image(db_session, admin.user_id)
         report = ImageReports(
             image_id=image.image_id,
@@ -805,9 +787,7 @@ class TestAdminGetReport:
 class TestAdminReportDismiss:
     """Tests for POST /api/v1/admin/reports/{report_id}/dismiss endpoint."""
 
-    async def test_dismiss_report_success(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_dismiss_report_success(self, client: AsyncClient, db_session: AsyncSession):
         """Test dismissing a report."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "report_manage")
@@ -1043,10 +1023,18 @@ class TestAdminReportAction:
         img = (await db_session.execute(select(Images).where(Images.image_id == iid))).scalar_one()
         assert img.status == ImageStatus.DEACTIVATED
         assert img.reason_category == DeactivationReason.LOW_QUALITY
-        hist = (await db_session.execute(
-            select(ImageStatusHistory).where(ImageStatusHistory.image_id == iid)
-        )).scalars().all()
-        assert any(h.new_status == ImageStatus.DEACTIVATED and h.reason == "too blurry" for h in hist)
+        hist = (
+            (
+                await db_session.execute(
+                    select(ImageStatusHistory).where(ImageStatusHistory.image_id == iid)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert any(
+            h.new_status == ImageStatus.DEACTIVATED and h.reason == "too blurry" for h in hist
+        )
 
     async def test_resolved_report_exposes_action_and_reason(
         self, client: AsyncClient, db_session: AsyncSession
@@ -1058,8 +1046,11 @@ class TestAdminReportAction:
         token = await login_user(client, admin.username, password)
         image = await create_test_image(db_session, admin.user_id)
         report = ImageReports(
-            image_id=image.image_id, user_id=admin.user_id, category=2,
-            reason_text="i think this is AI", status=ReportStatus.PENDING,
+            image_id=image.image_id,
+            user_id=admin.user_id,
+            category=2,
+            reason_text="i think this is AI",
+            status=ReportStatus.PENDING,
         )
         db_session.add(report)
         await db_session.commit()
@@ -1094,17 +1085,24 @@ class TestAdminReportAction:
         token = await login_user(client, admin.username, password)
         image = await create_test_image(db_session, admin.user_id)
         report = ImageReports(
-            image_id=image.image_id, user_id=admin.user_id, category=4,
+            image_id=image.image_id,
+            user_id=admin.user_id,
+            category=4,
             status=ReportStatus.REVIEWED,
         )
         db_session.add(report)
         await db_session.commit()
         await db_session.refresh(report)
         # The audit row apply_tag_suggestions writes: REPORT_ACTION, no new_status.
-        db_session.add(AdminActions(
-            user_id=admin.user_id, action_type=AdminActionType.REPORT_ACTION,
-            report_id=report.report_id, image_id=image.image_id,
-            details={"action": "apply_tag_suggestions"}))
+        db_session.add(
+            AdminActions(
+                user_id=admin.user_id,
+                action_type=AdminActionType.REPORT_ACTION,
+                report_id=report.report_id,
+                image_id=image.image_id,
+                details={"action": "apply_tag_suggestions"},
+            )
+        )
         await db_session.commit()
 
         r = await client.get(
@@ -1421,7 +1419,9 @@ class TestReportPermissionDenials:
     ):
         """Test escalating report without REPORT_MANAGE permission fails."""
         user, password = await create_auth_user(db_session, username="noperm3")
-        await grant_permission(db_session, user.user_id, "review_start")  # Has review_start but not report_manage
+        await grant_permission(
+            db_session, user.user_id, "review_start"
+        )  # Has review_start but not report_manage
         token = await login_user(client, user.username, password)
 
         image = await create_test_image(db_session, user.user_id)
@@ -1452,7 +1452,9 @@ class TestReportPermissionDenials:
     ):
         """Test escalating report without REVIEW_START permission fails."""
         user, password = await create_auth_user(db_session, username="noperm4")
-        await grant_permission(db_session, user.user_id, "report_manage")  # Has report_manage but not review_start
+        await grant_permission(
+            db_session, user.user_id, "report_manage"
+        )  # Has report_manage but not review_start
         token = await login_user(client, user.username, password)
 
         image = await create_test_image(db_session, user.user_id)
@@ -1557,9 +1559,7 @@ class TestReportValidation:
         reason="API currently accepts any integer for new_status. "
         "Future: Add Literal type or validator to ReportActionRequest schema."
     )
-    async def test_action_with_invalid_status(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_action_with_invalid_status(self, client: AsyncClient, db_session: AsyncSession):
         """Test action with invalid image status fails.
 
         Note: Currently the API accepts any integer for new_status.
@@ -1610,7 +1610,11 @@ class TestReportWithTagSuggestions:
             f"/api/v1/images/{image.image_id}/report",
             json={
                 "category": 4,
-                "suggested_tag_ids_add": [tags[0].tag_id, 999999, tags[1].tag_id],  # 999999 is invalid
+                "suggested_tag_ids_add": [
+                    tags[0].tag_id,
+                    999999,
+                    tags[1].tag_id,
+                ],  # 999999 is invalid
             },
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -1678,7 +1682,11 @@ class TestReportWithTagSuggestions:
             f"/api/v1/images/{image.image_id}/report",
             json={
                 "category": 4,
-                "suggested_tag_ids_add": [tags[0].tag_id, tags[0].tag_id, tags[1].tag_id],  # Duplicate
+                "suggested_tag_ids_add": [
+                    tags[0].tag_id,
+                    tags[0].tag_id,
+                    tags[1].tag_id,
+                ],  # Duplicate
             },
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -1801,9 +1809,7 @@ class TestReportWithTagSuggestions:
 class TestAdminApplyTagSuggestions:
     """Tests for POST /api/v1/admin/reports/{report_id}/apply-tag-suggestions endpoint."""
 
-    async def test_apply_all_suggestions(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_apply_all_suggestions(self, client: AsyncClient, db_session: AsyncSession):
         """Test applying all tag suggestions to an image."""
         admin, password = await create_auth_user(db_session, username="applytest1", admin=True)
         await grant_permission(db_session, admin.user_id, "report_manage")
@@ -1894,9 +1900,7 @@ class TestAdminApplyTagSuggestions:
         assert ml_suggestion.status == "approved"
         assert ml_suggestion.reviewed_by_user_id == admin.user_id
 
-    async def test_apply_partial_suggestions(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_apply_partial_suggestions(self, client: AsyncClient, db_session: AsyncSession):
         """Test applying only some tag suggestions."""
         admin, password = await create_auth_user(db_session, username="applytest2", admin=True)
         await grant_permission(db_session, admin.user_id, "report_manage")
@@ -1988,9 +1992,7 @@ class TestAdminApplyTagSuggestions:
         assert suggestions[0].accepted is False
         assert suggestions[1].accepted is False
 
-    async def test_apply_with_admin_notes(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_apply_with_admin_notes(self, client: AsyncClient, db_session: AsyncSession):
         """Test applying suggestions with admin notes."""
         admin, password = await create_auth_user(db_session, username="applytest4", admin=True)
         await grant_permission(db_session, admin.user_id, "report_manage")
@@ -2146,9 +2148,7 @@ class TestAdminApplyTagSuggestions:
         all_tag_links = tag_links.scalars().all()
         assert len(all_tag_links) == 3  # 1 already present + 2 newly added
 
-    async def test_apply_removal_suggestions(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_apply_removal_suggestions(self, client: AsyncClient, db_session: AsyncSession):
         """Test applying removal suggestions removes tags from image."""
         admin, password = await create_auth_user(db_session, username="removeapply1", admin=True)
         await grant_permission(db_session, admin.user_id, "report_manage")
@@ -2539,9 +2539,7 @@ class TestApplyTagSuggestionsSnapshotConflictRetry:
         assert len(response.json()["applied_tags"]) == 2
 
         # ...and linked once per tag.
-        tag_links = await db_session.execute(
-            select(TagLinks).where(TagLinks.image_id == image_id)
-        )
+        tag_links = await db_session.execute(select(TagLinks).where(TagLinks.image_id == image_id))
         assert len(list(tag_links.scalars().all())) == 2
 
         # The report transitioned exactly once.

--- a/tests/api/v1/test_reviews.py
+++ b/tests/api/v1/test_reviews.py
@@ -194,9 +194,7 @@ class TestReviewsList:
 class TestCreateReview:
     """Tests for POST /api/v1/admin/images/{image_id}/review endpoint."""
 
-    async def test_create_review_success(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_create_review_success(self, client: AsyncClient, db_session: AsyncSession):
         """Test creating a review directly on an image."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_start")
@@ -225,9 +223,7 @@ class TestCreateReview:
         await db_session.refresh(image)
         assert image.status == ImageStatus.REVIEW
 
-    async def test_create_review_with_reason(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_create_review_with_reason(self, client: AsyncClient, db_session: AsyncSession):
         """Test creating a review with an optional reason."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_start")
@@ -411,9 +407,7 @@ class TestCreateReview:
 class TestReviewVote:
     """Tests for POST /api/v1/admin/reviews/{review_id}/vote endpoint."""
 
-    async def test_cast_vote_keep(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_cast_vote_keep(self, client: AsyncClient, db_session: AsyncSession):
         """Test casting a 'keep' vote on a review."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_vote")
@@ -442,9 +436,7 @@ class TestReviewVote:
         assert data["vote_label"] == "Keep"
         assert data["comment"] == "Looks fine to me"
 
-    async def test_cast_vote_remove(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_cast_vote_remove(self, client: AsyncClient, db_session: AsyncSession):
         """Test casting a 'remove' vote on a review."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_vote")
@@ -472,9 +464,7 @@ class TestReviewVote:
         assert data["vote"] == 0
         assert data["vote_label"] == "Remove"
 
-    async def test_update_existing_vote(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_update_existing_vote(self, client: AsyncClient, db_session: AsyncSession):
         """Test updating an existing vote."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_vote")
@@ -702,9 +692,7 @@ class TestReviewVote:
         await db_session.refresh(review)
         assert review.status == ReviewStatus.OPEN
 
-    async def test_vote_on_closed_review_fails(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_vote_on_closed_review_fails(self, client: AsyncClient, db_session: AsyncSession):
         """Test voting on closed review fails."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_vote")
@@ -735,9 +723,7 @@ class TestReviewVote:
 class TestReviewClose:
     """Tests for POST /api/v1/admin/reviews/{review_id}/close endpoint."""
 
-    async def test_close_review_keep(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_close_review_keep(self, client: AsyncClient, db_session: AsyncSession):
         """Test closing review with keep outcome."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_close_early")
@@ -773,9 +759,7 @@ class TestReviewClose:
         await db_session.refresh(image)
         assert image.status == ImageStatus.ACTIVE
 
-    async def test_close_review_remove(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_close_review_remove(self, client: AsyncClient, db_session: AsyncSession):
         """Test closing review with remove outcome."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_close_early")
@@ -911,9 +895,7 @@ class TestReviewClose:
 class TestReviewExtend:
     """Tests for POST /api/v1/admin/reviews/{review_id}/extend endpoint."""
 
-    async def test_extend_review_success(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_extend_review_success(self, client: AsyncClient, db_session: AsyncSession):
         """Test extending a review deadline."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_start")
@@ -970,9 +952,7 @@ class TestReviewExtend:
         assert response.status_code == 400
         assert "already been used" in response.json()["detail"]
 
-    async def test_extend_closed_review_fails(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_extend_closed_review_fails(self, client: AsyncClient, db_session: AsyncSession):
         """Test extending closed review fails."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_start")
@@ -1002,9 +982,7 @@ class TestReviewExtend:
 class TestReviewDetail:
     """Tests for GET /api/v1/admin/reviews/{review_id} endpoint."""
 
-    async def test_get_review_with_votes(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_review_with_votes(self, client: AsyncClient, db_session: AsyncSession):
         """Test getting review details with all votes."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_view")
@@ -1078,9 +1056,7 @@ class TestReviewDetail:
         data = response.json()
         assert data["reason"] == "Needs community review"
 
-    async def test_get_nonexistent_review(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_nonexistent_review(self, client: AsyncClient, db_session: AsyncSession):
         """Test getting non-existent review returns 404."""
         admin, password = await create_auth_user(db_session, username="admin", admin=True)
         await grant_permission(db_session, admin.user_id, "review_view")

--- a/tests/api/v1/test_search.py
+++ b/tests/api/v1/test_search.py
@@ -142,9 +142,7 @@ class TestSearchEndpoint:
         mock_search_service: AsyncMock,
     ):
         """The exclude_aliases flag is forwarded to search_tags."""
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[], total=0
-        )
+        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
 
         response = await client_with_search.get(
             "/api/v1/search", params={"q": "test", "exclude_aliases": True}
@@ -195,13 +193,9 @@ class TestSearchEndpoint:
         mock_search_service: AsyncMock,
     ):
         """Empty Meilisearch results yield empty hits list."""
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[], total=0
-        )
+        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
 
-        response = await client_with_search.get(
-            "/api/v1/search", params={"q": "nonexistent"}
-        )
+        response = await client_with_search.get("/api/v1/search", params={"q": "nonexistent"})
         assert response.status_code == 200
 
         data = response.json()
@@ -268,9 +262,7 @@ class TestSearchEndpoint:
         """If Meilisearch errors during search, endpoint returns 503."""
         mock_search_service.search_tags.side_effect = Exception("Connection refused")
 
-        response = await client_with_search.get(
-            "/api/v1/search", params={"q": "test"}
-        )
+        response = await client_with_search.get("/api/v1/search", params={"q": "test"})
         assert response.status_code == 503
         assert "temporarily unavailable" in response.json()["detail"]
 
@@ -376,9 +368,7 @@ class TestSearchEndpoint:
             tag_ids=[99999, 99998], total=2
         )
 
-        response = await client_with_search.get(
-            "/api/v1/search", params={"q": "ghost"}
-        )
+        response = await client_with_search.get("/api/v1/search", params={"q": "ghost"})
         assert response.status_code == 200
 
         data = response.json()

--- a/tests/api/v1/test_similar_images.py
+++ b/tests/api/v1/test_similar_images.py
@@ -17,9 +17,7 @@ class TestSimilarImages:
         assert response.json()["detail"] == "Image not found"
 
     @pytest.mark.asyncio
-    async def test_similar_images_no_thumbnail(
-        self, client: AsyncClient, test_image, db_session
-    ):
+    async def test_similar_images_no_thumbnail(self, client: AsyncClient, test_image, db_session):
         """Returns 404 if thumbnail doesn't exist."""
         # The test_image fixture creates a DB record but no actual file
         with patch("app.api.v1.images.FilePath.exists", return_value=False):
@@ -29,9 +27,7 @@ class TestSimilarImages:
         assert "thumbnail not found" in response.json()["detail"]
 
     @pytest.mark.asyncio
-    async def test_similar_images_empty_results(
-        self, client: AsyncClient, test_image, db_session
-    ):
+    async def test_similar_images_empty_results(self, client: AsyncClient, test_image, db_session):
         """Returns empty list when IQDB finds no similar images."""
         with (
             patch("app.api.v1.images.FilePath.exists", return_value=True),
@@ -226,8 +222,9 @@ class TestSimilarImages:
     ):
         """When iqdb_hash is set, route calls check_iqdb_similarity_by_hash, not _by_file."""
         # Populate iqdb_hash on the test image.
-        from app.models.image import Images
         from sqlalchemy import update
+
+        from app.models.image import Images
 
         await db_session.execute(
             update(Images)
@@ -248,9 +245,7 @@ class TestSimilarImages:
                 return_value=[],
             ) as mock_by_file,
         ):
-            response = await client.get(
-                f"/api/v1/images/{test_image.image_id}/similar"
-            )
+            response = await client.get(f"/api/v1/images/{test_image.image_id}/similar")
 
         assert response.status_code == 200
         mock_by_hash.assert_called_once()
@@ -278,9 +273,7 @@ class TestSimilarImages:
                 return_value=[],
             ) as mock_by_file,
         ):
-            response = await client.get(
-                f"/api/v1/images/{test_image.image_id}/similar"
-            )
+            response = await client.get(f"/api/v1/images/{test_image.image_id}/similar")
 
         assert response.status_code == 200
         mock_by_hash.assert_not_called()
@@ -293,9 +286,10 @@ class TestIQDBService:
     @pytest.mark.asyncio
     async def test_check_iqdb_similarity_success(self, db_session):
         """check_iqdb_similarity returns filtered results on success."""
-        from app.services.iqdb import check_iqdb_similarity
         from pathlib import Path
         from unittest.mock import MagicMock
+
+        from app.services.iqdb import check_iqdb_similarity
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -316,9 +310,7 @@ class TestIQDBService:
             mock_client_class.return_value = mock_client
 
             # Pass explicit threshold to test filtering
-            result = await check_iqdb_similarity(
-                Path("/fake/path.jpg"), db_session, threshold=80
-            )
+            result = await check_iqdb_similarity(Path("/fake/path.jpg"), db_session, threshold=80)
 
         # Threshold is 80, so only first two should be returned
         assert len(result) == 2
@@ -329,9 +321,10 @@ class TestIQDBService:
     @pytest.mark.asyncio
     async def test_check_iqdb_similarity_unavailable(self, db_session):
         """Returns empty list when IQDB is unavailable."""
-        from app.services.iqdb import check_iqdb_similarity
         from pathlib import Path
         from unittest.mock import MagicMock
+
+        from app.services.iqdb import check_iqdb_similarity
 
         mock_response = MagicMock()
         mock_response.status_code = 500
@@ -353,9 +346,11 @@ class TestIQDBService:
     @pytest.mark.asyncio
     async def test_check_iqdb_similarity_timeout(self, db_session):
         """Returns empty list on timeout."""
-        from app.services.iqdb import check_iqdb_similarity
         from pathlib import Path
+
         import httpx
+
+        from app.services.iqdb import check_iqdb_similarity
 
         with (
             patch("app.services.iqdb.open", create=True),
@@ -374,12 +369,11 @@ class TestIQDBService:
     @pytest.mark.asyncio
     async def test_check_iqdb_similarity_file_not_found(self, db_session):
         """Returns empty list when image file doesn't exist."""
-        from app.services.iqdb import check_iqdb_similarity
         from pathlib import Path
 
-        result = await check_iqdb_similarity(
-            Path("/nonexistent/path/image.jpg"), db_session
-        )
+        from app.services.iqdb import check_iqdb_similarity
+
+        result = await check_iqdb_similarity(Path("/nonexistent/path/image.jpg"), db_session)
         assert result == []
 
 

--- a/tests/api/v1/test_tag_audit_log.py
+++ b/tests/api/v1/test_tag_audit_log.py
@@ -1475,9 +1475,7 @@ class TestGetTagHistory:
         assert entry["user"]["user_id"] == admin.user_id
         assert entry["user"]["username"] == "historyuseradmin"
 
-    async def test_get_tag_history_404_for_nonexistent_tag(
-        self, client: AsyncClient
-    ) -> None:
+    async def test_get_tag_history_404_for_nonexistent_tag(self, client: AsyncClient) -> None:
         """Should return 404 for nonexistent tag."""
         response = await client.get("/api/v1/tags/99999999/history")
         assert response.status_code == 404
@@ -1532,14 +1530,12 @@ class TestGetTagHistory:
         for i in range(3):
             await client.put(
                 f"/api/v1/tags/{tag.tag_id}",
-                json={"title": f"pagination tag v{i+2}", "desc": "test", "type": TagType.THEME},
+                json={"title": f"pagination tag v{i + 2}", "desc": "test", "type": TagType.THEME},
                 headers={"Authorization": f"Bearer {access_token}"},
             )
 
         # Get first page with per_page=2
-        response = await client.get(
-            f"/api/v1/tags/{tag.tag_id}/history?page=1&per_page=2"
-        )
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}/history?page=1&per_page=2")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 1
@@ -1548,9 +1544,7 @@ class TestGetTagHistory:
         assert data["total"] >= 3
 
         # Get second page
-        response = await client.get(
-            f"/api/v1/tags/{tag.tag_id}/history?page=2&per_page=2"
-        )
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}/history?page=2&per_page=2")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 2
@@ -1840,10 +1834,10 @@ class TestTagAuditLogExternalLinks:
         assert response.status_code == 201
 
         entries = (
-            await db_session.execute(
-                select(TagAuditLog).where(TagAuditLog.tag_id == tag.tag_id)
-            )
-        ).scalars().all()
+            (await db_session.execute(select(TagAuditLog).where(TagAuditLog.tag_id == tag.tag_id)))
+            .scalars()
+            .all()
+        )
 
         assert len(entries) == 1
         assert entries[0].action_type == TagAuditActionType.LINK_ADDED
@@ -1879,10 +1873,10 @@ class TestTagAuditLogExternalLinks:
         ).status_code == 409
 
         entries = (
-            await db_session.execute(
-                select(TagAuditLog).where(TagAuditLog.tag_id == tag_id)
-            )
-        ).scalars().all()
+            (await db_session.execute(select(TagAuditLog).where(TagAuditLog.tag_id == tag_id)))
+            .scalars()
+            .all()
+        )
         assert len(entries) == 1
 
     async def test_delete_link_creates_link_removed_entry(
@@ -1905,12 +1899,16 @@ class TestTagAuditLogExternalLinks:
         assert response.status_code == 204
 
         entries = (
-            await db_session.execute(
-                select(TagAuditLog)
-                .where(TagAuditLog.tag_id == tag.tag_id)
-                .where(TagAuditLog.action_type == TagAuditActionType.LINK_REMOVED)
+            (
+                await db_session.execute(
+                    select(TagAuditLog)
+                    .where(TagAuditLog.tag_id == tag.tag_id)
+                    .where(TagAuditLog.action_type == TagAuditActionType.LINK_REMOVED)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
         assert len(entries) == 1
         assert entries[0].link_url == "https://example.com/gone"
@@ -1941,10 +1939,10 @@ class TestTagAuditLogExternalLinks:
         assert response.status_code == 200
 
         entries = (
-            await db_session.execute(
-                select(TagAuditLog).where(TagAuditLog.tag_id == tag.tag_id)
-            )
-        ).scalars().all()
+            (await db_session.execute(select(TagAuditLog).where(TagAuditLog.tag_id == tag.tag_id)))
+            .scalars()
+            .all()
+        )
         # Only the two link_added rows from setup.
         assert [e.action_type for e in entries] == [TagAuditActionType.LINK_ADDED] * 2
 
@@ -1961,13 +1959,17 @@ class TestTagAuditLogExternalLinks:
 
     async def _link_entries(self, db_session: AsyncSession, tag_id: int, action: str):
         return (
-            await db_session.execute(
-                select(TagAuditLog)
-                .where(TagAuditLog.tag_id == tag_id)
-                .where(TagAuditLog.action_type == action)
-                .order_by(TagAuditLog.id)
+            (
+                await db_session.execute(
+                    select(TagAuditLog)
+                    .where(TagAuditLog.tag_id == tag_id)
+                    .where(TagAuditLog.action_type == action)
+                    .order_by(TagAuditLog.id)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
     async def test_marking_link_dead_creates_entry(
         self, client: AsyncClient, db_session: AsyncSession
@@ -2030,9 +2032,7 @@ class TestTagAuditLogExternalLinks:
         )
 
         assert (
-            await self._link_entries(
-                db_session, tag.tag_id, TagAuditActionType.LINK_DEAD_CLEARED
-            )
+            await self._link_entries(db_session, tag.tag_id, TagAuditActionType.LINK_DEAD_CLEARED)
             == []
         )
 
@@ -2128,7 +2128,11 @@ class TestTagAuditLogExternalLinks:
         shared = "https://example.com/shared"
         unique = "https://example.com/unique"
 
-        for tag_id, url in ((canonical.tag_id, shared), (alias.tag_id, shared), (alias.tag_id, unique)):
+        for tag_id, url in (
+            (canonical.tag_id, shared),
+            (alias.tag_id, shared),
+            (alias.tag_id, unique),
+        ):
             created = await client.post(
                 f"/api/v1/tags/{tag_id}/links", json={"url": url}, headers=headers
             )
@@ -2163,7 +2167,9 @@ class TestTagAuditLogExternalLinks:
 class TestTagAuditLogCreation:
     """A tag born as an alias or child must have that recorded."""
 
-    async def _admin_token(self, client: AsyncClient, db_session: AsyncSession, username: str) -> str:
+    async def _admin_token(
+        self, client: AsyncClient, db_session: AsyncSession, username: str
+    ) -> str:
         for title, desc in (("tag_create", "Create tags"), ("tag_update", "Update tags")):
             db_session.add(Perms(title=title, desc=desc))
         await db_session.commit()
@@ -2183,9 +2189,7 @@ class TestTagAuditLogCreation:
 
         perms = (await db_session.execute(select(Perms))).scalars().all()
         for perm in perms:
-            db_session.add(
-                UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1)
-            )
+            db_session.add(UserPerms(user_id=admin.user_id, perm_id=perm.perm_id, permvalue=1))
         await db_session.commit()
 
         login = await client.post(
@@ -2216,10 +2220,10 @@ class TestTagAuditLogCreation:
         new_id = response.json()["tag_id"]
 
         entries = (
-            await db_session.execute(
-                select(TagAuditLog).where(TagAuditLog.tag_id == new_id)
-            )
-        ).scalars().all()
+            (await db_session.execute(select(TagAuditLog).where(TagAuditLog.tag_id == new_id)))
+            .scalars()
+            .all()
+        )
 
         assert len(entries) == 1
         assert entries[0].action_type == TagAuditActionType.ALIAS_SET
@@ -2248,10 +2252,10 @@ class TestTagAuditLogCreation:
         new_id = response.json()["tag_id"]
 
         entries = (
-            await db_session.execute(
-                select(TagAuditLog).where(TagAuditLog.tag_id == new_id)
-            )
-        ).scalars().all()
+            (await db_session.execute(select(TagAuditLog).where(TagAuditLog.tag_id == new_id)))
+            .scalars()
+            .all()
+        )
 
         assert len(entries) == 1
         assert entries[0].action_type == TagAuditActionType.PARENT_SET
@@ -2284,10 +2288,10 @@ class TestTagAuditLogCreation:
         new_id = response.json()["tag_id"]
 
         entries = (
-            await db_session.execute(
-                select(TagAuditLog).where(TagAuditLog.tag_id == new_id)
-            )
-        ).scalars().all()
+            (await db_session.execute(select(TagAuditLog).where(TagAuditLog.tag_id == new_id)))
+            .scalars()
+            .all()
+        )
 
         assert len(entries) == 2
         by_action = {entry.action_type: entry for entry in entries}
@@ -2309,10 +2313,14 @@ class TestTagAuditLogCreation:
         assert response.status_code == 200
 
         entries = (
-            await db_session.execute(
-                select(TagAuditLog).where(TagAuditLog.tag_id == response.json()["tag_id"])
+            (
+                await db_session.execute(
+                    select(TagAuditLog).where(TagAuditLog.tag_id == response.json()["tag_id"])
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         assert entries == []
 
 
@@ -2404,9 +2412,7 @@ class TestTagHistoryIncomingRelations:
         assert items[0]["action_type"] == TagAuditActionType.RENAME
         assert items[0]["subject_tag"]["tag_id"] == tag.tag_id
 
-    async def test_link_fields_are_exposed(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_link_fields_are_exposed(self, client: AsyncClient, db_session: AsyncSession):
         tag = Tags(title="link fields exposed", type=TagType.THEME)
         db_session.add(tag)
         await db_session.commit()

--- a/tests/api/v1/test_tag_suggestion_stats.py
+++ b/tests/api/v1/test_tag_suggestion_stats.py
@@ -129,9 +129,7 @@ async def test_suggestion_stats_minimum_threshold(
     assert data["items"] == []
 
 
-async def test_suggestion_stats_at_threshold(
-    client: AsyncClient, db_session: AsyncSession
-) -> None:
+async def test_suggestion_stats_at_threshold(client: AsyncClient, db_session: AsyncSession) -> None:
     """Users at exactly the minimum threshold (5) are included."""
     user = await create_user(db_session, "atthreshold")
     image = await create_image(db_session, user.user_id)

--- a/tests/api/v1/test_tag_type_flags.py
+++ b/tests/api/v1/test_tag_type_flags.py
@@ -49,6 +49,7 @@ class TestTagTypeFlagsHelper:
         assert img.has_artist is True
 
         from sqlalchemy import delete
+
         await db_session.execute(
             delete(TagLinks).where(
                 TagLinks.image_id == img.image_id, TagLinks.tag_id == artist.tag_id
@@ -80,6 +81,7 @@ class TestTagTypeFlagsHelper:
         assert img.has_artist is True
 
         from sqlalchemy import delete
+
         await db_session.execute(
             delete(TagLinks).where(
                 TagLinks.image_id == img.image_id, TagLinks.tag_id == artist_a.tag_id

--- a/tests/api/v1/test_tag_usage_history.py
+++ b/tests/api/v1/test_tag_usage_history.py
@@ -114,9 +114,7 @@ class TestGetTagUsageHistory:
             assert item["tag_id"] == tag.tag_id
             assert item["action"] in ["added", "removed"]
 
-    async def test_includes_user_info(
-        self, client: AsyncClient, db_session: AsyncSession
-    ) -> None:
+    async def test_includes_user_info(self, client: AsyncClient, db_session: AsyncSession) -> None:
         """History entries should include user info."""
         # Create a user
         user = Users(
@@ -182,9 +180,7 @@ class TestGetTagUsageHistory:
         response = await client.get("/api/v1/tags/99999999/usage-history")
         assert response.status_code == 404
 
-    async def test_pagination_works(
-        self, client: AsyncClient, db_session: AsyncSession
-    ) -> None:
+    async def test_pagination_works(self, client: AsyncClient, db_session: AsyncSession) -> None:
         """Should support pagination."""
         # Create a user
         user = Users(
@@ -230,9 +226,7 @@ class TestGetTagUsageHistory:
         await db_session.commit()
 
         # Get first page with per_page=2
-        response = await client.get(
-            f"/api/v1/tags/{tag.tag_id}/usage-history?page=1&per_page=2"
-        )
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}/usage-history?page=1&per_page=2")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 1
@@ -241,18 +235,14 @@ class TestGetTagUsageHistory:
         assert data["total"] == 5
 
         # Get second page
-        response = await client.get(
-            f"/api/v1/tags/{tag.tag_id}/usage-history?page=2&per_page=2"
-        )
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}/usage-history?page=2&per_page=2")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 2
         assert len(data["items"]) == 2
 
         # Get third page
-        response = await client.get(
-            f"/api/v1/tags/{tag.tag_id}/usage-history?page=3&per_page=2"
-        )
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}/usage-history?page=3&per_page=2")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 3
@@ -359,9 +349,7 @@ class TestGetTagUsageHistory:
         assert data["items"][1]["tag_history_id"] == history2.tag_history_id
         assert data["items"][2]["tag_history_id"] == history1.tag_history_id
 
-    async def test_handles_null_user(
-        self, client: AsyncClient, db_session: AsyncSession
-    ) -> None:
+    async def test_handles_null_user(self, client: AsyncClient, db_session: AsyncSession) -> None:
         """Should handle history entries with null user_id gracefully."""
         # Create a tag
         tag = Tags(title="null user usage tag", type=TagType.THEME)
@@ -809,9 +797,7 @@ class TestGetTagUsageHistory:
 
         # Global rank 11 (offset=10) is history[5] (tie winner via lane DESC);
         # rank 12 (offset=11) is link[5].
-        response = await client.get(
-            f"/api/v1/tags/{tag.tag_id}/usage-history?page=11&per_page=1"
-        )
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}/usage-history?page=11&per_page=1")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 20
@@ -819,9 +805,7 @@ class TestGetTagUsageHistory:
         assert data["items"][0]["image_id"] == history_images[5].image_id
         assert data["items"][0]["action"] == "removed"
 
-        response = await client.get(
-            f"/api/v1/tags/{tag.tag_id}/usage-history?page=12&per_page=1"
-        )
+        response = await client.get(f"/api/v1/tags/{tag.tag_id}/usage-history?page=12&per_page=1")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 20

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -10,7 +10,7 @@ These tests cover the /api/v1/tags endpoints including:
 - Get images by tag
 """
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 import pytest
 from httpx import AsyncClient
@@ -20,10 +20,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.v1.tags import get_tag_hierarchy
 from app.config import TagType
 from app.core.security import get_password_hash
+from app.models.character_source_link import CharacterSourceLinks
 from app.models.image import Images
 from app.models.permissions import Perms, UserPerms
 from app.models.tag import Tags
-from app.models.character_source_link import CharacterSourceLinks
 from app.models.tag_external_link import TagExternalLinks
 from app.models.tag_link import TagLinks
 from app.models.user import Users
@@ -68,9 +68,7 @@ class TestListTags:
         assert data["total"] == 1
         assert data["tags"][0]["title"] == "school uniform"
 
-    async def test_search_tags_with_periods(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_search_tags_with_periods(self, client: AsyncClient, db_session: AsyncSession):
         """Test searching tags containing periods like 'C.C.'.
 
         MySQL fulltext treats periods as word delimiters, so "C.C." becomes tokens
@@ -95,9 +93,7 @@ class TestListTags:
         assert "Regular Tag" not in titles
 
     @pytest.mark.needs_commit
-    async def test_search_tags_with_hyphens(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_search_tags_with_hyphens(self, client: AsyncClient, db_session: AsyncSession):
         """Test searching tags containing hyphens like 'Deep-Blue Series'.
 
         MySQL fulltext treats hyphens as word delimiters, so "Deep-Blue" becomes
@@ -117,9 +113,7 @@ class TestListTags:
         titles = {tag["title"] for tag in data["tags"]}
         assert "Deep-Blue Series" in titles
 
-    async def test_filter_tags_by_type(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_filter_tags_by_type(self, client: AsyncClient, db_session: AsyncSession):
         """Test filtering tags by type."""
         # Create tags of different types
         tag1 = Tags(title="tag1", type=TagType.THEME)
@@ -136,9 +130,7 @@ class TestListTags:
         for tag in data["tags"]:
             assert tag["type"] == TagType.THEME
 
-    async def test_filter_tags_by_ids(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_filter_tags_by_ids(self, client: AsyncClient, db_session: AsyncSession):
         """Test filtering tags by specific IDs."""
         # Create test tags
         tag1 = Tags(title="tag1", type=TagType.THEME)
@@ -265,7 +257,9 @@ class TestListTags:
     ):
         """Test filtering tags by parent tag ID (get child tags)."""
         # Create parent tag
-        parent_tag = Tags(title="swimsuit", desc="Parent tag for swimsuit types", type=TagType.THEME)
+        parent_tag = Tags(
+            title="swimsuit", desc="Parent tag for swimsuit types", type=TagType.THEME
+        )
         db_session.add(parent_tag)
         await db_session.commit()
         await db_session.refresh(parent_tag)
@@ -448,9 +442,7 @@ class TestTagListSorting:
         titles = [t["title"] for t in data["tags"] if "usage" in t["title"]]
         assert titles == ["high usage", "mid usage", "low usage"]
 
-    async def test_sort_by_title_asc(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_sort_by_title_asc(self, client: AsyncClient, db_session: AsyncSession):
         """Test sorting tags alphabetically by title ascending."""
         tags = [
             Tags(title="cherry", type=TagType.SOURCE, usage_count=0),
@@ -467,9 +459,7 @@ class TestTagListSorting:
         titles = [t["title"] for t in data["tags"]]
         assert titles == ["apple", "banana", "cherry"]
 
-    async def test_sort_by_title_desc(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_sort_by_title_desc(self, client: AsyncClient, db_session: AsyncSession):
         """Test sorting tags alphabetically by title descending."""
         tags = [
             Tags(title="cherry", type=TagType.SOURCE, usage_count=0),
@@ -486,9 +476,7 @@ class TestTagListSorting:
         titles = [t["title"] for t in data["tags"]]
         assert titles == ["cherry", "banana", "apple"]
 
-    async def test_sort_by_tag_id_asc(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_sort_by_tag_id_asc(self, client: AsyncClient, db_session: AsyncSession):
         """Test sorting tags by tag_id ascending (chronological)."""
         tag1 = Tags(title="first created", type=TagType.ARTIST, usage_count=0)
         tag2 = Tags(title="second created", type=TagType.ARTIST, usage_count=0)
@@ -518,9 +506,7 @@ class TestTagListSorting:
         titles = [t["title"] for t in data["tags"]]
         assert titles == ["third created", "second created", "first created"]
 
-    async def test_sort_by_type(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_sort_by_type(self, client: AsyncClient, db_session: AsyncSession):
         """Test sorting tags by type."""
         tags = [
             Tags(title="sort type artist", type=TagType.ARTIST, usage_count=0),
@@ -540,9 +526,7 @@ class TestTagListSorting:
         # Types should be in ascending order
         assert types == sorted(types)
 
-    async def test_sort_by_usage_count_asc(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_sort_by_usage_count_asc(self, client: AsyncClient, db_session: AsyncSession):
         """Test sorting by usage_count ascending."""
         tags = [
             Tags(title="popular sort", type=TagType.CHARACTER, usage_count=200),
@@ -598,8 +582,7 @@ class TestTagListSorting:
     ):
         """Equal counts order by tag_id so pagination is stable across pages."""
         tags = [
-            Tags(title=f"tiebreak {i}", type=TagType.CHARACTER, usage_count=7)
-            for i in range(3)
+            Tags(title=f"tiebreak {i}", type=TagType.CHARACTER, usage_count=7) for i in range(3)
         ]
         for tag in tags:
             db_session.add(tag)
@@ -641,9 +624,7 @@ class TestTagListSorting:
         ids = [t["tag_id"] for t in response.json()["tags"] if t["title"].startswith("tiebreak")]
         assert ids == list(reversed(ids_in_creation_order))
 
-    async def test_sort_order_case_insensitive(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_sort_order_case_insensitive(self, client: AsyncClient, db_session: AsyncSession):
         """Test that sort_order accepts lowercase values."""
         response = await client.get("/api/v1/tags?sort_by=usage_count&sort_order=desc")
         assert response.status_code == 200
@@ -666,9 +647,7 @@ class TestTagListSorting:
         # With explicit sort_by=usage_count ASC, "match partial" (1) comes before
         # "match" (999), proving sort_by overrides relevance (which would put
         # the exact match "match" first).
-        response = await client.get(
-            "/api/v1/tags?search=match&sort_by=usage_count&sort_order=ASC"
-        )
+        response = await client.get("/api/v1/tags?search=match&sort_by=usage_count&sort_order=ASC")
         assert response.status_code == 200
         data = response.json()
         matching = [t for t in data["tags"] if t["title"].startswith("match")]
@@ -849,9 +828,7 @@ class TestAliasOfName:
                 assert tag["is_alias"] is True
 
     @pytest.mark.needs_commit  # FULLTEXT search requires committed data
-    async def test_alias_of_name_with_search(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_alias_of_name_with_search(self, client: AsyncClient, db_session: AsyncSession):
         """Test that alias_of_name works correctly with full-text search."""
         # Create original tag
         original_tag = Tags(
@@ -941,9 +918,7 @@ class TestFuzzyTagSearch:
     Searching "sakura kinomoto" should find "kinomoto sakura".
     """
 
-    async def test_short_query_prefix_match(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_short_query_prefix_match(self, client: AsyncClient, db_session: AsyncSession):
         """Test that short queries (< 3 chars) use prefix matching."""
         # Create test tags
         tag1 = Tags(title="sakura kinomoto", type=TagType.CHARACTER)
@@ -982,7 +957,9 @@ class TestFuzzyTagSearch:
         # Create tags with same words but different order
         tag1 = Tags(title="kinomoto sakura", type=TagType.CHARACTER)
         tag2 = Tags(title="sakura kinomoto", type=TagType.CHARACTER)
-        tag3 = Tags(title="sakura mitsuki", type=TagType.CHARACTER)  # Different person (not kinomoto)
+        tag3 = Tags(
+            title="sakura mitsuki", type=TagType.CHARACTER
+        )  # Different person (not kinomoto)
         db_session.add_all([tag1, tag2, tag3])
         await db_session.commit()
 
@@ -1032,14 +1009,14 @@ class TestFuzzyTagSearch:
         titles = {tag["title"] for tag in data["tags"]}
         assert "school uniform" in titles
 
-    async def test_full_text_relevance_sorting(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_full_text_relevance_sorting(self, client: AsyncClient, db_session: AsyncSession):
         """Test that full-text search results include relevant matches."""
         # Create tags with varying relevance
         tag1 = Tags(title="cat ears", type=TagType.THEME)  # Exact word match
         tag2 = Tags(title="feline ears", type=TagType.THEME)  # Contains "ears" but not "cat"
-        tag3 = Tags(title="category tags", type=TagType.THEME)  # "category" contains "cat" but is different word
+        tag3 = Tags(
+            title="category tags", type=TagType.THEME
+        )  # "category" contains "cat" but is different word
         db_session.add_all([tag1, tag2, tag3])
         await db_session.commit()
 
@@ -1099,9 +1076,7 @@ class TestFuzzyTagSearch:
         # Should find all tags starting with "sa" (case-insensitive)
         assert data["total"] == 3
 
-    async def test_search_with_stopwords(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_search_with_stopwords(self, client: AsyncClient, db_session: AsyncSession):
         """Test that search works correctly when query contains stopwords like 'The'.
 
         This addresses a bug where searching for "The Forgotten" would fail because
@@ -1130,9 +1105,7 @@ class TestFuzzyTagSearch:
         # Actually after fix, we filter out "The" as a stopword, so "Forgotten" is what's searched
         # This means "Forgotten Dreams" might also be returned - that's acceptable
 
-    async def test_search_with_short_terms(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_search_with_short_terms(self, client: AsyncClient, db_session: AsyncSession):
         """Test that search works when query contains very short terms (< 3 chars).
 
         MySQL/MariaDB fulltext has a minimum token size (default 3). Terms shorter
@@ -1232,9 +1205,7 @@ class TestFuzzyTagSearch:
         titles = {tag["title"] for tag in data["tags"]}
         assert "The Forgotten Field" in titles
 
-    async def test_hybrid_search_with_filters(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_hybrid_search_with_filters(self, client: AsyncClient, db_session: AsyncSession):
         """Test that fuzzy search works with other filters (type, exclude_aliases, etc)."""
         # Create test tags with different types
         tag1 = Tags(title="kinomoto sakura", type=TagType.CHARACTER)
@@ -1283,7 +1254,6 @@ class TestFuzzyTagSearch:
         assert data["total"] >= 1, "Search for 'yano_0o0' should find 'Yano (yano_0o0)'"
         titles = {tag["title"] for tag in data["tags"]}
         assert "Yano (yano_0o0)" in titles
-
 
 
 @pytest.mark.api
@@ -1353,7 +1323,9 @@ class TestGetTag:
         assert "date_added" in data
         assert data["date_added"] is not None
 
-    async def test_get_tag_includes_creator_avatar_url(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_get_tag_includes_creator_avatar_url(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
         """Ensure created_by includes avatar_url when user has an avatar"""
         from app.config import settings
 
@@ -1386,7 +1358,10 @@ class TestGetTag:
         data = response.json()
 
         assert data["created_by"]["avatar"] == "avatar.png"
-        assert data["created_by"]["avatar_url"] == f"{settings.IMAGE_BASE_URL}/images/avatars/avatar.png"
+        assert (
+            data["created_by"]["avatar_url"]
+            == f"{settings.IMAGE_BASE_URL}/images/avatars/avatar.png"
+        )
 
     async def test_get_tag_includes_creator_groups(
         self, client: AsyncClient, db_session: AsyncSession
@@ -1537,20 +1512,22 @@ class TestGetTag:
 
         # Create images with various statuses
         statuses = [
-            ImageStatus.ACTIVE,    # public
-            ImageStatus.ACTIVE,    # public
-            ImageStatus.SPOILER,   # public
-            ImageStatus.REPOST,    # public
-            ImageStatus.OTHER,     # non-public (status=0)
+            ImageStatus.ACTIVE,  # public
+            ImageStatus.ACTIVE,  # public
+            ImageStatus.SPOILER,  # public
+            ImageStatus.REPOST,  # public
+            ImageStatus.OTHER,  # non-public (status=0)
             ImageStatus.INAPPROPRIATE,  # non-public (status=-2)
         ]
         for i, status_val in enumerate(statuses):
             img_data = sample_image_data.copy()
-            img_data.update({
-                "filename": f"count-test-{i}",
-                "md5_hash": f"counttest{i:018d}",
-                "status": status_val,
-            })
+            img_data.update(
+                {
+                    "filename": f"count-test-{i}",
+                    "md5_hash": f"counttest{i:018d}",
+                    "status": status_val,
+                }
+            )
             img = Images(**img_data)
             db_session.add(img)
             await db_session.flush()
@@ -1595,11 +1572,13 @@ class TestGetTag:
         ]
         for i, status_val in enumerate(statuses):
             img_data = sample_image_data.copy()
-            img_data.update({
-                "filename": f"showall-test-{i}",
-                "md5_hash": f"showalltest{i:015d}",
-                "status": status_val,
-            })
+            img_data.update(
+                {
+                    "filename": f"showall-test-{i}",
+                    "md5_hash": f"showalltest{i:015d}",
+                    "status": status_val,
+                }
+            )
             img = Images(**img_data)
             db_session.add(img)
             await db_session.flush()
@@ -1648,11 +1627,13 @@ class TestGetTag:
         ]
         for i, status_val in enumerate(statuses):
             img_data = sample_image_data.copy()
-            img_data.update({
-                "filename": f"noshow-test-{i}",
-                "md5_hash": f"noshowtest{i:015d}",
-                "status": status_val,
-            })
+            img_data.update(
+                {
+                    "filename": f"noshow-test-{i}",
+                    "md5_hash": f"noshowtest{i:015d}",
+                    "status": status_val,
+                }
+            )
             img = Images(**img_data)
             db_session.add(img)
             await db_session.flush()
@@ -1660,12 +1641,14 @@ class TestGetTag:
 
         # User's own non-public image (should be counted)
         own_img_data = sample_image_data.copy()
-        own_img_data.update({
-            "filename": "noshow-own",
-            "md5_hash": "noshowown" + "0" * 16,
-            "status": ImageStatus.OTHER,
-            "user_id": user.user_id,
-        })
+        own_img_data.update(
+            {
+                "filename": "noshow-own",
+                "md5_hash": "noshowown" + "0" * 16,
+                "status": ImageStatus.OTHER,
+                "user_id": user.user_id,
+            }
+        )
         own_img = Images(**own_img_data)
         db_session.add(own_img)
         await db_session.flush()
@@ -1710,11 +1693,13 @@ class TestGetTag:
         statuses = [ImageStatus.ACTIVE, ImageStatus.ACTIVE, ImageStatus.SPOILER, ImageStatus.REPOST]
         for i, status_val in enumerate(statuses):
             img_data = sample_image_data.copy()
-            img_data.update({
-                "filename": f"hidereposts-{i}",
-                "md5_hash": f"hidereposts{i:015d}",
-                "status": status_val,
-            })
+            img_data.update(
+                {
+                    "filename": f"hidereposts-{i}",
+                    "md5_hash": f"hidereposts{i:015d}",
+                    "status": status_val,
+                }
+            )
             img = Images(**img_data)
             db_session.add(img)
             await db_session.flush()
@@ -1758,11 +1743,13 @@ class TestGetTag:
         statuses = [ImageStatus.ACTIVE, ImageStatus.OTHER, ImageStatus.REPOST]
         for i, status_val in enumerate(statuses):
             img_data = sample_image_data.copy()
-            img_data.update({
-                "filename": f"showallhide-{i}",
-                "md5_hash": f"showallhide{i:015d}",
-                "status": status_val,
-            })
+            img_data.update(
+                {
+                    "filename": f"showallhide-{i}",
+                    "md5_hash": f"showallhide{i:015d}",
+                    "status": status_val,
+                }
+            )
             img = Images(**img_data)
             db_session.add(img)
             await db_session.flush()
@@ -1864,9 +1851,7 @@ class TestGetImagesByTag:
         await db_session.commit()
 
         # tag_depth=0: only exact tag, no children
-        response = await client.get(
-            f"/api/v1/tags/{parent.tag_id}/images?tag_depth=0"
-        )
+        response = await client.get(f"/api/v1/tags/{parent.tag_id}/images?tag_depth=0")
 
         assert response.status_code == 200
         data = response.json()
@@ -1914,9 +1899,7 @@ class TestGetImagesByTag:
 class TestCreateTag:
     """Tests for POST /api/v1/tags endpoint (admin only)."""
 
-    async def test_create_tag_as_admin(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_create_tag_as_admin(self, client: AsyncClient, db_session: AsyncSession):
         """Test creating a tag as admin."""
         # Create TAG_CREATE permission
         perm = Perms(title="tag_create", desc="Create tags")
@@ -1971,9 +1954,7 @@ class TestCreateTag:
         assert data["type"] == TagType.THEME
 
         # Verify user_id is stored in database
-        tag_result = await db_session.execute(
-            select(Tags).where(Tags.tag_id == data["tag_id"])
-        )
+        tag_result = await db_session.execute(select(Tags).where(Tags.tag_id == data["tag_id"]))
         created_tag = tag_result.scalar_one()
         assert created_tag.user_id == admin.user_id
 
@@ -2058,9 +2039,7 @@ class TestCreateTag:
         assert response.status_code == 200
         assert response.json()["desc"] == "x" * 200
 
-    async def test_create_tag_as_non_admin(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_create_tag_as_non_admin(self, client: AsyncClient, db_session: AsyncSession):
         """Test non-admin user cannot create tags."""
         # Create regular user
         user = Users(
@@ -2105,9 +2084,7 @@ class TestCreateTag:
         response = await client.post("/api/v1/tags", json=tag_data)
         assert response.status_code == 401
 
-    async def test_create_duplicate_tag(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_create_duplicate_tag(self, client: AsyncClient, db_session: AsyncSession):
         """Test creating a duplicate tag."""
         # Create TAG_CREATE permission
         perm = Perms(title="tag_create", desc="Create tags")
@@ -2444,9 +2421,7 @@ class TestCreateTag:
 class TestUpdateTag:
     """Tests for PUT /api/v1/tags/{tag_id} endpoint (admin only)."""
 
-    async def test_update_tag_as_admin(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_update_tag_as_admin(self, client: AsyncClient, db_session: AsyncSession):
         """Test admin updating a tag."""
         # Create TAG_UPDATE permission
         perm = Perms(title="tag_update", desc="Update tags")
@@ -2553,9 +2528,7 @@ class TestUpdateTag:
         )
         assert response.status_code == 422
 
-    async def test_update_tag_as_non_admin(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_update_tag_as_non_admin(self, client: AsyncClient, db_session: AsyncSession):
         """Test non-admin cannot update tags."""
         # Create regular user
         user = Users(
@@ -2742,7 +2715,9 @@ class TestUpdateTag:
         await db_session.commit()
         await db_session.refresh(canonical)
 
-        alias = Tags(title="bathing suit upd", desc="", type=TagType.THEME, alias_of=canonical.tag_id)
+        alias = Tags(
+            title="bathing suit upd", desc="", type=TagType.THEME, alias_of=canonical.tag_id
+        )
         child = Tags(title="bikini upd", desc="", type=TagType.THEME)
         db_session.add_all([alias, child])
         await db_session.commit()
@@ -2810,8 +2785,12 @@ class TestUpdateTag:
         await db_session.commit()
         await db_session.refresh(parent)
 
-        child1 = Tags(title="bikini child", desc="", type=TagType.THEME, inheritedfrom_id=parent.tag_id)
-        child2 = Tags(title="one-piece", desc="", type=TagType.THEME, inheritedfrom_id=parent.tag_id)
+        child1 = Tags(
+            title="bikini child", desc="", type=TagType.THEME, inheritedfrom_id=parent.tag_id
+        )
+        child2 = Tags(
+            title="one-piece", desc="", type=TagType.THEME, inheritedfrom_id=parent.tag_id
+        )
         db_session.add_all([child1, child2])
         await db_session.commit()
         await db_session.refresh(child1)
@@ -3405,7 +3384,6 @@ class TestUpdateTag:
         alias_links = result.all()
         assert len(alias_links) == 0
 
-
     async def test_setting_alias_migrates_character_source_links_for_source(
         self, client: AsyncClient, db_session: AsyncSession
     ):
@@ -3892,8 +3870,12 @@ class TestUpdateTag:
             .execution_options(populate_existing=True)
         )
         pre_img = pre_result.scalar_one()
-        assert pre_img.has_artist is True, "Precondition failed: has_artist should be True before type change"
-        assert pre_img.has_source is False, "Precondition failed: has_source should be False before type change"
+        assert pre_img.has_artist is True, (
+            "Precondition failed: has_artist should be True before type change"
+        )
+        assert pre_img.has_source is False, (
+            "Precondition failed: has_source should be False before type change"
+        )
 
         # Login as admin
         login_response = await client.post(
@@ -3917,8 +3899,12 @@ class TestUpdateTag:
             .execution_options(populate_existing=True)
         )
         post_img = post_result.scalar_one()
-        assert post_img.has_artist is False, "has_artist should be False after tag type changed from ARTIST to SOURCE"
-        assert post_img.has_source is True, "has_source should be True after tag type changed from ARTIST to SOURCE"
+        assert post_img.has_artist is False, (
+            "has_artist should be False after tag type changed from ARTIST to SOURCE"
+        )
+        assert post_img.has_source is True, (
+            "has_source should be True after tag type changed from ARTIST to SOURCE"
+        )
 
     async def test_alias_reassignment_preserves_tag_type_flags(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict
@@ -3980,7 +3966,9 @@ class TestUpdateTag:
             .execution_options(populate_existing=True)
         )
         pre_img = pre_result.scalar_one()
-        assert pre_img.has_artist is True, "Precondition failed: has_artist should be True before alias reassignment"
+        assert pre_img.has_artist is True, (
+            "Precondition failed: has_artist should be True before alias reassignment"
+        )
 
         # Login as admin
         login_response = await client.post(
@@ -4004,7 +3992,9 @@ class TestUpdateTag:
             .execution_options(populate_existing=True)
         )
         post_img = post_result.scalar_one()
-        assert post_img.has_artist is True, "has_artist should still be True after alias reassignment"
+        assert post_img.has_artist is True, (
+            "has_artist should still be True after alias reassignment"
+        )
 
     async def test_setting_alias_reparents_incoming_alias(
         self, client: AsyncClient, db_session: AsyncSession
@@ -4173,9 +4163,7 @@ class TestUpdateTag:
         await db_session.commit()
         await db_session.refresh(tag_a)
 
-        tag_p = Tags(
-            title="Tag P type cascade", desc="", type=TagType.THEME, alias_of=tag_a.tag_id
-        )
+        tag_p = Tags(title="Tag P type cascade", desc="", type=TagType.THEME, alias_of=tag_a.tag_id)
         db_session.add(tag_p)
         await db_session.commit()
         await db_session.refresh(tag_p)
@@ -4319,9 +4307,7 @@ class TestUpdateTag:
         await db_session.refresh(source_tag)
 
         db_session.add(
-            CharacterSourceLinks(
-                character_tag_id=char_tag.tag_id, source_tag_id=source_tag.tag_id
-            )
+            CharacterSourceLinks(character_tag_id=char_tag.tag_id, source_tag_id=source_tag.tag_id)
         )
         await db_session.commit()
 
@@ -4358,9 +4344,7 @@ class TestUpdateTag:
         await db_session.refresh(source_tag)
 
         db_session.add(
-            CharacterSourceLinks(
-                character_tag_id=char_tag.tag_id, source_tag_id=source_tag.tag_id
-            )
+            CharacterSourceLinks(character_tag_id=char_tag.tag_id, source_tag_id=source_tag.tag_id)
         )
         await db_session.commit()
 
@@ -4390,9 +4374,7 @@ class TestUpdateTag:
         await db_session.refresh(source_tag)
 
         db_session.add(
-            CharacterSourceLinks(
-                character_tag_id=char_tag.tag_id, source_tag_id=source_tag.tag_id
-            )
+            CharacterSourceLinks(character_tag_id=char_tag.tag_id, source_tag_id=source_tag.tag_id)
         )
         await db_session.commit()
 
@@ -4502,9 +4484,7 @@ class TestUpdateTag:
 class TestDeleteTag:
     """Tests for DELETE /api/v1/tags/{tag_id} endpoint (admin only)."""
 
-    async def test_delete_tag_as_admin(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_delete_tag_as_admin(self, client: AsyncClient, db_session: AsyncSession):
         """Test admin deleting a tag."""
         # Create TAG_DELETE permission
         perm = Perms(title="tag_delete", desc="Delete tags")
@@ -4558,9 +4538,7 @@ class TestDeleteTag:
         get_response = await client.get(f"/api/v1/tags/{tag.tag_id}")
         assert get_response.status_code == 404
 
-    async def test_delete_tag_as_non_admin(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_delete_tag_as_non_admin(self, client: AsyncClient, db_session: AsyncSession):
         """Test non-admin cannot delete tags."""
         # Create regular user
         user = Users(
@@ -4652,7 +4630,9 @@ class TestDeleteTag:
             .execution_options(populate_existing=True)
         )
         pre_img = fresh_result.scalar_one()
-        assert pre_img.has_artist is True, "Precondition failed: has_artist should be True before delete"
+        assert pre_img.has_artist is True, (
+            "Precondition failed: has_artist should be True before delete"
+        )
 
         # Login as admin
         login_response = await client.post(
@@ -4675,16 +4655,16 @@ class TestDeleteTag:
             .execution_options(populate_existing=True)
         )
         post_img = post_result.scalar_one()
-        assert post_img.has_artist is False, "has_artist should be False after the only artist tag is deleted"
+        assert post_img.has_artist is False, (
+            "has_artist should be False after the only artist tag is deleted"
+        )
 
 
 @pytest.mark.api
 class TestAddTagLink:
     """Tests for POST /api/v1/tags/{tag_id}/links endpoint."""
 
-    async def test_add_link_to_tag(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_add_link_to_tag(self, client: AsyncClient, db_session: AsyncSession):
         """Test adding an external link to a tag."""
         # Create TAG_UPDATE permission
         perm = Perms(title="tag_update", desc="Update tags")
@@ -4741,9 +4721,7 @@ class TestAddTagLink:
         assert "link_id" in data
         assert "date_added" in data
 
-    async def test_add_link_without_protocol(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_add_link_without_protocol(self, client: AsyncClient, db_session: AsyncSession):
         """Test that URLs without http/https are rejected."""
         # Create TAG_UPDATE permission
         perm = Perms(title="tag_update", desc="Update tags")
@@ -4796,9 +4774,7 @@ class TestAddTagLink:
         )
         assert response.status_code == 422  # Validation error
 
-    async def test_add_empty_url(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_add_empty_url(self, client: AsyncClient, db_session: AsyncSession):
         """Test that empty URLs (whitespace only) are rejected."""
         # Create TAG_UPDATE permission
         perm = Perms(title="tag_update", desc="Update tags")
@@ -4851,9 +4827,7 @@ class TestAddTagLink:
         )
         assert response.status_code == 422  # Validation error
 
-    async def test_add_duplicate_link(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_add_duplicate_link(self, client: AsyncClient, db_session: AsyncSession):
         """Test that adding duplicate URL to same tag returns 409."""
         # Create TAG_UPDATE permission
         perm = Perms(title="tag_update", desc="Update tags")
@@ -4910,9 +4884,7 @@ class TestAddTagLink:
         )
         assert response.status_code == 409
 
-    async def test_add_link_to_nonexistent_tag(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_add_link_to_nonexistent_tag(self, client: AsyncClient, db_session: AsyncSession):
         """Test adding link to non-existent tag returns 404."""
         # Create TAG_UPDATE permission
         perm = Perms(title="tag_update", desc="Update tags")
@@ -4959,9 +4931,7 @@ class TestAddTagLink:
         )
         assert response.status_code == 404
 
-    async def test_add_link_without_permission(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_add_link_without_permission(self, client: AsyncClient, db_session: AsyncSession):
         """Test that users without TAG_UPDATE permission cannot add links."""
         # Create regular user without permission
         user = Users(
@@ -5003,9 +4973,7 @@ class TestAddTagLink:
 class TestDeleteTagLink:
     """Tests for DELETE /api/v1/tags/{tag_id}/links/{link_id} endpoint."""
 
-    async def test_delete_link_from_tag(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_delete_link_from_tag(self, client: AsyncClient, db_session: AsyncSession):
         """Test deleting an external link from a tag."""
         # Create TAG_UPDATE permission
         perm = Perms(title="tag_update", desc="Update tags")
@@ -5061,9 +5029,7 @@ class TestDeleteTagLink:
         )
         assert response.status_code == 204
 
-    async def test_delete_nonexistent_link(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_delete_nonexistent_link(self, client: AsyncClient, db_session: AsyncSession):
         """Test deleting non-existent link returns 404."""
         # Create TAG_UPDATE permission
         perm = Perms(title="tag_update", desc="Update tags")
@@ -5114,9 +5080,7 @@ class TestDeleteTagLink:
         )
         assert response.status_code == 404
 
-    async def test_delete_link_from_wrong_tag(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_delete_link_from_wrong_tag(self, client: AsyncClient, db_session: AsyncSession):
         """Test deleting link using wrong tag_id returns 404."""
         # Create TAG_UPDATE permission
         perm = Perms(title="tag_update", desc="Update tags")
@@ -5222,9 +5186,7 @@ class TestDeleteTagLink:
 class TestGetTagWithLinks:
     """Tests for GET /api/v1/tags/{tag_id} endpoint with links."""
 
-    async def test_get_tag_with_links(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_tag_with_links(self, client: AsyncClient, db_session: AsyncSession):
         """Test that tag details include external links with full metadata."""
         # Create tag with links
         tag = Tags(title="test tag", desc="Test", type=TagType.ARTIST)
@@ -5259,9 +5221,7 @@ class TestGetTagWithLinks:
             assert "date_added" in link
             assert isinstance(link["link_id"], int)
 
-    async def test_get_tag_without_links(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_get_tag_without_links(self, client: AsyncClient, db_session: AsyncSession):
         """Test that tags without links have empty links array."""
         # Create tag without links
         tag = Tags(title="test tag", desc="Test", type=TagType.ARTIST)
@@ -5480,9 +5440,7 @@ class TestTagLinkOrdering:
         )
         assert resp.status_code == 400
 
-    async def test_reorder_requires_permission(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_reorder_requires_permission(self, client: AsyncClient, db_session: AsyncSession):
         """A user without tag_update cannot reorder links."""
         user = Users(
             username="noreorderuser",
@@ -5520,9 +5478,7 @@ class TestTagLinkOrdering:
         )
         assert resp.status_code == 403
 
-    async def test_new_wiki_link_floats_to_top(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_new_wiki_link_floats_to_top(self, client: AsyncClient, db_session: AsyncSession):
         """A newly added shuu-wiki link goes to the very top, above an existing wiki link."""
         token = await self._admin_token(client, db_session, "wikitop")
 
@@ -5589,9 +5545,7 @@ class TestTagLinkOrdering:
         urls = [link["url"] for link in response.json()["links"]]
         assert urls[0] == "https://wiki.e-shuushuu.net/artists/iromi"
 
-    async def test_new_non_wiki_link_appends(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_new_non_wiki_link_appends(self, client: AsyncClient, db_session: AsyncSession):
         """A newly added non-wiki link appends (does not jump above existing links)."""
         token = await self._admin_token(client, db_session, "nonwiki")
 
@@ -5625,9 +5579,7 @@ class TestTagLinkOrdering:
 class TestUpdateTagExternalLink:
     """Tests for PATCH /tags/{tag_id}/links/{link_id} endpoint."""
 
-    async def test_mark_link_as_dead(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_mark_link_as_dead(self, client: AsyncClient, db_session: AsyncSession):
         """Test marking an external link as dead sets dead_at timestamp."""
         perm = Perms(title="tag_update", desc="Update tags")
         db_session.add(perm)
@@ -5739,11 +5691,12 @@ class TestUpdateTagExternalLink:
         assert response.status_code == 200
         data = response.json()
         assert data["dead_at"] is not None
-        assert data["archive_url"] == "https://web.archive.org/web/20090302035041/https://example.com/archived"
+        assert (
+            data["archive_url"]
+            == "https://web.archive.org/web/20090302035041/https://example.com/archived"
+        )
 
-    async def test_unmark_link_as_dead(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_unmark_link_as_dead(self, client: AsyncClient, db_session: AsyncSession):
         """Test setting is_dead=False clears dead_at."""
         perm = Perms(title="tag_update", desc="Update tags")
         db_session.add(perm)
@@ -5802,9 +5755,7 @@ class TestUpdateTagExternalLink:
         data = response.json()
         assert data["dead_at"] is None
 
-    async def test_set_archive_url_only(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_set_archive_url_only(self, client: AsyncClient, db_session: AsyncSession):
         """Test setting archive_url without changing dead status."""
         perm = Perms(title="tag_update", desc="Update tags")
         db_session.add(perm)
@@ -5850,17 +5801,20 @@ class TestUpdateTagExternalLink:
 
         response = await client.patch(
             f"/api/v1/tags/{tag.tag_id}/links/{link.link_id}",
-            json={"archive_url": "https://web.archive.org/web/2024/https://example.com/archive-only"},
+            json={
+                "archive_url": "https://web.archive.org/web/2024/https://example.com/archive-only"
+            },
             headers={"Authorization": f"Bearer {access_token}"},
         )
         assert response.status_code == 200
         data = response.json()
         assert data["dead_at"] is None
-        assert data["archive_url"] == "https://web.archive.org/web/2024/https://example.com/archive-only"
+        assert (
+            data["archive_url"]
+            == "https://web.archive.org/web/2024/https://example.com/archive-only"
+        )
 
-    async def test_update_nonexistent_link(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_update_nonexistent_link(self, client: AsyncClient, db_session: AsyncSession):
         """Test updating a nonexistent link returns 404."""
         perm = Perms(title="tag_update", desc="Update tags")
         db_session.add(perm)
@@ -5999,9 +5953,7 @@ class TestUpdateTagExternalLink:
         )
         assert response.status_code == 422
 
-    async def test_mark_dead_is_idempotent(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_mark_dead_is_idempotent(self, client: AsyncClient, db_session: AsyncSession):
         """Test that marking an already-dead link doesn't change dead_at timestamp."""
         perm = Perms(title="tag_update", desc="Update tags")
         db_session.add(perm)
@@ -6061,9 +6013,7 @@ class TestUpdateTagExternalLink:
         data = response.json()
         assert data["dead_at"] == "2025-01-01T00:00:00Z"
 
-    async def test_clear_archive_url(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_clear_archive_url(self, client: AsyncClient, db_session: AsyncSession):
         """Test that sending archive_url: null clears an existing archive URL."""
         perm = Perms(title="tag_update", desc="Update tags")
         db_session.add(perm)
@@ -6120,9 +6070,7 @@ class TestUpdateTagExternalLink:
         data = response.json()
         assert data["archive_url"] is None
 
-    async def test_update_link_on_wrong_tag(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_update_link_on_wrong_tag(self, client: AsyncClient, db_session: AsyncSession):
         """Test that patching a link via a different tag's URL returns 404."""
         perm = Perms(title="tag_update", desc="Update tags")
         db_session.add(perm)
@@ -6201,7 +6149,10 @@ class TestUpdateTagExternalLink:
         assert len(data["links"]) == 1
         link_data = data["links"][0]
         assert link_data["dead_at"] == "2025-06-15T00:00:00Z"
-        assert link_data["archive_url"] == "https://web.archive.org/web/2025/https://example.com/detail"
+        assert (
+            link_data["archive_url"]
+            == "https://web.archive.org/web/2025/https://example.com/detail"
+        )
 
 
 @pytest.mark.api
@@ -6294,23 +6245,17 @@ class TestGetTagHierarchy:
         await db_session.commit()
         await db_session.refresh(level1)
 
-        level2 = Tags(
-            title="level2", type=TagType.THEME, inheritedfrom_id=level1.tag_id
-        )
+        level2 = Tags(title="level2", type=TagType.THEME, inheritedfrom_id=level1.tag_id)
         db_session.add(level2)
         await db_session.commit()
         await db_session.refresh(level2)
 
-        level3 = Tags(
-            title="level3", type=TagType.THEME, inheritedfrom_id=level2.tag_id
-        )
+        level3 = Tags(title="level3", type=TagType.THEME, inheritedfrom_id=level2.tag_id)
         db_session.add(level3)
         await db_session.commit()
         await db_session.refresh(level3)
 
-        level4 = Tags(
-            title="level4", type=TagType.THEME, inheritedfrom_id=level3.tag_id
-        )
+        level4 = Tags(title="level4", type=TagType.THEME, inheritedfrom_id=level3.tag_id)
         db_session.add(level4)
         await db_session.commit()
         await db_session.refresh(level4)
@@ -6375,9 +6320,7 @@ class TestTagNameValidation:
     - Consecutive spaces are normalized to single space
     """
 
-    async def test_valid_latin_tag_name(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_valid_latin_tag_name(self, client: AsyncClient, db_session: AsyncSession):
         """Test that basic Latin letters are allowed."""
         # Create TAG_CREATE permission and admin user
         perm = Perms(title="tag_create", desc="Create tags")
@@ -6418,9 +6361,7 @@ class TestTagNameValidation:
         assert response.status_code == 200
         assert response.json()["title"] == "School Uniform"
 
-    async def test_reject_cjk_tag_name(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_reject_cjk_tag_name(self, client: AsyncClient, db_session: AsyncSession):
         """Test that CJK characters (Japanese kanji, Chinese) are rejected."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)
@@ -6506,9 +6447,7 @@ class TestTagNameValidation:
         )
         assert response.status_code == 422
 
-    async def test_reject_korean_tag_name(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_reject_korean_tag_name(self, client: AsyncClient, db_session: AsyncSession):
         """Test that Korean Hangul is rejected."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)
@@ -6591,7 +6530,7 @@ class TestTagNameValidation:
             "One, Two, Three",  # comma
         ]
 
-        for i, name in enumerate(valid_names):
+        for _i, name in enumerate(valid_names):
             response = await client.post(
                 "/api/v1/tags",
                 json={"title": name, "type": TagType.THEME},
@@ -6599,9 +6538,7 @@ class TestTagNameValidation:
             )
             assert response.status_code == 200, f"Failed for: {name}"
 
-    async def test_invalid_decorative_symbols(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_invalid_decorative_symbols(self, client: AsyncClient, db_session: AsyncSession):
         """Test that decorative unicode symbols are rejected."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)
@@ -6696,9 +6633,7 @@ class TestTagNameValidation:
             )
             assert response.status_code == 422, f"Should reject fullwidth: {name}"
 
-    async def test_invalid_cyrillic_greek(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_invalid_cyrillic_greek(self, client: AsyncClient, db_session: AsyncSession):
         """Test that Cyrillic and Greek letters are rejected."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)
@@ -6743,9 +6678,7 @@ class TestTagNameValidation:
             )
             assert response.status_code == 422, f"Should reject: {name}"
 
-    async def test_minimum_length_validation(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_minimum_length_validation(self, client: AsyncClient, db_session: AsyncSession):
         """Test that tag names must be at least 2 characters."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)
@@ -6791,9 +6724,7 @@ class TestTagNameValidation:
         )
         assert response.status_code == 200
 
-    async def test_maximum_length_validation(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_maximum_length_validation(self, client: AsyncClient, db_session: AsyncSession):
         """Test that tag names cannot exceed 255 characters."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)
@@ -6881,9 +6812,7 @@ class TestTagNameValidation:
         # The title should be normalized
         assert response.json()["title"] == "School Uniform"
 
-    async def test_reject_leading_bang_or_dash(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_reject_leading_bang_or_dash(self, client: AsyncClient, db_session: AsyncSession):
         """Test that tags starting with ! or - are rejected."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)
@@ -6944,9 +6873,7 @@ class TestTagNameValidation:
         )
         assert response.status_code == 200
 
-    async def test_reject_backtick_in_tag_name(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_reject_backtick_in_tag_name(self, client: AsyncClient, db_session: AsyncSession):
         """Test that backtick character is rejected."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)
@@ -6983,9 +6910,7 @@ class TestTagNameValidation:
         )
         assert response.status_code == 422
 
-    async def test_tag_update_validation(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_tag_update_validation(self, client: AsyncClient, db_session: AsyncSession):
         """Test that tag update also validates the title."""
         # Create permissions
         create_perm = Perms(title="tag_create", desc="Create tags")
@@ -7036,9 +6961,7 @@ class TestTagNameValidation:
         )
         assert response.status_code == 422
 
-    async def test_create_tag_requires_title(
-        self, client: AsyncClient, db_session: AsyncSession
-    ):
+    async def test_create_tag_requires_title(self, client: AsyncClient, db_session: AsyncSession):
         """Test that creating a tag without title is rejected."""
         perm = Perms(title="tag_create", desc="Create tags")
         db_session.add(perm)

--- a/tests/api/v1/test_url_import.py
+++ b/tests/api/v1/test_url_import.py
@@ -105,8 +105,9 @@ class TestFetchExternal:
         assert response.status_code == 403
 
     async def test_streams_image_with_baked_headers(self, resolve_client):
-        import httpx
         from unittest.mock import patch
+
+        import httpx
 
         from app.services.url_import.tokens import mint_token
 
@@ -132,8 +133,9 @@ class TestFetchExternal:
         assert seen["referer"] == "https://www.pixiv.net/"
 
     async def test_non_image_content_type_502(self, resolve_client):
-        import httpx
         from unittest.mock import patch
+
+        import httpx
 
         from app.services.url_import.tokens import mint_token
 
@@ -148,8 +150,9 @@ class TestFetchExternal:
         assert response.status_code == 502
 
     async def test_oversize_content_length_413(self, resolve_client):
-        import httpx
         from unittest.mock import patch
+
+        import httpx
 
         from app.config import settings
         from app.services.url_import.tokens import mint_token
@@ -172,8 +175,9 @@ class TestFetchExternal:
         assert response.status_code == 413
 
     async def test_malformed_content_length_ignored(self, resolve_client):
-        import httpx
         from unittest.mock import patch
+
+        import httpx
 
         from app.services.url_import.tokens import mint_token
 
@@ -192,11 +196,10 @@ class TestFetchExternal:
         assert response.status_code == 200
         assert response.content == b"\x89PNG-fake-bytes"
 
-    async def test_oversize_streaming_without_content_length_413(
-        self, resolve_client, monkeypatch
-    ):
-        import httpx
+    async def test_oversize_streaming_without_content_length_413(self, resolve_client, monkeypatch):
         from unittest.mock import patch
+
+        import httpx
 
         from app.config import settings
         from app.services.url_import.tokens import mint_token
@@ -220,9 +223,9 @@ class TestFetchExternal:
         assert response.status_code == 413
 
     async def test_webp_is_transcoded_to_png(self, resolve_client):
-        import httpx
         from unittest.mock import patch
 
+        import httpx
         from PIL import Image as PILImage
 
         from app.services.url_import.tokens import mint_token
@@ -232,9 +235,7 @@ class TestFetchExternal:
         webp_bytes = buffer.getvalue()
 
         def handler(request):
-            return httpx.Response(
-                200, content=webp_bytes, headers={"content-type": "image/webp"}
-            )
+            return httpx.Response(200, content=webp_bytes, headers={"content-type": "image/webp"})
 
         token = mint_token("https://cdn.bsky.app/img/feed_fullsize/plain/x/abc")
         with patch("app.api.v1.url_import._make_http_client", self._factory(handler)):
@@ -246,9 +247,9 @@ class TestFetchExternal:
         assert response.content[:8] == b"\x89PNG\r\n\x1a\n"
 
     async def test_webp_transcoded_despite_lying_content_type(self, resolve_client):
-        import httpx
         from unittest.mock import patch
 
+        import httpx
         from PIL import Image as PILImage
 
         from app.services.url_import.tokens import mint_token
@@ -260,9 +261,7 @@ class TestFetchExternal:
         def handler(request):
             # Upstream claims jpeg but actually serves webp bytes -- the
             # proxy must sniff the magic, not trust the header.
-            return httpx.Response(
-                200, content=webp_bytes, headers={"content-type": "image/jpeg"}
-            )
+            return httpx.Response(200, content=webp_bytes, headers={"content-type": "image/jpeg"})
 
         token = mint_token("https://example.test/lying.jpg")
         with patch("app.api.v1.url_import._make_http_client", self._factory(handler)):
@@ -274,17 +273,16 @@ class TestFetchExternal:
         assert response.content[:8] == b"\x89PNG\r\n\x1a\n"
 
     async def test_non_webp_passes_through_unchanged(self, resolve_client):
-        import httpx
         from unittest.mock import patch
+
+        import httpx
 
         from app.services.url_import.tokens import mint_token
 
         real_png = b"\x89PNG\r\n\x1a\n" + b"not-really-png-data-but-not-webp-either"
 
         def handler(request):
-            return httpx.Response(
-                200, content=real_png, headers={"content-type": "image/png"}
-            )
+            return httpx.Response(200, content=real_png, headers={"content-type": "image/png"})
 
         token = mint_token("https://example.test/real.png")
         with patch("app.api.v1.url_import._make_http_client", self._factory(handler)):
@@ -296,9 +294,9 @@ class TestFetchExternal:
         assert response.content == real_png
 
     async def test_animated_webp_rejected(self, resolve_client):
-        import httpx
         from unittest.mock import patch
 
+        import httpx
         from PIL import Image as PILImage
 
         from app.services.url_import.tokens import mint_token
@@ -312,9 +310,7 @@ class TestFetchExternal:
         webp_bytes = buffer.getvalue()
 
         def handler(request):
-            return httpx.Response(
-                200, content=webp_bytes, headers={"content-type": "image/webp"}
-            )
+            return httpx.Response(200, content=webp_bytes, headers={"content-type": "image/webp"})
 
         token = mint_token("https://example.test/animated.webp")
         with patch("app.api.v1.url_import._make_http_client", self._factory(handler)):
@@ -326,13 +322,12 @@ class TestFetchExternal:
 
     async def test_transcoded_png_too_large_413(self, resolve_client, monkeypatch):
         import os
-
-        import httpx
         from unittest.mock import patch
 
-        from app.config import settings
+        import httpx
         from PIL import Image as PILImage
 
+        from app.config import settings
         from app.services.url_import.tokens import mint_token
 
         # Random noise barely compresses under lossy webp (quality=1) but
@@ -350,9 +345,7 @@ class TestFetchExternal:
         assert len(webp_bytes) < 2000  # sanity: raw bytes must clear the cap
 
         def handler(request):
-            return httpx.Response(
-                200, content=webp_bytes, headers={"content-type": "image/webp"}
-            )
+            return httpx.Response(200, content=webp_bytes, headers={"content-type": "image/webp"})
 
         token = mint_token("https://example.test/noise.webp")
         with patch("app.api.v1.url_import._make_http_client", self._factory(handler)):
@@ -362,8 +355,9 @@ class TestFetchExternal:
         assert response.status_code == 413
 
     async def test_webp_decode_failure_502(self, resolve_client):
-        import httpx
         from unittest.mock import patch
+
+        import httpx
 
         from app.services.url_import.tokens import mint_token
 
@@ -373,9 +367,7 @@ class TestFetchExternal:
         garbage = b"RIFFxxxxWEBPnot-a-real-webp"
 
         def handler(request):
-            return httpx.Response(
-                200, content=garbage, headers={"content-type": "image/webp"}
-            )
+            return httpx.Response(200, content=garbage, headers={"content-type": "image/webp"})
 
         token = mint_token("https://example.test/garbage.webp")
         with patch("app.api.v1.url_import._make_http_client", self._factory(handler)):
@@ -386,8 +378,9 @@ class TestFetchExternal:
         assert "unreadable" in response.json()["detail"]
 
     async def test_upstream_500_becomes_502(self, resolve_client):
-        import httpx
         from unittest.mock import patch
+
+        import httpx
 
         from app.services.url_import.tokens import mint_token
 

--- a/tests/api/v1/test_user_history_endpoint.py
+++ b/tests/api/v1/test_user_history_endpoint.py
@@ -405,9 +405,7 @@ class TestGetUserHistory:
         assert data["items"] == []
         assert data["page"] == 1
 
-    async def test_pagination_works(
-        self, client: AsyncClient, db_session: AsyncSession
-    ) -> None:
+    async def test_pagination_works(self, client: AsyncClient, db_session: AsyncSession) -> None:
         """Should support pagination."""
         # Create a user
         user = Users(
@@ -440,9 +438,7 @@ class TestGetUserHistory:
         await db_session.commit()
 
         # Get first page with per_page=2
-        response = await client.get(
-            f"/api/v1/users/{user.user_id}/history?page=1&per_page=2"
-        )
+        response = await client.get(f"/api/v1/users/{user.user_id}/history?page=1&per_page=2")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 1
@@ -451,18 +447,14 @@ class TestGetUserHistory:
         assert data["total"] == 5
 
         # Get second page
-        response = await client.get(
-            f"/api/v1/users/{user.user_id}/history?page=2&per_page=2"
-        )
+        response = await client.get(f"/api/v1/users/{user.user_id}/history?page=2&per_page=2")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 2
         assert len(data["items"]) == 2
 
         # Get third page
-        response = await client.get(
-            f"/api/v1/users/{user.user_id}/history?page=3&per_page=2"
-        )
+        response = await client.get(f"/api/v1/users/{user.user_id}/history?page=3&per_page=2")
         assert response.status_code == 200
         data = response.json()
         assert data["page"] == 3

--- a/tests/api/v1/test_user_ratings_endpoint.py
+++ b/tests/api/v1/test_user_ratings_endpoint.py
@@ -31,7 +31,9 @@ async def _make_user(db_session: AsyncSession, username: str) -> Users:
     return user
 
 
-async def _make_image(db_session: AsyncSession, owner: Users, suffix: str, status: int = 1) -> Images:
+async def _make_image(
+    db_session: AsyncSession, owner: Users, suffix: str, status: int = 1
+) -> Images:
     # Field set mirrors the `test_image` fixture in tests/conftest.py — `rating`
     # and `locked` are not nullable and have no server default.
     image = Images(
@@ -74,9 +76,7 @@ class TestUserRatingsHappyPath:
         image = await _make_image(db_session, rater, "aaa")
         await _rate(db_session, rater, image, 7)
 
-        response = await _authenticate(client, rater).get(
-            f"/api/v1/users/{rater.user_id}/ratings"
-        )
+        response = await _authenticate(client, rater).get(f"/api/v1/users/{rater.user_id}/ratings")
 
         assert response.status_code == 200
         body = response.json()
@@ -100,9 +100,7 @@ class TestUserRatingsHappyPath:
         await _rate(db_session, rater, mine, 5)
         await _rate(db_session, stranger, theirs, 9)
 
-        response = await _authenticate(client, rater).get(
-            f"/api/v1/users/{rater.user_id}/ratings"
-        )
+        response = await _authenticate(client, rater).get(f"/api/v1/users/{rater.user_id}/ratings")
 
         assert response.status_code == 200
         body = response.json()
@@ -120,9 +118,7 @@ class TestUserRatingsHappyPath:
         db_session.add(Favorites(user_id=rater.user_id, image_id=loved.image_id))
         await db_session.commit()
 
-        response = await _authenticate(client, rater).get(
-            f"/api/v1/users/{rater.user_id}/ratings"
-        )
+        response = await _authenticate(client, rater).get(f"/api/v1/users/{rater.user_id}/ratings")
 
         assert response.status_code == 200
         by_id = {img["image_id"]: img["is_favorited"] for img in response.json()["images"]}
@@ -149,9 +145,7 @@ class TestUserRatingsAuthorization:
         image = await _make_image(db_session, rater, "eee")
         await _rate(db_session, rater, image, 6)
 
-        response = await _authenticate(client, nosy).get(
-            f"/api/v1/users/{rater.user_id}/ratings"
-        )
+        response = await _authenticate(client, nosy).get(f"/api/v1/users/{rater.user_id}/ratings")
 
         assert response.status_code == 403
 
@@ -164,9 +158,7 @@ class TestUserRatingsAuthorization:
         image = await _make_image(db_session, rater, "fff")
         await _rate(db_session, rater, image, 10)
 
-        response = await _authenticate(client, mod).get(
-            f"/api/v1/users/{rater.user_id}/ratings"
-        )
+        response = await _authenticate(client, mod).get(f"/api/v1/users/{rater.user_id}/ratings")
 
         assert response.status_code == 200
         body = response.json()
@@ -195,9 +187,7 @@ class TestUserRatingsVisibility:
         await _rate(db_session, rater, visible, 3)
         await _rate(db_session, rater, hidden, 8)
 
-        response = await _authenticate(client, rater).get(
-            f"/api/v1/users/{rater.user_id}/ratings"
-        )
+        response = await _authenticate(client, rater).get(f"/api/v1/users/{rater.user_id}/ratings")
 
         assert response.status_code == 200
         body = response.json()
@@ -216,9 +206,7 @@ class TestUserRatingsVisibility:
         await _rate(db_session, rater, visible, 3)
         await _rate(db_session, rater, hidden, 8)
 
-        response = await _authenticate(client, mod).get(
-            f"/api/v1/users/{rater.user_id}/ratings"
-        )
+        response = await _authenticate(client, mod).get(f"/api/v1/users/{rater.user_id}/ratings")
 
         assert response.status_code == 200
         body = response.json()
@@ -301,9 +289,7 @@ class TestUserRatingsFiltersAndSorting:
             await _rate(db_session, rater, image, score)
             images.append(image)
 
-        response = await _authenticate(client, rater).get(
-            f"/api/v1/users/{rater.user_id}/ratings"
-        )
+        response = await _authenticate(client, rater).get(f"/api/v1/users/{rater.user_id}/ratings")
 
         assert response.status_code == 200
         returned = [img["image_id"] for img in response.json()["images"]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,8 +26,8 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine, text
-from sqlalchemy.exc import OperationalError
 from sqlalchemy.engine import make_url
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.database import get_db
@@ -41,10 +41,14 @@ from app.main import app as main_app
 # Override via environment variables if your local setup differs
 
 DEFAULT_TEST_DB_USER = "shuushuu"
-DEFAULT_TEST_DB_PASSWORD = "shuushuu_password"  # Matches local .env; CI overrides via TEST_DATABASE_URL
+DEFAULT_TEST_DB_PASSWORD = (
+    "shuushuu_password"  # Matches local .env; CI overrides via TEST_DATABASE_URL
+)
 DEFAULT_TEST_DB_HOST = "localhost"
 DEFAULT_TEST_DB_PORT = "3306"
-DEFAULT_TEST_DB_NAME = "shuushuu_pytest"  # Separate from staging environment (shuushuu_test on the test host)
+DEFAULT_TEST_DB_NAME = (
+    "shuushuu_pytest"  # Separate from staging environment (shuushuu_test on the test host)
+)
 DEFAULT_ROOT_PASSWORD = "root_password"
 
 # Under pytest-xdist each worker process gets its own database (and Redis DB)
@@ -170,7 +174,9 @@ def setup_test_database():
 
     # Get MySQL root password from environment or use default
     # First try MARIADB_ROOT_PASSWORD (from .env files), then fall back to MYSQL_ROOT_PASSWORD
-    root_password = os.getenv("MARIADB_ROOT_PASSWORD") or os.getenv("MYSQL_ROOT_PASSWORD", DEFAULT_ROOT_PASSWORD)
+    root_password = os.getenv("MARIADB_ROOT_PASSWORD") or os.getenv(
+        "MYSQL_ROOT_PASSWORD", DEFAULT_ROOT_PASSWORD
+    )
 
     # Get test user credentials (these can be overridden via environment)
     test_user = os.getenv("TEST_DB_USER", DEFAULT_TEST_DB_USER)
@@ -428,7 +434,7 @@ async def _create_test_users(session: AsyncSession) -> None:
 
 
 @pytest.fixture(scope="function")
-async def db_session(engine, request) -> AsyncGenerator[AsyncSession, None]:
+async def db_session(engine, request) -> AsyncGenerator[AsyncSession]:
     """
     Create a new database session for each test.
 
@@ -583,7 +589,7 @@ def app(db_session: AsyncSession, mock_redis) -> FastAPI:
     This overrides the database dependency to use the test session.
     """
 
-    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+    async def override_get_db() -> AsyncGenerator[AsyncSession]:
         yield db_session
 
     async def override_get_redis():
@@ -601,7 +607,7 @@ def app(db_session: AsyncSession, mock_redis) -> FastAPI:
 def app_real_redis(db_session: AsyncSession, redis_client) -> FastAPI:
     """FastAPI app wired to the real Redis client (instead of mock_redis)."""
 
-    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+    async def override_get_db() -> AsyncGenerator[AsyncSession]:
         yield db_session
 
     async def override_get_redis():
@@ -616,7 +622,7 @@ def app_real_redis(db_session: AsyncSession, redis_client) -> FastAPI:
 
 
 @pytest.fixture(scope="function")
-async def client(app: FastAPI) -> AsyncGenerator[AsyncClient, None]:
+async def client(app: FastAPI) -> AsyncGenerator[AsyncClient]:
     """
     Create async HTTP client for testing API endpoints.
 
@@ -633,7 +639,7 @@ async def client(app: FastAPI) -> AsyncGenerator[AsyncClient, None]:
 
 
 @pytest.fixture(scope="function")
-async def client_real_redis(app_real_redis: FastAPI) -> AsyncGenerator[AsyncClient, None]:
+async def client_real_redis(app_real_redis: FastAPI) -> AsyncGenerator[AsyncClient]:
     """Async HTTP client using app_real_redis (real Redis override)."""
     async with AsyncClient(
         transport=ASGITransport(app=app_real_redis),

--- a/tests/integration/test_banner_preferences_service.py
+++ b/tests/integration/test_banner_preferences_service.py
@@ -120,8 +120,9 @@ class TestPinBanner:
         assert pin.banner_id == banner.banner_id
 
     async def test_rejects_nonexistent_banner(self, db_session: AsyncSession):
-        from app.services.banner import pin_banner
         from fastapi import HTTPException
+
+        from app.services.banner import pin_banner
 
         with pytest.raises(HTTPException) as exc_info:
             await pin_banner(
@@ -134,8 +135,9 @@ class TestPinBanner:
         assert exc_info.value.status_code == 404
 
     async def test_rejects_inactive_banner(self, db_session: AsyncSession):
-        from app.services.banner import pin_banner
         from fastapi import HTTPException
+
+        from app.services.banner import pin_banner
 
         banner = Banners(
             name="inactive",
@@ -160,8 +162,9 @@ class TestPinBanner:
         assert exc_info.value.status_code == 400
 
     async def test_rejects_size_mismatch(self, db_session: AsyncSession):
-        from app.services.banner import pin_banner
         from fastapi import HTTPException
+
+        from app.services.banner import pin_banner
 
         banner = Banners(
             name="large_banner",
@@ -186,8 +189,9 @@ class TestPinBanner:
         assert exc_info.value.status_code == 400
 
     async def test_rejects_theme_mismatch(self, db_session: AsyncSession):
-        from app.services.banner import pin_banner
         from fastapi import HTTPException
+
+        from app.services.banner import pin_banner
 
         banner = Banners(
             name="light_only",
@@ -290,9 +294,7 @@ class TestUnpinBanner:
         db_session.add(pin)
         await db_session.commit()
 
-        await unpin_banner(
-            user_id=1, size=BannerSize.small, theme=BannerTheme.dark, db=db_session
-        )
+        await unpin_banner(user_id=1, size=BannerSize.small, theme=BannerTheme.dark, db=db_session)
 
         from sqlalchemy import select
 
@@ -306,8 +308,9 @@ class TestUnpinBanner:
         assert result.scalar_one_or_none() is None
 
     async def test_404_when_no_pin(self, db_session: AsyncSession):
-        from app.services.banner import unpin_banner
         from fastapi import HTTPException
+
+        from app.services.banner import unpin_banner
 
         with pytest.raises(HTTPException) as exc_info:
             await unpin_banner(
@@ -319,14 +322,20 @@ class TestUnpinBanner:
 @pytest.mark.integration
 class TestGetCurrentBannerWithPreferences:
     async def test_anonymous_uses_query_param_size(
-        self, db_session: AsyncSession, redis_client: redis.Redis,
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,
     ):
         """Anonymous user: size comes from query param, not preferences."""
         from app.services.banner import get_current_banner
 
         banner = Banners(
-            name="small_banner", size=BannerSize.small, supports_dark=True,
-            supports_light=True, full_image="s.png", active=True,
+            name="small_banner",
+            size=BannerSize.small,
+            supports_dark=True,
+            supports_light=True,
+            full_image="s.png",
+            active=True,
         )
         db_session.add(banner)
         await db_session.commit()
@@ -335,7 +344,9 @@ class TestGetCurrentBannerWithPreferences:
         assert result.size == BannerSize.small
 
     async def test_authenticated_user_preferred_size_overrides_param(
-        self, db_session: AsyncSession, redis_client: redis.Redis,
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,
     ):
         """Authenticated user with preferred_size=large gets large banners."""
         from app.services.banner import get_current_banner
@@ -344,75 +355,115 @@ class TestGetCurrentBannerWithPreferences:
         db_session.add(prefs)
 
         banner = Banners(
-            name="large_banner", size=BannerSize.large, supports_dark=True,
-            supports_light=True, full_image="lg.png", active=True,
+            name="large_banner",
+            size=BannerSize.large,
+            supports_dark=True,
+            supports_light=True,
+            full_image="lg.png",
+            active=True,
         )
         db_session.add(banner)
         await db_session.commit()
 
         # Pass user_id=1; the size param "small" should be overridden by preferred_size
         result = await get_current_banner(
-            "dark", "small", db_session, redis_client, user_id=1,
+            "dark",
+            "small",
+            db_session,
+            redis_client,
+            user_id=1,
         )
         assert result.size == BannerSize.large
 
     async def test_authenticated_user_with_pin_returns_pinned(
-        self, db_session: AsyncSession, redis_client: redis.Redis,
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,
     ):
         """Authenticated user with a pin for the effective size+theme gets pinned banner."""
         from app.services.banner import get_current_banner
 
         pinned = Banners(
-            name="my_fave", size=BannerSize.small, supports_dark=True,
-            supports_light=True, full_image="fave.png", active=True,
+            name="my_fave",
+            size=BannerSize.small,
+            supports_dark=True,
+            supports_light=True,
+            full_image="fave.png",
+            active=True,
         )
         other = Banners(
-            name="other", size=BannerSize.small, supports_dark=True,
-            supports_light=True, full_image="other.png", active=True,
+            name="other",
+            size=BannerSize.small,
+            supports_dark=True,
+            supports_light=True,
+            full_image="other.png",
+            active=True,
         )
         db_session.add_all([pinned, other])
         await db_session.commit()
         await db_session.refresh(pinned)
 
         pin = UserBannerPins(
-            user_id=1, size=BannerSize.small, theme=BannerTheme.dark,
+            user_id=1,
+            size=BannerSize.small,
+            theme=BannerTheme.dark,
             banner_id=pinned.banner_id,
         )
         db_session.add(pin)
         await db_session.commit()
 
         result = await get_current_banner(
-            "dark", "small", db_session, redis_client, user_id=1,
+            "dark",
+            "small",
+            db_session,
+            redis_client,
+            user_id=1,
         )
         assert result.banner_id == pinned.banner_id
         assert result.name == "my_fave"
 
     async def test_pinned_inactive_banner_falls_through(
-        self, db_session: AsyncSession, redis_client: redis.Redis,
+        self,
+        db_session: AsyncSession,
+        redis_client: redis.Redis,
     ):
         """Pin on inactive banner falls through to normal rotation."""
         from app.services.banner import get_current_banner
 
         inactive = Banners(
-            name="inactive_pinned", size=BannerSize.small, supports_dark=True,
-            supports_light=True, full_image="inactive.png", active=False,
+            name="inactive_pinned",
+            size=BannerSize.small,
+            supports_dark=True,
+            supports_light=True,
+            full_image="inactive.png",
+            active=False,
         )
         fallback = Banners(
-            name="fallback", size=BannerSize.small, supports_dark=True,
-            supports_light=True, full_image="fallback.png", active=True,
+            name="fallback",
+            size=BannerSize.small,
+            supports_dark=True,
+            supports_light=True,
+            full_image="fallback.png",
+            active=True,
         )
         db_session.add_all([inactive, fallback])
         await db_session.commit()
         await db_session.refresh(inactive)
 
         pin = UserBannerPins(
-            user_id=1, size=BannerSize.small, theme=BannerTheme.dark,
+            user_id=1,
+            size=BannerSize.small,
+            theme=BannerTheme.dark,
             banner_id=inactive.banner_id,
         )
         db_session.add(pin)
         await db_session.commit()
 
         result = await get_current_banner(
-            "dark", "small", db_session, redis_client, user_id=1,
+            "dark",
+            "small",
+            db_session,
+            redis_client,
+            user_id=1,
         )
         assert result.name == "fallback"

--- a/tests/integration/test_banner_service.py
+++ b/tests/integration/test_banner_service.py
@@ -7,7 +7,7 @@ import redis.asyncio as redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
-from app.models.misc import BannerSize, Banners
+from app.models.misc import Banners, BannerSize
 
 
 @pytest.mark.integration

--- a/tests/integration/test_datetime_round_trip.py
+++ b/tests/integration/test_datetime_round_trip.py
@@ -51,9 +51,7 @@ async def temp_dt_table(engine: AsyncEngine):
 class TestUtcDateTimeRoundTrip:
     """End-to-end round-trip through the aiomysql driver."""
 
-    async def test_utc_aware_round_trips(
-        self, engine: AsyncEngine, temp_dt_table: Table
-    ):
+    async def test_utc_aware_round_trips(self, engine: AsyncEngine, temp_dt_table: Table):
         """A UTC-aware datetime survives write+read with tz preserved."""
         ts = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
 
@@ -63,9 +61,7 @@ class TestUtcDateTimeRoundTrip:
 
         async with engine.connect() as conn:
             row = (
-                await conn.execute(
-                    select(temp_dt_table.c.ts).where(temp_dt_table.c.id == row_id)
-                )
+                await conn.execute(select(temp_dt_table.c.ts).where(temp_dt_table.c.id == row_id))
             ).one()
 
         loaded = row.ts
@@ -87,9 +83,7 @@ class TestUtcDateTimeRoundTrip:
 
         async with engine.connect() as conn:
             row = (
-                await conn.execute(
-                    select(temp_dt_table.c.ts).where(temp_dt_table.c.id == row_id)
-                )
+                await conn.execute(select(temp_dt_table.c.ts).where(temp_dt_table.c.id == row_id))
             ).one()
 
         loaded = row.ts
@@ -97,9 +91,7 @@ class TestUtcDateTimeRoundTrip:
         assert loaded == ts_est  # equal as instants
         assert loaded.tzinfo == UTC
 
-    async def test_naive_datetime_bind_raises(
-        self, engine: AsyncEngine, temp_dt_table: Table
-    ):
+    async def test_naive_datetime_bind_raises(self, engine: AsyncEngine, temp_dt_table: Table):
         """Binding a naive datetime raises TypeError before hitting the DB.
 
         SQLAlchemy wraps bind-time exceptions in StatementError; assert the

--- a/tests/integration/test_fk_constraint_names.py
+++ b/tests/integration/test_fk_constraint_names.py
@@ -39,9 +39,7 @@ def test_all_fks_use_fk_prefix_convention():
                 name = fk.get("name") or ""
                 cols = ",".join(fk.get("constrained_columns") or [])
                 if not name.startswith("fk_"):
-                    failures.append(
-                        f"{table}({cols}): expected fk_-prefixed name, got {name!r}"
-                    )
+                    failures.append(f"{table}({cols}): expected fk_-prefixed name, got {name!r}")
     finally:
         engine.dispose()
 
@@ -49,6 +47,5 @@ def test_all_fks_use_fk_prefix_convention():
         pytest.fail(
             "FK constraints without explicit fk_-prefixed names found. "
             "Add `name=` to the ForeignKeyConstraint(...) in the migration "
-            "that created the table. Convention: fk_<table>_<column>.\n\n"
-            + "\n".join(failures)
+            "that created the table. Convention: fk_<table>_<column>.\n\n" + "\n".join(failures)
         )

--- a/tests/integration/test_generate_character_mappings.py
+++ b/tests/integration/test_generate_character_mappings.py
@@ -30,6 +30,7 @@ def _mr(danbooru: str, iid: int, action: str = "map", match_type: str = "exact")
         action=action,
     )
 
+
 # (tag_id, title)
 INTERNAL = [
     (82250, "Kinomoto Sakura"),
@@ -136,7 +137,9 @@ def test_linked_only_demotes_merge_collisions_even_if_linked():
 
 
 def test_linked_only_leaves_review_and_ignore_untouched():
-    res = [_mr("x", 0, action="review", match_type="fuzzy"),
-           _mr("y", 0, action="ignore", match_type="none")]
+    res = [
+        _mr("x", 0, action="review", match_type="fuzzy"),
+        _mr("y", 0, action="ignore", match_type="none"),
+    ]
     out = apply_linked_only(res, {10})
     assert [r.action for r in out] == ["review", "ignore"]

--- a/tests/integration/test_import_tag_mappings.py
+++ b/tests/integration/test_import_tag_mappings.py
@@ -7,7 +7,6 @@ loaded theme tags, so every character mapping silently failed to import.
 
 from pathlib import Path
 
-import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -109,10 +108,14 @@ async def test_import_unchanged_when_mapping_matches(
     assert summary["updated"] == 0
     assert summary["unchanged"] == 1
     rows = (
-        await db_session.execute(
-            select(TagMappings).where(TagMappings.external_tag == "zzz_existing")
+        (
+            await db_session.execute(
+                select(TagMappings).where(TagMappings.external_tag == "zzz_existing")
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(rows) == 1  # not duplicated
 
 
@@ -127,17 +130,13 @@ async def test_import_maps_by_explicit_id_ignoring_ambiguity(
     await db_session.flush()
 
     # title alone would be ambiguous; the explicit id pins it to the theme tag
-    csv_path = _write_csv_with_id(
-        tmp_path, [("zzz_dup", "Zzz Dup", str(theme.tag_id), "map")]
-    )
+    csv_path = _write_csv_with_id(tmp_path, [("zzz_dup", "Zzz Dup", str(theme.tag_id), "map")])
     summary = await import_mappings(db_session, csv_path)
 
     assert summary["created"] == 1
     assert summary["errors"] == []
     row = (
-        await db_session.execute(
-            select(TagMappings).where(TagMappings.external_tag == "zzz_dup")
-        )
+        await db_session.execute(select(TagMappings).where(TagMappings.external_tag == "zzz_dup"))
     ).scalar_one()
     assert row.internal_tag_id == theme.tag_id
 
@@ -151,22 +150,16 @@ async def test_import_upsert_updates_changed_target(
     b = Tags(title="Zzz Target B", type=4, user_id=user.user_id)
     db_session.add_all([a, b])
     await db_session.flush()
-    db_session.add(
-        TagMappings(external_tag="zzz_move", internal_tag_id=a.tag_id, confidence=1.0)
-    )
+    db_session.add(TagMappings(external_tag="zzz_move", internal_tag_id=a.tag_id, confidence=1.0))
     await db_session.flush()
 
-    csv_path = _write_csv_with_id(
-        tmp_path, [("zzz_move", "Zzz Target B", str(b.tag_id), "map")]
-    )
+    csv_path = _write_csv_with_id(tmp_path, [("zzz_move", "Zzz Target B", str(b.tag_id), "map")])
     summary = await import_mappings(db_session, csv_path)
 
     assert summary["created"] == 0
     assert summary["updated"] == 1
     row = (
-        await db_session.execute(
-            select(TagMappings).where(TagMappings.external_tag == "zzz_move")
-        )
+        await db_session.execute(select(TagMappings).where(TagMappings.external_tag == "zzz_move"))
     ).scalar_one()
     assert row.internal_tag_id == b.tag_id
 
@@ -176,9 +169,7 @@ async def test_import_explicit_id_not_found_is_error(
 ) -> None:
     """An internal_tag_id that doesn't exist is reported as an error and not mapped."""
     await _make_user(db_session)
-    csv_path = _write_csv_with_id(
-        tmp_path, [("zzz_ghost", "Whatever", "999999999", "map")]
-    )
+    csv_path = _write_csv_with_id(tmp_path, [("zzz_ghost", "Whatever", "999999999", "map")])
     summary = await import_mappings(db_session, csv_path)
 
     assert summary["created"] == 0
@@ -186,9 +177,7 @@ async def test_import_explicit_id_not_found_is_error(
     assert isinstance(errors, list) and len(errors) == 1
     assert "999999999" in errors[0]
     row = (
-        await db_session.execute(
-            select(TagMappings).where(TagMappings.external_tag == "zzz_ghost")
-        )
+        await db_session.execute(select(TagMappings).where(TagMappings.external_tag == "zzz_ghost"))
     ).scalar_one_or_none()
     assert row is None
 

--- a/tests/integration/test_ml_gpu_infer.py
+++ b/tests/integration/test_ml_gpu_infer.py
@@ -30,7 +30,9 @@ assert _spec is not None and _spec.loader is not None
 ml_gpu_infer = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(ml_gpu_infer)
 
-_MODEL_DIR = Path(os.environ.get("ML_MODELS_PATH", "ml_models")) / "swinv2_base_window8_256.dbv4-full"
+_MODEL_DIR = (
+    Path(os.environ.get("ML_MODELS_PATH", "ml_models")) / "swinv2_base_window8_256.dbv4-full"
+)
 
 
 @pytest.mark.unit
@@ -60,8 +62,12 @@ def test_standalone_preprocess_matches_canonical(tmp_path):
     # non-square pipeline through both copies so the twin cannot diverge on the
     # width/height axis silently.
     nonsquare_pipeline = [
-        {"type": "pad_to_size", "size": [400, 512], "background_color": "white",
-         "interpolation": "bilinear"},
+        {
+            "type": "pad_to_size",
+            "size": [400, 512],
+            "background_color": "white",
+            "interpolation": "bilinear",
+        },
         {"type": "resize", "size": [200, 256], "interpolation": "bicubic"},
         {"type": "center_crop", "size": [128, 192]},
         {"type": "maybe_to_tensor"},
@@ -70,9 +76,7 @@ def test_standalone_preprocess_matches_canonical(tmp_path):
     mine_ns = ml_gpu_infer.apply_test_pipeline(
         ml_gpu_infer.load_rgb(str(img_path)), nonsquare_pipeline
     )
-    want_ns = canonical.apply_test_pipeline(
-        canonical.load_rgb(str(img_path)), nonsquare_pipeline
-    )
+    want_ns = canonical.apply_test_pipeline(canonical.load_rgb(str(img_path)), nonsquare_pipeline)
     assert mine_ns.shape == want_ns.shape == (1, 3, 128, 192)  # H=128, W=192
     assert np.allclose(mine_ns, want_ns, atol=1e-7)
 
@@ -98,13 +102,20 @@ async def test_predict_matches_canonical(tmp_path):
 
     subprocess.run(
         [
-            sys.executable, str(_RUNNER),
-            "--manifest", str(manifest),
-            "--out", str(out),
-            "--model-dir", str(_MODEL_DIR),
-            "--storage-path", str(storage),
-            "--variant", "fullsize",
-            "--min-confidence", "0.35",
+            sys.executable,
+            str(_RUNNER),
+            "--manifest",
+            str(manifest),
+            "--out",
+            str(out),
+            "--model-dir",
+            str(_MODEL_DIR),
+            "--storage-path",
+            str(storage),
+            "--variant",
+            "fullsize",
+            "--min-confidence",
+            "0.35",
             "--no-include-character",  # compare general-only against canonical
         ],
         check=True,
@@ -152,17 +163,29 @@ def test_corrupt_image_is_skipped_not_fatal(tmp_path):
 
     manifest = tmp_path / "m.jsonl"
     manifest.write_text(
-        json.dumps({"image_id": 1, "filename": "bad", "ext": "png"}) + "\n"
-        + json.dumps({"image_id": 2, "filename": "good", "ext": "png"}) + "\n"
+        json.dumps({"image_id": 1, "filename": "bad", "ext": "png"})
+        + "\n"
+        + json.dumps({"image_id": 2, "filename": "good", "ext": "png"})
+        + "\n"
     )
     out = tmp_path / "r.jsonl"
 
     proc = subprocess.run(
         [
-            sys.executable, str(_RUNNER),
-            "--manifest", str(manifest), "--out", str(out),
-            "--model-dir", str(_MODEL_DIR), "--storage-path", str(storage),
-            "--variant", "fullsize", "--min-confidence", "0.35",
+            sys.executable,
+            str(_RUNNER),
+            "--manifest",
+            str(manifest),
+            "--out",
+            str(out),
+            "--model-dir",
+            str(_MODEL_DIR),
+            "--storage-path",
+            str(storage),
+            "--variant",
+            "fullsize",
+            "--min-confidence",
+            "0.35",
         ],
         check=True,
         capture_output=True,
@@ -177,6 +200,7 @@ def test_corrupt_image_is_skipped_not_fatal(tmp_path):
 # ---------------------------------------------------------------------------
 # Synthetic predict() tests — no real model or GPU required
 # ---------------------------------------------------------------------------
+
 
 class _FakeSession:
     """Minimal ONNX session stub for predict() unit tests."""
@@ -207,10 +231,10 @@ def _make_fake_pipeline_patches(monkeypatch):
 #   index 2: character tag "reimu",   category=4 (CHARACTER), threshold=0.35, prob=0.7
 #   index 3: general tag "outdoors",  category=0 (GENERAL), threshold=0.35, prob=0.5
 
-_NAMES      = ["sky",  "safe", "reimu",   "outdoors"]
-_CATEGORIES = [0,      9,      4,         0         ]
-_THRESHOLDS = [0.35,   0.35,   0.35,      0.35      ]
-_PROBS      = [0.9,    0.8,    0.7,       0.5       ]
+_NAMES = ["sky", "safe", "reimu", "outdoors"]
+_CATEGORIES = [0, 9, 4, 0]
+_THRESHOLDS = [0.35, 0.35, 0.35, 0.35]
+_PROBS = [0.9, 0.8, 0.7, 0.5]
 
 DUMMY_PIPELINE: list = []
 
@@ -277,8 +301,8 @@ def test_predict_no_include_character_emits_general_only(monkeypatch, tmp_path):
 
     assert "sky" in emitted_tags
     assert "outdoors" in emitted_tags
-    assert "reimu" not in emitted_tags   # character tag suppressed
-    assert "safe" not in emitted_tags    # rating tag suppressed
+    assert "reimu" not in emitted_tags  # character tag suppressed
+    assert "safe" not in emitted_tags  # rating tag suppressed
 
     assert emitted_categories == {ml_gpu_infer.GENERAL_CATEGORY}
 

--- a/tests/integration/test_ml_tag_suggestion_workflow.py
+++ b/tests/integration/test_ml_tag_suggestion_workflow.py
@@ -68,7 +68,9 @@ async def _passthrough_resolver(db, suggestions):
     return suggestions
 
 
-async def _make_user(db_session: AsyncSession, suffix: str, salt: str = "testsalt12345678") -> Users:
+async def _make_user(
+    db_session: AsyncSession, suffix: str, salt: str = "testsalt12345678"
+) -> Users:
     user = Users(
         username=f"wf_{suffix}",
         email=f"wf_{suffix}@example.com",
@@ -597,9 +599,7 @@ class TestMlTagSuggestionWorkflow:
 
         suggestion = (
             await db_session.execute(
-                select(MlTagSuggestions).where(
-                    MlTagSuggestions.suggestion_id == suggestion_id
-                )
+                select(MlTagSuggestions).where(MlTagSuggestions.suggestion_id == suggestion_id)
             )
         ).scalar_one()
         assert suggestion.status == "approved"

--- a/tests/integration/test_r2_sync_backfill.py
+++ b/tests/integration/test_r2_sync_backfill.py
@@ -39,15 +39,9 @@ class TestBackfillLocations:
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         monkeypatch.setattr(settings, "R2_ALLOW_BULK_BACKFILL", True)
 
-        db_session.add(
-            Images(user_id=1, filename="a", ext="jpg", status=ImageStatus.ACTIVE)
-        )
-        db_session.add(
-            Images(user_id=1, filename="b", ext="jpg", status=ImageStatus.REVIEW)
-        )
-        db_session.add(
-            Images(user_id=1, filename="c", ext="jpg", status=ImageStatus.REPOST)
-        )
+        db_session.add(Images(user_id=1, filename="a", ext="jpg", status=ImageStatus.ACTIVE))
+        db_session.add(Images(user_id=1, filename="b", ext="jpg", status=ImageStatus.REVIEW))
+        db_session.add(Images(user_id=1, filename="c", ext="jpg", status=ImageStatus.REPOST))
         await db_session.commit()
 
         await backfill_locations(batch_size=2)

--- a/tests/integration/test_r2_sync_split.py
+++ b/tests/integration/test_r2_sync_split.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import ImageStatus, settings
 from app.core.r2_constants import R2Location
-from app.models.image import Images, VariantStatus
+from app.models.image import Images
 from scripts.r2_sync import split_existing
 
 
@@ -39,9 +39,7 @@ class TestSplitExisting:
         ):
             yield
 
-    async def test_moves_protected_images_only(
-        self, db_session: AsyncSession, monkeypatch
-    ):
+    async def test_moves_protected_images_only(self, db_session: AsyncSession, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
 
         db_session.add(
@@ -88,9 +86,7 @@ class TestSplitExisting:
         assert "fullsize/2026-04-17-1.jpg" not in copied_keys
         assert "fullsize/2026-04-17-3.jpg" not in copied_keys
 
-    async def test_dry_run_does_not_copy(
-        self, db_session: AsyncSession, monkeypatch
-    ):
+    async def test_dry_run_does_not_copy(self, db_session: AsyncSession, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
 
         db_session.add(
@@ -112,9 +108,7 @@ class TestSplitExisting:
         mock_r2.copy_object.assert_not_awaited()
         mock_r2.delete_object.assert_not_awaited()
 
-    async def test_skips_missing_objects(
-        self, db_session: AsyncSession, monkeypatch
-    ):
+    async def test_skips_missing_objects(self, db_session: AsyncSession, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
 
         db_session.add(

--- a/tests/integration/test_review_constraints.py
+++ b/tests/integration/test_review_constraints.py
@@ -70,9 +70,7 @@ class TestReportConstraints:
         reason="Unique constraint on (image_id, user_id) for pending reports "
         "is enforced at API level, not database level. Test via test_reports.py instead."
     )
-    async def test_duplicate_pending_report_from_same_user_fails(
-        self, db_session: AsyncSession
-    ):
+    async def test_duplicate_pending_report_from_same_user_fails(self, db_session: AsyncSession):
         """User cannot have two pending reports for the same image.
 
         Note: This constraint is enforced by the API endpoint, not the database.
@@ -81,9 +79,7 @@ class TestReportConstraints:
         """
         pass
 
-    async def test_different_users_can_report_same_image(
-        self, db_session: AsyncSession
-    ):
+    async def test_different_users_can_report_same_image(self, db_session: AsyncSession):
         """Different users can report the same image."""
         user1 = await create_test_user(db_session, 1001, "reporter2")
         user2 = await create_test_user(db_session, 1002, "reporter3")
@@ -115,9 +111,7 @@ class TestReportConstraints:
         reports = result.scalars().all()
         assert len(reports) == 2
 
-    async def test_user_can_report_after_previous_dismissed(
-        self, db_session: AsyncSession
-    ):
+    async def test_user_can_report_after_previous_dismissed(self, db_session: AsyncSession):
         """User can report again after previous report was dismissed."""
         user = await create_test_user(db_session, 1003, "reporter4")
         image = await create_test_image(db_session, user.user_id)
@@ -178,9 +172,7 @@ class TestReviewConstraints:
         """
         pass
 
-    async def test_can_create_review_after_previous_closed(
-        self, db_session: AsyncSession
-    ):
+    async def test_can_create_review_after_previous_closed(self, db_session: AsyncSession):
         """Can create new review after previous one was closed."""
         user = await create_test_user(db_session, 1011, "reviewer2")
         image = await create_test_image(db_session, user.user_id)
@@ -226,9 +218,7 @@ class TestVoteConstraints:
         "The API updates existing votes instead of creating duplicates. "
         "Test via test_reviews.py::TestReviewVote::test_update_existing_vote"
     )
-    async def test_same_user_cannot_vote_twice_on_same_review(
-        self, db_session: AsyncSession
-    ):
+    async def test_same_user_cannot_vote_twice_on_same_review(self, db_session: AsyncSession):
         """Same admin cannot have two votes on the same review.
 
         Note: The API endpoint handles this by updating the existing vote
@@ -237,9 +227,7 @@ class TestVoteConstraints:
         """
         pass
 
-    async def test_different_users_can_vote_on_same_review(
-        self, db_session: AsyncSession
-    ):
+    async def test_different_users_can_vote_on_same_review(self, db_session: AsyncSession):
         """Different admins can vote on the same review."""
         user1 = await create_test_user(db_session, 1021, "voter2")
         user2 = await create_test_user(db_session, 1022, "voter3")
@@ -283,9 +271,7 @@ class TestVoteConstraints:
         votes = result.scalars().all()
         assert len(votes) == 2
 
-    async def test_same_user_can_vote_on_different_reviews(
-        self, db_session: AsyncSession
-    ):
+    async def test_same_user_can_vote_on_different_reviews(self, db_session: AsyncSession):
         """Same admin can vote on different reviews."""
         user = await create_test_user(db_session, 1023, "voter4")
         image1 = await create_test_image(db_session, user.user_id)

--- a/tests/integration/test_search_integration.py
+++ b/tests/integration/test_search_integration.py
@@ -16,7 +16,9 @@ from app.models.tag import Tags
 from app.services.search import SearchService, configure_tags_index
 
 MEILISEARCH_URL = os.getenv("MEILISEARCH_URL", "http://localhost:7700")
-MEILISEARCH_KEY = os.getenv("MEILISEARCH_API_KEY") or os.getenv("MEILI_MASTER_KEY", "dev_master_key")
+MEILISEARCH_KEY = os.getenv("MEILISEARCH_API_KEY") or os.getenv(
+    "MEILI_MASTER_KEY", "dev_master_key"
+)
 
 # Use a test-specific index prefix to avoid colliding with dev data.
 # Suffix with the xdist worker id so parallel workers don't share an index.

--- a/tests/services/test_animetimm_preprocess.py
+++ b/tests/services/test_animetimm_preprocess.py
@@ -62,8 +62,12 @@ def test_respects_pipeline_resolution(tmp_path):
     """A 384-res pipeline (like caformer_b36) yields a 384x384 tensor."""
     img = Image.new("RGB", (640, 480), (10, 20, 30))
     pipeline = [
-        {"type": "pad_to_size", "size": [512, 512], "background_color": "white",
-         "interpolation": "bilinear"},
+        {
+            "type": "pad_to_size",
+            "size": [512, 512],
+            "background_color": "white",
+            "interpolation": "bilinear",
+        },
         {"type": "resize", "size": 384, "interpolation": "bicubic"},
         {"type": "center_crop", "size": [384, 384]},
         {"type": "maybe_to_tensor"},
@@ -81,8 +85,12 @@ def test_pad_to_size_non_square_is_h_w():
     """
     img = Image.new("RGB", (200, 100), (10, 20, 30))  # non-square input
     pipeline = [
-        {"type": "pad_to_size", "size": [384, 512], "background_color": "white",
-         "interpolation": "bilinear"},
+        {
+            "type": "pad_to_size",
+            "size": [384, 512],
+            "background_color": "white",
+            "interpolation": "bilinear",
+        },
         {"type": "maybe_to_tensor"},
     ]
     out = apply_test_pipeline(img, pipeline)

--- a/tests/services/test_image_status_service.py
+++ b/tests/services/test_image_status_service.py
@@ -48,7 +48,9 @@ async def test_deactivate_sets_fields_history_and_audit(db_session: AsyncSession
     img = await _mk_image(db_session, actor.user_id)
 
     await change_image_status(
-        db_session, img, actor,
+        db_session,
+        img,
+        actor,
         new_status=ImageStatus.DEACTIVATED,
         reason_category=DeactivationReason.SPAM,
         reason="advertising",
@@ -61,17 +63,23 @@ async def test_deactivate_sets_fields_history_and_audit(db_session: AsyncSession
     assert img.status_reason == "advertising"
     assert img.status_user_id == actor.user_id
 
-    hist = (await db_session.execute(
-        select(ImageStatusHistory).where(ImageStatusHistory.image_id == img.image_id)
-    )).scalars().all()
+    hist = (
+        (
+            await db_session.execute(
+                select(ImageStatusHistory).where(ImageStatusHistory.image_id == img.image_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
     assert len(hist) == 1
     assert hist[0].new_status == ImageStatus.DEACTIVATED
     assert hist[0].reason_category == DeactivationReason.SPAM
     assert hist[0].reason == "advertising"
 
-    action = (await db_session.execute(
-        select(AdminActions).where(AdminActions.image_id == img.image_id)
-    )).scalar_one()
+    action = (
+        await db_session.execute(select(AdminActions).where(AdminActions.image_id == img.image_id))
+    ).scalar_one()
     assert action.action_type == AdminActionType.IMAGE_STATUS_CHANGE
     assert action.details["new_status"] == ImageStatus.DEACTIVATED
     assert action.details["reason"] == "advertising"  # free-text reason in the audit row itself
@@ -90,9 +98,15 @@ async def test_no_history_row_when_status_unchanged(db_session: AsyncSession):
     img = await _mk_image(db_session, actor.user_id)
     await change_image_status(db_session, img, actor, locked=True)  # lock only
     await db_session.commit()
-    hist = (await db_session.execute(
-        select(ImageStatusHistory).where(ImageStatusHistory.image_id == img.image_id)
-    )).scalars().all()
+    hist = (
+        (
+            await db_session.execute(
+                select(ImageStatusHistory).where(ImageStatusHistory.image_id == img.image_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
     assert hist == []
     assert img.locked == 1
 
@@ -100,17 +114,27 @@ async def test_no_history_row_when_status_unchanged(db_session: AsyncSession):
 async def test_system_actor_writes_null_user(db_session: AsyncSession):
     img = await _mk_image(db_session, 1, status=ImageStatus.REVIEW)
     await change_image_status(
-        db_session, img, None, new_status=ImageStatus.ACTIVE,
-        action_type=AdminActionType.REVIEW_CLOSE, extra_details={"automatic": True},
+        db_session,
+        img,
+        None,
+        new_status=ImageStatus.ACTIVE,
+        action_type=AdminActionType.REVIEW_CLOSE,
+        extra_details={"automatic": True},
     )
     await db_session.commit()
-    hist = (await db_session.execute(
-        select(ImageStatusHistory).where(ImageStatusHistory.image_id == img.image_id)
-    )).scalars().all()
+    hist = (
+        (
+            await db_session.execute(
+                select(ImageStatusHistory).where(ImageStatusHistory.image_id == img.image_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
     assert hist and hist[0].user_id is None  # system action
-    action = (await db_session.execute(
-        select(AdminActions).where(AdminActions.image_id == img.image_id)
-    )).scalar_one()
+    action = (
+        await db_session.execute(select(AdminActions).where(AdminActions.image_id == img.image_id))
+    ).scalar_one()
     assert action.action_type == AdminActionType.REVIEW_CLOSE
     assert action.user_id is None
     assert action.details["automatic"] is True
@@ -125,14 +149,21 @@ async def test_report_id_stamped_on_audit_row(db_session: AsyncSession):
     await db_session.refresh(report)
 
     await change_image_status(
-        db_session, img, actor, new_status=ImageStatus.DEACTIVATED,
-        reason_category=DeactivationReason.SPAM, reason="ad",
-        action_type=AdminActionType.REPORT_ACTION, report_id=report.report_id,
+        db_session,
+        img,
+        actor,
+        new_status=ImageStatus.DEACTIVATED,
+        reason_category=DeactivationReason.SPAM,
+        reason="ad",
+        action_type=AdminActionType.REPORT_ACTION,
+        report_id=report.report_id,
     )
     await db_session.commit()
-    action = (await db_session.execute(
-        select(AdminActions).where(AdminActions.report_id == report.report_id)
-    )).scalar_one()
+    action = (
+        await db_session.execute(
+            select(AdminActions).where(AdminActions.report_id == report.report_id)
+        )
+    ).scalar_one()
     assert action.action_type == AdminActionType.REPORT_ACTION
     assert action.details["reason"] == "ad"
 
@@ -173,7 +204,10 @@ async def test_triage_unhide_requires_reason(db_session: AsyncSession):
     img = await _mk_image(db_session, actor.user_id, status=ImageStatus.DEACTIVATED)
     with pytest.raises(HTTPException) as exc:
         await change_image_status(
-            db_session, img, actor, new_status=ImageStatus.SPOILER,
+            db_session,
+            img,
+            actor,
+            new_status=ImageStatus.SPOILER,
             action_type=AdminActionType.REPORT_ACTION,
         )
     assert exc.value.status_code == 400
@@ -197,14 +231,25 @@ async def test_status_history_row_records_report_id(db_session: AsyncSession):
     await db_session.commit()
     await db_session.refresh(report)
     await change_image_status(
-        db_session, img, actor, new_status=ImageStatus.DEACTIVATED,
-        reason_category=DeactivationReason.INAPPROPRIATE, reason="x",
-        action_type=AdminActionType.REPORT_ACTION, report_id=report.report_id,
+        db_session,
+        img,
+        actor,
+        new_status=ImageStatus.DEACTIVATED,
+        reason_category=DeactivationReason.INAPPROPRIATE,
+        reason="x",
+        action_type=AdminActionType.REPORT_ACTION,
+        report_id=report.report_id,
     )
     await db_session.commit()
-    hist = (await db_session.execute(
-        select(ImageStatusHistory).where(ImageStatusHistory.image_id == img.image_id)
-    )).scalars().all()
+    hist = (
+        (
+            await db_session.execute(
+                select(ImageStatusHistory).where(ImageStatusHistory.image_id == img.image_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
     assert hist[0].report_id == report.report_id
     assert hist[0].review_id is None
 
@@ -241,10 +286,14 @@ async def test_status_change_syncs_ml_suggestions(db_session: AsyncSession):
     await db_session.commit()
 
     remaining = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == img.image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == img.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert remaining == []
 
 

--- a/tests/services/test_ml_backfill.py
+++ b/tests/services/test_ml_backfill.py
@@ -68,7 +68,10 @@ def test_select_shard_validates_arguments():
 def test_jsonl_roundtrip_and_resume_ids(tmp_path):
     out = tmp_path / "results.jsonl"
     rows = [
-        {"image_id": 1, "predictions": [{"external_tag": "a", "confidence": 0.9, "model_version": "v3"}]},
+        {
+            "image_id": 1,
+            "predictions": [{"external_tag": "a", "confidence": 0.9, "model_version": "v3"}],
+        },
         {"image_id": 2, "predictions": []},
     ]
     write_results(out, rows)
@@ -125,7 +128,12 @@ async def _make_user(db_session, suffix: str) -> Users:
 
 
 async def _make_image(
-    db_session, user: Users, suffix: str, *, has_theme: bool = False, status: int = ImageStatus.ACTIVE
+    db_session,
+    user: Users,
+    suffix: str,
+    *,
+    has_theme: bool = False,
+    status: int = ImageStatus.ACTIVE,
 ) -> Images:
     image = Images(
         filename=f"2024-01-01-{suffix}",
@@ -315,8 +323,18 @@ async def test_ingest_results_creates_rows(db_session):
     await db_session.commit()
 
     results = [
-        {"image_id": img1.image_id, "predictions": [{"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}]},
-        {"image_id": img2.image_id, "predictions": [{"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}]},
+        {
+            "image_id": img1.image_id,
+            "predictions": [
+                {"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}
+            ],
+        },
+        {
+            "image_id": img2.image_id,
+            "predictions": [
+                {"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}
+            ],
+        },
     ]
     mapped = [{"tag_id": 46, "confidence": 0.9, "model_version": "v3"}]
 
@@ -344,8 +362,18 @@ async def test_ingest_results_skips_given_ids(db_session):
     await db_session.commit()
 
     results = [
-        {"image_id": img1.image_id, "predictions": [{"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}]},
-        {"image_id": img2.image_id, "predictions": [{"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}]},
+        {
+            "image_id": img1.image_id,
+            "predictions": [
+                {"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}
+            ],
+        },
+        {
+            "image_id": img2.image_id,
+            "predictions": [
+                {"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}
+            ],
+        },
     ]
     mapped = [{"tag_id": 46, "confidence": 0.9, "model_version": "v3"}]
 
@@ -378,8 +406,18 @@ async def test_ingest_results_skips_missing_image_and_continues(db_session):
     good_id = good.image_id  # capture before ingest: the rollback below expires `good`
 
     results = [
-        {"image_id": 99999999, "predictions": [{"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}]},
-        {"image_id": good_id, "predictions": [{"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}]},
+        {
+            "image_id": 99999999,
+            "predictions": [
+                {"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}
+            ],
+        },
+        {
+            "image_id": good_id,
+            "predictions": [
+                {"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}
+            ],
+        },
     ]
     mapped = [{"tag_id": 46, "confidence": 0.9, "model_version": "v3"}]
 
@@ -426,11 +464,15 @@ async def test_ingest_results_records_exception_and_continues(db_session):
     results = [
         {
             "image_id": bad_id,
-            "predictions": [{"external_tag": "ghost_tag", "confidence": 0.9, "model_version": "v3"}],
+            "predictions": [
+                {"external_tag": "ghost_tag", "confidence": 0.9, "model_version": "v3"}
+            ],
         },
         {
             "image_id": good_id,
-            "predictions": [{"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}],
+            "predictions": [
+                {"external_tag": "long_hair", "confidence": 0.9, "model_version": "v3"}
+            ],
         },
     ]
 

--- a/tests/services/test_ml_raw_store.py
+++ b/tests/services/test_ml_raw_store.py
@@ -7,7 +7,6 @@ Idempotency is verified by running each function twice and asserting the
 second call inserts nothing.
 """
 
-import pytest
 from sqlalchemy import select
 
 from app.models.image import Images
@@ -172,10 +171,14 @@ async def test_ingest_coexists_across_models(db_session, tmp_path):
     assert created2 == 1, "same (image, external_tag) under a different model must be a new row"
 
     raw_rows = (
-        await db_session.execute(
-            select(MlRawPredictions).where(MlRawPredictions.image_id == img.image_id)
+        (
+            await db_session.execute(
+                select(MlRawPredictions).where(MlRawPredictions.image_id == img.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(raw_rows) == 2, "one row per (image, model, external_tag)"
 
     # Same external_tag_id, distinct model_ids

--- a/tests/services/test_ml_remap.py
+++ b/tests/services/test_ml_remap.py
@@ -46,10 +46,7 @@ SWINV2 = "wd-swinv2-tagger-v3"
 
 def _preds(*tag_ids: int, model: str = CAFORMER, confidence: float = 0.9) -> list[dict[str, Any]]:
     """Build canned predictions already carrying internal tag_ids (resolvers will be patched out)."""
-    return [
-        {"tag_id": tid, "confidence": confidence, "model_version": model}
-        for tid in tag_ids
-    ]
+    return [{"tag_id": tid, "confidence": confidence, "model_version": model} for tid in tag_ids]
 
 
 async def _resolver_passthrough(db, suggestions):
@@ -127,10 +124,14 @@ async def test_adds_pending_for_new_implied_tag(db_session, monkeypatch):
     assert added == 1
 
     rows = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(rows) == 1
     row = rows[0]
     assert row.tag_id == 101
@@ -156,15 +157,21 @@ async def test_deletes_stale_same_model_pending(db_session, monkeypatch):
     # tag 201 — stale pending (same model, NOT in new implied set)
     db_session.add(
         MlTagSuggestions(
-            image_id=image.image_id, tag_id=201, confidence=0.8,
-            model_version=CAFORMER, status="pending",
+            image_id=image.image_id,
+            tag_id=201,
+            confidence=0.8,
+            model_version=CAFORMER,
+            status="pending",
         )
     )
     # tag 202 — still-implied pending (same model, IS in new implied set)
     db_session.add(
         MlTagSuggestions(
-            image_id=image.image_id, tag_id=202, confidence=0.8,
-            model_version=CAFORMER, status="pending",
+            image_id=image.image_id,
+            tag_id=202,
+            confidence=0.8,
+            model_version=CAFORMER,
+            status="pending",
         )
     )
     await db_session.commit()
@@ -182,10 +189,14 @@ async def test_deletes_stale_same_model_pending(db_session, monkeypatch):
     assert added == 0
 
     rows = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     tag_ids = {r.tag_id for r in rows}
     # Stale tag 201 must be gone
@@ -211,8 +222,11 @@ async def test_preserves_different_model_pending(db_session, monkeypatch):
     # tag 301 — pending from swinv2, NOT in caformer implied set
     db_session.add(
         MlTagSuggestions(
-            image_id=image.image_id, tag_id=301, confidence=0.85,
-            model_version=SWINV2, status="pending",
+            image_id=image.image_id,
+            tag_id=301,
+            confidence=0.85,
+            model_version=SWINV2,
+            status="pending",
         )
     )
     await db_session.commit()
@@ -230,10 +244,14 @@ async def test_preserves_different_model_pending(db_session, monkeypatch):
     assert added == 1
 
     rows = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     by_tag = {r.tag_id: r for r in rows}
 
     # swinv2 row for tag 301 must still be there — cross-source clobber guard
@@ -261,12 +279,18 @@ async def test_preserves_approved_and_rejected(db_session, monkeypatch):
     await _make_tags(db_session, 401, 402)
 
     approved_row = MlTagSuggestions(
-        image_id=image.image_id, tag_id=401, confidence=0.9,
-        model_version=CAFORMER, status="approved",
+        image_id=image.image_id,
+        tag_id=401,
+        confidence=0.9,
+        model_version=CAFORMER,
+        status="approved",
     )
     rejected_row = MlTagSuggestions(
-        image_id=image.image_id, tag_id=402, confidence=0.9,
-        model_version=CAFORMER, status="rejected",
+        image_id=image.image_id,
+        tag_id=402,
+        confidence=0.9,
+        model_version=CAFORMER,
+        status="rejected",
     )
     db_session.add_all([approved_row, rejected_row])
     await db_session.commit()
@@ -283,10 +307,14 @@ async def test_preserves_approved_and_rejected(db_session, monkeypatch):
     assert added == 0
 
     rows = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(rows) == 2
     by_tag = {r.tag_id: r for r in rows}
 
@@ -311,8 +339,11 @@ async def test_does_not_reset_approved_when_tag_removed(db_session, monkeypatch)
 
     # Approved suggestion; tag 501 is NOT in TagLinks (tag was removed from image)
     approved_row = MlTagSuggestions(
-        image_id=image.image_id, tag_id=501, confidence=0.9,
-        model_version=CAFORMER, status="approved",
+        image_id=image.image_id,
+        tag_id=501,
+        confidence=0.9,
+        model_version=CAFORMER,
+        status="approved",
     )
     db_session.add(approved_row)
     await db_session.commit()
@@ -329,10 +360,14 @@ async def test_does_not_reset_approved_when_tag_removed(db_session, monkeypatch)
     assert added == 0
 
     rows = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(rows) == 1
     # remap_image must not have reset the approved row — it stays approved
     assert rows[0].status == "approved", "approved row must NOT be reset by remap_image"
@@ -385,10 +420,14 @@ async def test_remap_image_from_store_creates_suggestion(db_session, monkeypatch
     assert added == 1
 
     rows = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(rows) == 1
     assert rows[0].tag_id == 601
     assert rows[0].status == "pending"
@@ -419,8 +458,11 @@ async def test_does_not_duplicate_tag_held_by_another_model(db_session, monkeypa
     # tag 601 (T) — existing pending row from a DIFFERENT model (swinv2)
     db_session.add(
         MlTagSuggestions(
-            image_id=image.image_id, tag_id=601, confidence=0.75,
-            model_version=SWINV2_FULL, status="pending",
+            image_id=image.image_id,
+            tag_id=601,
+            confidence=0.75,
+            model_version=SWINV2_FULL,
+            status="pending",
         )
     )
     await db_session.commit()
@@ -439,10 +481,14 @@ async def test_does_not_duplicate_tag_held_by_another_model(db_session, monkeypa
     assert added == 1
 
     rows = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     # Exactly one row for tag T — no duplication
     t_rows = [r for r in rows if r.tag_id == 601]
@@ -511,11 +557,13 @@ async def test_remap_images_for_tag_scopes_to_mapped_images(db_session, monkeypa
     def _resolver_for_tag_801(rows):
         """Return tag_id=801 only when the prediction list is non-empty (image A),
         otherwise return empty (image B will have no blue_eyes prediction)."""
+
         async def _inner(db, suggestions):
             if not suggestions:
                 return []
             # Passthrough for the known external_tag; inject tag_id
             return [dict(r) for r in rows]
+
         return _inner
 
     with (
@@ -529,20 +577,28 @@ async def test_remap_images_for_tag_scopes_to_mapped_images(db_session, monkeypa
 
     # Image A must have a pending suggestion for internal tag 801
     rows_a = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image_a.image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image_a.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(rows_a) == 1
     assert rows_a[0].tag_id == 801
     assert rows_a[0].status == "pending"
 
     # Image B must have NO suggestion rows
     rows_b = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image_b.image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image_b.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert rows_b == [], "image B must not receive any suggestion (unrelated raw pred)"
 
 
@@ -577,14 +633,18 @@ async def test_run_rolls_back_and_continues_after_failed_image(
 
     db_session.add(
         MlRawPredictions(
-            image_id=image_bad.image_id, model_id=model_row.id,
-            external_tag_id=ext_bad.id, confidence=0.9,
+            image_id=image_bad.image_id,
+            model_id=model_row.id,
+            external_tag_id=ext_bad.id,
+            confidence=0.9,
         )
     )
     db_session.add(
         MlRawPredictions(
-            image_id=image_good.image_id, model_id=model_row.id,
-            external_tag_id=ext_good.id, confidence=0.9,
+            image_id=image_good.image_id,
+            model_id=model_row.id,
+            external_tag_id=ext_good.id,
+            confidence=0.9,
         )
     )
     await db_session.commit()
@@ -600,13 +660,9 @@ async def test_run_rolls_back_and_continues_after_failed_image(
         out = []
         for s in suggestions:
             if s["external_tag"] == "bad_ext":
-                out.append(
-                    {"tag_id": missing_tag_id, "confidence": 0.9, "model_version": CAFORMER}
-                )
+                out.append({"tag_id": missing_tag_id, "confidence": 0.9, "model_version": CAFORMER})
             elif s["external_tag"] == "good_ext":
-                out.append(
-                    {"tag_id": good_tag_id, "confidence": 0.9, "model_version": CAFORMER}
-                )
+                out.append({"tag_id": good_tag_id, "confidence": 0.9, "model_version": CAFORMER})
         return out
 
     class _SessionCtx:
@@ -636,20 +692,28 @@ async def test_run_rolls_back_and_continues_after_failed_image(
 
     # The good image processed despite the bad one failing first.
     rows_good = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == good_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == good_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(rows_good) == 1, "later image must still be processed after a failure"
     assert rows_good[0].tag_id == good_tag_id
     assert rows_good[0].status == "pending"
 
     # The bad image stored nothing (its commit was rolled back).
     rows_bad = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == bad_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == bad_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert rows_bad == []
 
     # The failure was counted and logged (exactly one error, for the bad image).
@@ -703,10 +767,14 @@ async def test_remap_image_from_store_ignores_other_model(db_session, monkeypatc
     assert added == 0
 
     rows = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert rows == [], "swinv2 raw predictions must not be picked up by caformer remap"
 
 
@@ -736,8 +804,12 @@ async def test_remap_skips_suggestion_ineligible_image(db_session, monkeypatch):
 
     assert added == 0
     rows = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert rows == []

--- a/tests/services/test_ml_runtime.py
+++ b/tests/services/test_ml_runtime.py
@@ -68,9 +68,7 @@ async def test_get_ml_service_loads_once_under_concurrency(monkeypatch):
 
     monkeypatch.setattr("app.services.ml_service.MLTagSuggestionService", _SlowService)
 
-    first, second = await asyncio.gather(
-        ml_runtime.get_ml_service(), ml_runtime.get_ml_service()
-    )
+    first, second = await asyncio.gather(ml_runtime.get_ml_service(), ml_runtime.get_ml_service())
 
     assert instances == 1, "model must be instantiated exactly once"
     assert loads == 1, "model must be loaded exactly once"
@@ -104,10 +102,12 @@ async def test_get_ml_service_reloads_after_failed_load(monkeypatch):
 
 async def test_warm_load_calls_get_ml_service_when_enabled(monkeypatch):
     called = False
+
     async def fake_get():
         nonlocal called
         called = True
         return object()
+
     monkeypatch.setattr(ml_runtime.settings, "ML_TAG_SUGGESTIONS_ENABLED", True)
     monkeypatch.setattr(ml_runtime, "get_ml_service", fake_get)
     await ml_runtime.warm_load_if_enabled()
@@ -116,10 +116,12 @@ async def test_warm_load_calls_get_ml_service_when_enabled(monkeypatch):
 
 async def test_warm_load_noop_when_disabled(monkeypatch):
     called = False
+
     async def fake_get():
         nonlocal called
         called = True
         return object()
+
     monkeypatch.setattr(ml_runtime.settings, "ML_TAG_SUGGESTIONS_ENABLED", False)
     monkeypatch.setattr(ml_runtime, "get_ml_service", fake_get)
     await ml_runtime.warm_load_if_enabled()

--- a/tests/services/test_ml_service.py
+++ b/tests/services/test_ml_service.py
@@ -48,9 +48,7 @@ class TestMLTagSuggestionServiceLoadModels:
     ) -> None:
         """Missing WD-Tagger files → FileNotFoundError naming the expected path."""
         monkeypatch.setattr("app.services.ml_service.settings.ML_MODELS_PATH", str(tmp_path))
-        monkeypatch.setattr(
-            "app.services.ml_service.settings.ML_MODEL_NAME", "wd-swinv2-tagger-v3"
-        )
+        monkeypatch.setattr("app.services.ml_service.settings.ML_MODEL_NAME", "wd-swinv2-tagger-v3")
 
         service = MLTagSuggestionService()
         with pytest.raises(FileNotFoundError, match=str(tmp_path)):

--- a/tests/services/test_ml_suggestion_lifecycle.py
+++ b/tests/services/test_ml_suggestion_lifecycle.py
@@ -76,11 +76,7 @@ async def _make_suggestion(
 
 async def _suggestion_rows(db: AsyncSession, image_id: int) -> list[MlTagSuggestions]:
     return list(
-        (
-            await db.execute(
-                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image_id)
-            )
-        )
+        (await db.execute(select(MlTagSuggestions).where(MlTagSuggestions.image_id == image_id)))
         .scalars()
         .all()
     )
@@ -150,9 +146,7 @@ class TestNoOpTransitions:
 
 
 class TestIneligibleToEligible:
-    async def test_reseeds_pending_from_raw_store(
-        self, db_session: AsyncSession, monkeypatch
-    ):
+    async def test_reseeds_pending_from_raw_store(self, db_session: AsyncSession, monkeypatch):
         """DEACTIVATED -> ACTIVE re-seeds pending rows from ml_raw_predictions."""
         monkeypatch.setattr(settings, "ML_MODEL_NAME", MODEL)
         monkeypatch.setattr(settings, "ML_MIN_CONFIDENCE", 0.35)
@@ -201,9 +195,7 @@ class TestIneligibleToEligible:
 
 
 class TestMigrateRepostData:
-    async def test_wipes_repost_rows_and_resolves_original(
-        self, db_session: AsyncSession
-    ):
+    async def test_wipes_repost_rows_and_resolves_original(self, db_session: AsyncSession):
         """Repost-marking wipes ALL the repost's suggestion rows and resolves the
         original's matching pending suggestion with a NULL reviewer."""
         from app.models.tag_link import TagLinks

--- a/tests/services/test_ml_suggestion_pipeline.py
+++ b/tests/services/test_ml_suggestion_pipeline.py
@@ -642,9 +642,7 @@ async def test_generate_and_store_populates_raw_store_and_suggestions(
     class FakeService:
         model_name = "v3"
 
-        async def generate_raw_predictions(
-            self, image_path, *, include_categories, min_confidence
-        ):
+        async def generate_raw_predictions(self, image_path, *, include_categories, min_confidence):
             assert include_categories == {0, 4}  # SUGGESTION_CATEGORIES
             return list(raw)
 
@@ -828,10 +826,14 @@ async def test_store_predictions_swallows_duplicate_race(db_session, tmp_path, m
     monkeypatch.setattr(db_session, "commit", real_commit)
     monkeypatch.setattr(db_session, "rollback", real_rollback)
     rows = (
-        await db_session.execute(
-            select(MlTagSuggestions).where(MlTagSuggestions.image_id == image_id)
+        (
+            await db_session.execute(
+                select(MlTagSuggestions).where(MlTagSuggestions.image_id == image_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert rows == []  # our aborted attempt persisted nothing
 
 

--- a/tests/services/test_ml_suggestion_queue.py
+++ b/tests/services/test_ml_suggestion_queue.py
@@ -450,7 +450,7 @@ class TestCountPendingByTagPagination:
         # 12 images so each tag gets exactly 1 pending suggestion
         images = [await _make_image(db_session, user, f"pag1_{i}") for i in range(12)]
         tags = [await _make_tag(db_session, user, f"pag1_t{i}") for i in range(12)]
-        for img, tag in zip(images, tags, strict=False):
+        for img, tag in zip(images, tags, strict=True):
             await _make_suggestion(db_session, img, tag)
         await db_session.commit()
 
@@ -471,7 +471,7 @@ class TestCountPendingByTagPagination:
         images = [await _make_image(db_session, user, f"pag2_{i}") for i in range(12)]
         tags = [await _make_tag(db_session, user, f"pag2_t{i}") for i in range(12)]
         seeded_tag_ids = {tag.tag_id for tag in tags}
-        for img, tag in zip(images, tags, strict=False):
+        for img, tag in zip(images, tags, strict=True):
             await _make_suggestion(db_session, img, tag)
         await db_session.commit()
 

--- a/tests/services/test_ml_suggestion_queue.py
+++ b/tests/services/test_ml_suggestion_queue.py
@@ -4,7 +4,6 @@ These tests exercise the service layer directly against the real test DB.
 No mocked behavior is asserted; all assertions target real DB rows.
 """
 
-import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import TagType
@@ -45,7 +44,9 @@ async def _make_image(db: AsyncSession, user: Users, suffix: str) -> Images:
     return image
 
 
-async def _make_tag(db: AsyncSession, user: Users, suffix: str, tag_type: int = TagType.THEME) -> Tags:
+async def _make_tag(
+    db: AsyncSession, user: Users, suffix: str, tag_type: int = TagType.THEME
+) -> Tags:
     tag = Tags(title=f"queue tag {suffix}", type=tag_type, user_id=user.user_id)
     db.add(tag)
     await db.flush()
@@ -268,7 +269,9 @@ class TestListPendingForTag:
         assert len(items) == 1
         assert items[0][0] == pending.suggestion_id
 
-    async def test_excludes_suggestions_whose_tag_is_already_applied(self, db_session: AsyncSession):
+    async def test_excludes_suggestions_whose_tag_is_already_applied(
+        self, db_session: AsyncSession
+    ):
         """A pending suggestion whose tag was applied out of band is not listed.
 
         Covers the review-queue staleness bug: tags applied without going
@@ -291,7 +294,9 @@ class TestListPendingForTag:
         assert len(items) == 1
         assert items[0][0] == remaining.suggestion_id
 
-    async def test_item_structure_has_suggestion_id_image_id_confidence(self, db_session: AsyncSession):
+    async def test_item_structure_has_suggestion_id_image_id_confidence(
+        self, db_session: AsyncSession
+    ):
         """Each item is a (suggestion_id, image_id, confidence) tuple."""
         user = await _make_user(db_session, "lst5")
         image = await _make_image(db_session, user, "lst5a")
@@ -344,7 +349,9 @@ class TestCountPendingByTagLimitAndSearch:
         results, _total = await count_pending_by_tag(db_session, per_page=2)
 
         tag_ids = [r[0] for r in results]
-        assert len([tid for tid in tag_ids if tid in {tag_x.tag_id, tag_y.tag_id, tag_z.tag_id}]) <= 2
+        assert (
+            len([tid for tid in tag_ids if tid in {tag_x.tag_id, tag_y.tag_id, tag_z.tag_id}]) <= 2
+        )
         # The two returned tags from this seed must be tag_x and tag_y (highest counts)
         seeded_ids = {tid for tid in tag_ids if tid in {tag_x.tag_id, tag_y.tag_id, tag_z.tag_id}}
         assert tag_x.tag_id in seeded_ids
@@ -443,7 +450,7 @@ class TestCountPendingByTagPagination:
         # 12 images so each tag gets exactly 1 pending suggestion
         images = [await _make_image(db_session, user, f"pag1_{i}") for i in range(12)]
         tags = [await _make_tag(db_session, user, f"pag1_t{i}") for i in range(12)]
-        for img, tag in zip(images, tags):
+        for img, tag in zip(images, tags, strict=False):
             await _make_suggestion(db_session, img, tag)
         await db_session.commit()
 
@@ -464,7 +471,7 @@ class TestCountPendingByTagPagination:
         images = [await _make_image(db_session, user, f"pag2_{i}") for i in range(12)]
         tags = [await _make_tag(db_session, user, f"pag2_t{i}") for i in range(12)]
         seeded_tag_ids = {tag.tag_id for tag in tags}
-        for img, tag in zip(images, tags):
+        for img, tag in zip(images, tags, strict=False):
             await _make_suggestion(db_session, img, tag)
         await db_session.commit()
 
@@ -494,11 +501,11 @@ class TestCountPendingByTagPagination:
         assert seeded_ids.index(tag_hi.tag_id) < seeded_ids.index(tag_lo.tag_id)
 
 
-async def _make_child_tag(
-    db: AsyncSession, user: Users, suffix: str, parent: Tags
-) -> Tags:
+async def _make_child_tag(db: AsyncSession, user: Users, suffix: str, parent: Tags) -> Tags:
     tag = Tags(
-        title=f"queue tag {suffix}", type=TagType.THEME, user_id=user.user_id,
+        title=f"queue tag {suffix}",
+        type=TagType.THEME,
+        user_id=user.user_id,
         inheritedfrom_id=parent.tag_id,
     )
     db.add(tag)
@@ -531,9 +538,7 @@ class TestListPendingDescendantHiding:
         )
         assert total == 1
 
-    async def test_pending_grandchild_hides_grandparent_row(
-        self, db_session: AsyncSession
-    ):
+    async def test_pending_grandchild_hides_grandparent_row(self, db_session: AsyncSession):
         """Transitive: the intermediate tag has NO suggestion row at all."""
         user = await _make_user(db_session, "hide2")
         image = await _make_image(db_session, user, "hide2")

--- a/tests/services/test_ml_suggestion_review_bulk.py
+++ b/tests/services/test_ml_suggestion_review_bulk.py
@@ -198,13 +198,17 @@ async def _make_chain(db: AsyncSession, user: Users, suffix: str) -> tuple[Tags,
     """grandparent <- parent <- child via inheritedfrom_id."""
     grandparent = await _make_tag(db, user, f"gp_{suffix}")
     parent = Tags(
-        title=f"bulk tag p_{suffix}", type=1, user_id=user.user_id,
+        title=f"bulk tag p_{suffix}",
+        type=1,
+        user_id=user.user_id,
         inheritedfrom_id=grandparent.tag_id,
     )
     db.add(parent)
     await db.flush()
     child = Tags(
-        title=f"bulk tag c_{suffix}", type=1, user_id=user.user_id,
+        title=f"bulk tag c_{suffix}",
+        type=1,
+        user_id=user.user_id,
         inheritedfrom_id=parent.tag_id,
     )
     db.add(child)
@@ -215,9 +219,7 @@ async def _make_chain(db: AsyncSession, user: Users, suffix: str) -> tuple[Tags,
 class TestAncestorCleanupOnApprove:
     """Creating a TagLink deletes now-redundant pending ancestor suggestions."""
 
-    async def test_review_approve_child_deletes_pending_ancestors(
-        self, db_session: AsyncSession
-    ):
+    async def test_review_approve_child_deletes_pending_ancestors(self, db_session: AsyncSession):
         user = await _make_user(db_session, "anc1")
         image = await _make_image(db_session, user, "anc1")
         grandparent, parent, child = await _make_chain(db_session, user, "anc1")
@@ -242,9 +244,7 @@ class TestAncestorCleanupOnApprove:
         rows = (
             (
                 await db_session.execute(
-                    select(MlTagSuggestions).where(
-                        MlTagSuggestions.image_id == image.image_id
-                    )
+                    select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
                 )
             )
             .scalars()
@@ -256,9 +256,7 @@ class TestAncestorCleanupOnApprove:
         assert parent.tag_id not in by_tag
         assert grandparent.tag_id not in by_tag
 
-    async def test_reviewed_ancestor_rows_are_never_touched(
-        self, db_session: AsyncSession
-    ):
+    async def test_reviewed_ancestor_rows_are_never_touched(self, db_session: AsyncSession):
         user = await _make_user(db_session, "anc2")
         image = await _make_image(db_session, user, "anc2")
         grandparent, parent, child = await _make_chain(db_session, user, "anc2")
@@ -276,9 +274,7 @@ class TestAncestorCleanupOnApprove:
         rows = (
             (
                 await db_session.execute(
-                    select(MlTagSuggestions).where(
-                        MlTagSuggestions.image_id == image.image_id
-                    )
+                    select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
                 )
             )
             .scalars()
@@ -328,9 +324,7 @@ class TestAncestorCleanupOnApprove:
         grandparent, _parent, child = await _make_chain(db_session, user, "anc4")
         await _make_suggestion(db_session, image, grandparent)
         await _make_suggestion(db_session, image, child)
-        db_session.add(
-            TagLinks(image_id=image.image_id, tag_id=child.tag_id, user_id=user.user_id)
-        )
+        db_session.add(TagLinks(image_id=image.image_id, tag_id=child.tag_id, user_id=user.user_id))
         await db_session.flush()
 
         await approve_pending_suggestions_for_links(
@@ -341,9 +335,7 @@ class TestAncestorCleanupOnApprove:
         rows = (
             (
                 await db_session.execute(
-                    select(MlTagSuggestions).where(
-                        MlTagSuggestions.image_id == image.image_id
-                    )
+                    select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
                 )
             )
             .scalars()
@@ -353,9 +345,7 @@ class TestAncestorCleanupOnApprove:
         assert by_tag[child.tag_id] == "approved"
         assert grandparent.tag_id not in by_tag
 
-    async def test_pending_descendant_of_applied_tag_survives(
-        self, db_session: AsyncSession
-    ):
+    async def test_pending_descendant_of_applied_tag_survives(self, db_session: AsyncSession):
         """Applying a PARENT tag must not delete the more-specific pending
         child suggestion (cleanup goes up the chain only)."""
         user = await _make_user(db_session, "anc5")
@@ -419,9 +409,7 @@ class TestAncestorCleanupOnApprove:
         rows = (
             (
                 await db_session.execute(
-                    select(MlTagSuggestions).where(
-                        MlTagSuggestions.image_id == image.image_id
-                    )
+                    select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
                 )
             )
             .scalars()

--- a/tests/services/test_onnx_model.py
+++ b/tests/services/test_onnx_model.py
@@ -19,7 +19,9 @@ class TestWDTaggerPreprocessing:
 
     def _make_model(self) -> WDTaggerModel:
         """Return an unloaded WDTaggerModel (no real files needed)."""
-        return WDTaggerModel(model_path="/nonexistent/model.onnx", tags_path="/nonexistent/tags.csv")
+        return WDTaggerModel(
+            model_path="/nonexistent/model.onnx", tags_path="/nonexistent/tags.csv"
+        )
 
     def test_output_shape(self, tmp_path: Path) -> None:
         """Output array must have NHWC shape (1, 448, 448, 3)."""

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -71,7 +71,9 @@ async def test_groups(db_session: AsyncSession, test_permissions: dict[str, int]
             GroupPerms(
                 group_id=group_mod.group_id, perm_id=test_permissions["image_edit"], permvalue=1
             ),
-            GroupPerms(group_id=group_mod.group_id, perm_id=test_permissions["user_ban"], permvalue=1),
+            GroupPerms(
+                group_id=group_mod.group_id, perm_id=test_permissions["user_ban"], permvalue=1
+            ),
         ]
     )
 
@@ -109,7 +111,9 @@ async def test_user_with_group(db_session: AsyncSession, test_groups: dict[str, 
 
 
 @pytest.fixture
-async def test_user_with_direct_perm(db_session: AsyncSession, test_permissions: dict[str, int]) -> Users:
+async def test_user_with_direct_perm(
+    db_session: AsyncSession, test_permissions: dict[str, int]
+) -> Users:
     """Create a test user with direct permission assignment."""
     user = Users(
         username="tagged_user",
@@ -244,28 +248,42 @@ class TestPermissionChecking:
         assert await has_permission(db_session, test_user_with_group.user_id, "image_edit")
         assert await has_permission(db_session, test_user_with_group.user_id, Permission.IMAGE_EDIT)
 
-    async def test_has_permission_false(self, db_session: AsyncSession, test_user_with_group: Users):
+    async def test_has_permission_false(
+        self, db_session: AsyncSession, test_user_with_group: Users
+    ):
         """User without permission should return False."""
         assert not await has_permission(db_session, test_user_with_group.user_id, "tag_create")
-        assert not await has_permission(db_session, test_user_with_group.user_id, Permission.TAG_CREATE)
+        assert not await has_permission(
+            db_session, test_user_with_group.user_id, Permission.TAG_CREATE
+        )
 
-    async def test_has_any_permission_true(self, db_session: AsyncSession, test_user_with_group: Users):
+    async def test_has_any_permission_true(
+        self, db_session: AsyncSession, test_user_with_group: Users
+    ):
         """User with at least one permission should return True."""
         assert await has_any_permission(
             db_session, test_user_with_group.user_id, ["tag_create", "image_edit", "user_ban"]
         )
 
-    async def test_has_any_permission_false(self, db_session: AsyncSession, test_user_with_group: Users):
+    async def test_has_any_permission_false(
+        self, db_session: AsyncSession, test_user_with_group: Users
+    ):
         """User with none of the permissions should return False."""
         assert not await has_any_permission(
             db_session, test_user_with_group.user_id, ["tag_create", "level_admin"]
         )
 
-    async def test_has_all_permissions_true(self, db_session: AsyncSession, test_user_with_group: Users):
+    async def test_has_all_permissions_true(
+        self, db_session: AsyncSession, test_user_with_group: Users
+    ):
         """User with all permissions should return True."""
-        assert await has_all_permissions(db_session, test_user_with_group.user_id, ["image_edit", "user_ban"])
+        assert await has_all_permissions(
+            db_session, test_user_with_group.user_id, ["image_edit", "user_ban"]
+        )
 
-    async def test_has_all_permissions_false(self, db_session: AsyncSession, test_user_with_group: Users):
+    async def test_has_all_permissions_false(
+        self, db_session: AsyncSession, test_user_with_group: Users
+    ):
         """User missing any permission should return False."""
         assert not await has_all_permissions(
             db_session, test_user_with_group.user_id, ["image_edit", "tag_create"]

--- a/tests/test_request_logging.py
+++ b/tests/test_request_logging.py
@@ -64,8 +64,7 @@ async def test_client_error_logs_client_host_and_user_agent(
         if "request_complete" in record.getMessage()
     ]
     assert request_logs, (
-        "no request_complete log emitted; "
-        f"got {[record.getMessage() for record in caplog.records]}"
+        f"no request_complete log emitted; got {[record.getMessage() for record in caplog.records]}"
     )
     assert any("test-agent/9.9" in message for message in request_logs), (
         f"user agent missing from access log; got {request_logs!r}"
@@ -95,8 +94,7 @@ async def test_fast_success_request_logged_at_debug(
         record for record in caplog.records if "request_complete" in record.getMessage()
     ]
     assert request_logs, (
-        "no request_complete log emitted; "
-        f"got {[record.getMessage() for record in caplog.records]}"
+        f"no request_complete log emitted; got {[record.getMessage() for record in caplog.records]}"
     )
     assert all(record.levelno == logging.DEBUG for record in request_logs), (
         "fast 2xx request_complete should log at DEBUG; got "

--- a/tests/unit/test_arq_jobs.py
+++ b/tests/unit/test_arq_jobs.py
@@ -1,9 +1,9 @@
 """Tests for arq background jobs."""
 
 import hashlib
-import pytest
-from pathlib import Path as FilePath
 from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
 
 from app.models.image import VariantStatus
 from app.tasks.image_jobs import create_thumbnail_job, create_variant_job
@@ -143,10 +143,11 @@ async def test_create_thumbnail_job_retry_on_failure():
 # Lockfile freshness check
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 def test_lockfile_check_passes_when_hash_matches(tmp_path):
     """No error when the mounted uv.lock hash matches the baked-in hash."""
-    lock_content = b'lockfile content'
+    lock_content = b"lockfile content"
     lock_path = tmp_path / "uv.lock"
     hash_path = tmp_path / ".uv-lock-hash"
     lock_path.write_bytes(lock_content)
@@ -154,6 +155,7 @@ def test_lockfile_check_passes_when_hash_matches(tmp_path):
 
     logger = Mock()
     with patch("app.tasks.worker.Path") as mock_path_cls:
+
         def _path_side_effect(p):
             s = str(p)
             if s.endswith(".uv-lock-hash"):
@@ -173,8 +175,8 @@ def test_lockfile_check_passes_when_hash_matches(tmp_path):
 @pytest.mark.unit
 def test_lockfile_check_exits_when_hash_differs(tmp_path):
     """SystemExit when the mounted uv.lock differs from the baked-in hash."""
-    lock_content = b'new lockfile content'
-    old_hash = hashlib.sha256(b'old lockfile content').hexdigest()
+    lock_content = b"new lockfile content"
+    old_hash = hashlib.sha256(b"old lockfile content").hexdigest()
 
     lock_path = tmp_path / "uv.lock"
     hash_path = tmp_path / ".uv-lock-hash"
@@ -183,6 +185,7 @@ def test_lockfile_check_exits_when_hash_differs(tmp_path):
 
     logger = Mock()
     with patch("app.tasks.worker.Path") as mock_path_cls:
+
         def _path_side_effect(p):
             s = str(p)
             if s.endswith(".uv-lock-hash"):
@@ -206,10 +209,11 @@ def test_lockfile_check_exits_when_hash_differs(tmp_path):
 def test_lockfile_check_skips_when_no_hash_file(tmp_path):
     """No error when the image predates the hash file (backward compatible)."""
     lock_path = tmp_path / "uv.lock"
-    lock_path.write_bytes(b'some lockfile')
+    lock_path.write_bytes(b"some lockfile")
 
     logger = Mock()
     with patch("app.tasks.worker.Path") as mock_path_cls:
+
         def _path_side_effect(p):
             s = str(p)
             if s.endswith(".uv-lock-hash"):

--- a/tests/unit/test_avatar_url_helper.py
+++ b/tests/unit/test_avatar_url_helper.py
@@ -86,9 +86,7 @@ def test_user_summary_excludes_avatar_in_r2_from_serialization() -> None:
     summary = UserSummary(user_id=1, username="alice", avatar="abc.png", avatar_in_r2=True)
 
     dumped = summary.model_dump()
-    assert "avatar_in_r2" not in dumped, (
-        f"avatar_in_r2 leaked into model_dump(): {sorted(dumped)}"
-    )
+    assert "avatar_in_r2" not in dumped, f"avatar_in_r2 leaked into model_dump(): {sorted(dumped)}"
 
     dumped_json = json.loads(summary.model_dump_json())
     assert "avatar_in_r2" not in dumped_json, (

--- a/tests/unit/test_banner_model.py
+++ b/tests/unit/test_banner_model.py
@@ -1,6 +1,6 @@
 """Tests for Banner model."""
 
-from app.models.misc import BannerSize, BannerTheme, Banners, UserBannerPins, UserBannerPreferences
+from app.models.misc import Banners, BannerSize, BannerTheme, UserBannerPins, UserBannerPreferences
 
 
 class TestBannerSize:

--- a/tests/unit/test_banner_schema.py
+++ b/tests/unit/test_banner_schema.py
@@ -234,6 +234,4 @@ def test_banner_response_round_trip_preserves_in_r2() -> None:
 
     round_tripped = BannerResponse.model_validate_json(resp.model_dump_json())
 
-    assert round_tripped.in_r2 is True, (
-        "in_r2 was lost across the cache serialization round trip"
-    )
+    assert round_tripped.in_r2 is True, "in_r2 was lost across the cache serialization round trip"

--- a/tests/unit/test_bbcode_converter.py
+++ b/tests/unit/test_bbcode_converter.py
@@ -23,38 +23,28 @@ class TestConvertBbcodeToMarkdown:
         assert modified is True
 
     def test_url_with_param(self):
-        text, modified = convert_bbcode_to_markdown(
-            '[url=http://example.com]click here[/url]'
-        )
+        text, modified = convert_bbcode_to_markdown("[url=http://example.com]click here[/url]")
         assert text == "[click here](http://example.com)"
         assert modified is True
 
     def test_url_with_quoted_param(self):
         """BBCode [url="http://..."] with quotes around URL."""
-        text, modified = convert_bbcode_to_markdown(
-            '[url="http://example.com"]click here[/url]'
-        )
+        text, modified = convert_bbcode_to_markdown('[url="http://example.com"]click here[/url]')
         assert text == "[click here](http://example.com)"
         assert modified is True
 
     def test_url_plain(self):
-        text, modified = convert_bbcode_to_markdown(
-            "[url]http://example.com[/url]"
-        )
+        text, modified = convert_bbcode_to_markdown("[url]http://example.com[/url]")
         assert text == "[http://example.com](http://example.com)"
         assert modified is True
 
     def test_spoiler_plain(self):
-        text, modified = convert_bbcode_to_markdown(
-            "[spoiler]hidden text[/spoiler]"
-        )
+        text, modified = convert_bbcode_to_markdown("[spoiler]hidden text[/spoiler]")
         assert text == "[spoiler]\nhidden text\n[/spoiler]"
         assert modified is True
 
     def test_spoiler_with_title(self):
-        text, modified = convert_bbcode_to_markdown(
-            '[spoiler="source"]hidden text[/spoiler]'
-        )
+        text, modified = convert_bbcode_to_markdown('[spoiler="source"]hidden text[/spoiler]')
         assert text == "[spoiler: source]\nhidden text\n[/spoiler]"
         assert modified is True
 
@@ -65,17 +55,13 @@ class TestConvertBbcodeToMarkdown:
 
     def test_already_broken_markdown_link_with_quoted_url(self):
         """Fix previously-converted links that have quotes around the URL."""
-        text, modified = convert_bbcode_to_markdown(
-            '[click here]("http://example.com")'
-        )
+        text, modified = convert_bbcode_to_markdown('[click here]("http://example.com")')
         assert text == "[click here](http://example.com)"
         assert modified is True
 
     def test_already_broken_markdown_link_single_quotes(self):
         """Fix previously-converted links with single quotes around URL."""
-        text, modified = convert_bbcode_to_markdown(
-            "[click here]('http://example.com')"
-        )
+        text, modified = convert_bbcode_to_markdown("[click here]('http://example.com')")
         assert text == "[click here](http://example.com)"
         assert modified is True
 
@@ -89,9 +75,7 @@ class TestConvertBbcodeToMarkdown:
 
     def test_multiple_broken_markdown_links(self):
         """Fix multiple broken markdown links in one text."""
-        text, modified = convert_bbcode_to_markdown(
-            '[a]("http://x.com") and [b]("http://y.com")'
-        )
+        text, modified = convert_bbcode_to_markdown('[a]("http://x.com") and [b]("http://y.com")')
         assert text == "[a](http://x.com) and [b](http://y.com)"
         assert modified is True
 
@@ -105,13 +89,13 @@ class TestConvertBbcodeToMarkdown:
     def test_real_php_bbcode_with_html_entities(self):
         """Test with actual BBCode from the legacy PHP database."""
         php_text = (
-            'Welcome. You can have an idea of the  '
-            '[url=&quot;http://e-shuushuu.net/about/tags/&quot;] tags here[/url]'
-            ' as tagging them are necessary and our '
-            '[url=&quot;http://e-shuushuu.net/about/rules/&quot;]rules here.[/url]'
-            ' If you have any questions, please do not hesitate to ask a '
-            'tagging team member [orange name] or a moderator [pink/red name]. '
-            'I hope you enjoy your stay.\n\n'
+            "Welcome. You can have an idea of the  "
+            "[url=&quot;http://e-shuushuu.net/about/tags/&quot;] tags here[/url]"
+            " as tagging them are necessary and our "
+            "[url=&quot;http://e-shuushuu.net/about/rules/&quot;]rules here.[/url]"
+            " If you have any questions, please do not hesitate to ask a "
+            "tagging team member [orange name] or a moderator [pink/red name]. "
+            "I hope you enjoy your stay.\n\n"
             "We don&#039;t allow AI-generated images on our board though, "
             "so I will need to disable these images."
         )

--- a/tests/unit/test_cloudflare_purge.py
+++ b/tests/unit/test_cloudflare_purge.py
@@ -91,8 +91,9 @@ class TestPurgeCacheByUrls:
 
         mock_client = _make_mock_client(raise_for_status=raise_for_status)
 
-        with caplog.at_level(logging.ERROR), patch(
-            "app.services.cloudflare.httpx.AsyncClient", return_value=mock_client
+        with (
+            caplog.at_level(logging.ERROR),
+            patch("app.services.cloudflare.httpx.AsyncClient", return_value=mock_client),
         ):
             with pytest.raises(httpx.HTTPStatusError):
                 await purge_cache_by_urls(["https://cdn.example.com/x.jpg"])
@@ -115,8 +116,9 @@ class TestPurgeCacheByUrls:
         mock_client.__aenter__.return_value = mock_client
         mock_client.__aexit__.return_value = False
 
-        with caplog.at_level(logging.ERROR), patch(
-            "app.services.cloudflare.httpx.AsyncClient", return_value=mock_client
+        with (
+            caplog.at_level(logging.ERROR),
+            patch("app.services.cloudflare.httpx.AsyncClient", return_value=mock_client),
         ):
             with pytest.raises(RuntimeError, match="success=false"):
                 await purge_cache_by_urls(["https://cdn.example.com/x.jpg"])

--- a/tests/unit/test_config_status.py
+++ b/tests/unit/test_config_status.py
@@ -28,7 +28,9 @@ def test_deactivation_reason_labels():
 
 
 def test_images_model_accepts_deactivated():
-    img = Images(user_id=1, filename="x", ext="jpg", md5_hash="a" * 32, status=ImageStatus.DEACTIVATED)
+    img = Images(
+        user_id=1, filename="x", ext="jpg", md5_hash="a" * 32, status=ImageStatus.DEACTIVATED
+    )
     assert img.status == ImageStatus.DEACTIVATED
     assert img.reason_category is None
     assert img.status_reason is None
@@ -38,7 +40,10 @@ def test_images_model_still_loads_legacy_statuses():
     # Old rows may still construct with legacy values during/after migration.
     # (0/DEACTIVATED is current, not legacy — covered by test_images_model_accepts_deactivated.)
     for legacy in (ImageStatus.INAPPROPRIATE, ImageStatus.LOW_QUALITY):
-        assert Images(user_id=1, filename="x", ext="jpg", md5_hash="a" * 32, status=legacy).status == legacy
+        assert (
+            Images(user_id=1, filename="x", ext="jpg", md5_hash="a" * 32, status=legacy).status
+            == legacy
+        )
 
 
 def test_images_model_rejects_unknown_status():
@@ -48,8 +53,11 @@ def test_images_model_rejects_unknown_status():
 
 def test_status_history_has_reason_fields():
     h = ImageStatusHistory(
-        image_id=1, old_status=ImageStatus.ACTIVE, new_status=ImageStatus.DEACTIVATED,
-        reason_category=DeactivationReason.SPAM, reason="ad spam",
+        image_id=1,
+        old_status=ImageStatus.ACTIVE,
+        new_status=ImageStatus.DEACTIVATED,
+        reason_category=DeactivationReason.SPAM,
+        reason="ad spam",
     )
     assert h.reason_category == DeactivationReason.SPAM
     assert h.reason == "ad spam"

--- a/tests/unit/test_daily_upload_limit.py
+++ b/tests/unit/test_daily_upload_limit.py
@@ -241,9 +241,7 @@ class TestDailyLimitEnforcement:
             db_session.add(_make_image(user.user_id, f"midnight-{i}"))
         await db_session.commit()
 
-        just_after_midnight = datetime.now(UTC).replace(
-            hour=0, minute=0, second=15, microsecond=0
-        )
+        just_after_midnight = datetime.now(UTC).replace(hour=0, minute=0, second=15, microsecond=0)
 
         class FrozenDatetime(datetime):
             @classmethod

--- a/tests/unit/test_image_processing.py
+++ b/tests/unit/test_image_processing.py
@@ -11,7 +11,11 @@ from fastapi import HTTPException
 from PIL import Image
 
 from app.config import settings
-from app.services.image_processing import create_large_variant, create_medium_variant, validate_image_file
+from app.services.image_processing import (
+    create_large_variant,
+    create_medium_variant,
+    validate_image_file,
+)
 
 
 # Fixtures use production-format names (`YYYY-MM-DD-<id>.<ext>`) so the
@@ -298,7 +302,9 @@ class TestFileSizeValidation:
 class TestValidateImageFile:
     """Tests for validate_image_file function."""
 
-    def _make_upload_file(self, content_type: str = "image/jpeg", filename: str = "test.jpg") -> MagicMock:
+    def _make_upload_file(
+        self, content_type: str = "image/jpeg", filename: str = "test.jpg"
+    ) -> MagicMock:
         mock = MagicMock()
         mock.content_type = content_type
         mock.filename = filename
@@ -324,7 +330,9 @@ class TestValidateImageFile:
             path = Path(f.name)
 
         try:
-            validate_image_file(self._make_upload_file(content_type="image/png", filename="test.png"), path)
+            validate_image_file(
+                self._make_upload_file(content_type="image/png", filename="test.png"), path
+            )
         finally:
             path.unlink(missing_ok=True)
 

--- a/tests/unit/test_image_response_groups.py
+++ b/tests/unit/test_image_response_groups.py
@@ -1,7 +1,7 @@
 """Tests for ImageDetailedResponse groups support."""
 
-from unittest.mock import MagicMock
 from datetime import datetime
+from unittest.mock import MagicMock
 
 from app.schemas.image import ImageDetailedResponse
 

--- a/tests/unit/test_image_status_helper.py
+++ b/tests/unit/test_image_status_helper.py
@@ -17,9 +17,7 @@ from app.services.image_status import enqueue_r2_sync_on_status_change
 class TestEnqueueR2SyncOnStatusChange:
     async def test_enqueues_when_status_changed_and_r2_enabled(self, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
-        with patch(
-            "app.services.image_status.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue:
+        with patch("app.services.image_status.enqueue_job", new_callable=AsyncMock) as mock_enqueue:
             await enqueue_r2_sync_on_status_change(
                 image_id=123,
                 old_status=ImageStatus.ACTIVE,
@@ -34,9 +32,7 @@ class TestEnqueueR2SyncOnStatusChange:
 
     async def test_noop_when_status_unchanged(self, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
-        with patch(
-            "app.services.image_status.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue:
+        with patch("app.services.image_status.enqueue_job", new_callable=AsyncMock) as mock_enqueue:
             await enqueue_r2_sync_on_status_change(
                 image_id=123,
                 old_status=ImageStatus.ACTIVE,
@@ -46,9 +42,7 @@ class TestEnqueueR2SyncOnStatusChange:
 
     async def test_noop_when_r2_disabled(self, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", False)
-        with patch(
-            "app.services.image_status.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue:
+        with patch("app.services.image_status.enqueue_job", new_callable=AsyncMock) as mock_enqueue:
             await enqueue_r2_sync_on_status_change(
                 image_id=123,
                 old_status=ImageStatus.ACTIVE,
@@ -59,9 +53,7 @@ class TestEnqueueR2SyncOnStatusChange:
     async def test_noop_when_transition_stays_on_public_side(self, monkeypatch):
         """ACTIVE→SPOILER: both public — worker would early-return, don't enqueue."""
         monkeypatch.setattr(settings, "R2_ENABLED", True)
-        with patch(
-            "app.services.image_status.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue:
+        with patch("app.services.image_status.enqueue_job", new_callable=AsyncMock) as mock_enqueue:
             await enqueue_r2_sync_on_status_change(
                 image_id=123,
                 old_status=ImageStatus.ACTIVE,
@@ -72,9 +64,7 @@ class TestEnqueueR2SyncOnStatusChange:
     async def test_noop_when_transition_stays_on_protected_side(self, monkeypatch):
         """REVIEW→INAPPROPRIATE: both protected — worker would early-return, don't enqueue."""
         monkeypatch.setattr(settings, "R2_ENABLED", True)
-        with patch(
-            "app.services.image_status.enqueue_job", new_callable=AsyncMock
-        ) as mock_enqueue:
+        with patch("app.services.image_status.enqueue_job", new_callable=AsyncMock) as mock_enqueue:
             await enqueue_r2_sync_on_status_change(
                 image_id=123,
                 old_status=ImageStatus.REVIEW,

--- a/tests/unit/test_image_url_generation.py
+++ b/tests/unit/test_image_url_generation.py
@@ -62,9 +62,7 @@ class TestUrlGenerationR2Off:
     """With R2 disabled, everything goes through /images/ — no exceptions."""
 
     @pytest.mark.parametrize("status", ALL_STATUSES)
-    @pytest.mark.parametrize(
-        "location", [R2Location.NONE, R2Location.PUBLIC, R2Location.PRIVATE]
-    )
+    @pytest.mark.parametrize("location", [R2Location.NONE, R2Location.PUBLIC, R2Location.PRIVATE])
     def test_url_fallback(self, r2_off, status, location):
         img = _make_image(status=status, r2_location=location)
         assert img.url == "http://localhost:3000/images/2026-04-17-1.jpg"
@@ -101,9 +99,7 @@ class TestUrlGenerationR2On:
             ImageStatus.OTHER,
         ],
     )
-    @pytest.mark.parametrize(
-        "location", [R2Location.NONE, R2Location.PUBLIC, R2Location.PRIVATE]
-    )
+    @pytest.mark.parametrize("location", [R2Location.NONE, R2Location.PUBLIC, R2Location.PRIVATE])
     def test_protected_never_direct_cdn(self, r2_on, status, location):
         """Protected statuses must never emit a CDN URL, regardless of location."""
         img = _make_image(status=status, r2_location=location)
@@ -128,8 +124,6 @@ class TestMediumLargeUrls:
         assert img.large_url == "https://cdn.example.com/large/2026-04-17-1.jpg"
 
     def test_medium_ready_fallback_when_none_location(self, r2_on):
-        img = _make_image(
-            status=ImageStatus.ACTIVE, r2_location=R2Location.NONE, medium=1, large=1
-        )
+        img = _make_image(status=ImageStatus.ACTIVE, r2_location=R2Location.NONE, medium=1, large=1)
         assert img.medium_url == "http://localhost:3000/medium/2026-04-17-1.jpg"
         assert img.large_url == "http://localhost:3000/large/2026-04-17-1.jpg"

--- a/tests/unit/test_iqdb_service.py
+++ b/tests/unit/test_iqdb_service.py
@@ -44,9 +44,7 @@ class TestCheckIqdbSimilarityByHash:
         mock_client.__aexit__.return_value = False
 
         with patch("httpx.AsyncClient", return_value=mock_client):
-            results = await check_iqdb_similarity_by_hash(
-                "iqdb_deadbeef", threshold=50.0
-            )
+            results = await check_iqdb_similarity_by_hash("iqdb_deadbeef", threshold=50.0)
 
         assert results == [
             {"image_id": 1, "score": 95.0},

--- a/tests/unit/test_markdown.py
+++ b/tests/unit/test_markdown.py
@@ -2,8 +2,6 @@
 Tests for safe Markdown parser
 """
 
-import pytest
-
 from app.utils.markdown import is_safe_url, parse_markdown, strip_markdown
 
 

--- a/tests/unit/test_permission_cache.py
+++ b/tests/unit/test_permission_cache.py
@@ -427,9 +427,7 @@ class TestPermissionCache:
         assert await has_any_permission(
             db_session, user.user_id, ["image_edit", "user_ban"], redis_client=None
         )
-        assert await has_any_permission(
-            db_session, user.user_id, ["image_edit", "user_ban"]
-        )
+        assert await has_any_permission(db_session, user.user_id, ["image_edit", "user_ban"])
 
     async def test_has_any_permission_negative_case(
         self,
@@ -571,9 +569,7 @@ class TestPermissionCache:
         assert await has_all_permissions(
             db_session, user.user_id, ["post_edit", "theme_edit"], redis_client=None
         )
-        assert await has_all_permissions(
-            db_session, user.user_id, ["post_edit", "theme_edit"]
-        )
+        assert await has_all_permissions(db_session, user.user_id, ["post_edit", "theme_edit"])
 
     async def test_has_all_permissions_negative_case(
         self,

--- a/tests/unit/test_permission_sync.py
+++ b/tests/unit/test_permission_sync.py
@@ -52,9 +52,7 @@ class TestSyncPermissions:
 
         await sync_permissions(db_session)
 
-        result = await db_session.execute(
-            select(Perms).where(Perms.title == "tag_create")
-        )
+        result = await db_session.execute(select(Perms).where(Perms.title == "tag_create"))
         perm = result.scalar_one()
 
         assert perm.desc == "Create new tags"

--- a/tests/unit/test_r2_client.py
+++ b/tests/unit/test_r2_client.py
@@ -25,9 +25,7 @@ class TestGetR2Storage:
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         monkeypatch.setattr(settings, "R2_ACCESS_KEY_ID", "ak")
         monkeypatch.setattr(settings, "R2_SECRET_ACCESS_KEY", "sk")
-        monkeypatch.setattr(
-            settings, "R2_ENDPOINT", "https://example.r2.cloudflarestorage.com"
-        )
+        monkeypatch.setattr(settings, "R2_ENDPOINT", "https://example.r2.cloudflarestorage.com")
         storage = get_r2_storage()
         assert isinstance(storage, R2Storage)
 
@@ -43,6 +41,4 @@ class TestGetR2Storage:
     async def test_dummy_upload_bytes_raises(self):
         storage = DummyR2Storage()
         with pytest.raises(RuntimeError, match="R2 is disabled"):
-            await storage.upload_bytes(
-                bucket="x", key="y", body=b"z", content_type="image/png"
-            )
+            await storage.upload_bytes(bucket="x", key="y", body=b"z", content_type="image/png")

--- a/tests/unit/test_r2_delete_job.py
+++ b/tests/unit/test_r2_delete_job.py
@@ -16,9 +16,10 @@ class TestR2DeleteImageJob:
         monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
 
         mock_r2 = AsyncMock()
-        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
-            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
-        ) as mock_purge:
+        with (
+            patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2),
+            patch("app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock) as mock_purge,
+        ):
             await r2_delete_image_job(
                 {},
                 image_id=42,
@@ -36,9 +37,10 @@ class TestR2DeleteImageJob:
     async def test_deletes_from_private_no_purge(self, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         mock_r2 = AsyncMock()
-        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
-            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
-        ) as mock_purge:
+        with (
+            patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2),
+            patch("app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock) as mock_purge,
+        ):
             await r2_delete_image_job(
                 {},
                 image_id=42,

--- a/tests/unit/test_r2_finalize_job.py
+++ b/tests/unit/test_r2_finalize_job.py
@@ -52,7 +52,9 @@ class TestR2FinalizeUploadJob:
         ):
             yield
 
-    async def test_uploads_two_variants_and_flips_public(self, fresh_image, db_session, monkeypatch, tmp_path):
+    async def test_uploads_two_variants_and_flips_public(
+        self, fresh_image, db_session, monkeypatch, tmp_path
+    ):
         """Image with no medium/large: uploads fullsize+thumbs to public bucket."""
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         monkeypatch.setattr(settings, "STORAGE_PATH", str(tmp_path))
@@ -68,10 +70,7 @@ class TestR2FinalizeUploadJob:
             await r2_finalize_upload_job({}, image_id=fresh_image.image_id)
 
         assert mock_r2.upload_file.await_count == 2
-        calls = {
-            (c.kwargs["bucket"], c.kwargs["key"])
-            for c in mock_r2.upload_file.await_args_list
-        }
+        calls = {(c.kwargs["bucket"], c.kwargs["key"]) for c in mock_r2.upload_file.await_args_list}
         assert (settings.R2_PUBLIC_BUCKET, "fullsize/2026-04-17-42.jpg") in calls
         assert (settings.R2_PUBLIC_BUCKET, "thumbs/2026-04-17-42.webp") in calls
 
@@ -145,9 +144,7 @@ class TestR2FinalizeUploadJob:
         mock_r2 = AsyncMock()
         with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2):
             with pytest.raises(Retry):
-                await r2_finalize_upload_job(
-                    {"job_try": 1}, image_id=fresh_image.image_id
-                )
+                await r2_finalize_upload_job({"job_try": 1}, image_id=fresh_image.image_id)
 
         await db_session.refresh(fresh_image)
         assert fresh_image.r2_location == R2Location.NONE  # no flip on retry

--- a/tests/unit/test_r2_status_sync_job.py
+++ b/tests/unit/test_r2_status_sync_job.py
@@ -83,9 +83,7 @@ class TestSyncImageStatusJob:
             )
         mock_r2.copy_object.assert_not_awaited()
 
-    async def test_public_to_protected_copies_deletes_and_purges(
-        self, db_session, monkeypatch
-    ):
+    async def test_public_to_protected_copies_deletes_and_purges(self, db_session, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         monkeypatch.setattr(settings, "R2_PUBLIC_CDN_URL", "https://cdn.example.com")
         # Simulate post-commit state: status already changed to REVIEW,
@@ -106,9 +104,10 @@ class TestSyncImageStatusJob:
         mock_r2 = AsyncMock()
         mock_r2.object_exists = AsyncMock(return_value=True)
 
-        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
-            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
-        ) as mock_purge:
+        with (
+            patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2),
+            patch("app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock) as mock_purge,
+        ):
             await sync_image_status_job(
                 {},
                 image_id=img.image_id,
@@ -125,9 +124,7 @@ class TestSyncImageStatusJob:
         assert all(u.startswith("https://cdn.example.com/") for u in urls)
         assert len(urls) == 3
 
-    async def test_protected_to_public_copies_deletes_no_purge(
-        self, db_session, monkeypatch
-    ):
+    async def test_protected_to_public_copies_deletes_no_purge(self, db_session, monkeypatch):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         img = Images(
             user_id=1,
@@ -142,9 +139,10 @@ class TestSyncImageStatusJob:
 
         mock_r2 = AsyncMock()
         mock_r2.object_exists = AsyncMock(return_value=True)
-        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
-            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
-        ) as mock_purge:
+        with (
+            patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2),
+            patch("app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock) as mock_purge,
+        ):
             await sync_image_status_job(
                 {},
                 image_id=img.image_id,
@@ -177,8 +175,9 @@ class TestSyncImageStatusJob:
         mock_r2 = AsyncMock()
         mock_r2.object_exists = AsyncMock(return_value=False)
 
-        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
-            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
+        with (
+            patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2),
+            patch("app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock),
         ):
             result = await sync_image_status_job(
                 {},
@@ -192,9 +191,7 @@ class TestSyncImageStatusJob:
         await db_session.refresh(img)
         assert img.r2_location == R2Location.PUBLIC
 
-    async def test_replay_when_src_missing_but_dst_exists_flips_db(
-        self, db_session, monkeypatch
-    ):
+    async def test_replay_when_src_missing_but_dst_exists_flips_db(self, db_session, monkeypatch):
         """Replay after prior run moved objects but failed before DB flip.
 
         Source is empty, destination has all variants → treat as already moved,
@@ -220,9 +217,10 @@ class TestSyncImageStatusJob:
 
         mock_r2.object_exists = AsyncMock(side_effect=object_exists)
 
-        with patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2), patch(
-            "app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock
-        ) as mock_purge:
+        with (
+            patch("app.tasks.r2_jobs.get_r2_storage", return_value=mock_r2),
+            patch("app.tasks.r2_jobs.purge_cache_by_urls", new_callable=AsyncMock) as mock_purge,
+        ):
             result = await sync_image_status_job(
                 {},
                 image_id=img.image_id,

--- a/tests/unit/test_r2_sync_avatars_backfill.py
+++ b/tests/unit/test_r2_sync_avatars_backfill.py
@@ -111,12 +111,8 @@ async def test_backfill_uploads_and_flips_bit(
     (avatar_settings / fname_a).write_bytes(b"\x89PNG-a")
     (avatar_settings / fname_b).write_bytes(b"\x89PNG-b")
 
-    user_a = _make_user(
-        db_session, username="bf_a", email="bf_a@x.test", avatar=fname_a
-    )
-    user_b = _make_user(
-        db_session, username="bf_b", email="bf_b@x.test", avatar=fname_b
-    )
+    user_a = _make_user(db_session, username="bf_a", email="bf_a@x.test", avatar=fname_a)
+    user_b = _make_user(db_session, username="bf_b", email="bf_b@x.test", avatar=fname_b)
     await db_session.commit()
 
     report = await cmd_avatars_backfill(dry_run=False, concurrency=4)
@@ -155,9 +151,7 @@ async def test_backfill_idempotent_skips_existing(
         content_type="image/png",
     )
 
-    user = _make_user(
-        db_session, username="bf_idem", email="bf_idem@x.test", avatar=fname
-    )
+    user = _make_user(db_session, username="bf_idem", email="bf_idem@x.test", avatar=fname)
     await db_session.commit()
 
     # Spy on upload_bytes to assert the script did NOT call it.
@@ -188,9 +182,7 @@ async def test_backfill_skips_when_local_missing(
     fname = "missing0000000000000000000000000.png"
     # Intentionally do NOT write the file to disk.
 
-    user = _make_user(
-        db_session, username="bf_miss", email="bf_miss@x.test", avatar=fname
-    )
+    user = _make_user(db_session, username="bf_miss", email="bf_miss@x.test", avatar=fname)
     await db_session.commit()
 
     with caplog.at_level(logging.WARNING):
@@ -204,9 +196,7 @@ async def test_backfill_skips_when_local_missing(
     assert user.avatar_in_r2 is False
 
     # No R2 object created
-    assert not await install_r2.object_exists(
-        bucket="public", key=f"avatars/{fname}"
-    )
+    assert not await install_r2.object_exists(bucket="public", key=f"avatars/{fname}")
 
     # Warning log emitted
     log_messages = " ".join(rec.getMessage() for rec in caplog.records)
@@ -224,9 +214,7 @@ async def test_backfill_dry_run_writes_nothing(
     fname = "dryrun00000000000000000000000000.png"
     (avatar_settings / fname).write_bytes(b"\x89PNG-dry")
 
-    user = _make_user(
-        db_session, username="bf_dry", email="bf_dry@x.test", avatar=fname
-    )
+    user = _make_user(db_session, username="bf_dry", email="bf_dry@x.test", avatar=fname)
     await db_session.commit()
 
     report = await cmd_avatars_backfill(dry_run=True, concurrency=2)
@@ -240,9 +228,7 @@ async def test_backfill_dry_run_writes_nothing(
 
     await db_session.refresh(user)
     assert user.avatar_in_r2 is False
-    assert not await install_r2.object_exists(
-        bucket="public", key=f"avatars/{fname}"
-    )
+    assert not await install_r2.object_exists(bucket="public", key=f"avatars/{fname}")
 
 
 @pytest.mark.unit
@@ -258,12 +244,8 @@ async def test_backfill_dry_run_reports_would_upload(
     (avatar_settings / fname_a).write_bytes(b"\x89PNG-a")
     (avatar_settings / fname_b).write_bytes(b"\x89PNG-b")
 
-    user_a = _make_user(
-        db_session, username="bf_wa", email="bf_wa@x.test", avatar=fname_a
-    )
-    user_b = _make_user(
-        db_session, username="bf_wb", email="bf_wb@x.test", avatar=fname_b
-    )
+    user_a = _make_user(db_session, username="bf_wa", email="bf_wa@x.test", avatar=fname_a)
+    user_b = _make_user(db_session, username="bf_wb", email="bf_wb@x.test", avatar=fname_b)
     await db_session.commit()
 
     report = await cmd_avatars_backfill(dry_run=True, concurrency=4)
@@ -279,9 +261,7 @@ async def test_backfill_dry_run_reports_would_upload(
     assert user_a.avatar_in_r2 is False
     assert user_b.avatar_in_r2 is False
     for fname in (fname_a, fname_b):
-        assert not await install_r2.object_exists(
-            bucket="public", key=f"avatars/{fname}"
-        )
+        assert not await install_r2.object_exists(bucket="public", key=f"avatars/{fname}")
 
 
 @pytest.mark.unit
@@ -299,15 +279,9 @@ async def test_backfill_continues_on_upload_failure(
     for fname in (fname_a, fname_b, fname_c):
         (avatar_settings / fname).write_bytes(b"\x89PNG-" + fname[:1].encode())
 
-    user_a = _make_user(
-        db_session, username="bf_fa", email="bf_fa@x.test", avatar=fname_a
-    )
-    user_b = _make_user(
-        db_session, username="bf_fb", email="bf_fb@x.test", avatar=fname_b
-    )
-    user_c = _make_user(
-        db_session, username="bf_fc", email="bf_fc@x.test", avatar=fname_c
-    )
+    user_a = _make_user(db_session, username="bf_fa", email="bf_fa@x.test", avatar=fname_a)
+    user_b = _make_user(db_session, username="bf_fb", email="bf_fb@x.test", avatar=fname_b)
+    user_c = _make_user(db_session, username="bf_fc", email="bf_fc@x.test", avatar=fname_c)
     await db_session.commit()
 
     real_upload = install_r2.__class__.upload_bytes

--- a/tests/unit/test_r2_sync_banners_backfill.py
+++ b/tests/unit/test_r2_sync_banners_backfill.py
@@ -99,9 +99,7 @@ async def test_backfill_full_image_banner(
 
     await db_session.refresh(banner)
     assert banner.in_r2 is True
-    assert await install_r2.object_exists(
-        bucket="public", key="banners/eva/full.jpg"
-    )
+    assert await install_r2.object_exists(bucket="public", key="banners/eva/full.jpg")
 
 
 @pytest.mark.unit
@@ -142,9 +140,7 @@ async def test_backfill_three_part_banner(
     # All three R2 objects exist with image/png content type
     async with moto_session.client("s3", endpoint_url=moto_server) as s3:
         for path in ("hw/l.png", "hw/m.png", "hw/r.png"):
-            head = await s3.head_object(
-                Bucket="public", Key=f"banners/{path}"
-            )
+            head = await s3.head_object(Bucket="public", Key=f"banners/{path}")
             assert head["ContentType"] == "image/png"
 
 
@@ -183,9 +179,9 @@ async def test_backfill_three_part_partial_missing_skips_row(
 
     # Critically: do NOT upload left/middle either — all-or-nothing per row.
     for path in ("partial/l.png", "partial/m.png", "partial/r.png"):
-        assert not await install_r2.object_exists(
-            bucket="public", key=f"banners/{path}"
-        ), f"unexpected R2 object for {path} (should be all-or-nothing)"
+        assert not await install_r2.object_exists(bucket="public", key=f"banners/{path}"), (
+            f"unexpected R2 object for {path} (should be all-or-nothing)"
+        )
 
     # Warning logged for the missing path
     log_messages = " ".join(rec.getMessage() for rec in caplog.records)
@@ -245,9 +241,7 @@ async def test_backfill_idempotent_skips_existing(
     assert banner.in_r2 is True
 
     # Only the two missing parts were uploaded; pre-existing one was skipped.
-    assert sorted(upload_keys) == sorted(
-        ["banners/idem/l.png", "banners/idem/r.png"]
-    )
+    assert sorted(upload_keys) == sorted(["banners/idem/l.png", "banners/idem/r.png"])
 
     # Pre-existing object preserved (its bytes were not overwritten).
     async with install_r2._acquire_client() as s3:
@@ -285,9 +279,7 @@ async def test_backfill_dry_run_writes_nothing(
 
     await db_session.refresh(banner)
     assert banner.in_r2 is False
-    assert not await install_r2.object_exists(
-        bucket="public", key="banners/dry/full.jpg"
-    )
+    assert not await install_r2.object_exists(bucket="public", key="banners/dry/full.jpg")
 
 
 @pytest.mark.unit
@@ -335,9 +327,7 @@ async def test_backfill_dry_run_reports_would_upload_parts(
 
     # No R2 writes
     for path in ("wu_full/full.jpg", "wu_3p/l.png", "wu_3p/m.png", "wu_3p/r.png"):
-        assert not await install_r2.object_exists(
-            bucket="public", key=f"banners/{path}"
-        )
+        assert not await install_r2.object_exists(bucket="public", key=f"banners/{path}")
 
     # No DB writes
     await db_session.refresh(banner_full)
@@ -401,9 +391,7 @@ async def test_backfill_dry_run_three_part_mixed(
 
     # The two missing parts were not actually uploaded.
     for path in ("drymix/l.png", "drymix/r.png"):
-        assert not await install_r2.object_exists(
-            bucket="public", key=f"banners/{path}"
-        )
+        assert not await install_r2.object_exists(bucket="public", key=f"banners/{path}")
 
     # Pre-existing middle object preserved (its bytes were not overwritten).
     async with install_r2._acquire_client() as s3:

--- a/tests/unit/test_r2_sync_remaining.py
+++ b/tests/unit/test_r2_sync_remaining.py
@@ -52,9 +52,7 @@ class TestHealth:
         ):
             yield
 
-    async def test_reports_unsynced_count_and_oldest_age(
-        self, db_session, monkeypatch, tmp_path
-    ):
+    async def test_reports_unsynced_count_and_oldest_age(self, db_session, monkeypatch, tmp_path):
         from app.models.image import Images
 
         monkeypatch.setattr(settings, "R2_ENABLED", True)
@@ -94,9 +92,7 @@ class TestPurgeCacheCommand:
         ):
             yield
 
-    async def test_calls_cloudflare_with_all_variant_urls(
-        self, db_session, monkeypatch
-    ):
+    async def test_calls_cloudflare_with_all_variant_urls(self, db_session, monkeypatch):
         from app.models.image import Images, VariantStatus
 
         monkeypatch.setattr(settings, "R2_ENABLED", True)
@@ -115,9 +111,7 @@ class TestPurgeCacheCommand:
         )
         await db_session.commit()
 
-        with patch(
-            "scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock
-        ) as mock_purge:
+        with patch("scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock) as mock_purge:
             await purge_cache_command(image_id=42)
         mock_purge.assert_awaited_once()
         urls = mock_purge.await_args.args[0]
@@ -134,9 +128,7 @@ class TestResyncImage:
         ):
             yield
 
-    async def test_prints_state_for_known_image(
-        self, db_session, monkeypatch, capsys
-    ):
+    async def test_prints_state_for_known_image(self, db_session, monkeypatch, capsys):
         from app.models.image import Images
 
         monkeypatch.setattr(settings, "R2_ENABLED", True)
@@ -162,9 +154,7 @@ class TestResyncImage:
         assert "image 99" in out
         assert "fullsize" in out and "thumbs" in out
 
-    async def test_prints_not_found_for_missing_image(
-        self, db_session, monkeypatch, capsys
-    ):
+    async def test_prints_not_found_for_missing_image(self, db_session, monkeypatch, capsys):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         await resync_image(99999999)
         assert "not found" in capsys.readouterr().out
@@ -210,9 +200,10 @@ class TestForceReuploadImage:
         await db_session.commit()
 
         mock_r2 = _attach_bulk_session(AsyncMock())
-        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2), patch(
-            "scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock
-        ) as mock_purge:
+        with (
+            patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2),
+            patch("scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock) as mock_purge,
+        ):
             await force_reupload_image(image_id=50, dry_run=False)
 
         assert mock_r2.delete_object.await_count == 4
@@ -220,9 +211,7 @@ class TestForceReuploadImage:
         # Public bucket -> purge CDN after reupload.
         mock_purge.assert_awaited_once()
 
-    async def test_private_bucket_does_not_purge(
-        self, db_session, monkeypatch, tmp_path
-    ):
+    async def test_private_bucket_does_not_purge(self, db_session, monkeypatch, tmp_path):
         from app.models.image import Images
 
         monkeypatch.setattr(settings, "R2_ENABLED", True)
@@ -241,17 +230,16 @@ class TestForceReuploadImage:
         await db_session.commit()
 
         mock_r2 = _attach_bulk_session(AsyncMock())
-        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2), patch(
-            "scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock
-        ) as mock_purge:
+        with (
+            patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2),
+            patch("scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock) as mock_purge,
+        ):
             await force_reupload_image(image_id=51, dry_run=False)
 
         assert mock_r2.upload_file.await_count == 2  # fullsize + thumbs only
         mock_purge.assert_not_awaited()
 
-    async def test_dry_run_does_not_touch_r2(
-        self, db_session, monkeypatch, tmp_path
-    ):
+    async def test_dry_run_does_not_touch_r2(self, db_session, monkeypatch, tmp_path):
         from app.models.image import Images
 
         monkeypatch.setattr(settings, "R2_ENABLED", True)
@@ -270,18 +258,17 @@ class TestForceReuploadImage:
         await db_session.commit()
 
         mock_r2 = _attach_bulk_session(AsyncMock())
-        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2), patch(
-            "scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock
-        ) as mock_purge:
+        with (
+            patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2),
+            patch("scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock) as mock_purge,
+        ):
             await force_reupload_image(image_id=52, dry_run=True)
 
         mock_r2.delete_object.assert_not_awaited()
         mock_r2.upload_file.assert_not_awaited()
         mock_purge.assert_not_awaited()
 
-    async def test_r2_location_none_refuses(
-        self, db_session, monkeypatch, tmp_path, capsys
-    ):
+    async def test_r2_location_none_refuses(self, db_session, monkeypatch, tmp_path, capsys):
         from app.models.image import Images
 
         monkeypatch.setattr(settings, "R2_ENABLED", True)
@@ -306,9 +293,7 @@ class TestForceReuploadImage:
         mock_r2.upload_file.assert_not_awaited()
         assert "reconcile" in capsys.readouterr().out
 
-    async def test_missing_local_file_skips_variant(
-        self, db_session, monkeypatch, tmp_path
-    ):
+    async def test_missing_local_file_skips_variant(self, db_session, monkeypatch, tmp_path):
         from app.models.image import Images
 
         monkeypatch.setattr(settings, "R2_ENABLED", True)
@@ -329,16 +314,15 @@ class TestForceReuploadImage:
         await db_session.commit()
 
         mock_r2 = _attach_bulk_session(AsyncMock())
-        with patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2), patch(
-            "scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock
+        with (
+            patch("scripts.r2_sync.get_r2_storage", return_value=mock_r2),
+            patch("scripts.r2_sync.purge_cache_by_urls", new_callable=AsyncMock),
         ):
             await force_reupload_image(image_id=54, dry_run=False)
 
         assert mock_r2.upload_file.await_count == 1  # fullsize only
 
-    async def test_prints_not_found_for_missing_image(
-        self, db_session, monkeypatch, capsys
-    ):
+    async def test_prints_not_found_for_missing_image(self, db_session, monkeypatch, capsys):
         monkeypatch.setattr(settings, "R2_ENABLED", True)
         await force_reupload_image(image_id=99999999, dry_run=False)
         assert "not found" in capsys.readouterr().out
@@ -378,9 +362,7 @@ class TestVerify:
             report = await verify(sample=None)
         assert report["discrepancies"] == []
 
-    async def test_none_with_unexpected_object_reports_unexpected(
-        self, db_session, monkeypatch
-    ):
+    async def test_none_with_unexpected_object_reports_unexpected(self, db_session, monkeypatch):
         """NONE row + object present in either bucket -> leaked upload."""
         from app.models.image import Images
 
@@ -406,9 +388,7 @@ class TestVerify:
         kinds = {d["kind"] for d in report["discrepancies"]}
         assert "unexpected" in kinds
 
-    async def test_cross_bucket_orphan_reports_wrong_bucket(
-        self, db_session, monkeypatch
-    ):
+    async def test_cross_bucket_orphan_reports_wrong_bucket(self, db_session, monkeypatch):
         """PUBLIC row with copy also in private bucket -> incomplete move."""
         from app.models.image import Images
 
@@ -432,9 +412,7 @@ class TestVerify:
         kinds = {d["kind"] for d in report["discrepancies"]}
         assert "wrong_bucket" in kinds
 
-    async def test_missing_from_expected_bucket_reports_missing(
-        self, db_session, monkeypatch
-    ):
+    async def test_missing_from_expected_bucket_reports_missing(self, db_session, monkeypatch):
         """PUBLIC row with object missing from public bucket -> report missing."""
         from app.models.image import Images
 

--- a/tests/unit/test_repost_cleanup.py
+++ b/tests/unit/test_repost_cleanup.py
@@ -75,17 +75,15 @@ class TestMigrateRepostData:
 
         # Favorite now on original
         fav_count = await db_session.execute(
-            select(func.count()).select_from(Favorites).where(
-                Favorites.image_id == original.image_id
-            )
+            select(func.count())
+            .select_from(Favorites)
+            .where(Favorites.image_id == original.image_id)
         )
         assert fav_count.scalar() == 1
 
         # No favorites on repost
         fav_count = await db_session.execute(
-            select(func.count()).select_from(Favorites).where(
-                Favorites.image_id == repost.image_id
-            )
+            select(func.count()).select_from(Favorites).where(Favorites.image_id == repost.image_id)
         )
         assert fav_count.scalar() == 0
 
@@ -104,17 +102,17 @@ class TestMigrateRepostData:
 
         # Rating now on original
         rating_count = await db_session.execute(
-            select(func.count()).select_from(ImageRatings).where(
-                ImageRatings.image_id == original.image_id
-            )
+            select(func.count())
+            .select_from(ImageRatings)
+            .where(ImageRatings.image_id == original.image_id)
         )
         assert rating_count.scalar() == 1
 
         # No ratings on repost
         rating_count = await db_session.execute(
-            select(func.count()).select_from(ImageRatings).where(
-                ImageRatings.image_id == repost.image_id
-            )
+            select(func.count())
+            .select_from(ImageRatings)
+            .where(ImageRatings.image_id == repost.image_id)
         )
         assert rating_count.scalar() == 0
 
@@ -125,9 +123,7 @@ class TestMigrateRepostData:
         repost = await _create_image(db_session, user.user_id, "repo3")
         tag = await _create_tag(db_session, "test tag")
 
-        db_session.add(TagLinks(
-            tag_id=tag.tag_id, image_id=repost.image_id, user_id=user.user_id
-        ))
+        db_session.add(TagLinks(tag_id=tag.tag_id, image_id=repost.image_id, user_id=user.user_id))
         await db_session.flush()
 
         result = await migrate_repost_data(repost.image_id, original.image_id, db_session)
@@ -136,17 +132,13 @@ class TestMigrateRepostData:
 
         # Tag link now on original
         tag_count = await db_session.execute(
-            select(func.count()).select_from(TagLinks).where(
-                TagLinks.image_id == original.image_id
-            )
+            select(func.count()).select_from(TagLinks).where(TagLinks.image_id == original.image_id)
         )
         assert tag_count.scalar() == 1
 
         # No tag links on repost
         tag_count = await db_session.execute(
-            select(func.count()).select_from(TagLinks).where(
-                TagLinks.image_id == repost.image_id
-            )
+            select(func.count()).select_from(TagLinks).where(TagLinks.image_id == repost.image_id)
         )
         assert tag_count.scalar() == 0
 
@@ -165,9 +157,9 @@ class TestMigrateRepostData:
         assert result["favorites_moved"] == 0
 
         fav_count = await db_session.execute(
-            select(func.count()).select_from(Favorites).where(
-                Favorites.image_id == original.image_id
-            )
+            select(func.count())
+            .select_from(Favorites)
+            .where(Favorites.image_id == original.image_id)
         )
         assert fav_count.scalar() == 1
 
@@ -200,7 +192,9 @@ class TestMigrateRepostData:
         repost = await _create_image(db_session, user.user_id, "repo6")
         tag = await _create_tag(db_session, "duptag")
 
-        db_session.add(TagLinks(tag_id=tag.tag_id, image_id=original.image_id, user_id=user.user_id))
+        db_session.add(
+            TagLinks(tag_id=tag.tag_id, image_id=original.image_id, user_id=user.user_id)
+        )
         db_session.add(TagLinks(tag_id=tag.tag_id, image_id=repost.image_id, user_id=user.user_id))
         await db_session.flush()
 
@@ -209,9 +203,7 @@ class TestMigrateRepostData:
         assert result["tags_moved"] == 0
 
         tag_count = await db_session.execute(
-            select(func.count()).select_from(TagLinks).where(
-                TagLinks.image_id == original.image_id
-            )
+            select(func.count()).select_from(TagLinks).where(TagLinks.image_id == original.image_id)
         )
         assert tag_count.scalar() == 1
 
@@ -279,9 +271,9 @@ class TestMigrateRepostData:
         db_session.add(theme_tag)
         await db_session.flush()
         await db_session.refresh(theme_tag)
-        db_session.add(TagLinks(
-            tag_id=theme_tag.tag_id, image_id=original.image_id, user_id=user.user_id
-        ))
+        db_session.add(
+            TagLinks(tag_id=theme_tag.tag_id, image_id=original.image_id, user_id=user.user_id)
+        )
 
         # repost has an artist tag (type=3)
         repost = await _create_image(db_session, user.user_id, "repo10")
@@ -289,9 +281,9 @@ class TestMigrateRepostData:
         db_session.add(artist_tag)
         await db_session.flush()
         await db_session.refresh(artist_tag)
-        db_session.add(TagLinks(
-            tag_id=artist_tag.tag_id, image_id=repost.image_id, user_id=user.user_id
-        ))
+        db_session.add(
+            TagLinks(tag_id=artist_tag.tag_id, image_id=repost.image_id, user_id=user.user_id)
+        )
 
         # Establish baseline flags
         await refresh_images_tag_type_flags(db_session, [original.image_id, repost.image_id])

--- a/tests/unit/test_review_deadline_job.py
+++ b/tests/unit/test_review_deadline_job.py
@@ -231,9 +231,7 @@ class TestRemoveDeactivates:
         await db_session.commit()
         await db_session.refresh(review)
 
-        transition = await _close_review(
-            db_session, review, ReviewOutcome.REMOVE, "quorum_reached"
-        )
+        transition = await _close_review(db_session, review, ReviewOutcome.REMOVE, "quorum_reached")
         await db_session.commit()
 
         await db_session.refresh(image)
@@ -244,12 +242,16 @@ class TestRemoveDeactivates:
 
         # Public status history row carries the category + reason
         hist = (
-            await db_session.execute(
-                select(ImageStatusHistory).where(
-                    ImageStatusHistory.image_id == image.image_id  # type: ignore[arg-type]
+            (
+                await db_session.execute(
+                    select(ImageStatusHistory).where(
+                        ImageStatusHistory.image_id == image.image_id  # type: ignore[arg-type]
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         assert any(
             h.new_status == ImageStatus.DEACTIVATED
             and h.reason_category == DeactivationReason.LOW_QUALITY
@@ -279,9 +281,7 @@ class TestNoQuorum:
     async def test_no_quorum_extend_first_time(self, db_session: AsyncSession):
         """2 votes total, deadline passed, extension_used=false -> extend deadline."""
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, extension_used=0
-        )
+        review = await create_test_review(db_session, image.image_id, extension_used=0)
         await add_votes(db_session, review.review_id, keep_count=1, remove_count=1)  # type: ignore[arg-type]
 
         old_deadline = review.deadline
@@ -298,9 +298,7 @@ class TestNoQuorum:
     async def test_no_quorum_default_keep_after_extension(self, db_session: AsyncSession):
         """2 votes total, deadline passed, extension_used=true -> close with outcome=KEEP."""
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, extension_used=1
-        )
+        review = await create_test_review(db_session, image.image_id, extension_used=1)
         await add_votes(db_session, review.review_id, keep_count=1, remove_count=1)  # type: ignore[arg-type]
 
         result = await check_review_deadlines(db_session)
@@ -321,9 +319,7 @@ class TestTieScenarios:
     async def test_tie_with_quorum_extend_first_time(self, db_session: AsyncSession):
         """2 keep, 2 remove, extension_used=false -> extend deadline."""
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, extension_used=0
-        )
+        review = await create_test_review(db_session, image.image_id, extension_used=0)
         await add_votes(db_session, review.review_id, keep_count=2, remove_count=2)  # type: ignore[arg-type]
 
         result = await check_review_deadlines(db_session)
@@ -337,9 +333,7 @@ class TestTieScenarios:
     async def test_tie_with_quorum_default_keep_after_extension(self, db_session: AsyncSession):
         """2 keep, 2 remove, extension_used=true -> close with outcome=KEEP."""
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, extension_used=1
-        )
+        review = await create_test_review(db_session, image.image_id, extension_used=1)
         await add_votes(db_session, review.review_id, keep_count=2, remove_count=2)  # type: ignore[arg-type]
 
         result = await check_review_deadlines(db_session)
@@ -360,9 +354,7 @@ class TestEdgeCases:
         """Review not past deadline -> no action taken."""
         image = await create_test_image(db_session)
         # Deadline in future
-        review = await create_test_review(
-            db_session, image.image_id, deadline_offset_days=7
-        )
+        review = await create_test_review(db_session, image.image_id, deadline_offset_days=7)
         await add_votes(db_session, review.review_id, keep_count=3, remove_count=0)  # type: ignore[arg-type]
 
         result = await check_review_deadlines(db_session)
@@ -387,9 +379,7 @@ class TestEdgeCases:
     async def test_zero_votes_extend_first_time(self, db_session: AsyncSession):
         """0 votes, deadline passed -> extend (first time)."""
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, extension_used=0
-        )
+        review = await create_test_review(db_session, image.image_id, extension_used=0)
         # No votes added
 
         result = await check_review_deadlines(db_session)
@@ -402,9 +392,7 @@ class TestEdgeCases:
     async def test_zero_votes_default_keep_after_extension(self, db_session: AsyncSession):
         """0 votes, deadline passed, extension used -> default keep."""
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, extension_used=1
-        )
+        review = await create_test_review(db_session, image.image_id, extension_used=1)
         # No votes added
 
         result = await check_review_deadlines(db_session)
@@ -449,9 +437,7 @@ class TestAuditLogging:
         from sqlalchemy import select
 
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, extension_used=0
-        )
+        review = await create_test_review(db_session, image.image_id, extension_used=0)
         await add_votes(db_session, review.review_id, keep_count=1, remove_count=0)  # type: ignore[arg-type]
 
         await check_review_deadlines(db_session)
@@ -505,7 +491,9 @@ class TestEarlyClose:
         """3 keep, 0 remove (margin=3) -> close with outcome=KEEP."""
         image = await create_test_image(db_session)
         review = await create_test_review(
-            db_session, image.image_id, deadline_offset_days=7  # Not expired
+            db_session,
+            image.image_id,
+            deadline_offset_days=7,  # Not expired
         )
         await add_votes(db_session, review.review_id, keep_count=3, remove_count=0)  # type: ignore[arg-type]
 
@@ -523,9 +511,7 @@ class TestEarlyClose:
     async def test_early_close_remove_margin_met(self, db_session: AsyncSession):
         """0 keep, 3 remove (margin=3) -> close with outcome=REMOVE."""
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, deadline_offset_days=7
-        )
+        review = await create_test_review(db_session, image.image_id, deadline_offset_days=7)
         await add_votes(db_session, review.review_id, keep_count=0, remove_count=3)  # type: ignore[arg-type]
 
         closed = await check_early_close(db_session, review)
@@ -543,9 +529,7 @@ class TestEarlyClose:
     async def test_early_close_margin_not_met(self, db_session: AsyncSession):
         """2 keep, 1 remove (margin=1, needs 3) -> stays open."""
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, deadline_offset_days=7
-        )
+        review = await create_test_review(db_session, image.image_id, deadline_offset_days=7)
         await add_votes(db_session, review.review_id, keep_count=2, remove_count=1)  # type: ignore[arg-type]
 
         closed = await check_early_close(db_session, review)
@@ -558,9 +542,7 @@ class TestEarlyClose:
     async def test_early_close_tie(self, db_session: AsyncSession):
         """3 keep, 3 remove (margin=0) -> stays open."""
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, deadline_offset_days=7
-        )
+        review = await create_test_review(db_session, image.image_id, deadline_offset_days=7)
         await add_votes(db_session, review.review_id, keep_count=3, remove_count=3)  # type: ignore[arg-type]
 
         closed = await check_early_close(db_session, review)
@@ -573,9 +555,7 @@ class TestEarlyClose:
     async def test_early_close_large_margin_keep(self, db_session: AsyncSession):
         """5 keep, 2 remove (margin=3) -> close with KEEP."""
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, deadline_offset_days=7
-        )
+        review = await create_test_review(db_session, image.image_id, deadline_offset_days=7)
         await add_votes(db_session, review.review_id, keep_count=5, remove_count=2)  # type: ignore[arg-type]
 
         closed = await check_early_close(db_session, review)
@@ -593,9 +573,7 @@ class TestEarlyClose:
         from sqlalchemy import select
 
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, deadline_offset_days=7
-        )
+        review = await create_test_review(db_session, image.image_id, deadline_offset_days=7)
         await add_votes(db_session, review.review_id, keep_count=3, remove_count=0)  # type: ignore[arg-type]
 
         await check_early_close(db_session, review)
@@ -615,9 +593,7 @@ class TestEarlyClose:
     async def test_early_close_no_votes(self, db_session: AsyncSession):
         """0 votes -> stays open."""
         image = await create_test_image(db_session)
-        review = await create_test_review(
-            db_session, image.image_id, deadline_offset_days=7
-        )
+        review = await create_test_review(db_session, image.image_id, deadline_offset_days=7)
 
         closed = await check_early_close(db_session, review)
 

--- a/tests/unit/test_review_system.py
+++ b/tests/unit/test_review_system.py
@@ -167,7 +167,9 @@ class TestSchemaValidation:
             ReviewCreate()
 
         # Default deadline with required fields
-        review = ReviewCreate(reason_category=DeactivationReason.INAPPROPRIATE, reason="needs review")
+        review = ReviewCreate(
+            reason_category=DeactivationReason.INAPPROPRIATE, reason="needs review"
+        )
         assert review.deadline_days is None
         assert review.reason_category == DeactivationReason.INAPPROPRIATE
         assert review.reason == "needs review"

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -9,8 +9,8 @@ from datetime import datetime
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from app.schemas.base import UTCDatetime, UTCDatetimeOptional
 from app.schemas.auth import ForgotPasswordRequest, ResetPasswordRequest
+from app.schemas.base import UTCDatetime, UTCDatetimeOptional
 from app.schemas.image import (
     ImageBase,
     ImageResponse,

--- a/tests/unit/test_schemas_audit.py
+++ b/tests/unit/test_schemas_audit.py
@@ -1,10 +1,10 @@
 """Tests for audit schemas."""
 
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
 from app.schemas.audit import (
-    TagAuditLogResponse,
     ImageStatusHistoryResponse,
+    TagAuditLogResponse,
     TagHistoryResponse,
 )
 

--- a/tests/unit/test_url_import_base.py
+++ b/tests/unit/test_url_import_base.py
@@ -46,7 +46,9 @@ class TestFetchJson:
 
         async with _client(handler) as client:
             await fetch_json(
-                client, "https://example.test/api", site="example",
+                client,
+                "https://example.test/api",
+                site="example",
                 headers={"Referer": "https://example.test/"},
             )
         assert seen["referer"] == "https://example.test/"
@@ -127,9 +129,7 @@ class TestAdvertisedSites:
         for entry in advertised_sites():
             owner = get_resolver(entry.example_url)
             assert owner is not None
-            assert owner.site == entry.site, (
-                f"{entry.site} example is claimed by {owner.site}"
-            )
+            assert owner.site == entry.site, f"{entry.site} example is claimed by {owner.site}"
 
     def test_every_advertised_entry_has_a_nonempty_example(self):
         entries = advertised_sites()

--- a/tests/unit/test_url_import_boorus.py
+++ b/tests/unit/test_url_import_boorus.py
@@ -104,7 +104,9 @@ class TestDanbooru:
                 await DanbooruResolver().resolve(self.URL, client)
 
     async def test_off_host_preview_url_rejects_whole_post(self):
-        async with _client({**self.POST, "preview_file_url": "https://evil.example/a.jpg"}) as client:
+        async with _client(
+            {**self.POST, "preview_file_url": "https://evil.example/a.jpg"}
+        ) as client:
             with pytest.raises(UpstreamError):
                 await DanbooruResolver().resolve(self.URL, client)
 

--- a/tests/unit/test_url_import_og.py
+++ b/tests/unit/test_url_import_og.py
@@ -62,7 +62,9 @@ class TestFetchOgPage:
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             with pytest.raises(UpstreamError):
                 await fetch_og_page(
-                    client, "https://www.zerochan.net/123", site="zerochan",
+                    client,
+                    "https://www.zerochan.net/123",
+                    site="zerochan",
                     allowed_hosts={"www.zerochan.net", "zerochan.net"},
                 )
 
@@ -77,7 +79,9 @@ class TestFetchOgPage:
 
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             tags = await fetch_og_page(
-                client, "https://www.zerochan.net/123", site="zerochan",
+                client,
+                "https://www.zerochan.net/123",
+                site="zerochan",
                 allowed_hosts={"www.zerochan.net", "zerochan.net"},
             )
         assert tags["image"].endswith("/full/1.jpg")
@@ -92,7 +96,9 @@ class TestFetchOgPage:
 
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             await fetch_og_page(
-                client, "https://www.zerochan.net/123", site="zerochan",
+                client,
+                "https://www.zerochan.net/123",
+                site="zerochan",
                 allowed_hosts={"www.zerochan.net", "zerochan.net"},
             )
         assert seen["user_agent"] == BROWSER_USER_AGENT
@@ -106,7 +112,9 @@ class TestFetchOgPage:
 
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             await fetch_og_page(
-                client, "https://www.zerochan.net/123", site="zerochan",
+                client,
+                "https://www.zerochan.net/123",
+                site="zerochan",
                 allowed_hosts={"www.zerochan.net", "zerochan.net"},
                 user_agent=TOOL_USER_AGENT,
             )
@@ -203,7 +211,9 @@ class TestKofi:
 
     async def test_resolve(self):
         def handler(request):
-            return httpx.Response(200, text=_page("https://storage.ko-fi.com/cdn/useruploads/post/x.png", "Fanart!"))
+            return httpx.Response(
+                200, text=_page("https://storage.ko-fi.com/cdn/useruploads/post/x.png", "Fanart!")
+            )
 
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             post = await KofiResolver().resolve(self.URL, client)
@@ -216,7 +226,9 @@ class TestKofi:
 
         def handler(request):
             fetched_urls.append(str(request.url))
-            return httpx.Response(200, text=_page("https://storage.ko-fi.com/cdn/useruploads/post/x.png"))
+            return httpx.Response(
+                200, text=_page("https://storage.ko-fi.com/cdn/useruploads/post/x.png")
+            )
 
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             bare_post = await KofiResolver().resolve("https://ko-fi.com/i/IX8X0ABC12", client)

--- a/tests/unit/test_url_import_pixiv.py
+++ b/tests/unit/test_url_import_pixiv.py
@@ -56,7 +56,9 @@ class TestMatch:
         assert not resolver.match("https://example.com/artworks/1")
 
     def test_registered(self):
-        assert isinstance(get_resolver("https://www.pixiv.net/en/artworks/138823691"), PixivResolver)
+        assert isinstance(
+            get_resolver("https://www.pixiv.net/en/artworks/138823691"), PixivResolver
+        )
 
 
 class TestResolve:
@@ -85,15 +87,18 @@ class TestResolve:
 
     async def test_multi_page_uses_pages_endpoint(self):
         pages = [
-            {"urls": {"original": f"https://i.pximg.net/img-original/img/x/138823691_p{i}.png",
-                      "small": f"https://i.pximg.net/c/540x540_70/img-master/img/x/138823691_p{i}_master1200.jpg"},
-             "width": 100, "height": 200}
+            {
+                "urls": {
+                    "original": f"https://i.pximg.net/img-original/img/x/138823691_p{i}.png",
+                    "small": f"https://i.pximg.net/c/540x540_70/img-master/img/x/138823691_p{i}_master1200.jpg",
+                },
+                "width": 100,
+                "height": 200,
+            }
             for i in range(3)
         ]
         async with _client(_illust_body(pageCount=3), pages) as client:
-            post = await PixivResolver().resolve(
-                "https://www.pixiv.net/artworks/138823691", client
-            )
+            post = await PixivResolver().resolve("https://www.pixiv.net/artworks/138823691", client)
         assert [img.full_url for img in post.images] == [p["urls"]["original"] for p in pages]
         assert post.images[1].width == 100
 
@@ -109,7 +114,14 @@ class TestResolve:
 
     async def test_error_payload_raises_not_found(self):
         def handler(request):
-            return httpx.Response(200, json={"error": True, "message": "該当作品は削除されたか、存在しない作品IDです。", "body": []})
+            return httpx.Response(
+                200,
+                json={
+                    "error": True,
+                    "message": "該当作品は削除されたか、存在しない作品IDです。",
+                    "body": [],
+                },
+            )
 
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             with pytest.raises(PostNotFoundError):
@@ -122,7 +134,12 @@ class TestResolve:
                 return httpx.Response(200, json={"error": False, "body": _illust_body(pageCount=3)})
             if path == "/ajax/illust/138823691/pages":
                 return httpx.Response(
-                    200, json={"error": True, "message": "該当作品は削除されたか、存在しない作品IDです。", "body": []}
+                    200,
+                    json={
+                        "error": True,
+                        "message": "該当作品は削除されたか、存在しない作品IDです。",
+                        "body": [],
+                    },
                 )
             return httpx.Response(404)
 
@@ -186,31 +203,45 @@ class TestResolve:
         assert post.images[0].full_url.endswith("_p0.png")
 
     async def test_off_host_original_url_rejects_whole_post(self):
-        body = _illust_body(urls={
-            "small": "https://i.pximg.net/c/540x540_70/img-master/img/x/138823691_p0_master1200.jpg",
-            "original": "https://evil.example/a.png",
-        })
+        body = _illust_body(
+            urls={
+                "small": "https://i.pximg.net/c/540x540_70/img-master/img/x/138823691_p0_master1200.jpg",
+                "original": "https://evil.example/a.png",
+            }
+        )
         async with _client(body) as client:
             with pytest.raises(UpstreamError):
                 await PixivResolver().resolve("https://www.pixiv.net/artworks/138823691", client)
 
     async def test_off_host_thumb_url_rejects_whole_post(self):
-        body = _illust_body(urls={
-            "small": "https://evil.example/thumb.jpg",
-            "original": "https://i.pximg.net/img-original/img/x/138823691_p0.png",
-        })
+        body = _illust_body(
+            urls={
+                "small": "https://evil.example/thumb.jpg",
+                "original": "https://i.pximg.net/img-original/img/x/138823691_p0.png",
+            }
+        )
         async with _client(body) as client:
             with pytest.raises(UpstreamError):
                 await PixivResolver().resolve("https://www.pixiv.net/artworks/138823691", client)
 
     async def test_off_host_page_url_rejects_whole_post(self):
         pages = [
-            {"urls": {"original": "https://i.pximg.net/img-original/img/x/138823691_p0.png",
-                      "small": "https://i.pximg.net/c/540x540_70/img-master/img/x/138823691_p0_master1200.jpg"},
-             "width": 100, "height": 200},
-            {"urls": {"original": "https://evil.example/p1.png",
-                      "small": "https://i.pximg.net/c/540x540_70/img-master/img/x/138823691_p1_master1200.jpg"},
-             "width": 100, "height": 200},
+            {
+                "urls": {
+                    "original": "https://i.pximg.net/img-original/img/x/138823691_p0.png",
+                    "small": "https://i.pximg.net/c/540x540_70/img-master/img/x/138823691_p0_master1200.jpg",
+                },
+                "width": 100,
+                "height": 200,
+            },
+            {
+                "urls": {
+                    "original": "https://evil.example/p1.png",
+                    "small": "https://i.pximg.net/c/540x540_70/img-master/img/x/138823691_p1_master1200.jpg",
+                },
+                "width": 100,
+                "height": 200,
+            },
         ]
         async with _client(_illust_body(pageCount=2), pages) as client:
             with pytest.raises(UpstreamError):

--- a/tests/unit/test_user_groups_relationship.py
+++ b/tests/unit/test_user_groups_relationship.py
@@ -24,9 +24,7 @@ async def test_user_groups_has_group_relationship(db_session: AsyncSession):
 
     # Query with eager loading
     result = await db_session.execute(
-        select(UserGroups)
-        .options(selectinload(UserGroups.group))
-        .where(UserGroups.user_id == 1)
+        select(UserGroups).options(selectinload(UserGroups.group)).where(UserGroups.user_id == 1)
     )
     ug = result.scalar_one()
 
@@ -52,9 +50,7 @@ async def test_users_has_groups_property(db_session: AsyncSession):
     # Query user with eager loading
     result = await db_session.execute(
         select(Users)
-        .options(
-            selectinload(Users.user_groups).selectinload(UserGroups.group)
-        )
+        .options(selectinload(Users.user_groups).selectinload(UserGroups.group))
         .where(Users.user_id == 1)
     )
     user = result.scalar_one()
@@ -70,9 +66,7 @@ async def test_users_groups_property_empty(db_session: AsyncSession):
     # User 1 exists from fixture but has no groups
     result = await db_session.execute(
         select(Users)
-        .options(
-            selectinload(Users.user_groups).selectinload(UserGroups.group)
-        )
+        .options(selectinload(Users.user_groups).selectinload(UserGroups.group))
         .where(Users.user_id == 1)
     )
     user = result.scalar_one()


### PR DESCRIPTION
Last of a four-PR stack. Base is `chore/db-tooling` (#329) — merge #327, #328, #329, then this.

## This corrects #327

That PR removed `scripts` from the exclude in `.pre-commit-config.yaml` and I reported it as enabling enforcement. It didn't. `pyproject.toml`'s `[tool.ruff] extend-exclude` still listed `scripts`, and the pre-commit hook passes `--force-exclude`, which honours that even for explicitly named files. Ruff printed `No Python files found under the given path(s)` and the hook reported `Passed`. The green was empty.

`extend-exclude` is now just `["docs"]` and the pre-commit exclude just `^docs/`. With both layers lifted, ruff sees **195 test files and 37 scripts for the first time** — 70 lint errors and 100 files needing format.

## What changed, and what deliberately didn't

Most errors were auto-fixed. Three categories were fixed only after checking each site: `zip()` gained `strict=True` where both sequences are built from the same `range()` and cannot diverge (ruff's autofix inserted `strict=False`; corrected to `strict=True` in 5df47cb after review); unused loop variables were dropped; one `dict()` call became a literal. In `test_images.py` a loop enumerated rating values it never used — they're applied by a second loop below it — so that one is now a plain `range(3)`.

Three categories are ignored rather than fixed, because fixing them would change what the tests do:

| rule | scope | why |
|---|---|---|
| `F841` | `tests/**` | Fixtures are bound to a name to keep the row alive for later assertions, never to read the value. Removing the binding removes the row. |
| `E402` | `test_user_ratings_endpoint.py` | Helpers imported partway down the file to avoid an import cycle. |
| `UP031` | `test_redacted_str.py` | The `%`-formatting is the subject of the assertions — it proves `RedactedStr` survives the `%r` path arq uses when logging job kwargs. Rewriting it would stop testing the leak path. |

## Verification

Verified by falsification rather than by a green, given how the first attempt failed: injecting a violation into a `tests/` file now makes the hook **fail**. Full suite passes — **2537 passed, 10 skipped**.

Also included: a corrected comment on why the pydantic mypy plugin stays disabled. The old note blamed a `typing_extensions` conflict; CLI mypy actually loads the plugin fine on mypy 1.19 / pydantic 2.12. The real reason is that it synthesises `__init__` from field names and misreports alias-based construction, and it does nothing for the SQLAlchemy errors that are most of the suppressions.

## Note for reviewers

114 files, but ~100 are mechanical whitespace reformats. The reviewable content is `pyproject.toml`, `.pre-commit-config.yaml`, and the handful of semantic edits listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx4tX6zYZWuMu4EWHy6F6D