### PR TITLE
test: make the privmsg thread tests report why they failed

### DIFF
--- a/tests/api/v1/test_privmsg_threads.py
+++ b/tests/api/v1/test_privmsg_threads.py
@@ -35,7 +35,10 @@ async def login(client: AsyncClient, username: str) -> str:
         "/api/v1/auth/login",
         json={"username": username, "password": "TestPassword123!"},
     )
-    assert response.status_code == 200
+    # Named in the message: a bare `assert 401 == 200` inside a shared helper
+    # doesn't say which user failed to log in, and this helper is the first
+    # thing every test here calls (#338).
+    assert response.status_code == 200, f"login({username!r}) failed: {response.text}"
     return response.json()["access_token"]
 
 
@@ -69,7 +72,7 @@ class TestGetThreads:
             "/api/v1/privmsgs/threads",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         assert data["total"] >= 1
 
@@ -83,7 +86,7 @@ class TestGetThreads:
     async def test_list_threads_unauthenticated(self, client: AsyncClient):
         """Test listing threads without authentication."""
         response = await client.get("/api/v1/privmsgs/threads")
-        assert response.status_code == 401
+        assert response.status_code == 401, response.text
 
     async def test_list_threads_filter_unread(self, client: AsyncClient, db_session: AsyncSession):
         """Test filtering threads to only unread."""
@@ -123,7 +126,7 @@ class TestGetThreads:
             "/api/v1/privmsgs/threads?filter=unread",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         thread_ids = [t["thread_id"] for t in data["threads"]]
         assert t2 in thread_ids
@@ -153,7 +156,7 @@ class TestGetThreads:
             "/api/v1/privmsgs/threads",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         thread_ids = [t["thread_id"] for t in response.json()["threads"]]
         assert thread_id not in thread_ids
 
@@ -197,7 +200,7 @@ class TestGetThreads:
             "/api/v1/privmsgs/threads",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         threads = response.json()["threads"]
         thread_ids = [t["thread_id"] for t in threads]
         assert thread_ids.index(t2) < thread_ids.index(t1)
@@ -220,7 +223,7 @@ class TestSendThreadedMessage:
             json={"to_user_id": user_b.user_id, "subject": "New thread", "message": "Hello"},
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert "thread_id" in data
         assert data["thread_id"] is not None
@@ -253,14 +256,20 @@ class TestSendThreadedMessage:
             },
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert data["thread_id"] == thread_id
 
     async def test_reply_resets_recipient_del_flag(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Test that replying to a left thread resets the recipient's del flag."""
+        """Test that replying to a left thread resets the recipient's del flag.
+
+        Failed once in a full sequential run and has not been reproduced since
+        (#338). Nothing here is order-dependent as far as the investigation
+        got, so the assertions below carry enough state to identify which step
+        broke if it happens again.
+        """
         user_a = await create_user(db_session, "reset_a", email_verified=True)
         user_b = await create_user(db_session, "reset_b", email_verified=True)
 
@@ -276,6 +285,7 @@ class TestSendThreadedMessage:
         db_session.add(msg)
         await db_session.commit()
         await db_session.refresh(msg)
+        assert msg.to_del == 1, "fixture message did not persist with to_del=1"
 
         # user_a sends a new message in the thread
         token = await login(client, "reset_a")
@@ -289,11 +299,15 @@ class TestSendThreadedMessage:
             },
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         # user_b's del flag on old messages should be reset
         await db_session.refresh(msg)
-        assert msg.to_del == 0
+        assert msg.to_del == 0, (
+            f"to_del not reset on privmsg_id={msg.privmsg_id} "
+            f"(thread_id={thread_id}, to_user_id={msg.to_user_id}, "
+            f"expected recipient {user_b.user_id})"
+        )
 
 
 @pytest.mark.api
@@ -326,7 +340,7 @@ class TestGetThreadMessages:
             f"/api/v1/privmsgs/threads/{thread_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         assert len(data["messages"]) == 3
         # Should be ordered chronologically (oldest first)
@@ -356,7 +370,7 @@ class TestGetThreadMessages:
             f"/api/v1/privmsgs/threads/{thread_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         # Check DB: message should now be viewed
         await db_session.refresh(msg)
@@ -384,7 +398,7 @@ class TestGetThreadMessages:
             f"/api/v1/privmsgs/threads/{thread_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 403
+        assert response.status_code == 403, response.text
 
     async def test_get_thread_not_found(self, client: AsyncClient, db_session: AsyncSession):
         """Test 404 for nonexistent thread."""
@@ -394,7 +408,7 @@ class TestGetThreadMessages:
             "/api/v1/privmsgs/threads/nonexistent-thread-id",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 404
+        assert response.status_code == 404, response.text
 
 
 @pytest.mark.api
@@ -427,7 +441,7 @@ class TestLeaveThread:
             f"/api/v1/privmsgs/threads/{thread_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 204
+        assert response.status_code == 204, response.text
 
         # Verify to_del is set for all messages
         for m in msgs:
@@ -456,7 +470,7 @@ class TestLeaveThread:
             f"/api/v1/privmsgs/threads/{thread_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 204
+        assert response.status_code == 204, response.text
 
         await db_session.refresh(msg)
         assert msg.from_del == 1
@@ -483,4 +497,4 @@ class TestLeaveThread:
             f"/api/v1/privmsgs/threads/{thread_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
-        assert response.status_code == 403
+        assert response.status_code == 403, response.text


### PR DESCRIPTION
Refs #338. **This does not fix the flake** — it makes the next occurrence diagnose itself, which is what the issue asks for. The issue stays open.

## What the investigation found

The flake did not reproduce, and several of the issue's framing assumptions turned out not to hold:

- **It is not an ordering flake.** `pytest-randomly` is not installed and `addopts` doesn't shuffle, so collection order is deterministic. `test_reply_resets_recipient_del_flag` is collection item **#796**, which matches the reporter's "790 tests in" — it failed at its own natural position, and an identical rerun passed. No preceding test is implicated by the evidence.
- **Not a username collision.** `users.username` is uniquely indexed, and nothing else in the suite uses `reset_a` / `reset_b`.
- **Not rate-limit state.** `mock_redis` is function-scoped and returns `None` for every `get`, so no limiter counters carry across tests.
- **Not a process-level cache.** The only module globals are the ML service, R2 client, and search service singletons — none keyed by user id, which matters because a `needs_commit` test's `TRUNCATE` resets `AUTO_INCREMENT` and ids do get reused.
- **Not the `enqueue_job` side effect.** `enqueue_job` swallows every exception and returns `None`, so it cannot fail the request.
- **Not session-isolation leakage.** Chased the `SAWarning: transaction already deassociated from connection` that the suite emits from `tests/conftest.py:507` on any test where app code calls `session.rollback()`. Probed it directly — rollback, then write, then commit — and nothing escapes the fixture's outer transaction. **The warning is noise**, worth knowing so the next person doesn't spend the same time on it.

Not reproduced across three clean full sequential runs.

## What this changes

The reason the one occurrence yielded nothing is that the test carries no evidence. All 16 status assertions in this file are bare, so a failure prints `assert 400 == 201` and nothing about why — and the shared `login()` helper's bare `assert 200` doesn't even say which user failed to authenticate.

- response bodies attached to all 16 status assertions
- `login()` names the user in its failure message
- the two domain assertions carry `privmsg_id`, `thread_id` and both user ids, so a missed UPDATE is distinguishable from a fixture row that never persisted
- an added `assert msg.to_del == 1` right after setup, so a bad fixture fails at the fixture rather than three steps later
- a docstring pointing at #338

Matches the `assert ..., response.text` convention already used in `test_batch_tag.py` and `test_admin_images.py`.

## Verification

```
uv run pytest tests/api/v1/test_privmsg_threads.py -q
15 passed

uv run ruff check / format   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Et6DRiWrbnTLCrFEfmWMJf