### PR TITLE
Rebuild the search index as part of the restore

### DIFF
--- a/scripts/db_utils.py
+++ b/scripts/db_utils.py
@@ -426,6 +426,44 @@ async def start_docker_services(project_root: Path) -> bool:
     return success
 
 
+async def reindex_search(project_root: Path) -> bool:
+    """
+    Rebuild the Meilisearch tags index from the database.
+
+    A restore repopulates MySQL and leaves Meilisearch untouched, so search
+    silently returns stale or empty results until the index is rebuilt — the
+    failure is invisible from the API, which answers normally with nothing in
+    it.
+
+    Runs inside the api container: reindex_search.py reads
+    settings.DATABASE_URL / settings.MEILISEARCH_URL directly, with no host
+    rewriting, and those compose hostnames only resolve on the network.
+
+    Returns:
+        True if successful, False otherwise. Callers treat failure as a
+        warning: a stale index is worth flagging loudly but is not a reason to
+        fail an otherwise complete restore.
+    """
+    cmd = [
+        "docker",
+        "compose",
+        "exec",
+        "-T",
+        "api",
+        "uv",
+        "run",
+        "--no-project",
+        "python",
+        "scripts/reindex_search.py",
+    ]
+
+    return await run_command(
+        cmd,
+        "Reindex Meilisearch from the restored database",
+        cwd=project_root,
+    )
+
+
 async def create_test_user(
     db_config: dict[str, str], dry_run: bool = False, use_docker: bool = False
 ) -> bool:

--- a/scripts/restore_prod_db.py
+++ b/scripts/restore_prod_db.py
@@ -18,12 +18,25 @@ Workflow:
 3. Import SQL dump (prod already has alembic_version stamped)
 4. alembic upgrade head (apply any migrations not yet on prod)
 5. Create test users (dev/test databases only)
-6. Start Docker services
+6. Restart Docker services
+7. Reindex Meilisearch from the restored database (--skip-reindex to opt out)
+
+A dump restores the database and nothing else, so the derived indexes are left
+describing the data that was there before. Step 7 rebuilds the Meilisearch tags
+index for that reason; it runs inside the api container and never fails the
+restore, since the database is already in place by then.
+
+IQDB is NOT rebuilt here — it is a long job over every image, so it stays an
+explicit choice. The summary says so, because an empty index is invisible in
+normal use: search and duplicate detection simply return nothing.
+
+    docker compose exec api uv run --no-project python scripts/populate_iqdb.py
 
 Usage:
     uv run python scripts/restore_prod_db.py /path/to/prod.sql
     uv run python scripts/restore_prod_db.py /path/to/prod.sql --dry-run
     uv run python scripts/restore_prod_db.py /path/to/prod.sql --auto-confirm
+    uv run python scripts/restore_prod_db.py /path/to/prod.sql --skip-reindex
 """
 
 import argparse
@@ -38,6 +51,7 @@ from db_utils import (  # type: ignore[import-not-found]
     import_sql_dump,
     parse_database_url,
     print_header,
+    reindex_search,
     run_alembic_upgrade,
     start_docker_services,
     stop_docker_services,
@@ -48,6 +62,7 @@ async def restore_prod_db(
     sql_file: Path,
     dry_run: bool = False,
     auto_confirm: bool = False,
+    skip_reindex: bool = False,
 ) -> bool:
     """
     Restore a production database dump.
@@ -56,6 +71,7 @@ async def restore_prod_db(
         sql_file: Path to the prod SQL dump file
         dry_run: If True, only show what would be done
         auto_confirm: If True, skip confirmation prompts
+        skip_reindex: If True, leave the Meilisearch index untouched
 
     Returns:
         True if successful, False otherwise
@@ -86,7 +102,11 @@ async def restore_prod_db(
         print(f"  3. Import SQL dump: {sql_file}")
         print("  4. Run alembic upgrade head")
         print("  5. Create test users (if dev/test database)")
-        print("  6. Start Docker services")
+        print("  6. Restart Docker services")
+        if skip_reindex:
+            print("  7. Reindex Meilisearch (SKIPPED via --skip-reindex)")
+        else:
+            print("  7. Reindex Meilisearch from the restored database")
         return True
 
     if not auto_confirm:
@@ -97,7 +117,7 @@ async def restore_prod_db(
             print("Restore cancelled.")
             return False
 
-    total_steps = 5
+    total_steps = 7
     success = True
 
     # Step 1: Stop Docker services
@@ -145,16 +165,39 @@ async def restore_prod_db(
     if not await create_test_user(db_config, use_docker=True):
         print("⚠️  Warning: Failed to create test users (continuing anyway)")
 
-    # Restart Docker services
+    # Step 6: Restart Docker services
     print("\n" + "=" * 80)
-    print("Restarting Docker services")
+    print(f"[6/{total_steps}] Restarting Docker services")
     print("=" * 80)
-    if await start_docker_services(project_root):
+    services_up = await start_docker_services(project_root)
+    if services_up:
         print("✅ Docker services restarted successfully")
     else:
         print("⚠️  Warning: Failed to restart Docker services")
         print("You may need to manually restart: docker compose start api arq-worker")
         success = False
+
+    # Step 6: Rebuild the search index. Runs after the restart because it
+    # executes inside the api container. Never fatal: the database is already
+    # restored by this point, and a stale index is a warning, not a rollback.
+    search_reindexed = False
+    if skip_reindex:
+        print("\n" + "=" * 80)
+        print(f"[{total_steps}/{total_steps}] Reindexing search (skipped)")
+        print("=" * 80)
+        print("Skipped via --skip-reindex.")
+    elif not services_up:
+        print("\n" + "=" * 80)
+        print(f"[{total_steps}/{total_steps}] Reindexing search (skipped)")
+        print("=" * 80)
+        print("⚠️  Skipped: the api container is not running.")
+    else:
+        print("\n" + "=" * 80)
+        print(f"[{total_steps}/{total_steps}] Reindexing search")
+        print("=" * 80)
+        search_reindexed = await reindex_search(project_root)
+        if not search_reindexed:
+            print("⚠️  Warning: search reindex failed (continuing anyway)")
 
     # Summary
     print_header("Restore Summary", width=80)
@@ -163,6 +206,21 @@ async def restore_prod_db(
         print(f"\nDatabase '{db_config['database']}' is ready for use.")
     else:
         print("⚠️  Restore completed with warnings (see above)")
+
+    # Derived indexes do not come back with the dump. Say so plainly either
+    # way: an empty index is invisible in normal use — search and duplicate
+    # detection just quietly return nothing.
+    print("\nDerived indexes:")
+    if search_reindexed:
+        print("  ✓ Meilisearch reindexed from the restored database")
+    else:
+        print("  ⚠️  Meilisearch NOT reindexed — search will return stale or no results.")
+        print("     Rebuild: docker compose exec api uv run --no-project \\")
+        print("              python scripts/reindex_search.py")
+    print("  ⚠️  IQDB is not rebuilt by this script — duplicate detection will")
+    print("     find nothing until it is populated. This is a long job over every")
+    print("     image, so run it deliberately:")
+    print("     docker compose exec api uv run --no-project python scripts/populate_iqdb.py")
 
     return success
 
@@ -182,6 +240,9 @@ Examples:
 
   # Preview what would happen
   uv run python scripts/restore_prod_db.py /path/to/prod.sql --dry-run
+
+  # Restore without rebuilding the search index
+  uv run python scripts/restore_prod_db.py /path/to/prod.sql --skip-reindex
         """,
     )
 
@@ -203,6 +264,12 @@ Examples:
         help="Skip confirmation prompts",
     )
 
+    parser.add_argument(
+        "--skip-reindex",
+        action="store_true",
+        help="Leave the Meilisearch index untouched (it will be stale)",
+    )
+
     args = parser.parse_args()
 
     sql_file = Path(args.sql_file)
@@ -214,6 +281,7 @@ Examples:
         sql_file=sql_file,
         dry_run=args.dry_run,
         auto_confirm=args.auto_confirm,
+        skip_reindex=args.skip_reindex,
     )
 
     sys.exit(0 if success else 1)

--- a/scripts/restore_prod_db.py
+++ b/scripts/restore_prod_db.py
@@ -177,7 +177,7 @@ async def restore_prod_db(
         print("You may need to manually restart: docker compose start api arq-worker")
         success = False
 
-    # Step 6: Rebuild the search index. Runs after the restart because it
+    # Step 7: Rebuild the search index. Runs after the restart because it
     # executes inside the api container. Never fatal: the database is already
     # restored by this point, and a stale index is a warning, not a rollback.
     search_reindexed = False

--- a/tests/unit/test_db_utils_reindex.py
+++ b/tests/unit/test_db_utils_reindex.py
@@ -1,0 +1,44 @@
+"""Tests for the post-restore search reindex step.
+
+A restore repopulates MySQL but leaves Meilisearch holding whatever it had
+before, so the instance has a silently stale search index until it is rebuilt.
+The rebuild runs inside the api container (reindex_search.py reads
+settings.DATABASE_URL directly, and the compose hostnames only resolve there),
+and must never turn a completed restore into a failure.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.db_utils import reindex_search
+
+PROJECT_ROOT = Path("/repo")
+
+
+@pytest.mark.unit
+class TestReindexSearch:
+    async def test_runs_the_reindex_script_inside_the_api_container(self, monkeypatch):
+        captured: list[list[str]] = []
+
+        async def fake_run_command(cmd, description, **kwargs):
+            captured.append(cmd)
+            return True
+
+        monkeypatch.setattr("scripts.db_utils.run_command", fake_run_command)
+
+        assert await reindex_search(PROJECT_ROOT) is True
+
+        cmd = captured[0]
+        assert cmd[:5] == ["docker", "compose", "exec", "-T", "api"]
+        assert "scripts/reindex_search.py" in cmd
+
+    async def test_returns_false_when_the_reindex_fails(self, monkeypatch):
+        """Caller decides what to do; a stale index must not fail the restore."""
+
+        async def fake_run_command(cmd, description, **kwargs):
+            return False
+
+        monkeypatch.setattr("scripts.db_utils.run_command", fake_run_command)
+
+        assert await reindex_search(PROJECT_ROOT) is False


### PR DESCRIPTION
> Stacked on #334 — review that first; this branch targets it, so the diff here is the single reindex commit.

## The problem

A dump restores the database and nothing else, so Meilisearch is left describing whatever was there before. Nothing surfaces the mismatch — the API answers normally, search just returns stale or no results.

On a freshly restored instance:

```
Meilisearch tags index:  7 documents
Database:                234,569 tags
```

It went unnoticed until the frontend e2e suite failed: 18 of 19 failures traced back to tag autocomplete waiting on a dropdown that could never populate. Reindexing fixed all 18.

## The change

Reindexing becomes step 7. It runs after the container restart, because `reindex_search.py` reads `settings.DATABASE_URL` / `MEILISEARCH_URL` directly and those compose hostnames only resolve inside the network. It is never fatal — the database is already in place by then, so a stale index is a warning, not a rollback — and `--skip-reindex` opts out.

The summary now reports derived-index state either way:

```
Derived indexes:
  ✓ Meilisearch reindexed from the restored database
  ⚠️  IQDB is not rebuilt by this script — duplicate detection will
     find nothing until it is populated. This is a long job over every
     image, so run it deliberately: ...populate_iqdb.py
```

## Why IQDB is not automatic

Same staleness, different cost: reindexing tags took 5.8s, while IQDB means perceptual hashing every image. So it stays an explicit choice — but the summary says so unconditionally, because an empty index is invisible in normal use. The same instance had **0 images in IQDB against 1.1M rows**, and duplicate detection had been silently doing nothing since the restore.

## Also

The restart step was printed unnumbered while the dry run listed it, leaving the two off by one (`total_steps = 5` against a 6-item dry-run list). Rather than extend that, the restart is now numbered; both agree at 7.

## Testing

Verified end to end by deleting the Meilisearch index first, so the restore had to genuinely rebuild it:

```
[7/7] Reindexing search
✓ Reindex Meilisearch from the restored database completed successfully

meili tags docs: 234565
db_tags:         234565
```

- Full 2.7G restore completed, steps numbered 1–7 with no gaps
- `--dry-run` and `--dry-run --skip-reindex` both list the right steps
- 2 new unit tests for `reindex_search()` (command shape, non-fatal on failure), red first
- `make pytest`: **2543 passed, 13 skipped** (remaining skips are a missing ML model)
- `mypy` clean on both changed scripts; `ruff check` and `format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPtaKuHZhJYkMQCpQNK9ZG