### PR TITLE
fix: skip the alias-map query on character-less pages

### DIFF
--- a/app/services/tag_context.py
+++ b/app/services/tag_context.py
@@ -49,14 +49,15 @@ async def stamp_context_sources(
     ).all()
     canon: dict[int, int] = dict(alias_rows)  # type: ignore[arg-type]
 
+    # Non-empty by construction: has_character above was set by a tag this
+    # same comprehension collects. (It used to be the guard that caught
+    # source-only pages, one query too late.)
     char_ids = {
         canon.get(t.tag_id, t.tag_id)
         for r in responses
         for t in r.tags or []
         if t.type_id == TagType.CHARACTER
     }
-    if not char_ids:
-        return
 
     link_rows = (
         await db.execute(

--- a/app/services/tag_context.py
+++ b/app/services/tag_context.py
@@ -26,11 +26,16 @@ async def stamp_context_sources(
 ) -> None:
     """Mutate responses in place per the exactly-one rule."""
     page_tag_ids: set[int] = set()
+    has_character = False
     for r in responses:
         for t in r.tags or []:
             if t.type_id in (TagType.CHARACTER, TagType.SOURCE):
                 page_tag_ids.add(t.tag_id)
-    if not page_tag_ids:
+                has_character = has_character or t.type_id == TagType.CHARACTER
+    # Sources alone can never be stamped, so a character-less page needs no
+    # query at all — not even the alias map, which exists to canonicalize the
+    # character ids this rule keys on.
+    if not has_character:
         return
 
     # Canonicalize alias tags among them (usually zero rows).

--- a/tests/services/test_tag_context.py
+++ b/tests/services/test_tag_context.py
@@ -1,0 +1,95 @@
+"""Query-count guards for stamp_context_sources.
+
+The module documents "at most two small indexed queries per request (alias map
++ links), skipped when the page has no character tags". These tests hold it to
+that: a page carrying source tags but zero character tags must not touch the
+database at all, since the stamping rule has nothing to stamp onto.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import TagType
+from app.models.character_source_link import CharacterSourceLinks
+from app.models.tag import Tags
+from app.schemas.image import ImageDetailedResponse, TagSummary
+from app.services.tag_context import stamp_context_sources
+
+
+def _response(image_id: int, tags: list[TagSummary]) -> ImageDetailedResponse:
+    return ImageDetailedResponse(
+        image_id=image_id,
+        user_id=1,
+        ext="jpg",
+        date_added=datetime(2026, 1, 1, tzinfo=UTC),
+        locked=0,
+        posts=0,
+        favorites=0,
+        bayesian_rating=0.0,
+        num_ratings=0,
+        medium=0,
+        large=0,
+        tags=tags,
+    )
+
+
+def _summary(tag_id: int, type_id: int) -> TagSummary:
+    return TagSummary(tag_id=tag_id, title=f"tag {tag_id}", type=type_id)
+
+
+class _ExecuteCounter:
+    """Count ORM executions issued through a session for the test's duration."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self._session = db.sync_session
+        self.count = 0
+
+    def __enter__(self) -> _ExecuteCounter:
+        event.listen(self._session, "do_orm_execute", self._on_execute)
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        event.remove(self._session, "do_orm_execute", self._on_execute)
+
+    def _on_execute(self, orm_execute_state: object) -> None:
+        self.count += 1
+
+
+async def test_source_only_page_issues_no_queries(db_session: AsyncSession):
+    """Sources without characters can never be stamped — don't ask the database."""
+    responses = [_response(9001, [_summary(901, TagType.SOURCE)])]
+
+    with _ExecuteCounter(db_session) as counter:
+        await stamp_context_sources(db_session, responses)
+
+    assert counter.count == 0
+    assert responses[0].tags is not None
+    assert responses[0].tags[0].context_source_tag_id is None
+
+
+async def test_tagless_page_issues_no_queries(db_session: AsyncSession):
+    responses = [_response(9002, []), _response(9003, None)]
+
+    with _ExecuteCounter(db_session) as counter:
+        await stamp_context_sources(db_session, responses)
+
+    assert counter.count == 0
+
+
+async def test_character_page_stamps_within_two_queries(db_session: AsyncSession):
+    db_session.add(Tags(tag_id=911, type=TagType.SOURCE, title="ctx q src"))
+    db_session.add(Tags(tag_id=912, type=TagType.CHARACTER, title="ctx q char"))
+    await db_session.flush()
+    db_session.add(CharacterSourceLinks(character_tag_id=912, source_tag_id=911))
+    await db_session.flush()
+
+    responses = [_response(9004, [_summary(912, TagType.CHARACTER), _summary(911, TagType.SOURCE)])]
+
+    with _ExecuteCounter(db_session) as counter:
+        await stamp_context_sources(db_session, responses)
+
+    assert counter.count == 2
+    assert responses[0].tags is not None
+    assert responses[0].tags[0].context_source_tag_id == 911


### PR DESCRIPTION
Closes #313.

## The bug

`stamp_context_sources`' first guard collects CHARACTER *and* SOURCE tag ids into one set and returns only when that set is empty. A page carrying source tags but zero character tags therefore passes the guard, fires the alias-map query, and only then hits the `if not char_ids: return` a few lines down. The query result is discarded every time.

The module docstring claimed the work is "skipped when the page has no character tags," which was not what the code did.

## The fix

Track whether any CHARACTER tag was seen while collecting the ids, and gate on that. `page_tag_ids` still holds both types — the alias map must canonicalize source ids too, once we know there is a character to stamp — so the shape of the query is unchanged for pages that reach it. The old `if not page_tag_ids` check is subsumed: a page with a character tag always has a non-empty set.

Correctness was never affected; this removes one round trip per character-less page and makes the docstring true.

## Tests

New `tests/services/test_tag_context.py` counts ORM executions through the session with a `do_orm_execute` listener:

- source-only page -> 0 queries (this test fails on `main`, 1 query)
- tagless / `tags=None` page -> 0 queries
- page with a linked character -> 2 queries, and it still stamps

The existing `tests/api/v1/test_image_tag_context.py` behaviour tests are untouched and pass.

## Verification

```
uv run pytest tests/api/v1/test_image_tag_context.py tests/api/v1/test_link_pictures.py tests/services/ -q
225 passed
uv run mypy app/services/tag_context.py   # Success
uv run ruff check / format                # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Et6DRiWrbnTLCrFEfmWMJf

---

### Review follow-up

Removed the now-unreachable `if not char_ids: return`. The reviewer flagged it as pre-existing dead code, but it wasn't: before this branch it was the guard that caught source-only pages — one query too late, which is the bug. `has_character` gating entry is what kills it, so it's the tail of this diff rather than unrelated cleanup. Replaced with a comment recording why the set is non-empty by construction.