### PR TITLE
docs: repoint frontend plan references at their quarter directories

### DIFF
--- a/docs/plans/2026-Q2/2026-06-23-ml-suggestions-on-upload-api-impl.md
+++ b/docs/plans/2026-Q2/2026-06-23-ml-suggestions-on-upload-api-impl.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** FastAPI · SQLAlchemy async · arq · redis.asyncio · onnxruntime · pytest (httpx AsyncClient + ASGITransport).
 
-**Companion spec:** `../../../shuushuu-frontend/docs/plans/2026-06-23-ml-suggestions-on-upload-design.md` (cross-repo design). This plan covers the **API** only; the frontend is a separate plan.
+**Companion spec:** `../../../shuushuu-frontend/docs/plans/2026-Q2/2026-06-23-ml-suggestions-on-upload-design.md` (cross-repo design). This plan covers the **API** only; the frontend is a separate plan.
 
 **Repo hygiene (CRITICAL):** the `shuushuu-api` working tree carries unrelated uncommitted user WIP. NEVER `git add -A`/`.`/`-u` or `git commit -a`. Stage only the exact files named in each task's commit step and verify `git status` first. Commit footer on every commit:
 ```

--- a/docs/plans/2026-Q3/2026-07-16-ml-suggestion-lifecycle-impl.md
+++ b/docs/plans/2026-Q3/2026-07-16-ml-suggestion-lifecycle-impl.md
@@ -10,7 +10,7 @@
 
 ## Global Constraints
 
-- Spec of record: `../shuushuu-frontend/docs/plans/2026-07-16-ml-suggestion-lifecycle-and-history-design.md` (Part 1); decisions: `docs/adr/0001-ml-queue-write-time-invalidation.md`, `docs/adr/0002-suggestion-rows-follow-image-status.md`; vocabulary: `CONTEXT.md` (suggestion-eligible, system resolution).
+- Spec of record: `../shuushuu-frontend/docs/plans/2026-Q3/2026-07-16-ml-suggestion-lifecycle-and-history-design.md` (Part 1); decisions: `docs/adr/0001-ml-queue-write-time-invalidation.md`, `docs/adr/0002-suggestion-rows-follow-image-status.md`; vocabulary: `CONTEXT.md` (suggestion-eligible, system resolution).
 - Suggestion-eligible statuses are exactly `{ImageStatus.ACTIVE, ImageStatus.SPOILER}` = `{1, 2}`. Real constants: `REVIEW=-4, LOW_QUALITY=-3, INAPPROPRIATE=-2, REPOST=-1, DEACTIVATED=0, ACTIVE=1, SPOILER=2` (`app/config.py:400-410`). Never invent status values.
 - Feature branch `feat/ml-suggestion-lifecycle` off `main`. This repo has unrelated uncommitted WIP (`scripts/db_utils.py`, `scripts/prune_inactive_users.py`, `scripts/restore_prod_db.py`, old `docs/plans/*.md`) — **never `git add -A`**; stage only the files you touched.
 - Lifecycle hooks are atomic with the status change: no try/except around them; flush-only, caller owns commit.
@@ -1031,5 +1031,5 @@ Expected: `ok`.
 git push origin HEAD
 gh pr create --base main --head feat/ml-suggestion-lifecycle \
   --title "feat(ml): suggestion rows follow the image-status lifecycle" \
-  --body "Closes #274. See docs/adr/0002-suggestion-rows-follow-image-status.md and the design doc in shuushuu-frontend/docs/plans/2026-07-16-ml-suggestion-lifecycle-and-history-design.md."
+  --body "Closes #274. See docs/adr/0002-suggestion-rows-follow-image-status.md and the design doc in shuushuu-frontend/docs/plans/2026-Q3/2026-07-16-ml-suggestion-lifecycle-and-history-design.md."
 ```

--- a/tests/api/v1/test_user_history_endpoint.py
+++ b/tests/api/v1/test_user_history_endpoint.py
@@ -1242,7 +1242,7 @@ class TestUserHistoryLinkedTags:
 
     Field naming mirrors TagAuditLogResponse 1:1 so the frontend can reuse
     its existing getLinkedTag() helper. See
-    https://github.com/anonymousobject/shuushuu-frontend/blob/main/docs/plans/2026-05-23-history-linked-tags-api-requirements.md
+    https://github.com/anonymousobject/shuushuu-frontend/blob/main/docs/plans/2026-Q2/2026-05-23-history-linked-tags-api-requirements.md
     """
 
     async def _make_user(self, db_session: AsyncSession, username: str) -> Users:


### PR DESCRIPTION
> **Merge [frontend#368](https://github.com/anonymousobject/shuushuu-frontend/pull/368) first.** The paths this PR points at only exist once that reorg lands.

shuushuu-frontend moved its 151 plans into `docs/plans/<YYYY>-Q<N>/`, mirroring what this repo did in #327. Four references here named the old flat paths:

| plan | now |
|---|---|
| `2026-05-23-history-linked-tags-api-requirements.md` | `2026-Q2/` |
| `2026-06-23-ml-suggestions-on-upload-design.md` | `2026-Q2/` |
| `2026-07-16-ml-suggestion-lifecycle-and-history-design.md` (×2) | `2026-Q3/` |

One of those is the GitHub blob URL in `tests/api/v1/test_user_history_endpoint.py`, which is worth recording: **a `blob/main` URL survives a change in how repos are checked out locally, but not a file move.** Only a commit-pinned permalink would. I'd previously cited that URL as the durable form of a cross-repo reference on the strength of it surviving *this* repo's reorg; it broke on the frontend's.

Not touched: `shuushuu-frontend/docs/plans/2026-07-06-forum-design.md`, which lives on that repo's unmerged `feat/forum` branch and is documented as such by the plan citing it.

Comment and docs changes only. `ruff`, `ruff format`, and `mypy app/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx4tX6zYZWuMu4EWHy6F6D