### PR TITLE
fix: retry transient DB conflicts and narrow the repost lock set

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -764,13 +764,20 @@ async def change_image_status(
             locked=status_data.locked,
         )
 
+        # The commit is the LAST statement in the retried unit. Anything after
+        # it that could raise would send a replay through a second audit row
+        # and status-history row on top of a commit that already landed, and
+        # nothing here re-fetches its way out of that.
         await db.commit()
-        await db.refresh(image)
         return image, previous_status
 
     image, previous_status = await retry_on_transient_conflict(
         db, _apply, what="image_status_change"
     )
+
+    # Outside the unit, per the note above: picks up whatever the DB wrote for
+    # itself during the commit (triggers, server defaults).
+    await db.refresh(image)
 
     if status_data.status is not None:
         await enqueue_r2_sync_on_status_change(
@@ -1749,8 +1756,12 @@ async def action_report(
         report.reviewed_by = actor_id
         report.reviewed_at = datetime.now(UTC)
 
+        # Read out before the commit, which is the LAST statement in the unit:
+        # anything after it that could raise would send a replay through a
+        # second audit row on top of a commit that already landed.
+        reported_image_id = report.image_id
         await db.commit()
-        return report.image_id, previous_status
+        return reported_image_id, previous_status
 
     reported_image_id, previous_status = await retry_on_transient_conflict(
         db, _apply, what="report_action"

--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -34,7 +34,7 @@ from app.config import (
 )
 from app.core.auth import get_current_user
 from app.core.database import get_db
-from app.core.db_retry import retry_on_snapshot_conflict
+from app.core.db_retry import retry_on_transient_conflict
 from app.core.permission_cache import invalidate_group_permissions, invalidate_user_permissions
 from app.core.permission_deps import require_all_permissions, require_permission
 from app.core.permissions import Permission
@@ -731,33 +731,46 @@ async def change_image_status(
 
     Requires IMAGE_EDIT permission.
     """
-    # Get the image
-    result = await db.execute(
-        select(Images).where(Images.image_id == image_id)  # type: ignore[arg-type]
+    actor_id = current_user.user_id
+
+    # Marking a repost migrates favourites, ratings, tags and ML suggestions in
+    # one transaction, which can deadlock against the ML pipeline writing the
+    # same suggestion rows (#335). Retry the whole unit; every non-DB side
+    # effect stays below the commit, so a replay repeats nothing external.
+    async def _apply() -> tuple[Images, int]:
+        # Re-fetched inside the unit: a retry rolls back, expiring every ORM
+        # instance the previous attempt loaded (see app/core/db_retry.py).
+        result = await db.execute(
+            select(Images).where(Images.image_id == image_id)  # type: ignore[arg-type]
+        )
+        image = result.scalar_one_or_none()
+
+        if not image:
+            raise HTTPException(status_code=404, detail="Image not found")
+
+        previous_status = image.status
+
+        # All mutation + audit logging goes through the unified service so this
+        # endpoint and the report-triage path stay consistent. (Imported under an
+        # alias because this route handler shares the service's name.)
+        await apply_image_status_change(
+            db,
+            image,
+            await db.get(Users, actor_id),
+            new_status=status_data.status,
+            reason_category=status_data.reason_category,
+            reason=status_data.reason,
+            replacement_id=status_data.replacement_id,
+            locked=status_data.locked,
+        )
+
+        await db.commit()
+        await db.refresh(image)
+        return image, previous_status
+
+    image, previous_status = await retry_on_transient_conflict(
+        db, _apply, what="image_status_change"
     )
-    image = result.scalar_one_or_none()
-
-    if not image:
-        raise HTTPException(status_code=404, detail="Image not found")
-
-    previous_status = image.status
-
-    # All mutation + audit logging goes through the unified service so this
-    # endpoint and the report-triage path stay consistent. (Imported under an
-    # alias because this route handler shares the service's name.)
-    await apply_image_status_change(
-        db,
-        image,
-        current_user,
-        new_status=status_data.status,
-        reason_category=status_data.reason_category,
-        reason=status_data.reason,
-        replacement_id=status_data.replacement_id,
-        locked=status_data.locked,
-    )
-
-    await db.commit()
-    await db.refresh(image)
 
     if status_data.status is not None:
         await enqueue_r2_sync_on_status_change(
@@ -1660,7 +1673,7 @@ async def apply_tag_suggestions(
         removed_tags,
         already_present,
         already_absent,
-    ) = await retry_on_snapshot_conflict(db, _apply, what="apply_tag_suggestions")
+    ) = await retry_on_transient_conflict(db, _apply, what="apply_tag_suggestions")
 
     return ApplyTagSuggestionsResponse(
         message=f"Applied {len(applied_tags)} tags, removed {len(removed_tags)} tags",
@@ -1686,52 +1699,65 @@ async def action_report(
 
     Requires REPORT_MANAGE permission.
     """
-    result = await db.execute(
-        select(ImageReports).where(ImageReports.report_id == report_id)  # type: ignore[arg-type]
+    actor_id = current_user.user_id
+
+    # Resolving a report as a repost runs the same multi-table migration as the
+    # direct PATCH, so it can lose the same deadlock (#335). Retried as one
+    # unit; the enqueues below stay outside it.
+    async def _apply() -> tuple[int, int]:
+        # Re-fetched inside the unit: a retry rolls back, expiring every ORM
+        # instance the previous attempt loaded (see app/core/db_retry.py).
+        result = await db.execute(
+            select(ImageReports).where(ImageReports.report_id == report_id)  # type: ignore[arg-type]
+        )
+        report = result.scalar_one_or_none()
+
+        if not report:
+            raise HTTPException(status_code=404, detail="Report not found")
+
+        if report.status != ReportStatus.PENDING:
+            raise HTTPException(status_code=400, detail="Report has already been processed")
+
+        # Get the image
+        image_result = await db.execute(
+            select(Images).where(Images.image_id == report.image_id)  # type: ignore[arg-type]
+        )
+        image = image_result.scalar_one_or_none()
+
+        if not image:
+            raise HTTPException(status_code=404, detail="Image not found")
+
+        previous_status = image.status
+
+        # All mutation + audit logging goes through the unified service: writes the
+        # public history row, enforces replacement_id for repost, stamps report_id on
+        # the REPORT_ACTION audit row (the report's resolution is derived from it).
+        await apply_image_status_change(
+            db,
+            image,
+            await db.get(Users, actor_id),
+            new_status=action_data.new_status,
+            reason_category=action_data.reason_category,
+            reason=action_data.reason,
+            replacement_id=action_data.replacement_id,
+            action_type=AdminActionType.REPORT_ACTION,
+            report_id=report_id,
+        )
+
+        # Update report
+        report.status = ReportStatus.REVIEWED
+        report.reviewed_by = actor_id
+        report.reviewed_at = datetime.now(UTC)
+
+        await db.commit()
+        return report.image_id, previous_status
+
+    reported_image_id, previous_status = await retry_on_transient_conflict(
+        db, _apply, what="report_action"
     )
-    report = result.scalar_one_or_none()
-
-    if not report:
-        raise HTTPException(status_code=404, detail="Report not found")
-
-    if report.status != ReportStatus.PENDING:
-        raise HTTPException(status_code=400, detail="Report has already been processed")
-
-    # Get the image
-    image_result = await db.execute(
-        select(Images).where(Images.image_id == report.image_id)  # type: ignore[arg-type]
-    )
-    image = image_result.scalar_one_or_none()
-
-    if not image:
-        raise HTTPException(status_code=404, detail="Image not found")
-
-    previous_status = image.status
-
-    # All mutation + audit logging goes through the unified service: writes the
-    # public history row, enforces replacement_id for repost, stamps report_id on
-    # the REPORT_ACTION audit row (the report's resolution is derived from it).
-    await apply_image_status_change(
-        db,
-        image,
-        current_user,
-        new_status=action_data.new_status,
-        reason_category=action_data.reason_category,
-        reason=action_data.reason,
-        replacement_id=action_data.replacement_id,
-        action_type=AdminActionType.REPORT_ACTION,
-        report_id=report_id,
-    )
-
-    # Update report
-    report.status = ReportStatus.REVIEWED
-    report.reviewed_by = current_user.user_id
-    report.reviewed_at = datetime.now(UTC)
-
-    await db.commit()
 
     await enqueue_r2_sync_on_status_change(
-        image_id=report.image_id,
+        image_id=reported_image_id,
         old_status=previous_status,
         new_status=action_data.new_status,
     )

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -49,7 +49,7 @@ from app.config import (
 )
 from app.core.auth import CurrentUser, VerifiedUser, get_current_user, get_optional_current_user
 from app.core.database import get_db, statement_timeout
-from app.core.db_retry import retry_on_snapshot_conflict
+from app.core.db_retry import retry_on_transient_conflict
 from app.core.logging import get_logger
 from app.core.permission_deps import require_permission
 from app.core.permissions import Permission, has_any_permission, has_permission
@@ -2518,7 +2518,7 @@ async def add_tag_to_image(
 
     # Non-DB side effect: the search sync stays outside the retried unit so a
     # retry never repeats it.
-    resolved_tag_id = await retry_on_snapshot_conflict(db, _apply_tag_add, what="image_tag_add")
+    resolved_tag_id = await retry_on_transient_conflict(db, _apply_tag_add, what="image_tag_add")
 
     # Re-fetch tag to get updated usage_count (maintained by DB trigger)
     tag_result = await db.execute(select(Tags).where(Tags.tag_id == resolved_tag_id))  # type: ignore[arg-type]
@@ -2605,7 +2605,7 @@ async def remove_tag_from_image(
 
     # Non-DB side effect: the search sync stays outside the retried unit so a
     # retry never repeats it.
-    await retry_on_snapshot_conflict(db, _apply_tag_remove, what="image_tag_remove")
+    await retry_on_transient_conflict(db, _apply_tag_remove, what="image_tag_remove")
 
     # Re-fetch tag to get updated usage_count (maintained by DB trigger)
     tag_result = await db.execute(select(Tags).where(Tags.tag_id == tag_id))  # type: ignore[arg-type]
@@ -2680,7 +2680,7 @@ async def rate_image(
         await db.commit()
         return message, stats
 
-    message, stats = await retry_on_snapshot_conflict(db, _apply_rating, what="rate_image")
+    message, stats = await retry_on_transient_conflict(db, _apply_rating, what="rate_image")
 
     return {
         "message": message,
@@ -2748,7 +2748,7 @@ async def favorite_image(
         await db.commit()
         return False, favorites_count
 
-    already_favorited, favorites_count = await retry_on_snapshot_conflict(
+    already_favorited, favorites_count = await retry_on_transient_conflict(
         db, _apply_favorite, what="favorite_image"
     )
 
@@ -2833,7 +2833,7 @@ async def unfavorite_image(
         await db.commit()
         return favorites_count
 
-    favorites_count = await retry_on_snapshot_conflict(
+    favorites_count = await retry_on_transient_conflict(
         db, _apply_unfavorite, what="unfavorite_image"
     )
 
@@ -3086,7 +3086,7 @@ async def upload_image(
             await db.commit()
             return image
 
-        new_image = await retry_on_snapshot_conflict(db, _insert_image, what="upload_image")
+        new_image = await retry_on_transient_conflict(db, _insert_image, what="upload_image")
         committed = True
         await db.refresh(new_image)
         image_id: int = new_image.image_id  # type: ignore[assignment]

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -40,7 +40,7 @@ from app.core.auth import (
     get_optional_current_user,
 )
 from app.core.database import get_db
-from app.core.db_retry import retry_on_snapshot_conflict
+from app.core.db_retry import retry_on_transient_conflict
 from app.core.logging import get_logger
 from app.core.permissions import Permission, has_permission
 from app.core.r2_client import get_r2_storage
@@ -763,7 +763,7 @@ async def _update_user_profile(
         # public or private response schemas depending on the endpoint.
         return user
 
-    return await retry_on_snapshot_conflict(db, _apply, what="user_profile_update")
+    return await retry_on_transient_conflict(db, _apply, what="user_profile_update")
 
 
 @router.get("/{user_id}/images", response_model=ImageDetailedListResponse)

--- a/app/core/db_retry.py
+++ b/app/core/db_retry.py
@@ -1,4 +1,4 @@
-"""Retry helper for transient MariaDB write conflicts.
+"""Retry helper for transient MariaDB write conflicts. See ADR-0004.
 
 Two different errors, one remedy — end the transaction and replay the unit on a
 fresh one:

--- a/app/core/db_retry.py
+++ b/app/core/db_retry.py
@@ -1,18 +1,32 @@
-"""Retry helper for MariaDB snapshot-isolation conflicts (ER_CHECKREAD, errno 1020).
+"""Retry helper for transient MariaDB write conflicts.
 
-With ``innodb_snapshot_isolation=ON`` (MariaDB 11.8), a locking
-statement that meets row/index versions committed *after* the transaction's
-snapshot aborts with error 1020 instead of returning stale data. The snapshot
-is pinned by the request's first read — the auth query — so the conflict
-window spans nearly the whole request, and any two requests writing the same
-rows (or inserting into the same index positions) concurrently can collide.
-Confirmed sites: the upload temp-row INSERT into ``images``; concurrent
-``PATCH /users/me`` UPDATEs of one ``users`` row.
+Two different errors, one remedy — end the transaction and replay the unit on a
+fresh one:
 
-The conflict is transient: a rollback ends the transaction, and the retry's
-new transaction gets a fresh snapshot that sees the other writer's rows. A
-savepoint is NOT sufficient — rolling back to a savepoint keeps the
-transaction (and its snapshot) alive, so the conflict would recur.
+**1020 (ER_CHECKREAD)** — with ``innodb_snapshot_isolation=ON`` (MariaDB 11.8),
+a locking statement that meets row/index versions committed *after* the
+transaction's snapshot aborts instead of returning stale data. The snapshot is
+pinned by the request's first read — the auth query — so the conflict window
+spans nearly the whole request, and any two requests writing the same rows (or
+inserting into the same index positions) concurrently can collide. Confirmed
+sites: the upload temp-row INSERT into ``images``; concurrent ``PATCH
+/users/me`` UPDATEs of one ``users`` row; ``ml_raw_predictions`` ingest racing
+the suggestion pipeline.
+
+**1213 (ER_LOCK_DEADLOCK)** — two transactions take locks on the same rows or
+index gaps in opposite orders and InnoDB breaks the cycle by rolling one back.
+Retrying is not a workaround here, it *is* the contract: MariaDB expects the
+victim to replay. Confirmed site: flagging a repost (whose migration updates
+``ml_tag_suggestions`` across the original's tags) while the ML pipeline
+inserts suggestions for a neighbouring image.
+
+Both leave the transaction dead, so both need the same rollback-and-replay.
+1205 (ER_LOCK_WAIT_TIMEOUT) is deliberately NOT included: it fires only after
+``innodb_lock_wait_timeout`` seconds, so replaying it multiplies an already
+pathological request latency rather than resolving a momentary collision.
+
+A savepoint is NOT sufficient for either — rolling back to a savepoint keeps
+the transaction (and its snapshot) alive, so the conflict would recur.
 
 Usage — wrap a *self-contained transactional unit* and retry it:
 
@@ -22,14 +36,17 @@ Usage — wrap a *self-contained transactional unit* and retry it:
         await db.commit()                     # or flush
         return row
 
-    thing = await retry_on_snapshot_conflict(db, _apply, what="thing_update")
+    thing = await retry_on_transient_conflict(db, _apply, what="thing_update")
 
 Rules for the callable:
 - Re-fetch rows inside it. The rollback between attempts expires every ORM
   instance in the session, and touching an expired attribute on an async
-  session raises; closures over previously-loaded instances are bugs.
+  session raises; closures over previously-loaded instances are bugs. This
+  includes the authenticated user loaded by the auth dependency.
 - DB work only. Non-DB side effects (file writes, redis/arq enqueues, email)
   would be repeated on retry; keep them outside the callable.
+- Idempotent under replay. A retry re-runs the whole unit against a clean
+  slate, so any count it derives must be derived again, not accumulated.
 - Non-conflict errors (HTTPException, other DB errors) propagate unchanged.
 
 This is deliberately opt-in per write path rather than request-replay
@@ -46,36 +63,49 @@ from app.core.logging import get_logger
 logger = get_logger(__name__)
 
 SNAPSHOT_CONFLICT_ERRNO = 1020
-SNAPSHOT_CONFLICT_ATTEMPTS = 3
+DEADLOCK_ERRNO = 1213
+TRANSIENT_CONFLICT_ERRNOS = frozenset({SNAPSHOT_CONFLICT_ERRNO, DEADLOCK_ERRNO})
+TRANSIENT_CONFLICT_ATTEMPTS = 3
 
 
-def is_snapshot_conflict(exc: OperationalError) -> bool:
-    """True when `exc` wraps MariaDB ER_CHECKREAD (errno 1020)."""
+def _conflict_errno(exc: OperationalError) -> int | None:
+    """The MariaDB errno `exc` carries, or None when it carries none."""
     args = getattr(exc.orig, "args", None)
     if not args:
-        return False
-    return bool(args[0] == SNAPSHOT_CONFLICT_ERRNO)
+        return None
+    errno = args[0]
+    return errno if isinstance(errno, int) else None
 
 
-async def retry_on_snapshot_conflict[T](
+def is_transient_conflict(exc: OperationalError) -> bool:
+    """True when `exc` is a conflict a fresh transaction can resolve."""
+    return _conflict_errno(exc) in TRANSIENT_CONFLICT_ERRNOS
+
+
+async def retry_on_transient_conflict[T](
     db: AsyncSession,
     fn: Callable[[], Awaitable[T]],
     *,
     what: str,
-    attempts: int = SNAPSHOT_CONFLICT_ATTEMPTS,
+    attempts: int = TRANSIENT_CONFLICT_ATTEMPTS,
 ) -> T:
-    """Run `fn`, retrying up to `attempts` times on snapshot conflicts.
+    """Run `fn`, retrying up to `attempts` times on transient write conflicts.
 
     Rolls back between attempts so each retry runs in a fresh transaction
-    (fresh snapshot). Exhausted retries and non-conflict errors re-raise.
-    `what` names the call site in the retry log line.
+    (fresh snapshot, no inherited locks). Exhausted retries and non-conflict
+    errors re-raise. `what` names the call site in the retry log line.
     """
     for attempt in range(1, attempts + 1):
         try:
             return await fn()
         except OperationalError as e:
-            if not is_snapshot_conflict(e) or attempt == attempts:
+            if not is_transient_conflict(e) or attempt == attempts:
                 raise
             await db.rollback()
-            logger.warning("snapshot_conflict_retry", what=what, attempt=attempt)
+            logger.warning(
+                "transient_conflict_retry",
+                what=what,
+                attempt=attempt,
+                errno=_conflict_errno(e),
+            )
     raise AssertionError("unreachable")  # pragma: no cover

--- a/app/services/batch_tag.py
+++ b/app/services/batch_tag.py
@@ -4,7 +4,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.db_retry import retry_on_snapshot_conflict
+from app.core.db_retry import retry_on_transient_conflict
 from app.core.logging import get_logger
 from app.models.image import Images
 from app.models.tag import Tags
@@ -164,7 +164,7 @@ async def batch_add_tags(
 
         return added, skipped
 
-    added, skipped = await retry_on_snapshot_conflict(db, _apply, what="batch_tag_add")
+    added, skipped = await retry_on_transient_conflict(db, _apply, what="batch_tag_add")
 
     # Sync affected tags to Meilisearch (usage_count updated by DB trigger).
     # Non-DB side effect: stays outside the retried unit so it never repeats.
@@ -321,7 +321,7 @@ async def batch_remove_tags(
 
         return removed, skipped
 
-    removed, skipped = await retry_on_snapshot_conflict(db, _apply, what="batch_tag_remove")
+    removed, skipped = await retry_on_transient_conflict(db, _apply, what="batch_tag_remove")
 
     # Sync affected tags to Meilisearch (usage_count updated by DB trigger).
     # Non-DB side effect: stays outside the retried unit so it never repeats.

--- a/app/services/ml_suggestion_pipeline.py
+++ b/app/services/ml_suggestion_pipeline.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import ImageStatus, TagType, settings
+from app.core.db_retry import retry_on_transient_conflict
 from app.core.logging import get_logger
 from app.models.image import Images
 from app.models.ml_tag_suggestion import MlTagSuggestions
@@ -346,9 +347,22 @@ async def persist_predictions(
 
     ingest_raw_predictions and store_predictions run in the SAME session;
     store_predictions issues the commit (do not add a second commit here).
-    Returns the number of suggestions created."""
-    await ingest_raw_predictions(db, [{"image_id": image_id, "predictions": raw_predictions}])
-    return await store_predictions(db, image_id, raw_predictions)
+    Returns the number of suggestions created.
+
+    Retried as one unit: this writes ml_raw_predictions and ml_tag_suggestions
+    for whatever image the worker is on while the request path writes the same
+    tables (a moderator flagging a repost, a tagger approving suggestions), so
+    either side can lose a snapshot conflict or a deadlock (#335). Replay is
+    safe because both halves are idempotent — INSERT IGNORE for the raw rows,
+    keep-existing for the suggestions — and both re-read everything they need
+    from the session rather than closing over rows the rollback expired.
+    ``raw_predictions`` is plain dicts, so it survives the rollback untouched."""
+
+    async def _persist() -> int:
+        await ingest_raw_predictions(db, [{"image_id": image_id, "predictions": raw_predictions}])
+        return await store_predictions(db, image_id, raw_predictions)
+
+    return await retry_on_transient_conflict(db, _persist, what="ml_persist_predictions")
 
 
 async def compute_implied_suggestions(

--- a/app/services/ml_suggestion_review.py
+++ b/app/services/ml_suggestion_review.py
@@ -15,7 +15,7 @@ from typing import Any
 from sqlalchemy import delete, select, tuple_, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.db_retry import retry_on_snapshot_conflict
+from app.core.db_retry import retry_on_transient_conflict
 from app.models.ml_tag_suggestion import MlTagSuggestions
 from app.models.tag import Tags
 from app.models.tag_history import TagHistory
@@ -302,7 +302,7 @@ async def review_ml_tag_suggestions(
         errors,
         created,
         removed_suggestion_ids,
-    ) = await retry_on_snapshot_conflict(db, _apply, what="ml_review_apply")
+    ) = await retry_on_transient_conflict(db, _apply, what="ml_review_apply")
 
     # Sync affected tags to Meilisearch (usage_count updated by DB trigger).
     # Non-DB side effect: stays outside the retried unit so it never repeats.
@@ -404,7 +404,7 @@ async def bulk_review_suggestions(
         errors,
         all_created_tag_ids,
         all_removed_suggestion_ids,
-    ) = await retry_on_snapshot_conflict(db, _apply, what="ml_review_bulk_apply")
+    ) = await retry_on_transient_conflict(db, _apply, what="ml_review_bulk_apply")
 
     # Single batched search-sync over the union of created tag_ids.
     # Non-DB side effect: stays outside the retried unit so it never repeats.

--- a/app/services/repost.py
+++ b/app/services/repost.py
@@ -17,6 +17,14 @@ from app.services.ml_suggestion_review import approve_pending_suggestions_for_li
 from app.services.tag_type_flags import refresh_images_tag_type_flags
 
 
+async def _tag_ids_for(db: AsyncSession, image_id: int) -> set[int]:
+    """The tag ids currently linked to `image_id`."""
+    result = await db.execute(
+        select(TagLinks.tag_id).where(TagLinks.image_id == image_id)  # type: ignore[call-overload]
+    )
+    return set(result.scalars().all())
+
+
 async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession) -> dict[str, int]:
     """
     Migrate favorites, ratings, and tags from a repost to the original image.
@@ -120,14 +128,16 @@ async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession
     )
 
     # --- Tags ---
-    before_tag = await db.execute(
-        select(func.count())
-        .select_from(TagLinks)
-        .where(
-            TagLinks.image_id == original_id  # type: ignore[arg-type]
-        )
-    )
-    tag_count_before = before_tag.scalar() or 0
+    # Read both sides' tag ids up front and diff them. tag_links is keyed on
+    # (tag_id, image_id), so the INSERT IGNORE below adds exactly the repost's
+    # tags that the original lacks — the difference IS the moved count, and it
+    # is also the precise scope of the suggestion resolution further down.
+    # (Replaces a COUNT-before/COUNT-after pair plus a third SELECT of the
+    # original's tag ids.)
+    original_tag_ids_before = await _tag_ids_for(db, original_id)
+    repost_tag_ids = await _tag_ids_for(db, repost_id)
+    moved_tag_ids = repost_tag_ids - original_tag_ids_before
+    tags_moved = len(moved_tag_ids)
 
     await db.execute(
         text(
@@ -137,16 +147,6 @@ async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession
         ),
         {"original_id": original_id, "repost_id": repost_id},
     )
-
-    after_tag = await db.execute(
-        select(func.count())
-        .select_from(TagLinks)
-        .where(
-            TagLinks.image_id == original_id  # type: ignore[arg-type]
-        )
-    )
-    tag_count_after = after_tag.scalar() or 0
-    tags_moved = tag_count_after - tag_count_before
 
     await db.execute(
         delete(TagLinks).where(
@@ -158,19 +158,17 @@ async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession
     # The migrated tags are now applied to the original: resolve its matching
     # pending suggestions. Reviewer stays NULL — this is data movement, not a
     # human review (system resolution; see CONTEXT.md and ADR-0001).
-    original_tag_ids = (
-        (
-            await db.execute(
-                select(TagLinks.tag_id).where(  # type: ignore[call-overload]
-                    TagLinks.image_id == original_id
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
+    #
+    # Scoped to the tags this migration actually added, matching every other
+    # caller of approve_pending_suggestions_for_links (single tag add, batch
+    # tagging, report resolution), which each pass only their own new links.
+    # Passing the original's WHOLE tag set instead made the UPDATE's lock set
+    # grow with the original's tag count and cover index gaps for tags with no
+    # suggestion row — the gaps the ML pipeline inserts into, and the deadlock
+    # in #335. A tag the original already carried is not this operation's to
+    # resolve: whatever applied it owned that.
     await approve_pending_suggestions_for_links(
-        db, [(original_id, tag_id) for tag_id in original_tag_ids], None
+        db, [(original_id, tag_id) for tag_id in sorted(moved_tag_ids)], None
     )
 
     # A repost is permanently out of review scope: wipe ALL its suggestion rows,

--- a/app/services/repost.py
+++ b/app/services/repost.py
@@ -166,7 +166,7 @@ async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession
     # grow with the original's tag count and cover index gaps for tags with no
     # suggestion row — the gaps the ML pipeline inserts into, and the deadlock
     # in #335. A tag the original already carried is not this operation's to
-    # resolve: whatever applied it owned that.
+    # resolve: whatever applied it owned that. (ADR-0005.)
     await approve_pending_suggestions_for_links(
         db, [(original_id, tag_id) for tag_id in sorted(moved_tag_ids)], None
     )

--- a/docs/adr/0004-transient-write-conflicts-are-retried-at-the-write-path.md
+++ b/docs/adr/0004-transient-write-conflicts-are-retried-at-the-write-path.md
@@ -1,0 +1,18 @@
+# Transient write conflicts are retried at the write path
+
+MariaDB aborts a transaction for two reasons that a fresh transaction resolves: ER_CHECKREAD (1020), raised under `innodb_snapshot_isolation=ON` when a locking statement meets a row version committed after this transaction's snapshot, and ER_LOCK_DEADLOCK (1213), raised when InnoDB breaks a lock cycle by rolling one side back. Both leave the transaction dead, and neither indicates a problem with the request. `retry_on_transient_conflict()` wraps a self-contained transactional unit, rolls back between attempts so each retry gets a fresh snapshot and no inherited locks, and replays up to three times. Write paths opt in individually rather than being covered by middleware.
+
+## Considered Options
+
+- **Surfacing the error** is what shipped, and a moderator flagging a repost while the ML pipeline writes suggestions eats a 500 with the migration abandoned partway (#335). For 1213 this also contradicts MariaDB's contract, which is that the deadlock victim replays.
+- **Request-replay middleware** would cover every path at once, but a replayed request re-runs its non-DB side effects — R2 enqueues, rating recalculation, file writes, email. Opting in per path keeps those below the retried unit where a replay cannot reach them.
+- **Ordering the lock acquisition** so the two writers cannot form a cycle removes one specific pair, at the cost of coupling the ML pipeline to the moderation path, and does nothing for the other pairs that can collide on the same rows. Narrowing the lock set is worth doing on its own merits (ADR-0005) but is a probability reduction, not a guarantee.
+- **Including ER_LOCK_WAIT_TIMEOUT (1205)** was rejected: it fires only after `innodb_lock_wait_timeout` seconds, so replaying it multiplies an already pathological request latency instead of resolving a momentary collision. It still surfaces as a 500, deliberately.
+
+## Consequences
+
+- A wrapped callable must be DB-only, idempotent under replay, and end at its `commit()`. Anything after the commit that can raise would send a replay through a second audit row on top of a commit that already landed.
+- `Session.rollback()` expires every ORM instance regardless of `expire_on_commit`, so a wrapped callable must re-fetch the rows it touches — including the user loaded by the auth dependency, which is why the retried admin paths re-`get()` the actor rather than closing over `current_user`.
+- Retries are bounded at three and logged as `transient_conflict_retry` with the call site and errno, so a path that starts thrashing is visible rather than silently slow.
+- Every call site added for 1020 now also absorbs deadlocks; they already satisfied the contract, so no site needed changing when 1213 was added.
+- A savepoint is not a substitute for the rollback: rolling back to a savepoint keeps the transaction and its snapshot alive, so the conflict recurs.

--- a/docs/adr/0005-suggestion-resolution-is-scoped-to-the-links-the-caller-created.md
+++ b/docs/adr/0005-suggestion-resolution-is-scoped-to-the-links-the-caller-created.md
@@ -1,0 +1,17 @@
+# Out-of-band suggestion resolution is scoped to the links the caller created
+
+ADR-0001 requires every path that applies a tag outside the ML review flow to resolve the matching pending suggestion via `approve_pending_suggestions_for_links()`. This ADR fixes the scope of that call: a caller passes only the `(image_id, tag_id)` pairs it just created, never the image's whole tag set. Repost migration was the one caller passing everything on the original; it now diffs the two images' tag ids up front and passes the difference, which is also what `INSERT IGNORE` adds and therefore the migration's `tags_moved` count.
+
+## Considered Options
+
+- **Passing the original's whole tag set** is what shipped. `EXPLAIN` on production-sized data (2.4M suggestion rows) shows the resulting UPDATE range-scanning `unique_ml_suggestion_image_tag`, so it takes a next-key lock per tag on the original *plus gap locks for tags with no suggestion row* — the gaps the ML pipeline inserts into for neighbouring images. The lock set grew with the original's tag count, and the resulting deadlock (#335) 500'd the moderator mid-migration.
+- **Keeping the wide list and relying on the retry** (ADR-0004) removes the 500 but leaves the collision rate where it is, so every busy repost pays retry latency for bookkeeping nobody waits on.
+- **Forcing a different index** addresses the lock shape without addressing the semantic over-reach: resolving suggestions for tags this operation did not touch is not the operation's business either way.
+- **Moving resolution to the job queue** shortens the request's transaction the most, but splits an atomic migration across two units of work — the tags land on the original while its suggestion rows briefly disagree.
+
+## Consequences
+
+- A pending suggestion for a tag the original **already carried** survives the repost. This state should not be reachable: generation excludes already-applied tags, and every tag-add path resolves its own links per ADR-0001. If one is ever observed, the bug is in whichever path applied that tag, and widening this call would hide it rather than fix it.
+- The moved-tag set is derived once and used for both the count and the resolution scope, so the two cannot drift apart.
+- Tag ids are passed sorted, giving concurrent repost migrations a consistent lock acquisition order.
+- The rule is now uniform across all four resolver callers (manual add, batch tagging, report resolution, repost migration), so "pass your own new links" is the pattern to copy for any future path that creates `tag_links`.

--- a/tests/api/v1/test_admin_images.py
+++ b/tests/api/v1/test_admin_images.py
@@ -21,6 +21,7 @@ from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
 from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
+from tests.transient_conflict import _deadlock_error, _flaky_commit
 
 
 async def create_admin_user(
@@ -333,6 +334,88 @@ class TestImageStatusChange:
         data = response.json()
         assert data["status"] == ImageStatus.ACTIVE
         assert data["replacement_id"] is None
+
+    @pytest.mark.needs_commit
+    async def test_repost_retries_deadlock_and_migrates_exactly_once(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A deadlock (#335) is retried, not surfaced as a 500.
+
+        The repost migration and the ML pipeline lock ml_tag_suggestions rows
+        and index gaps in opposite orders, so InnoDB rolls one of them back.
+        The retry replays the whole unit on a fresh transaction; because the
+        first attempt persisted nothing, the migration must land exactly once —
+        no double-counted tags, no duplicated audit row.
+        """
+        admin, admin_password = await create_admin_user(db_session)
+        await grant_permission(db_session, admin.user_id, "image_edit")
+
+        original = await create_test_image(db_session, admin.user_id)
+        repost = Images(
+            user_id=admin.user_id,
+            filename="deadlock_repost",
+            ext="jpg",
+            md5_hash="dead1ockdead1ockdead1ockdead1ock",
+            status=ImageStatus.ACTIVE,
+        )
+        db_session.add(repost)
+        tag = Tags(title="deadlock repost tag", type=TagType.THEME, user_id=admin.user_id)
+        db_session.add(tag)
+        await db_session.commit()
+        await db_session.refresh(repost)
+        await db_session.refresh(tag)
+
+        db_session.add(TagLinks(image_id=repost.image_id, tag_id=tag.tag_id, user_id=admin.user_id))
+        db_session.add(Favorites(image_id=repost.image_id, user_id=admin.user_id))
+        await db_session.commit()
+
+        # The route shares this session, so its retry rollback expires every
+        # instance above. Hold the ids as plain ints for the assertions.
+        repost_id, original_id, tag_id = repost.image_id, original.image_id, tag.tag_id
+        token = await login_user(client, admin.username, admin_password)
+
+        commit_patch, calls = _flaky_commit(1, _deadlock_error())
+        with commit_patch:
+            response = await client.patch(
+                f"/api/v1/admin/images/{repost_id}",
+                json={
+                    "status": ImageStatus.REPOST,
+                    "replacement_id": original_id,
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert response.status_code == 200, response.text
+        assert len(calls) >= 2  # failed attempt + successful retry
+        assert response.json()["status"] == ImageStatus.REPOST
+
+        # The migration landed once: the tag and favourite moved to the original
+        # and the repost keeps neither.
+        moved_tags = await db_session.execute(
+            select(func.count())
+            .select_from(TagLinks)
+            .where(TagLinks.image_id == original_id, TagLinks.tag_id == tag_id)
+        )
+        assert moved_tags.scalar_one() == 1
+        leftover_tags = await db_session.execute(
+            select(func.count()).select_from(TagLinks).where(TagLinks.image_id == repost_id)
+        )
+        assert leftover_tags.scalar_one() == 0
+        moved_favs = await db_session.execute(
+            select(func.count()).select_from(Favorites).where(Favorites.image_id == original_id)
+        )
+        assert moved_favs.scalar_one() == 1
+
+        # ...and audited once, not once per attempt.
+        audit_rows = await db_session.execute(
+            select(func.count())
+            .select_from(AdminActions)
+            .where(
+                AdminActions.image_id == repost_id,
+                AdminActions.action_type == AdminActionType.IMAGE_STATUS_CHANGE,
+            )
+        )
+        assert audit_rows.scalar_one() == 1
 
     async def test_requires_image_edit_permission(
         self, client: AsyncClient, db_session: AsyncSession

--- a/tests/api/v1/test_batch_tag.py
+++ b/tests/api/v1/test_batch_tag.py
@@ -15,7 +15,7 @@ from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
 from app.services.tag_type_flags import refresh_image_tag_type_flags
-from tests.snapshot_conflict import _flaky_flush, _snapshot_conflict_error
+from tests.transient_conflict import _flaky_flush, _snapshot_conflict_error
 
 
 async def _create_user_with_tag_permission(

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -21,7 +21,7 @@ from app.models.ml_tag_suggestion import MlTagSuggestions
 from app.models.permissions import Groups, UserGroups
 from app.models.tag_history import TagHistory
 from app.services.tag_type_flags import refresh_image_tag_type_flags
-from tests.snapshot_conflict import _db_error, _flaky_flush, _snapshot_conflict_error
+from tests.transient_conflict import _db_error, _flaky_flush, _snapshot_conflict_error
 
 
 @pytest.mark.api
@@ -4644,7 +4644,7 @@ class TestFavoriteRatingSnapshotConflictRetry:
         await db_session.commit()
         await db_session.refresh(image)
 
-        flush_patch, calls = _flaky_flush(100, _db_error(1213, "Deadlock found"))
+        flush_patch, calls = _flaky_flush(100, _db_error(1062, "Duplicate entry"))
         with flush_patch, pytest.raises(OperationalError):
             await authenticated_client.post(f"/api/v1/images/{image.image_id}/favorite")
 
@@ -4828,7 +4828,7 @@ class TestTagWriteSnapshotConflictRetry:
         image_id: int = image.image_id
         tag_id: int = tag.tag_id
 
-        flush_patch, calls = _flaky_flush(100, _db_error(1213, "Deadlock found"))
+        flush_patch, calls = _flaky_flush(100, _db_error(1062, "Duplicate entry"))
         with flush_patch, pytest.raises(OperationalError):
             await authenticated_client.post(f"/api/v1/images/{image_id}/tags/{tag_id}")
 

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -31,7 +31,7 @@ from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
 from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
-from tests.snapshot_conflict import _flaky_flush, _snapshot_conflict_error
+from tests.transient_conflict import _flaky_flush, _snapshot_conflict_error
 
 
 async def create_auth_user(

--- a/tests/api/v1/test_upload.py
+++ b/tests/api/v1/test_upload.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.security import create_access_token
 from app.models.user import Users
 from app.schemas.image import SimilarImageResult
-from tests.snapshot_conflict import (
+from tests.transient_conflict import (
     _db_error,
     _flaky_flush,
     _flaky_flush_nth,
@@ -578,8 +578,8 @@ class TestUploadSnapshotConflictRetry:
     async def test_upload_does_not_retry_other_db_errors(
         self, upload_client: AsyncClient, verified_user: Users
     ):
-        """Non-1020 database errors fail immediately with no retry."""
-        flush_patch, calls = _flaky_flush(100, _db_error(1213, "Deadlock found"))
+        """Database errors outside the transient set fail immediately with no retry."""
+        flush_patch, calls = _flaky_flush(100, _db_error(1062, "Duplicate entry"))
         with (
             _mock_upload_storage("snapshotretry3"),
             patch(

--- a/tests/services/test_ml_suggestion_lifecycle.py
+++ b/tests/services/test_ml_suggestion_lifecycle.py
@@ -227,3 +227,72 @@ class TestMigrateRepostData:
         assert original_pending.status == "approved"
         assert original_pending.reviewed_by_user_id is None
         assert original_pending.reviewed_at is not None
+
+    async def test_resolves_only_the_tags_the_migration_moved(self, db_session: AsyncSession):
+        """The approve pass is scoped to the tags this migration actually added.
+
+        A pending suggestion for a tag the original ALREADY carried is not this
+        operation's business — resolving it would widen the UPDATE's lock set to
+        the original's whole tag set, which is what deadlocked against the ML
+        pipeline (#335). Every other caller of
+        approve_pending_suggestions_for_links passes only its own new links.
+        """
+        from app.models.tag_link import TagLinks
+        from app.services.repost import migrate_repost_data
+
+        user = await _make_user(db_session, "repost_scope")
+        repost = await _make_image(db_session, user, "scope_r", ImageStatus.ACTIVE)
+        original = await _make_image(db_session, user, "scope_o", ImageStatus.ACTIVE)
+        moved_tag = await _make_tag(db_session, user, "scope_moved")
+        preexisting_tag = await _make_tag(db_session, user, "scope_preexisting")
+
+        # moved_tag arrives with the repost; preexisting_tag is already on the
+        # original. Both have a pending suggestion on the original.
+        db_session.add(
+            TagLinks(image_id=repost.image_id, tag_id=moved_tag.tag_id, user_id=user.user_id)
+        )
+        db_session.add(
+            TagLinks(
+                image_id=original.image_id, tag_id=preexisting_tag.tag_id, user_id=user.user_id
+            )
+        )
+        moved_pending = await _make_suggestion(db_session, original, moved_tag, status="pending")
+        untouched_pending = await _make_suggestion(
+            db_session, original, preexisting_tag, status="pending"
+        )
+        await db_session.commit()
+
+        result = await migrate_repost_data(repost.image_id, original.image_id, db_session)
+        await db_session.commit()
+
+        assert result["tags_moved"] == 1
+
+        await db_session.refresh(moved_pending)
+        assert moved_pending.status == "approved"
+
+        await db_session.refresh(untouched_pending)
+        assert untouched_pending.status == "pending"
+        assert untouched_pending.reviewed_at is None
+
+    async def test_tags_already_on_the_original_are_not_counted_as_moved(
+        self, db_session: AsyncSession
+    ):
+        """A tag on both images is deduped by INSERT IGNORE, so it moved nothing."""
+        from app.models.tag_link import TagLinks
+        from app.services.repost import migrate_repost_data
+
+        user = await _make_user(db_session, "repost_dupe")
+        repost = await _make_image(db_session, user, "dupe_r", ImageStatus.ACTIVE)
+        original = await _make_image(db_session, user, "dupe_o", ImageStatus.ACTIVE)
+        shared_tag = await _make_tag(db_session, user, "dupe_shared")
+
+        for image in (repost, original):
+            db_session.add(
+                TagLinks(image_id=image.image_id, tag_id=shared_tag.tag_id, user_id=user.user_id)
+            )
+        await db_session.commit()
+
+        result = await migrate_repost_data(repost.image_id, original.image_id, db_session)
+        await db_session.commit()
+
+        assert result["tags_moved"] == 0

--- a/tests/services/test_ml_suggestion_pipeline.py
+++ b/tests/services/test_ml_suggestion_pipeline.py
@@ -28,8 +28,10 @@ from app.services.ml_suggestion_pipeline import (
     filter_superseded_parents,
     find_superseded_parents,
     generate_and_store_suggestions,
+    persist_predictions,
     store_predictions,
 )
+from tests.transient_conflict import _flaky_commit, _snapshot_conflict_error
 
 PIPELINE = "app.services.ml_suggestion_pipeline"
 
@@ -756,6 +758,53 @@ async def test_store_predictions_skips_ineligible_image(db_session):
         select(MlTagSuggestions).where(MlTagSuggestions.image_id == image.image_id)
     )
     assert result.scalars().all() == []
+
+
+@pytest.mark.needs_commit
+async def test_persist_predictions_retries_transient_conflict(db_session, tmp_path, monkeypatch):
+    """persist_predictions replays on a transient conflict rather than 500ing.
+
+    The pipeline writes ml_raw_predictions and ml_tag_suggestions for whatever
+    image the worker is on while moderators write the same tables from the
+    request path, so either side can lose a snapshot conflict or a deadlock
+    (#335). The unit is idempotent — INSERT IGNORE for the raw rows, keep-
+    existing for the suggestions — so a replay must leave exactly one row per
+    suggested tag, not two.
+    """
+    tags = [Tags(tag_id=46, title="long hair"), Tags(tag_id=161, title="short hair")]
+    db_session.add_all(tags)
+    await db_session.flush()
+
+    user = await _make_user(db_session, "retry")
+    image = await _make_image(db_session, user, "retry", tmp_path)
+    await db_session.commit()
+    image_id = image.image_id
+
+    predictions = [
+        {"external_tag": "long_hair", "confidence": 0.92, "model_version": "v3"},
+        {"external_tag": "short_hair", "confidence": 0.88, "model_version": "v3"},
+    ]
+    mapped = [
+        {"tag_id": 46, "confidence": 0.92, "model_version": "v3"},
+        {"tag_id": 161, "confidence": 0.88, "model_version": "v3"},
+    ]
+
+    commit_patch, calls = _flaky_commit(1, _snapshot_conflict_error("ml_raw_predictions"))
+    with (
+        commit_patch,
+        patch(f"{PIPELINE}.resolve_external_tags", _resolver_to_tag_ids(mapped)),
+        patch(f"{PIPELINE}.resolve_tag_relationships", _passthrough_resolver),
+    ):
+        created = await persist_predictions(db_session, image_id, predictions)
+
+    assert len(calls) >= 2  # failed attempt + successful retry
+    assert created == 2
+
+    result = await db_session.execute(
+        select(MlTagSuggestions).where(MlTagSuggestions.image_id == image_id)
+    )
+    suggestions = result.scalars().all()
+    assert sorted(s.tag_id for s in suggestions) == [46, 161]
 
 
 @pytest.mark.needs_commit

--- a/tests/transient_conflict.py
+++ b/tests/transient_conflict.py
@@ -1,13 +1,19 @@
-"""Helpers for testing the MariaDB snapshot-conflict retry (app/core/db_retry.py).
+"""Helpers for testing the MariaDB transient-conflict retry (app/core/db_retry.py).
 
-Under ``innodb_snapshot_isolation=ON`` a locking statement that meets a row
-version committed after this transaction's snapshot aborts with ER_CHECKREAD
-(errno 1020) rather than reading the stale version. Write paths wrap their
-transactional unit in ``retry_on_snapshot_conflict`` so the conflict is retried
-on a fresh snapshot instead of surfacing a 500.
+Two errors get the same rollback-and-replay treatment:
 
-These helpers inject that error into a route's explicit flush, which is what
-lets a test exercise the real helper without racing two live requests.
+- ER_CHECKREAD (1020), raised under ``innodb_snapshot_isolation=ON`` when a
+  locking statement meets a row version committed after this transaction's
+  snapshot rather than reading the stale version.
+- ER_LOCK_DEADLOCK (1213), raised when InnoDB breaks a lock cycle by rolling
+  one of the transactions back.
+
+Write paths wrap their transactional unit in ``retry_on_transient_conflict`` so
+either one is retried on a fresh transaction instead of surfacing a 500.
+
+These helpers inject the error into a route's explicit flush or its commit,
+which is what lets a test exercise the real helper without racing two live
+requests.
 """
 
 from unittest.mock import patch
@@ -31,6 +37,34 @@ def _snapshot_conflict_error(table: str = "images") -> OperationalError:
     handler, not the parent row that actually moved.
     """
     return _db_error(1020, f"Record has changed since last read in table '{table}'")
+
+
+def _deadlock_error() -> OperationalError:
+    """The error MariaDB raises when it picks this transaction as the deadlock
+    victim (ER_LOCK_DEADLOCK). Carries no table name — InnoDB reports the cycle,
+    not a single row."""
+    return _db_error(1213, "Deadlock found when trying to get lock; try restarting transaction")
+
+
+def _flaky_commit(fail_times: int, error: OperationalError):
+    """Patch AsyncSession.commit to raise `error` for the first `fail_times`
+    calls, then delegate to the real commit.
+
+    The flush-based helpers below can't reach a route whose transactional unit
+    has no explicit ``db.flush()`` of its own — the repost migration is all
+    Core-level execute() calls ending at the route's commit. Failing the commit
+    aborts the attempt with nothing persisted, which is exactly what a real
+    deadlock does. Returns (patch_ctx, calls)."""
+    real_commit = AsyncSession.commit
+    calls: list[int] = []
+
+    async def commit(self, *args, **kwargs):
+        calls.append(1)
+        if len(calls) <= fail_times:
+            raise error
+        await real_commit(self, *args, **kwargs)
+
+    return patch.object(AsyncSession, "commit", commit), calls
 
 
 def _flaky_flush(fail_times: int, error: OperationalError):

--- a/tests/unit/test_db_retry.py
+++ b/tests/unit/test_db_retry.py
@@ -1,10 +1,10 @@
-"""Tests for the snapshot-conflict retry helper (app/core/db_retry.py)."""
+"""Tests for the transient-conflict retry helper (app/core/db_retry.py)."""
 
 import pymysql
 import pytest
 from sqlalchemy.exc import OperationalError
 
-from app.core.db_retry import is_snapshot_conflict, retry_on_snapshot_conflict
+from app.core.db_retry import is_transient_conflict, retry_on_transient_conflict
 
 
 def _db_error(errno: int, message: str) -> OperationalError:
@@ -13,6 +13,10 @@ def _db_error(errno: int, message: str) -> OperationalError:
 
 def _conflict() -> OperationalError:
     return _db_error(1020, "Record has changed since last read in table 'images'")
+
+
+def _deadlock() -> OperationalError:
+    return _db_error(1213, "Deadlock found when trying to get lock; try restarting transaction")
 
 
 class _StubSession:
@@ -25,18 +29,27 @@ class _StubSession:
         self.rollbacks += 1
 
 
-class TestIsSnapshotConflict:
-    def test_matches_errno_1020(self):
-        assert is_snapshot_conflict(_conflict()) is True
+class TestIsTransientConflict:
+    def test_matches_snapshot_conflict_errno_1020(self):
+        assert is_transient_conflict(_conflict()) is True
+
+    def test_matches_deadlock_errno_1213(self):
+        assert is_transient_conflict(_deadlock()) is True
 
     def test_rejects_other_errnos(self):
-        assert is_snapshot_conflict(_db_error(1213, "Deadlock found")) is False
+        # Duplicate key is a real data conflict, not a transient lock conflict:
+        # replaying it produces the same error, so it must surface to the caller.
+        assert is_transient_conflict(_db_error(1062, "Duplicate entry")) is False
+
+    def test_rejects_lock_wait_timeout(self):
+        # 1205 is deliberately excluded — see the module docstring.
+        assert is_transient_conflict(_db_error(1205, "Lock wait timeout exceeded")) is False
 
     def test_rejects_error_without_args(self):
-        assert is_snapshot_conflict(OperationalError("STATEMENT", None, Exception())) is False
+        assert is_transient_conflict(OperationalError("STATEMENT", None, Exception())) is False
 
 
-class TestRetryOnSnapshotConflict:
+class TestRetryOnTransientConflict:
     @pytest.mark.asyncio
     async def test_returns_value_on_first_success_without_rollback(self):
         db = _StubSession()
@@ -44,7 +57,7 @@ class TestRetryOnSnapshotConflict:
         async def fn() -> str:
             return "ok"
 
-        assert await retry_on_snapshot_conflict(db, fn, what="test") == "ok"
+        assert await retry_on_transient_conflict(db, fn, what="test") == "ok"
         assert db.rollbacks == 0
 
     @pytest.mark.asyncio
@@ -59,9 +72,25 @@ class TestRetryOnSnapshotConflict:
                 raise _conflict()
             return "ok"
 
-        assert await retry_on_snapshot_conflict(db, fn, what="test") == "ok"
+        assert await retry_on_transient_conflict(db, fn, what="test") == "ok"
         assert calls == 3
         assert db.rollbacks == 2  # one per failed attempt
+
+    @pytest.mark.asyncio
+    async def test_retries_deadlock_with_rollback_between_attempts(self):
+        db = _StubSession()
+        calls = 0
+
+        async def fn() -> str:
+            nonlocal calls
+            calls += 1
+            if calls < 2:
+                raise _deadlock()
+            return "ok"
+
+        assert await retry_on_transient_conflict(db, fn, what="test") == "ok"
+        assert calls == 2
+        assert db.rollbacks == 1
 
     @pytest.mark.asyncio
     async def test_reraises_after_attempts_exhausted(self):
@@ -74,7 +103,7 @@ class TestRetryOnSnapshotConflict:
             raise _conflict()
 
         with pytest.raises(OperationalError):
-            await retry_on_snapshot_conflict(db, fn, what="test")
+            await retry_on_transient_conflict(db, fn, what="test")
         assert calls == 3  # default bound
         assert db.rollbacks == 2  # no rollback after the final, re-raised failure
 
@@ -86,10 +115,10 @@ class TestRetryOnSnapshotConflict:
         async def fn() -> None:
             nonlocal calls
             calls += 1
-            raise _db_error(1213, "Deadlock found")
+            raise _db_error(1062, "Duplicate entry")
 
         with pytest.raises(OperationalError):
-            await retry_on_snapshot_conflict(db, fn, what="test")
+            await retry_on_transient_conflict(db, fn, what="test")
         assert calls == 1
         assert db.rollbacks == 0
 
@@ -101,7 +130,7 @@ class TestRetryOnSnapshotConflict:
             raise ValueError("boom")
 
         with pytest.raises(ValueError):
-            await retry_on_snapshot_conflict(db, fn, what="test")
+            await retry_on_transient_conflict(db, fn, what="test")
         assert db.rollbacks == 0
 
     @pytest.mark.asyncio
@@ -115,6 +144,6 @@ class TestRetryOnSnapshotConflict:
             raise _conflict()
 
         with pytest.raises(OperationalError):
-            await retry_on_snapshot_conflict(db, fn, what="test", attempts=5)
+            await retry_on_transient_conflict(db, fn, what="test", attempts=5)
         assert calls == 5
         assert db.rollbacks == 4


### PR DESCRIPTION
Closes #335.

## Root cause

`migrate_repost_data` and the ML pipeline's `persist_predictions` write the same `ml_tag_suggestions` rows in opposite lock orders. InnoDB breaks the cycle by rolling one back with errno 1213, and **neither side retries**, so the loser surfaces as a 500 to the moderator.

Evidence gathered on the prod-scale dev DB (2.4M suggestion rows):

```
EXPLAIN UPDATE ml_tag_suggestions SET status='approved'
  WHERE status='pending' AND (image_id, tag_id) IN (<40 tuples>);

type=range  key=unique_ml_suggestion_image_tag  rows=40
```

The optimizer picks the `(image_id, tag_id)` unique index, so the UPDATE takes one next-key lock per tag on the original — **including gap locks for tags with no suggestion row**. Those gaps are exactly where the pipeline inserts suggestions for neighbouring images, which is why the e2e repro (two freshly-uploaded, adjacent image ids) trips it so reliably.

Compounding it: `repost.py` is the **only** caller of `approve_pending_suggestions_for_links` that passes an image's whole tag set. Every other caller (single tag add, batch tag, report resolution) passes just the links it created.

## The fix

**1. Retry — `app/core/db_retry.py`**

The helper already existed for snapshot conflicts (1020). A deadlock is the same class of failure: the transaction is dead, and replaying on a fresh one resolves it — that is MariaDB's documented contract for the victim, not a workaround. So it now covers `{1020, 1213}` and is renamed `retry_on_transient_conflict` / `is_transient_conflict` to match what it does. All 12 existing call sites already satisfy the contract (self-contained, DB-only, re-fetching), so they get deadlock resilience for free.

1205 (lock wait timeout) is **deliberately excluded** — it fires only after `innodb_lock_wait_timeout` seconds, so replaying it multiplies an already pathological latency rather than resolving a momentary collision. That's documented in the module docstring.

Three paths are now wrapped:

| Path | Why |
|---|---|
| `PATCH /admin/images/{id}` | the 500 in the issue |
| `POST /admin/reports/{id}/action` | the other repost-capable path — same migration, same deadlock |
| `persist_predictions` | the pipeline side; the issue's 5x errno 1020. Wrapped at the DB half, not the endpoint, so a retry never re-runs inference |

Each unit re-fetches its rows inside the callable — **including the actor**, since the rollback expires every ORM instance the previous attempt loaded. All non-DB side effects (R2 enqueue, rating recalc) already sat below the commit, so a replay repeats nothing external.

**2. Narrowing — `app/services/repost.py`**

Resolve only the tags the migration actually moved, matching every other caller. The moved set is computed by diffing the two images' tag ids up front; since `tag_links` is keyed on `(tag_id, image_id)`, that difference *is* what `INSERT IGNORE` adds, so it doubles as the moved count. Net effect:

- lock set is proportional to what moved, not to the original's tag count
- three queries (COUNT before, COUNT after, SELECT all tag ids) become two SELECTs
- tag ids are passed sorted, giving concurrent migrations a consistent lock order

### Behaviour change worth flagging

A pending suggestion for a tag the original **already carried** is no longer resolved as a side effect of a repost. That was incidental cleanup unrelated to the operation — whatever applied that tag owned resolving it — and it is the entire reason the lock set was wide. Covered by a test.

## Tests

- `tests/unit/test_db_retry.py` — 1213 and 1020 both retried; 1062 (duplicate key, a real data conflict) and 1205 are not
- `tests/api/v1/test_admin_images.py` — repost PATCH survives an injected deadlock and migrates **exactly once**: one tag link, one favourite, one audit row, nothing double-counted
- `tests/services/test_ml_suggestion_pipeline.py` — `persist_predictions` replays cleanly, one row per suggested tag
- `tests/services/test_ml_suggestion_lifecycle.py` — only moved tags are resolved; a tag on both images counts as moving nothing
- New `tests/transient_conflict.py` helpers: `_deadlock_error()`, and `_flaky_commit()` for units with no explicit flush of their own (the repost migration is all Core `execute()` calls ending at the route's commit)

Three pre-existing tests asserted "1213 is not retried" — the exact contract this changes. They now use 1062, which keeps their real intent: errors outside the transient set must fail immediately.

## Verification

```
uv run pytest tests/ -q -n 4 --ignore=tests/integration
2478 passed, 4 skipped

uv run mypy app/     # Success: no issues found in 165 source files
uv run ruff check / format   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Et6DRiWrbnTLCrFEfmWMJf

---

### Review follow-up

Both retried units now **end at the commit**. `change_image_status` had `commit()` then `refresh()` inside the closure, and `action_report` read `report.image_id` after its commit. Neither is likely to raise — a plain SELECT after a fresh commit takes no locks, and `expire_on_commit=False` makes the attribute read pure — but anything that *did* raise there would replay the whole unit on top of a commit that already landed, writing a second audit row and a second status-history row with no re-fetch that could undo it. The refresh moved out of the closure and the image id is now read before the commit, so "idempotent under replay" is structural rather than an argument about which statements can throw.

Not changed: the `TestFavoriteRatingSnapshotConflictRetry` / `TestTagWriteSnapshotConflictRetry` class names. Those classes do primarily exercise 1020, so the names are still accurate, and renaming them would be churn.

Re-verified: `2478 passed, 4 skipped`, mypy clean on 165 files.

---

### ADRs

Two decisions here are re-litigable, so they ship with the code (matching ADR-0003, which landed in the same commit as its fix):

- **ADR-0004** — why 1020 and 1213 share one remedy, why retries are opt-in per write path rather than request-replay middleware, and why 1205 is excluded.
- **ADR-0005** — `approve_pending_suggestions_for_links()` is scoped to the caller's own new links, with the behaviour change stated plainly.

ADR-0005 matters most: ADR-0001 names "repost tag migration" as a resolver path without bounding what it resolves, so someone reading 0001 alone would take the wide tag list for intent. Without 0005, the natural "fix" for a stale pending on an original is to widen the list back and reintroduce this deadlock.

Neither contradicts an existing ADR — 0005 sharpens ADR-0001's invariant rather than replacing it, and ADR-0001's "any new code path that creates tag_links must call the helper" consequence is unchanged. `CONTEXT.md`'s **System resolution** entry still reads correctly and was left alone.