### PR TITLE
Discover nginx template variables instead of hardcoding them

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -16,7 +16,37 @@ export STORAGE_PATH=${STORAGE_PATH:-/shuushuu/testing}
 # template references it; unset means the long-standing default.
 export FRONTEND_DEV_PORT=${FRONTEND_DEV_PORT:-5173}
 
+TEMPLATE=/etc/nginx/conf.d/frontend.conf.template
+
+# Discover the placeholders the template actually uses instead of hardcoding a
+# list here. The template is bind-mounted from the repo, so it updates on a git
+# pull, while this script only updates when the image is rebuilt. A hardcoded
+# list means adding a ${VAR} to the template silently breaks every host that
+# pulls without rebuilding: the placeholder survives substitution and nginx
+# reads it as one of its own variables ("unknown 'frontend_dev_port' variable").
+#
+# Matching only ${BRACED} names is what makes this safe — nginx's own variables
+# are written bare ($host, $remote_addr) and are never touched.
+VARS=$(grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' "$TEMPLATE" | sort -u | tr '\n' ' ')
+
+# An unset name would substitute to empty and produce a config that is broken
+# in a way nginx reports obscurely (e.g. `proxy_pass http://host:;`). Say which
+# variable is missing instead. Set-but-empty is allowed: that is a deliberate
+# choice, not an oversight.
+MISSING=
+for placeholder in $VARS; do
+  name=$(printf '%s' "$placeholder" | tr -d '${}')
+  eval "is_set=\${$name+yes}"
+  [ -n "${is_set:-}" ] || MISSING="$MISSING $name"
+done
+if [ -n "$MISSING" ]; then
+  echo "ERROR: $TEMPLATE references unset variable(s):$MISSING" >&2
+  echo "Set them in .env / compose, or remove them from the template." >&2
+  exit 1
+fi
+
 echo "Substituting environment variables in nginx config..."
+echo "Template variables: $VARS"
 echo "STORAGE_PATH: $STORAGE_PATH"
 echo "FRONTEND_DEV_PORT: $FRONTEND_DEV_PORT"
 
@@ -24,7 +54,7 @@ echo "FRONTEND_DEV_PORT: $FRONTEND_DEV_PORT"
 rm -f /etc/nginx/conf.d/default.conf
 
 # Process nginx config template
-envsubst '${STORAGE_PATH},${NGINX_HOST},${NGINX_PORT},${FRONTEND_DEV_PORT}' < /etc/nginx/conf.d/frontend.conf.template > /etc/nginx/conf.d/default.conf
+envsubst "$VARS" < "$TEMPLATE" > /etc/nginx/conf.d/default.conf
 
 echo "Testing nginx config..."
 nginx -t


### PR DESCRIPTION
## What broke

The nginx config template is bind-mounted from the repo, so a `git pull` updates it. The `envsubst` variable list lived in the image's entrypoint, so it only updated on a rebuild. Those two facts together mean **adding a `${VAR}` to the template breaks every host that pulls without rebuilding** — the placeholder survives substitution and nginx reads it as one of its own variables.

#334 added `${FRONTEND_DEV_PORT}` and did exactly this to the dev host on its next `docker compose up -d`:

```
Substituting environment variables in nginx config...
STORAGE_PATH: /shuushuu-testing          <- no FRONTEND_DEV_PORT line: old image
nginx: [emerg] unknown "frontend_dev_port" variable
nginx: configuration file /etc/nginx/nginx.conf test failed
```

nginx sat in a restart loop while every other service came up healthy. `up -d --build nginx` cleared it, but the trap stays armed for the next variable anyone adds.

## The fix

Derive the list from the template at container start:

```sh
VARS=$(grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' "$TEMPLATE" | sort -u | tr '\n' ' ')
envsubst "$VARS" < "$TEMPLATE" > /etc/nginx/conf.d/default.conf
```

Matching only `${BRACED}` names is what makes this safe — nginx's own variables are written bare (`$host`, `$remote_addr`) and are never touched. A template can now gain a variable with no image change at all.

Unset variables also fail with their name now. Previously they substituted to empty and produced a config broken in a way nginx reports obscurely (`proxy_pass http://host:;`). Set-but-empty still passes: that is a deliberate choice, not an oversight.

Drops `NGINX_PORT`, which no template references.

## Testing

Built the image and ran it against every real template:

| case | result |
|---|---|
| dev template, `FRONTEND_DEV_PORT` unset | `host.docker.internal:5173` (default) |
| dev template, `FRONTEND_DEV_PORT=15173` | `host.docker.internal:15173` |
| **template gains `${BRAND_NEW_PORT}` the image never knew, var set** | `host.docker.internal:19999` — the scenario that broke the dev host, now works with no rebuild |
| same template, `BRAND_NEW_PORT` unset | `ERROR: ... references unset variable(s): BRAND_NEW_PORT`, exit 1 |
| `frontend.conf.test` with `NGINX_HOST` | `server_name example.test`, 0 leftover `${...}` |
| `frontend-production.conf.template` with `NGINX_HOST` | `server_name example.test`, 0 leftover `${...}` |

All three templates reference only variables their compose file or the entrypoint default provides, so the new fail-fast cannot fire on a correct setup.

## Note for whoever deploys this

This fix is itself in the image, so **this one upgrade still needs `up -d --build nginx`**. After that, template variables stop requiring rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPtaKuHZhJYkMQCpQNK9ZG