### PR TITLE
Fix in-container mariadb port; make dev and pytest ports configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,11 @@ CORS_ORIGINS=https://test.shuushuu.com
 # Storage
 STORAGE_PATH=/shuushuu/images
 
+# Dev only: host port of the Vite dev server nginx proxies '/' to. Defaults to
+# 5173; set it when that port is taken, and match it with DEV_PORT in the
+# frontend repo's .env.
+# FRONTEND_DEV_PORT=5173
+
 # S3 Configuration (optional, for production)
 # STORAGE_TYPE=s3
 # S3_BUCKET=your-bucket-name

--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,11 @@ STORAGE_PATH=/shuushuu/images
 # used by `make pytest`). Defaults to 3316; set it when that port is taken.
 # PYTEST_DB_PORT=3316
 
+# Dev only: xdist workers for `make pytest`. Defaults to `auto` (one per core).
+# Cap it on a host that is also running a dev stack — each worker adds its own
+# connections and temp tables on top, and overshooting invites the OOM killer.
+# PYTEST_WORKERS=auto
+
 # S3 Configuration (optional, for production)
 # STORAGE_TYPE=s3
 # S3_BUCKET=your-bucket-name

--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,10 @@ STORAGE_PATH=/shuushuu/images
 # frontend repo's .env.
 # FRONTEND_DEV_PORT=5173
 
+# Dev only: host port for the isolated pytest MariaDB (docker-compose.pytest.yml,
+# used by `make pytest`). Defaults to 3316; set it when that port is taken.
+# PYTEST_DB_PORT=3316
+
 # S3 Configuration (optional, for production)
 # STORAGE_TYPE=s3
 # S3_BUCKET=your-bucket-name

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ env/
 *.crt
 .htpasswd
 
+# Host-local compose override (e.g. a second dev instance with remapped ports)
+docker-compose.local.yml
+
 # Database
 *.db
 *.sqlite

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -12,14 +12,19 @@ set -e
 # Default STORAGE_PATH if not set
 export STORAGE_PATH=${STORAGE_PATH:-/shuushuu/testing}
 
+# Host port of the Vite dev server the dev config proxies to. Only the dev
+# template references it; unset means the long-standing default.
+export FRONTEND_DEV_PORT=${FRONTEND_DEV_PORT:-5173}
+
 echo "Substituting environment variables in nginx config..."
 echo "STORAGE_PATH: $STORAGE_PATH"
+echo "FRONTEND_DEV_PORT: $FRONTEND_DEV_PORT"
 
 # Remove default configs
 rm -f /etc/nginx/conf.d/default.conf
 
 # Process nginx config template
-envsubst '${STORAGE_PATH},${NGINX_HOST},${NGINX_PORT}' < /etc/nginx/conf.d/frontend.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '${STORAGE_PATH},${NGINX_HOST},${NGINX_PORT},${FRONTEND_DEV_PORT}' < /etc/nginx/conf.d/frontend.conf.template > /etc/nginx/conf.d/default.conf
 
 echo "Testing nginx config..."
 nginx -t

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ help:
 	@echo "  test-build-frontend     Rebuild frontend image"
 	@echo ""
 	@echo "Python test suite (isolated DB on :3316):"
-	@echo "  pytest       Run the pytest suite (-n auto) against an isolated MariaDB"
+	@echo "  pytest       Run the pytest suite against an isolated MariaDB"
+	@echo "               (workers: PYTEST_WORKERS in .env, default auto)"
 	@echo "  pytest-db-up   Start the isolated pytest MariaDB"
 	@echo "  pytest-db-down Stop the isolated pytest MariaDB"
 	@echo ""
@@ -131,7 +132,7 @@ test-build-frontend: check-env-test
 # pytest targets — run the Python unit/integration suite against an isolated,
 # right-sized MariaDB (docker-compose.pytest.yml) instead of the shared,
 # memory-saturated dev container. See that file's header for the OOM root cause
-# this avoids. This is the supported way to run `pytest -n auto` locally.
+# this avoids. This is the supported way to run the suite locally.
 # Host port for the isolated DB. Defaults to 3316; a host where that is taken
 # (a second instance alongside another stack) sets PYTEST_DB_PORT in .env.
 # Compose reads .env by itself, make does not, so pull the same value through
@@ -142,6 +143,15 @@ ifeq ($(strip $(PYTEST_DB_PORT)),)
 PYTEST_DB_PORT := 3316
 endif
 COMPOSE_PYTEST = PYTEST_DB_PORT=$(PYTEST_DB_PORT) docker compose -f docker-compose.pytest.yml
+# xdist worker count, same .env-or-default mechanism. 'auto' takes every core,
+# which is right on a machine doing nothing else; a host also running a dev
+# stack (or two) wants a cap, since each worker carries its own DB connections
+# and temp tables on top of whatever the stack already holds. Overshooting here
+# is what invites the OOM killer, not a slow suite.
+PYTEST_WORKERS ?= $(shell sed -n 's/^PYTEST_WORKERS=[[:space:]]*//p' .env 2>/dev/null | tail -1)
+ifeq ($(strip $(PYTEST_WORKERS)),)
+PYTEST_WORKERS := auto
+endif
 # Pin the suite at the isolated DB regardless of what else .env holds.
 # DATABASE_URL is what the app engine builds from at import; the TEST_DB_*
 # components are what conftest builds the test engine AND the root admin engine
@@ -164,7 +174,7 @@ pytest-db-down:
 	$(COMPOSE_PYTEST) down
 
 pytest: pytest-db-up
-	$(PYTEST_DB_ENV) uv run pytest -n auto --dist loadgroup $(ARGS)
+	$(PYTEST_DB_ENV) uv run pytest -n $(PYTEST_WORKERS) --dist loadgroup $(ARGS)
 
 # Production targets
 prod: check-env-prod

--- a/Makefile
+++ b/Makefile
@@ -132,17 +132,26 @@ test-build-frontend: check-env-test
 # right-sized MariaDB (docker-compose.pytest.yml) instead of the shared,
 # memory-saturated dev container. See that file's header for the OOM root cause
 # this avoids. This is the supported way to run `pytest -n auto` locally.
-COMPOSE_PYTEST = docker compose -f docker-compose.pytest.yml
-# Pin the suite at the isolated DB (port 3316) regardless of what .env holds.
+# Host port for the isolated DB. Defaults to 3316; a host where that is taken
+# (a second instance alongside another stack) sets PYTEST_DB_PORT in .env.
+# Compose reads .env by itself, make does not, so pull the same value through
+# here — and hand it back to compose explicitly so a value coming from the
+# environment or the command line reaches both halves.
+PYTEST_DB_PORT ?= $(shell sed -n 's/^PYTEST_DB_PORT=[[:space:]]*//p' .env 2>/dev/null | tail -1)
+ifeq ($(strip $(PYTEST_DB_PORT)),)
+PYTEST_DB_PORT := 3316
+endif
+COMPOSE_PYTEST = PYTEST_DB_PORT=$(PYTEST_DB_PORT) docker compose -f docker-compose.pytest.yml
+# Pin the suite at the isolated DB regardless of what else .env holds.
 # DATABASE_URL is what the app engine builds from at import; the TEST_DB_*
 # components are what conftest builds the test engine AND the root admin engine
 # (which creates the per-worker databases) from -- the root path reads
 # TEST_DB_HOST/TEST_DB_PORT, not TEST_DATABASE_URL, so set the components.
 PYTEST_DB_ENV = \
-	DATABASE_URL="mysql+aiomysql://shuushuu:shuushuu_password@127.0.0.1:3316/shuushuu_pytest?charset=utf8mb4" \
-	DATABASE_URL_SYNC="mysql+pymysql://shuushuu:shuushuu_password@127.0.0.1:3316/shuushuu_pytest?charset=utf8mb4" \
+	DATABASE_URL="mysql+aiomysql://shuushuu:shuushuu_password@127.0.0.1:$(PYTEST_DB_PORT)/shuushuu_pytest?charset=utf8mb4" \
+	DATABASE_URL_SYNC="mysql+pymysql://shuushuu:shuushuu_password@127.0.0.1:$(PYTEST_DB_PORT)/shuushuu_pytest?charset=utf8mb4" \
 	TEST_DB_HOST=127.0.0.1 \
-	TEST_DB_PORT=3316 \
+	TEST_DB_PORT=$(PYTEST_DB_PORT) \
 	TEST_DB_USER=shuushuu \
 	TEST_DB_PASSWORD=shuushuu_password \
 	TEST_DB_NAME=shuushuu_pytest \

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,6 +17,10 @@ services:
     environment:
       - NGINX_HOST=localhost
       - NGINX_PORT=80
+      # Host port of the Vite dev server nginx proxies '/' to. Override in .env
+      # on a host where 5173 is taken (e.g. a second instance alongside another
+      # stack); the frontend's DEV_PORT must match.
+      - FRONTEND_DEV_PORT=${FRONTEND_DEV_PORT:-5173}
     restart: unless-stopped
     depends_on:
       - api

--- a/docker-compose.pytest.yml
+++ b/docker-compose.pytest.yml
@@ -34,7 +34,8 @@
 # `pytest -n auto` runs clean 3x in a row with zero connection-death errors,
 # and ~8x faster (~172 s -> ~21 s) thanks to the small pool + tmpfs.
 #
-# Isolated from the dev/test/prod stacks: own container name, own port (3316),
+# Isolated from the dev/test/prod stacks: own container name, own port (3316 by
+# default, PYTEST_DB_PORT to move it),
 # ephemeral tmpfs data. Use it via the Makefile:
 #
 #   make pytest            # start this DB (if needed) and run the suite on it
@@ -56,8 +57,10 @@ services:
       --innodb_buffer_pool_size=256M
     ports:
       # localhost-only bind: credentials are hardcoded throwaway values and must
-      # never be network-reachable from off-host
-      - "127.0.0.1:3316:3306"
+      # never be network-reachable from off-host.
+      # Port defaults to 3316; set PYTEST_DB_PORT in .env on a host where that
+      # is taken. The Makefile reads the same variable so the suite follows.
+      - "127.0.0.1:${PYTEST_DB_PORT:-3316}:3306"
     # RAM-backed datadir: the pytest databases are ephemeral and rebuilt each
     # session, so there is nothing to persist. Also makes migrations/truncates
     # dramatically faster than fsync-ing to disk.

--- a/docker/nginx/frontend.conf.dev
+++ b/docker/nginx/frontend.conf.dev
@@ -84,8 +84,11 @@ server {
     }
 
     # Frontend - proxy to Vite dev server running on host (including SvelteKit routes)
+    # Port is substituted at container start (defaults to 5173) so a host running
+    # a second instance can move the dev server off the default — set
+    # FRONTEND_DEV_PORT in .env.
     location / {
-        proxy_pass http://host.docker.internal:5173;
+        proxy_pass http://host.docker.internal:${FRONTEND_DEV_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/scripts/db_utils.py
+++ b/scripts/db_utils.py
@@ -141,6 +141,29 @@ async def run_command(
 # Compose service name of the MariaDB container (see docker-compose.yml)
 MARIADB_SERVICE = "mariadb"
 
+# Port MariaDB listens on inside the container. The published port can differ
+# (a host running a second dev instance remaps it, e.g. 13306), so anything
+# executing inside the container must dial this one, not the published one.
+MARIADB_INTERNAL_PORT = "3306"
+
+
+def _resolve_connection(db_config: dict[str, str], use_docker: bool) -> tuple[str, str]:
+    """
+    Resolve the (host, port) the mariadb client should dial.
+
+    Inside the compose service the server is reached on its internal port; the
+    published port from DATABASE_URL is meaningless there. From the host the
+    Docker hostname 'mariadb' does not resolve, so dial localhost on the
+    published port instead.
+    """
+    if use_docker:
+        return "127.0.0.1", MARIADB_INTERNAL_PORT
+
+    host = db_config["host"]
+    if host == MARIADB_SERVICE:
+        host = "localhost"
+    return host, db_config["port"]
+
 
 def _maybe_docker_exec(cmd: list[str], use_docker: bool) -> list[str]:
     """
@@ -161,14 +184,12 @@ def _maybe_docker_exec(cmd: list[str], use_docker: bool) -> list[str]:
 
 def _build_mysql_cmd(db_config: dict[str, str], use_docker: bool = False) -> list[str]:
     """Build base mariadb CLI command from db config."""
-    host = db_config["host"]
-    if host == "mariadb":
-        host = "localhost"
+    host, port = _resolve_connection(db_config, use_docker)
 
     cmd = [
         "mariadb",
         f"--host={host}",
-        f"--port={db_config['port']}",
+        f"--port={port}",
         f"--user={db_config['user']}",
     ]
 
@@ -200,10 +221,8 @@ async def drop_and_create_database(db_config: dict[str, str], use_docker: bool =
 
     print(f"⚠️  Dropping database '{database_name}' if it exists...")
 
-    # Replace Docker hostname 'mariadb' with 'localhost' when running from host
-    host = db_config["host"]
-    if host == "mariadb":
-        host = "localhost"
+    host, port = _resolve_connection(db_config, use_docker)
+    if not use_docker and db_config["host"] == MARIADB_SERVICE:
         print("Note: Replacing Docker hostname 'mariadb' with 'localhost' for host execution")
 
     # Build mysql command for drop/create (no database name appended: the
@@ -211,7 +230,7 @@ async def drop_and_create_database(db_config: dict[str, str], use_docker: bool =
     mysql_cmd = [
         "mariadb",
         f"--host={host}",
-        f"--port={db_config['port']}",
+        f"--port={port}",
         f"--user={db_config['user']}",
     ]
 
@@ -254,10 +273,7 @@ async def import_sql_dump(
     print(f"Importing SQL dump from: {sql_file}")
     print(f"Into database: {db_config['database']}")
 
-    # Replace Docker hostname 'mariadb' with 'localhost' when running from host
-    host = db_config["host"]
-    if host == "mariadb":
-        host = "localhost"
+    host, port = _resolve_connection(db_config, use_docker)
 
     # Build mysql import command with optimizations for large imports
     # Use 1GB for max-allowed-packet (in bytes)
@@ -266,7 +282,7 @@ async def import_sql_dump(
     mysql_cmd = [
         "mariadb",
         f"--host={host}",
-        f"--port={db_config['port']}",
+        f"--port={port}",
         f"--user={db_config['user']}",
     ]
 

--- a/tests/unit/test_db_utils_connection.py
+++ b/tests/unit/test_db_utils_connection.py
@@ -1,0 +1,103 @@
+"""Tests for db_utils connection resolution.
+
+The mariadb client is invoked two ways: on the host (dialing the port compose
+publishes) and inside the compose mariadb service via `docker compose exec`
+(dialing the server's internal port). These must not use the same port when the
+published port is remapped, as it is on a host running a second dev instance.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.db_utils import (
+    _build_mysql_cmd,
+    _resolve_connection,
+    drop_and_create_database,
+    import_sql_dump,
+)
+
+# Published port deliberately differs from the container's internal 3306, the
+# way a second dev instance remaps it (see docker-compose.skinny.yml).
+REMAPPED_CONFIG = {
+    "host": "mariadb",
+    "port": "13306",
+    "user": "shuushuu_dev",
+    "password": "secret",
+    "database": "shuushuu_dev",
+}
+
+
+def _port_of(cmd: list[str]) -> str:
+    return next(arg for arg in cmd if arg.startswith("--port=")).removeprefix("--port=")
+
+
+def _host_of(cmd: list[str]) -> str:
+    return next(arg for arg in cmd if arg.startswith("--host=")).removeprefix("--host=")
+
+
+@pytest.mark.unit
+class TestResolveConnection:
+    def test_docker_exec_uses_internal_port(self):
+        """Inside the container the published port is meaningless."""
+        host, port = _resolve_connection(REMAPPED_CONFIG, use_docker=True)
+        assert port == "3306"
+        assert host in ("127.0.0.1", "localhost")
+
+    def test_host_execution_uses_published_port(self):
+        host, port = _resolve_connection(REMAPPED_CONFIG, use_docker=False)
+        assert port == "13306"
+        assert host == "localhost"
+
+    def test_host_execution_preserves_non_compose_host(self):
+        config = REMAPPED_CONFIG | {"host": "db.example.com"}
+        host, port = _resolve_connection(config, use_docker=False)
+        assert host == "db.example.com"
+        assert port == "13306"
+
+
+@pytest.mark.unit
+class TestBuildMysqlCmd:
+    def test_docker_exec_targets_internal_port(self):
+        cmd = _build_mysql_cmd(REMAPPED_CONFIG, use_docker=True)
+        assert cmd[:5] == ["docker", "compose", "exec", "-T", "mariadb"]
+        assert _port_of(cmd) == "3306"
+
+    def test_host_execution_targets_published_port(self):
+        cmd = _build_mysql_cmd(REMAPPED_CONFIG, use_docker=False)
+        assert cmd[0] == "mariadb"
+        assert _port_of(cmd) == "13306"
+        assert _host_of(cmd) == "localhost"
+
+
+@pytest.mark.unit
+class TestCommandsUseResolvedPort:
+    """The drop/create and import paths build their own command lists."""
+
+    async def test_drop_and_create_uses_internal_port_under_docker(self, monkeypatch):
+        captured: list[list[str]] = []
+
+        async def fake_run_command(cmd, description, **kwargs):
+            captured.append(cmd)
+            return True
+
+        monkeypatch.setattr("scripts.db_utils.run_command", fake_run_command)
+
+        assert await drop_and_create_database(REMAPPED_CONFIG, use_docker=True)
+        assert _port_of(captured[0]) == "3306"
+
+    async def test_import_uses_internal_port_under_docker(self, monkeypatch, tmp_path: Path):
+        dump = tmp_path / "dump.sql"
+        dump.write_text("SELECT 1;\n")
+        captured: list[list[str]] = []
+
+        async def fake_run_command(cmd, description, **kwargs):
+            captured.append(cmd)
+            return True
+
+        monkeypatch.setattr("scripts.db_utils.run_command", fake_run_command)
+
+        assert await import_sql_dump(dump, REMAPPED_CONFIG, use_docker=True)
+        flat = " ".join(str(part) for cmd in captured for part in cmd)
+        assert "--port=3306" in flat
+        assert "--port=13306" not in flat

--- a/tests/unit/test_db_utils_connection.py
+++ b/tests/unit/test_db_utils_connection.py
@@ -18,7 +18,7 @@ from scripts.db_utils import (
 )
 
 # Published port deliberately differs from the container's internal 3306, the
-# way a second dev instance remaps it (see docker-compose.skinny.yml).
+# way a second dev instance remaps it (see docker-compose.local.yml).
 REMAPPED_CONFIG = {
     "host": "mariadb",
     "port": "13306",


### PR DESCRIPTION
Two changes that came out of standing a second dev instance up on a host where the usual ports were already taken. Both are worth having regardless of that setup — one is an outright bug, the other removes the last hardcoded port from a file that is otherwise a template.

## `fix:` dial mariadb's internal port when the client runs in the container

`_build_mysql_cmd`, `drop_and_create_database` and `import_sql_dump` each rewrote the hostname `mariadb` → `localhost` but kept the port from `DATABASE_URL`, then handed the result to `docker compose exec`. The published port and the port inside the container are different address spaces, so on any host that remaps the published port the client dialed a port nothing listens on:

```
docker compose exec -T mariadb mariadb --host=localhost --port=13306 ...
❌ Failed to drop/create database
```

`restore_prod_db.py` dies at step 2. This is latent on a normal host only because it publishes 3306 on 3306.

The rewrite was triplicated across the three call sites; it is now one `_resolve_connection()` helper returning the container-internal port for docker exec and the published port for host execution.

New `tests/unit/test_db_utils_connection.py` covers both modes plus the two commands that build their own command lists — 7 tests, written first and confirmed red on the missing helper.

## `chore:` make the dev frontend port configurable

`docker/nginx/frontend.conf.dev` hardcoded the Vite dev server on 5173 — the one fixed value in a file that is otherwise an `envsubst` template (`STORAGE_PATH`, `NGINX_HOST`, `NGINX_PORT` all substitute already). A host where 5173 is taken could not point nginx elsewhere without forking the config.

It now substitutes `${FRONTEND_DEV_PORT}`, defaulted to 5173 in the nginx entrypoint and threaded through `docker-compose.override.yml` as `${FRONTEND_DEV_PORT:-5173}`, so a host sets it in `.env` alone. Documented in `.env.example`.

Pairs with `DEV_PORT` in anonymousobject/shuushuu-frontend#372 — the two must match, since this is the port nginx proxies `/` to.

Also ignores `docker-compose.local.yml` for host-local compose overrides.

## `chore:` make the isolated pytest DB port configurable

`docker-compose.pytest.yml` bound `127.0.0.1:3316`, and the Makefile repeated 3316 three more times in `PYTEST_DB_ENV`. On a host where 3316 is taken, `make pytest` could not start the DB at all — the suite was simply unrunnable:

```
failed to bind host port 127.0.0.1:3316/tcp: address already in use
make: *** [Makefile:152: pytest-db-up] Error 1
```

Both sides now read `PYTEST_DB_PORT`, defaulting to 3316. Compose reads `.env` itself; make does not, so the Makefile pulls the same value and hands it back to compose explicitly — keeping the DB and the suite in step whether the value comes from `.env`, the environment, or the command line.

Verified all three paths: no variable → 3316, `.env` value → that value, `make pytest PYTEST_DB_PORT=9999` → 9999. And `make pytest` now runs unaided on a host where it previously could not start: **2510 passed, 44 skipped**.

## Backward compatibility

With `FRONTEND_DEV_PORT` unset the generated nginx config is byte-identical to before. Verified rather than assumed:

```
$ docker compose --env-file /dev/null -f docker-compose.yml -f docker-compose.override.yml config
with empty env-file -> 5173

$ docker exec <container> grep host.docker.internal /etc/nginx/conf.d/default.conf
proxy_pass http://host.docker.internal:5173;
```

## Testing

- `make pytest`: **2510 passed, 44 skipped** (before this branch it could not start on this host at all)
- The 38 skips were services unreachable on this host; re-ran the Redis and Meilisearch groups against live instances: **24 passed**
- `uv run mypy scripts/db_utils.py` clean; `ruff check` and `ruff format --check` clean
- End-to-end: `restore_prod_db.py` completed a full 2.7G restore after the fix (it failed at step 2 before), and the resulting stack serves `/`, `/api/` and images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPtaKuHZhJYkMQCpQNK9ZG

