### PR TITLE
docs: cite frontend files by placeholder, not a relative path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,16 @@ Its API types are generated from this repo's OpenAPI schema, so a change to a
 response model there is a frontend change too — regenerate and commit the types
 with the frontend code that needs them.
 
+When prose in this repo cites a file in that one, write it as
+`<shuushuu-frontend-repo>/docs/plans/...` — a placeholder, not a path. Paths in
+comments and docs here are repo-root-relative (`app/services/...`), so a
+`../shuushuu-frontend/...` prefix reads as relative to the citing file and
+resolves to nothing from anywhere except the root. The placeholder can't be
+mistaken for something an editor should resolve, and stays greppable when
+either repo moves files. Tooling that genuinely runs from the repo root —
+`docker-compose*.yml`, shell scripts — keeps the real `../shuushuu-frontend`
+path.
+
 ## Legacy Migration Notes
 - PHP codebase in `shuu-php/` is read-only reference for business logic understanding
 - Database schema originated from PHP; migrations track changes going forward

--- a/app/api/v1/url_import.py
+++ b/app/api/v1/url_import.py
@@ -1,6 +1,6 @@
 """URL-import endpoints: resolve external post URLs and proxy vetted image fetches.
 
-Design: docs/plans/2026-07-06-url-import-design.md (frontend repo).
+Design: <shuushuu-frontend-repo>/docs/plans/2026-Q3/2026-07-06-url-import-design.md
 """
 
 import io

--- a/app/config.py
+++ b/app/config.py
@@ -240,7 +240,7 @@ class Settings(BaseSettings):
     )
     REGISTRATION_RATE_WINDOW_HOURS: int = Field(default=1, description="Rate limit window in hours")
 
-    # URL Import (see docs/plans/2026-07-06-url-import-design.md in the frontend repo)
+    # URL Import (see <shuushuu-frontend-repo>/docs/plans/2026-Q3/2026-07-06-url-import-design.md)
     URL_RESOLVE_RATE_PER_MINUTE: int = 5
     URL_RESOLVE_GLOBAL_RATE_PER_MINUTE: int = 60
     EXTERNAL_FETCH_RATE_PER_MINUTE: int = 40

--- a/app/services/url_import/base.py
+++ b/app/services/url_import/base.py
@@ -2,7 +2,7 @@
 
 Resolvers pattern-match an external post URL, extract an ID, and construct
 their own requests against pinned hostnames — user-provided URLs are never
-fetched directly (see docs/plans/2026-07-06-url-import-design.md).
+fetched directly (see <shuushuu-frontend-repo>/docs/plans/2026-Q3/2026-07-06-url-import-design.md).
 """
 
 from dataclasses import dataclass, field

--- a/tests/unit/test_comment_search.py
+++ b/tests/unit/test_comment_search.py
@@ -1,8 +1,8 @@
 """Unit tests for the comment-search query parser.
 
 Every case here maps to a behaviour measured against the live corpus and
-recorded in docs/plans/2026-08-10-comment-search-and-semantics-impl.md in the
-frontend repo.
+recorded in
+<shuushuu-frontend-repo>/docs/plans/2026-Q3/2026-08-10-comment-search-and-semantics-impl.md.
 """
 
 from app.utils.comment_search import (


### PR DESCRIPTION
Follow-up to #332, which repaired the cross-repo references it could match and missed four it couldn't.

Those four cite shuushuu-frontend plans in **prose** — `(frontend repo)`, `in the frontend repo` — rather than as anything resolvable. #332's sweep keyed on a `shuushuu-frontend/` prefix, so these were invisible to it, and they went stale when that repo moved its plans into quarter directories.

## Why a placeholder rather than `../shuushuu-frontend/`

My first attempt used a relative path. That was wrong, and it's worth spelling out because the same mistake is easy to repeat.

Every prose path in this repo is **repo-root-relative** — `app/services/...`, `docs/plans/...` — none of them resolve from the citing file's own directory either. But `docs/plans/…` doesn't *look* like a filesystem path, whereas `../` does. From `app/api/v1/url_import.py`, a reader or editor resolves `../shuushuu-frontend/` to `app/api/shuushuu-frontend/` and finds nothing. Verified:

```
app/api/v1/url_import.py           dir=app/api/v1   ../ -> shuushuu-api/app/api
app/services/url_import/base.py    dir=app/services/url_import  ../ -> shuushuu-api/app/services
```

It resolves only from the repo root, which is not where any of these files live.

`<shuushuu-frontend-repo>/docs/plans/2026-Q3/…` can't be mistaken for something to resolve, doesn't assume the sibling repo sits at any particular path (or is checked out at all), and stays greppable when either repo moves files.

## Scope

| file | now |
|---|---|
| `app/api/v1/url_import.py` | `<shuushuu-frontend-repo>/docs/plans/2026-Q3/2026-07-06-url-import-design.md` |
| `app/config.py` | same |
| `app/services/url_import/base.py` | same |
| `tests/unit/test_comment_search.py` | `…/2026-08-10-comment-search-and-semantics-impl.md` |

`AGENTS.md` records the convention, including the exception: `docker-compose*.yml` and shell scripts keep the real `../shuushuu-frontend` path, because those genuinely execute from the repo root.

Verified each placeholder still points at a real file by substituting the repo location. Ruff, format, `mypy app/`, and the 34 affected unit tests pass.

## Not in this PR

~25 plan documents across both repos already use `../shuushuu-api/` / `../shuushuu-frontend/` in prose and have the same ambiguity. They predate this and are a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx4tX6zYZWuMu4EWHy6F6D