### PR TITLE
docs: note that the frontend repo has its own AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,17 @@ await upload.check_upload_rate_limit(user_id, db)
 await iqdb.add_to_iqdb(image_id, file_path)
 ```
 
+## Working across repos
+
+The SvelteKit frontend lives at `../shuushuu-frontend` and has its own
+`AGENTS.md`. If a task takes you into that repo, read its instructions before
+editing there: its conventions, tooling, and test commands are not these. The
+same holds in reverse for an agent based in that repo reaching into this one.
+
+Its API types are generated from this repo's OpenAPI schema, so a change to a
+response model there is a frontend change too — regenerate and commit the types
+with the frontend code that needs them.
+
 ## Legacy Migration Notes
 - PHP codebase in `shuu-php/` is read-only reference for business logic understanding
 - Database schema originated from PHP; migrations track changes going forward


### PR DESCRIPTION
Pairs with [frontend#369](https://github.com/anonymousobject/shuushuu-frontend/pull/369), which adds the matching note on that side. Independent of everything else here.

Features are often built by one agent working both repos, and an agent based in either one **never loads the other's `AGENTS.md`** — `CLAUDE.md` discovery only walks up from the working directory, and a sibling checkout is not an ancestor. So conventions silently fail to cross: this file's `uv`, pytest and SQLModel rules say nothing useful about SvelteKit, and vice versa.

Adds a pointer in each repo to read the other's instructions before editing there, plus the one workflow that genuinely spans both: the frontend's API types are generated from this repo's OpenAPI schema, so changing a response model is a frontend change too.

One line of `AGENTS.md`. No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx4tX6zYZWuMu4EWHy6F6D