### PR TITLE
feat(users): profile favorite tags — tables, grouped GET, mutations

### DIFF
--- a/alembic/versions/10eef13f525a_add_user_favorite_tables.py
+++ b/alembic/versions/10eef13f525a_add_user_favorite_tables.py
@@ -1,0 +1,80 @@
+"""add user favorite tables
+
+Revision ID: 10eef13f525a
+Revises: 0a2bc955ec55
+Create Date: 2026-08-18 07:36:53.410876
+
+"""
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '10eef13f525a'
+down_revision: str | Sequence[str] | None = '0a2bc955ec55'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "user_favorite_links",
+        sa.Column("user_id", mysql.INTEGER(unsigned=True), nullable=False),
+        sa.Column("link_id", mysql.INTEGER(unsigned=True), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("current_timestamp()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("user_id", "link_id"),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.user_id"],
+            name="fk_user_favorite_links_user_id",
+            ondelete="CASCADE", onupdate="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["link_id"], ["character_source_links.id"],
+            name="fk_user_favorite_links_link_id",
+            ondelete="CASCADE", onupdate="CASCADE",
+        ),
+    )
+    op.create_index("idx_user_favorite_links_link_id", "user_favorite_links", ["link_id"])
+
+    op.create_table(
+        "user_favorite_tags",
+        sa.Column("user_id", mysql.INTEGER(unsigned=True), nullable=False),
+        sa.Column("tag_id", mysql.INTEGER(unsigned=True), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("current_timestamp()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("user_id", "tag_id"),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.user_id"],
+            name="fk_user_favorite_tags_user_id",
+            ondelete="CASCADE", onupdate="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tag_id"], ["tags.tag_id"],
+            name="fk_user_favorite_tags_tag_id",
+            ondelete="CASCADE", onupdate="CASCADE",
+        ),
+    )
+    op.create_index("idx_user_favorite_tags_tag_id", "user_favorite_tags", ["tag_id"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("idx_user_favorite_tags_tag_id", table_name="user_favorite_tags")
+    op.drop_table("user_favorite_tags")
+    op.drop_index("idx_user_favorite_links_link_id", table_name="user_favorite_links")
+    op.drop_table("user_favorite_links")

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -1151,6 +1151,17 @@ async def add_favorite_tag(
             )
         # Cap counts only THIS tag-type's favorites (sources and artists
         # are independent categories sharing one table).
+        #
+        # TOCTOU: the count check, the max(position) read, and the INSERT
+        # below aren't in one atomic unit, so two concurrent POSTs from the
+        # same user can both pass the cap at 19 (landing at 21) or both read
+        # the same max_pos (tied positions). Accepted, not locked: prod runs
+        # innodb_snapshot_isolation=ON, under which SELECT...FOR UPDATE
+        # raises error 1020 app-wide, so locking here would trade a cosmetic
+        # race for real 500s under contention. The race is same-user-only
+        # (personal curation, never cross-user), overshoot is bounded to one
+        # per in-flight request, and tied positions self-heal on the next
+        # reorder (which rewrites 0..n-1).
         count = (
             await db.execute(
                 select(func.count())
@@ -1206,6 +1217,8 @@ async def add_favorite_tag(
     link = link_result.scalar_one_or_none()
     if not link:
         raise HTTPException(status_code=404, detail="Link not found")
+    # Same cap-check/max-position TOCTOU tradeoff as the tag path above —
+    # accepted there, not locked; see that comment for why.
     count = (
         await db.execute(
             select(func.count())

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -6,6 +6,7 @@ import hashlib
 import re
 import secrets
 import tempfile
+from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path as FilePath
 from typing import Annotated, Any
@@ -23,6 +24,7 @@ from fastapi import (
     status,
 )
 from sqlalchemy import asc, case, delete, desc, func, or_, select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
 
@@ -67,6 +69,8 @@ from app.schemas.taste_profile import TasteProfileResponse, TasteProfileSummary,
 from app.schemas.user import (
     AcknowledgeWarningsResponse,
     FavoriteCharacterEntry,
+    FavoriteOrderUpdate,
+    FavoriteTagCreate,
     FavoriteTagEntry,
     UserCreate,
     UserCreateResponse,
@@ -960,25 +964,23 @@ async def get_user_favorites(
     )
 
 
-@router.get("/{user_id}/favorite-tags", response_model=UserFavoriteTagsResponse)
-async def get_user_favorite_tags(
-    user_id: Annotated[int, Path(description="User ID")],
-    db: AsyncSession = Depends(get_db),
-) -> UserFavoriteTagsResponse:
-    """
-    A user's public profile favorites, grouped and position-ordered.
+def _character_link_select() -> Any:
+    """Base 18-column select for one favorited character combo's display row.
 
-    Characters are per (character, source) link and carry the link's
-    picture when one is set and its image is still publicly visible —
-    the same read-time re-check the tag-detail embed does.
-    """
-    user_result = await db.execute(select(Users).where(Users.user_id == user_id))  # type: ignore[arg-type]
-    if not user_result.scalar_one_or_none():
-        raise HTTPException(status_code=404, detail="User not found")
+    Typed ``Any``, not ``Select[Any]``: the 18-column ``select()`` call below
+    already fails mypy's overload resolution (see its own ignore comment) and
+    resolves to ``Any`` at that point, exactly as it did inline in Task 1 --
+    an explicit ``Select[Any]`` return annotation would make mypy check the
+    chained ``.join()``/``.where()``/``.order_by()`` calls at every call site
+    for real, which is a much bigger surface than this helper is worth.
 
+    Shared by the grouped GET (many rows, one query) and
+    ``_favorite_character_entry`` (one row, filtered by link_id) — the join
+    shape lives here exactly once.
+    """
     char_tags = aliased(Tags)
     src_tags = aliased(Tags)
-    link_rows = await db.execute(
+    return (
         select(  # type: ignore[call-overload, misc]
             UserFavoriteLinks.link_id,
             UserFavoriteLinks.position,
@@ -1007,51 +1009,89 @@ async def get_user_favorite_tags(
             CharacterSourceLinkPictures.link_id == CharacterSourceLinks.id,
         )
         .outerjoin(Images, Images.image_id == CharacterSourceLinkPictures.image_id)
+    )
+
+
+def _character_entry_from_row(row: Any) -> FavoriteCharacterEntry:
+    """Turn one ``_character_link_select`` row into its response entry."""
+    (
+        link_id,
+        position,
+        c_id,
+        c_title,
+        c_type,
+        c_usage,
+        s_id,
+        s_title,
+        s_type,
+        s_usage,
+        pic_image_id,
+        crop_x,
+        crop_y,
+        crop_w,
+        crop_h,
+        filename,
+        status,
+        r2_location,
+    ) = row
+    picture = None
+    # Re-checked at read time: a deactivated image must not leak through.
+    if pic_image_id is not None and status in PUBLIC_IMAGE_STATUSES:
+        picture = LinkPictureInfo(
+            image_id=pic_image_id,
+            thumbnail_url=thumbnail_url_for(filename, status, r2_location),
+            crop_x=crop_x,
+            crop_y=crop_y,
+            crop_w=crop_w,
+            crop_h=crop_h,
+        )
+    return FavoriteCharacterEntry(
+        link_id=link_id,
+        position=position,
+        character=LinkedTag(tag_id=c_id, title=c_title, type=c_type, usage_count=c_usage),
+        source=LinkedTag(tag_id=s_id, title=s_title, type=s_type, usage_count=s_usage),
+        picture=picture,
+    )
+
+
+async def _favorite_character_entry(
+    db: AsyncSession, user_id: int, link_id: int
+) -> FavoriteCharacterEntry | None:
+    """Single-row echo of one favorited combo — shares the grouped GET's join."""
+    result = await db.execute(
+        _character_link_select().where(
+            UserFavoriteLinks.user_id == user_id,
+            UserFavoriteLinks.link_id == link_id,
+        )
+    )
+    row = result.first()
+    if row is None:
+        return None
+    return _character_entry_from_row(row)
+
+
+@router.get("/{user_id}/favorite-tags", response_model=UserFavoriteTagsResponse)
+async def get_user_favorite_tags(
+    user_id: Annotated[int, Path(description="User ID")],
+    db: AsyncSession = Depends(get_db),
+) -> UserFavoriteTagsResponse:
+    """
+    A user's public profile favorites, grouped and position-ordered.
+
+    Characters are per (character, source) link and carry the link's
+    picture when one is set and its image is still publicly visible —
+    the same read-time re-check the tag-detail embed does.
+    """
+    user_result = await db.execute(select(Users).where(Users.user_id == user_id))  # type: ignore[arg-type]
+    if not user_result.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="User not found")
+
+    link_rows = await db.execute(
+        _character_link_select()
         .where(UserFavoriteLinks.user_id == user_id)
         .order_by(UserFavoriteLinks.position)
     )
-    characters = []
-    for row in link_rows.all():
-        (
-            link_id,
-            position,
-            c_id,
-            c_title,
-            c_type,
-            c_usage,
-            s_id,
-            s_title,
-            s_type,
-            s_usage,
-            pic_image_id,
-            crop_x,
-            crop_y,
-            crop_w,
-            crop_h,
-            filename,
-            status,
-            r2_location,
-        ) = row
-        picture = None
-        # Re-checked at read time: a deactivated image must not leak through.
-        if pic_image_id is not None and status in PUBLIC_IMAGE_STATUSES:
-            picture = LinkPictureInfo(
-                image_id=pic_image_id,
-                thumbnail_url=thumbnail_url_for(filename, status, r2_location),
-                crop_x=crop_x,
-                crop_y=crop_y,
-                crop_w=crop_w,
-                crop_h=crop_h,
-            )
-        characters.append(
-            FavoriteCharacterEntry(
-                link_id=link_id,
-                position=position,
-                character=LinkedTag(tag_id=c_id, title=c_title, type=c_type, usage_count=c_usage),
-                source=LinkedTag(tag_id=s_id, title=s_title, type=s_type, usage_count=s_usage),
-                picture=picture,
-            )
-        )
+    characters = [_character_entry_from_row(row) for row in link_rows.all()]
 
     tag_rows = await db.execute(
         select(  # type: ignore[call-overload]
@@ -1075,6 +1115,223 @@ async def get_user_favorite_tags(
         (sources if tag_type == TagType.SOURCE else artists).append(entry)
 
     return UserFavoriteTagsResponse(characters=characters, sources=sources, artists=artists)
+
+
+FAVORITES_PER_CATEGORY_CAP = 20
+
+
+@router.post("/me/favorite-tags", status_code=201)
+async def add_favorite_tag(
+    body: FavoriteTagCreate,
+    current_user: Annotated[Users, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> FavoriteCharacterEntry | FavoriteTagEntry:
+    """Add a favorite (source/artist tag by tag_id, character combo by link_id)."""
+    if (body.tag_id is None) == (body.link_id is None):
+        raise HTTPException(status_code=400, detail="Provide exactly one of tag_id or link_id")
+    assert current_user.user_id is not None
+
+    if body.tag_id is not None:
+        tag_result = await db.execute(
+            select(Tags).where(Tags.tag_id == body.tag_id)  # type: ignore[arg-type]
+        )
+        tag = tag_result.scalar_one_or_none()
+        if not tag:
+            raise HTTPException(status_code=404, detail="Tag not found")
+        if tag.type not in (TagType.SOURCE, TagType.ARTIST):
+            raise HTTPException(
+                status_code=400,
+                detail="Only Source or Artist tags can be favorited directly "
+                "(characters are favorited per source combo)",
+            )
+        if tag.alias_of is not None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Cannot favorite an alias tag; use the canonical tag (id: {tag.alias_of})",
+            )
+        # Cap counts only THIS tag-type's favorites (sources and artists
+        # are independent categories sharing one table).
+        count = (
+            await db.execute(
+                select(func.count())
+                .select_from(UserFavoriteTags)
+                .join(Tags, Tags.tag_id == UserFavoriteTags.tag_id)  # type: ignore[arg-type]
+                .where(
+                    UserFavoriteTags.user_id == current_user.user_id,  # type: ignore[arg-type]
+                    Tags.type == tag.type,  # type: ignore[arg-type]
+                )
+            )
+        ).scalar() or 0
+        if count >= FAVORITES_PER_CATEGORY_CAP:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Favorite limit reached ({FAVORITES_PER_CATEGORY_CAP} per category)",
+            )
+        max_pos = (
+            await db.execute(
+                select(func.max(UserFavoriteTags.position))
+                .join(Tags, Tags.tag_id == UserFavoriteTags.tag_id)  # type: ignore[arg-type]
+                .where(
+                    UserFavoriteTags.user_id == current_user.user_id,  # type: ignore[arg-type]
+                    Tags.type == tag.type,  # type: ignore[arg-type]
+                )
+            )
+        ).scalar()
+        position = 0 if max_pos is None else max_pos + 1
+        db.add(
+            UserFavoriteTags(user_id=current_user.user_id, tag_id=body.tag_id, position=position)
+        )
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            raise HTTPException(status_code=409, detail="Already favorited") from None
+        return FavoriteTagEntry(
+            position=position,
+            tag=LinkedTag(
+                tag_id=tag.tag_id or 0,
+                title=tag.title,
+                type=tag.type,
+                usage_count=tag.usage_count,
+            ),
+        )
+
+    # link_id path
+    assert body.link_id is not None  # guaranteed by the XOR check above
+    link_result = await db.execute(
+        select(CharacterSourceLinks).where(
+            CharacterSourceLinks.id == body.link_id  # type: ignore[arg-type]
+        )
+    )
+    link = link_result.scalar_one_or_none()
+    if not link:
+        raise HTTPException(status_code=404, detail="Link not found")
+    count = (
+        await db.execute(
+            select(func.count())
+            .select_from(UserFavoriteLinks)
+            .where(UserFavoriteLinks.user_id == current_user.user_id)  # type: ignore[arg-type]
+        )
+    ).scalar() or 0
+    if count >= FAVORITES_PER_CATEGORY_CAP:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Favorite limit reached ({FAVORITES_PER_CATEGORY_CAP} per category)",
+        )
+    max_pos = (
+        await db.execute(
+            select(func.max(UserFavoriteLinks.position)).where(
+                UserFavoriteLinks.user_id == current_user.user_id  # type: ignore[arg-type]
+            )
+        )
+    ).scalar()
+    position = 0 if max_pos is None else max_pos + 1
+    db.add(UserFavoriteLinks(user_id=current_user.user_id, link_id=body.link_id, position=position))
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Already favorited") from None
+
+    # Echo in the GET's entry shape — reuse the grouped GET's join for one row.
+    entry = await _favorite_character_entry(db, current_user.user_id, body.link_id)
+    assert entry is not None
+    return entry
+
+
+@router.delete("/me/favorite-tags/tag/{tag_id}", status_code=204)
+async def remove_favorite_tag(
+    tag_id: Annotated[int, Path()],
+    current_user: Annotated[Users, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Remove a favorited source/artist tag."""
+    result = await db.execute(
+        select(UserFavoriteTags).where(
+            UserFavoriteTags.user_id == current_user.user_id,  # type: ignore[arg-type]
+            UserFavoriteTags.tag_id == tag_id,  # type: ignore[arg-type]
+        )
+    )
+    row = result.scalar_one_or_none()
+    if not row:
+        raise HTTPException(status_code=404, detail="Not favorited")
+    await db.delete(row)
+    await db.commit()
+
+
+@router.delete("/me/favorite-tags/link/{link_id}", status_code=204)
+async def remove_favorite_link(
+    link_id: Annotated[int, Path()],
+    current_user: Annotated[Users, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Remove a favorited character combo."""
+    result = await db.execute(
+        select(UserFavoriteLinks).where(
+            UserFavoriteLinks.user_id == current_user.user_id,  # type: ignore[arg-type]
+            UserFavoriteLinks.link_id == link_id,  # type: ignore[arg-type]
+        )
+    )
+    row = result.scalar_one_or_none()
+    if not row:
+        raise HTTPException(status_code=404, detail="Not favorited")
+    await db.delete(row)
+    await db.commit()
+
+
+@router.put("/me/favorite-tags/order", status_code=204)
+async def reorder_favorite_tags(
+    body: FavoriteOrderUpdate,
+    current_user: Annotated[Users, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Atomically rewrite one category's positions to match the given id order."""
+    assert current_user.user_id is not None
+    rows: Sequence[UserFavoriteLinks] | Sequence[UserFavoriteTags]
+    if body.category == "characters":
+        rows = (
+            (
+                await db.execute(
+                    select(UserFavoriteLinks).where(
+                        UserFavoriteLinks.user_id == current_user.user_id  # type: ignore[arg-type]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        current_ids = {row.link_id for row in rows}
+    else:
+        wanted_type = TagType.SOURCE if body.category == "sources" else TagType.ARTIST
+        rows = (
+            (
+                await db.execute(
+                    select(UserFavoriteTags)
+                    .join(Tags, Tags.tag_id == UserFavoriteTags.tag_id)  # type: ignore[arg-type]
+                    .where(
+                        UserFavoriteTags.user_id == current_user.user_id,  # type: ignore[arg-type]
+                        Tags.type == wanted_type,  # type: ignore[arg-type]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        current_ids = {row.tag_id for row in rows}
+
+    if len(body.ids) != len(current_ids) or set(body.ids) != current_ids:
+        raise HTTPException(
+            status_code=400,
+            detail="ids must be a permutation of the category's current favorites",
+        )
+
+    by_id = {
+        (row.link_id if body.category == "characters" else row.tag_id): row  # type: ignore[union-attr]
+        for row in rows
+    }
+    for position, entry_id in enumerate(body.ids):
+        by_id[entry_id].position = position
+    await db.commit()
 
 
 @router.get("/{user_id}/ratings", response_model=UserRatingsListResponse)

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -1130,6 +1130,9 @@ async def add_favorite_tag(
     if (body.tag_id is None) == (body.link_id is None):
         raise HTTPException(status_code=400, detail="Provide exactly one of tag_id or link_id")
     assert current_user.user_id is not None
+    # Capture as a primitive: a snapshot-conflict retry below rolls back the
+    # transaction, which expires ORM instances (including current_user).
+    user_id: int = current_user.user_id
 
     if body.tag_id is not None:
         tag_result = await db.execute(
@@ -1149,28 +1152,95 @@ async def add_favorite_tag(
                 status_code=400,
                 detail=f"Cannot favorite an alias tag; use the canonical tag (id: {tag.alias_of})",
             )
-        # Cap counts only THIS tag-type's favorites (sources and artists
-        # are independent categories sharing one table).
+        # Capture as primitives too: `tag` is touched again inside the
+        # retried unit below (cap-check join condition, response echo), and
+        # a retry's rollback would expire it just like current_user above.
+        tag_id_val = tag.tag_id
+        tag_title = tag.title
+        tag_type = tag.type
+        tag_usage = tag.usage_count
+
+        # The cap count, max(position) read, and INSERT below are a single
+        # unit that can hit ER_CHECKREAD (1020) under innodb_snapshot_isolation
+        # when it races another write on the same rows (e.g. a double-submit
+        # re-adding/reordering this tag-type). Retry on a fresh snapshot
+        # instead of surfacing a 500 (see app/core/db_retry.py; ADR-0004).
+        # The unit re-fetches its rows.
         #
-        # TOCTOU: the count check, the max(position) read, and the INSERT
-        # below aren't in one atomic unit, so two concurrent POSTs from the
-        # same user can both pass the cap at 19 (landing at 21) or both read
-        # the same max_pos (tied positions). Accepted, not locked: prod runs
-        # innodb_snapshot_isolation=ON, under which SELECT...FOR UPDATE
-        # raises error 1020 app-wide, so locking here would trade a cosmetic
-        # race for real 500s under contention. The race is same-user-only
-        # (personal curation, never cross-user), overshoot is bounded to one
-        # per in-flight request, and tied positions self-heal on the next
-        # reorder (which rewrites 0..n-1).
+        # That retry does not close every race: two concurrent POSTs for
+        # DIFFERENT tag_ids insert into different rows, so neither locks the
+        # other and no 1020 fires — both can still pass this cap check before
+        # either commits. That residual race is accepted: same-user only,
+        # overshoot bounded to one per in-flight request, and positions
+        # self-heal on the next reorder (which rewrites 0..n-1).
+        async def _apply_tag() -> FavoriteTagEntry:
+            # Cap counts only THIS tag-type's favorites (sources and artists
+            # are independent categories sharing one table).
+            count = (
+                await db.execute(
+                    select(func.count())
+                    .select_from(UserFavoriteTags)
+                    .join(Tags, Tags.tag_id == UserFavoriteTags.tag_id)  # type: ignore[arg-type]
+                    .where(
+                        UserFavoriteTags.user_id == user_id,  # type: ignore[arg-type]
+                        Tags.type == tag_type,  # type: ignore[arg-type]
+                    )
+                )
+            ).scalar() or 0
+            if count >= FAVORITES_PER_CATEGORY_CAP:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Favorite limit reached ({FAVORITES_PER_CATEGORY_CAP} per category)",
+                )
+            max_pos = (
+                await db.execute(
+                    select(func.max(UserFavoriteTags.position))
+                    .join(Tags, Tags.tag_id == UserFavoriteTags.tag_id)  # type: ignore[arg-type]
+                    .where(
+                        UserFavoriteTags.user_id == user_id,  # type: ignore[arg-type]
+                        Tags.type == tag_type,  # type: ignore[arg-type]
+                    )
+                )
+            ).scalar()
+            position = 0 if max_pos is None else max_pos + 1
+            db.add(UserFavoriteTags(user_id=user_id, tag_id=tag_id_val, position=position))
+            try:
+                await db.commit()
+            except IntegrityError:
+                await db.rollback()
+                raise HTTPException(status_code=409, detail="Already favorited") from None
+            return FavoriteTagEntry(
+                position=position,
+                tag=LinkedTag(
+                    tag_id=tag_id_val or 0,
+                    title=tag_title,
+                    type=tag_type,
+                    usage_count=tag_usage,
+                ),
+            )
+
+        return await retry_on_transient_conflict(db, _apply_tag, what="add_favorite_tag")
+
+    # link_id path
+    assert body.link_id is not None  # guaranteed by the XOR check above
+    link_id = body.link_id
+    link_result = await db.execute(
+        select(CharacterSourceLinks).where(
+            CharacterSourceLinks.id == link_id  # type: ignore[arg-type]
+        )
+    )
+    link = link_result.scalar_one_or_none()
+    if not link:
+        raise HTTPException(status_code=404, detail="Link not found")
+
+    # Same cap/max-position race and ADR-0004 retry coverage as the tag path
+    # above — see that comment for why.
+    async def _apply_link() -> FavoriteCharacterEntry:
         count = (
             await db.execute(
                 select(func.count())
-                .select_from(UserFavoriteTags)
-                .join(Tags, Tags.tag_id == UserFavoriteTags.tag_id)  # type: ignore[arg-type]
-                .where(
-                    UserFavoriteTags.user_id == current_user.user_id,  # type: ignore[arg-type]
-                    Tags.type == tag.type,  # type: ignore[arg-type]
-                )
+                .select_from(UserFavoriteLinks)
+                .where(UserFavoriteLinks.user_id == user_id)  # type: ignore[arg-type]
             )
         ).scalar() or 0
         if count >= FAVORITES_PER_CATEGORY_CAP:
@@ -1180,76 +1250,26 @@ async def add_favorite_tag(
             )
         max_pos = (
             await db.execute(
-                select(func.max(UserFavoriteTags.position))
-                .join(Tags, Tags.tag_id == UserFavoriteTags.tag_id)  # type: ignore[arg-type]
-                .where(
-                    UserFavoriteTags.user_id == current_user.user_id,  # type: ignore[arg-type]
-                    Tags.type == tag.type,  # type: ignore[arg-type]
+                select(func.max(UserFavoriteLinks.position)).where(
+                    UserFavoriteLinks.user_id == user_id  # type: ignore[arg-type]
                 )
             )
         ).scalar()
         position = 0 if max_pos is None else max_pos + 1
-        db.add(
-            UserFavoriteTags(user_id=current_user.user_id, tag_id=body.tag_id, position=position)
-        )
+        db.add(UserFavoriteLinks(user_id=user_id, link_id=link_id, position=position))
         try:
             await db.commit()
         except IntegrityError:
             await db.rollback()
             raise HTTPException(status_code=409, detail="Already favorited") from None
-        return FavoriteTagEntry(
-            position=position,
-            tag=LinkedTag(
-                tag_id=tag.tag_id or 0,
-                title=tag.title,
-                type=tag.type,
-                usage_count=tag.usage_count,
-            ),
-        )
 
-    # link_id path
-    assert body.link_id is not None  # guaranteed by the XOR check above
-    link_result = await db.execute(
-        select(CharacterSourceLinks).where(
-            CharacterSourceLinks.id == body.link_id  # type: ignore[arg-type]
-        )
-    )
-    link = link_result.scalar_one_or_none()
-    if not link:
-        raise HTTPException(status_code=404, detail="Link not found")
-    # Same cap-check/max-position TOCTOU tradeoff as the tag path above —
-    # accepted there, not locked; see that comment for why.
-    count = (
-        await db.execute(
-            select(func.count())
-            .select_from(UserFavoriteLinks)
-            .where(UserFavoriteLinks.user_id == current_user.user_id)  # type: ignore[arg-type]
-        )
-    ).scalar() or 0
-    if count >= FAVORITES_PER_CATEGORY_CAP:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Favorite limit reached ({FAVORITES_PER_CATEGORY_CAP} per category)",
-        )
-    max_pos = (
-        await db.execute(
-            select(func.max(UserFavoriteLinks.position)).where(
-                UserFavoriteLinks.user_id == current_user.user_id  # type: ignore[arg-type]
-            )
-        )
-    ).scalar()
-    position = 0 if max_pos is None else max_pos + 1
-    db.add(UserFavoriteLinks(user_id=current_user.user_id, link_id=body.link_id, position=position))
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        raise HTTPException(status_code=409, detail="Already favorited") from None
+        # Echo in the GET's entry shape — reuse the grouped GET's join for one
+        # row. A fresh query every attempt, so no stale-instance risk here.
+        entry = await _favorite_character_entry(db, user_id, link_id)
+        assert entry is not None
+        return entry
 
-    # Echo in the GET's entry shape — reuse the grouped GET's join for one row.
-    entry = await _favorite_character_entry(db, current_user.user_id, body.link_id)
-    assert entry is not None
-    return entry
+    return await retry_on_transient_conflict(db, _apply_link, what="add_favorite_tag")
 
 
 @router.delete("/me/favorite-tags/tag/{tag_id}", status_code=204)
@@ -1300,51 +1320,65 @@ async def reorder_favorite_tags(
 ) -> None:
     """Atomically rewrite one category's positions to match the given id order."""
     assert current_user.user_id is not None
-    rows: Sequence[UserFavoriteLinks] | Sequence[UserFavoriteTags]
-    if body.category == "characters":
-        rows = (
-            (
-                await db.execute(
-                    select(UserFavoriteLinks).where(
-                        UserFavoriteLinks.user_id == current_user.user_id  # type: ignore[arg-type]
+    # Capture as a primitive: a snapshot-conflict retry below rolls back the
+    # transaction, which expires ORM instances (including current_user).
+    user_id: int = current_user.user_id
+
+    # Same shape as user_profile_update's confirmed 1020 site: a
+    # read-then-UPDATE-many-then-commit unit on rows this user exclusively
+    # owns. A double-submit (or a reorder racing an add/remove touching the
+    # same rows) can abort the position UPDATEs under
+    # innodb_snapshot_isolation. Retry on a fresh snapshot instead of
+    # surfacing a 500 (see app/core/db_retry.py; ADR-0004). The unit
+    # re-fetches its rows.
+    async def _apply() -> None:
+        rows: Sequence[UserFavoriteLinks] | Sequence[UserFavoriteTags]
+        if body.category == "characters":
+            rows = (
+                (
+                    await db.execute(
+                        select(UserFavoriteLinks).where(
+                            UserFavoriteLinks.user_id == user_id  # type: ignore[arg-type]
+                        )
                     )
                 )
+                .scalars()
+                .all()
             )
-            .scalars()
-            .all()
-        )
-        current_ids = {row.link_id for row in rows}
-    else:
-        wanted_type = TagType.SOURCE if body.category == "sources" else TagType.ARTIST
-        rows = (
-            (
-                await db.execute(
-                    select(UserFavoriteTags)
-                    .join(Tags, Tags.tag_id == UserFavoriteTags.tag_id)  # type: ignore[arg-type]
-                    .where(
-                        UserFavoriteTags.user_id == current_user.user_id,  # type: ignore[arg-type]
-                        Tags.type == wanted_type,  # type: ignore[arg-type]
+            current_ids = {row.link_id for row in rows}
+        else:
+            wanted_type = TagType.SOURCE if body.category == "sources" else TagType.ARTIST
+            rows = (
+                (
+                    await db.execute(
+                        select(UserFavoriteTags)
+                        .join(Tags, Tags.tag_id == UserFavoriteTags.tag_id)  # type: ignore[arg-type]
+                        .where(
+                            UserFavoriteTags.user_id == user_id,  # type: ignore[arg-type]
+                            Tags.type == wanted_type,  # type: ignore[arg-type]
+                        )
                     )
                 )
+                .scalars()
+                .all()
             )
-            .scalars()
-            .all()
-        )
-        current_ids = {row.tag_id for row in rows}
+            current_ids = {row.tag_id for row in rows}
 
-    if len(body.ids) != len(current_ids) or set(body.ids) != current_ids:
-        raise HTTPException(
-            status_code=400,
-            detail="ids must be a permutation of the category's current favorites",
-        )
+        if len(body.ids) != len(current_ids) or set(body.ids) != current_ids:
+            raise HTTPException(
+                status_code=400,
+                detail="ids must be a permutation of the category's current favorites",
+            )
 
-    by_id = {
-        (row.link_id if body.category == "characters" else row.tag_id): row  # type: ignore[union-attr]
-        for row in rows
-    }
-    for position, entry_id in enumerate(body.ids):
-        by_id[entry_id].position = position
-    await db.commit()
+        by_id = {
+            (row.link_id if body.category == "characters" else row.tag_id): row  # type: ignore[union-attr]
+            for row in rows
+        }
+        for position, entry_id in enumerate(body.ids):
+            by_id[entry_id].position = position
+        await db.commit()
+
+    await retry_on_transient_conflict(db, _apply, what="reorder_favorite_tags")
 
 
 @router.get("/{user_id}/ratings", response_model=UserRatingsListResponse)

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -24,7 +24,7 @@ from fastapi import (
 )
 from sqlalchemy import asc, case, delete, desc, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import aliased, selectinload
 
 from app.api.dependencies import (
     ImageSortParams,
@@ -32,7 +32,7 @@ from app.api.dependencies import (
     UserRatingsSortParams,
     UserSortParams,
 )
-from app.config import ImageStatus, SuspensionAction, settings
+from app.config import ImageStatus, SuspensionAction, TagType, settings
 from app.core.auth import (
     get_client_ip,
     get_current_user,
@@ -48,8 +48,11 @@ from app.core.redis import get_redis
 from app.core.security import RedactedStr, get_password_hash, validate_password_strength
 from app.core.user_loader import image_uploader_load
 from app.models import Favorites, ImageRatings, Images, TagLinks, Tags, Users
+from app.models.character_source_link import CharacterSourceLinks
+from app.models.character_source_link_picture import CharacterSourceLinkPictures
 from app.models.permissions import UserGroups
 from app.models.refresh_token import RefreshTokens
+from app.models.user_favorite import UserFavoriteLinks, UserFavoriteTags
 from app.models.user_suspension import UserSuspensions
 from app.models.user_tag_affinity import UserTagAffinity
 from app.schemas.image import (
@@ -57,12 +60,17 @@ from app.schemas.image import (
     ImageDetailedResponse,
     ImageWithRatingResponse,
     UserRatingsListResponse,
+    thumbnail_url_for,
 )
+from app.schemas.tag import LinkedTag, LinkPictureInfo
 from app.schemas.taste_profile import TasteProfileResponse, TasteProfileSummary, TasteProfileTag
 from app.schemas.user import (
     AcknowledgeWarningsResponse,
+    FavoriteCharacterEntry,
+    FavoriteTagEntry,
     UserCreate,
     UserCreateResponse,
+    UserFavoriteTagsResponse,
     UserListResponse,
     UserPrivateResponse,
     UserResponse,
@@ -950,6 +958,123 @@ async def get_user_favorites(
         per_page=pagination.per_page,
         images=[ImageDetailedResponse.model_validate(img) for img in images],
     )
+
+
+@router.get("/{user_id}/favorite-tags", response_model=UserFavoriteTagsResponse)
+async def get_user_favorite_tags(
+    user_id: Annotated[int, Path(description="User ID")],
+    db: AsyncSession = Depends(get_db),
+) -> UserFavoriteTagsResponse:
+    """
+    A user's public profile favorites, grouped and position-ordered.
+
+    Characters are per (character, source) link and carry the link's
+    picture when one is set and its image is still publicly visible —
+    the same read-time re-check the tag-detail embed does.
+    """
+    user_result = await db.execute(select(Users).where(Users.user_id == user_id))  # type: ignore[arg-type]
+    if not user_result.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="User not found")
+
+    char_tags = aliased(Tags)
+    src_tags = aliased(Tags)
+    link_rows = await db.execute(
+        select(  # type: ignore[call-overload, misc]
+            UserFavoriteLinks.link_id,
+            UserFavoriteLinks.position,
+            char_tags.tag_id,
+            char_tags.title,
+            char_tags.type,
+            char_tags.usage_count,
+            src_tags.tag_id,
+            src_tags.title,
+            src_tags.type,
+            src_tags.usage_count,
+            CharacterSourceLinkPictures.image_id,
+            CharacterSourceLinkPictures.crop_x,
+            CharacterSourceLinkPictures.crop_y,
+            CharacterSourceLinkPictures.crop_w,
+            CharacterSourceLinkPictures.crop_h,
+            Images.filename,
+            Images.status,
+            Images.r2_location,
+        )
+        .join(CharacterSourceLinks, CharacterSourceLinks.id == UserFavoriteLinks.link_id)
+        .join(char_tags, char_tags.tag_id == CharacterSourceLinks.character_tag_id)
+        .join(src_tags, src_tags.tag_id == CharacterSourceLinks.source_tag_id)
+        .outerjoin(
+            CharacterSourceLinkPictures,
+            CharacterSourceLinkPictures.link_id == CharacterSourceLinks.id,
+        )
+        .outerjoin(Images, Images.image_id == CharacterSourceLinkPictures.image_id)
+        .where(UserFavoriteLinks.user_id == user_id)
+        .order_by(UserFavoriteLinks.position)
+    )
+    characters = []
+    for row in link_rows.all():
+        (
+            link_id,
+            position,
+            c_id,
+            c_title,
+            c_type,
+            c_usage,
+            s_id,
+            s_title,
+            s_type,
+            s_usage,
+            pic_image_id,
+            crop_x,
+            crop_y,
+            crop_w,
+            crop_h,
+            filename,
+            status,
+            r2_location,
+        ) = row
+        picture = None
+        # Re-checked at read time: a deactivated image must not leak through.
+        if pic_image_id is not None and status in PUBLIC_IMAGE_STATUSES:
+            picture = LinkPictureInfo(
+                image_id=pic_image_id,
+                thumbnail_url=thumbnail_url_for(filename, status, r2_location),
+                crop_x=crop_x,
+                crop_y=crop_y,
+                crop_w=crop_w,
+                crop_h=crop_h,
+            )
+        characters.append(
+            FavoriteCharacterEntry(
+                link_id=link_id,
+                position=position,
+                character=LinkedTag(tag_id=c_id, title=c_title, type=c_type, usage_count=c_usage),
+                source=LinkedTag(tag_id=s_id, title=s_title, type=s_type, usage_count=s_usage),
+                picture=picture,
+            )
+        )
+
+    tag_rows = await db.execute(
+        select(  # type: ignore[call-overload]
+            UserFavoriteTags.position,
+            Tags.tag_id,
+            Tags.title,
+            Tags.type,
+            Tags.usage_count,
+        )
+        .join(Tags, Tags.tag_id == UserFavoriteTags.tag_id)
+        .where(UserFavoriteTags.user_id == user_id)
+        .order_by(UserFavoriteTags.position)
+    )
+    sources: list[FavoriteTagEntry] = []
+    artists: list[FavoriteTagEntry] = []
+    for position, tag_id, title, tag_type, usage_count in tag_rows.all():
+        entry = FavoriteTagEntry(
+            position=position,
+            tag=LinkedTag(tag_id=tag_id, title=title, type=tag_type, usage_count=usage_count),
+        )
+        (sources if tag_type == TagType.SOURCE else artists).append(entry)
+
+    return UserFavoriteTagsResponse(characters=characters, sources=sources, artists=artists)
 
 
 @router.get("/{user_id}/ratings", response_model=UserRatingsListResponse)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -59,6 +59,7 @@ from app.models.tag_history import TagHistory
 from app.models.tag_link import TagLinks
 from app.models.tag_mapping import TagMappings
 from app.models.user import Users
+from app.models.user_favorite import UserFavoriteLinks, UserFavoriteTags
 from app.models.user_tag_affinity import UserTagAffinity
 
 __all__ = [
@@ -76,6 +77,8 @@ __all__ = [
     "TagMappings",
     "CharacterSourceLinks",
     "CharacterSourceLinkPictures",
+    "UserFavoriteLinks",
+    "UserFavoriteTags",
     "TagAuditLog",
     "TagHistory",
     "ImageRatings",

--- a/app/models/user_favorite.py
+++ b/app/models/user_favorite.py
@@ -1,0 +1,93 @@
+"""
+SQLModel-based user favorite tag/link models.
+
+MAL-style public profile favorites. Characters are favorited per
+(character, source) LINK — a row references character_source_links, so
+the same character from two sources is two distinct favoritable combos.
+Sources and artists are favorited as plain tags; the category derives
+from tags.type (validated SOURCE/ARTIST on write, no stored kind).
+CASCADE from users/tags/links means favorites clean themselves up.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Column, ForeignKeyConstraint, Index, text
+from sqlmodel import Field, SQLModel
+
+from app.models.types import UtcDateTime
+
+
+class UserFavoriteLinks(SQLModel, table=True):
+    """A user's favorite character combos, ordered by position."""
+
+    __tablename__ = "user_favorite_links"
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id"],
+            ["users.user_id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="fk_user_favorite_links_user_id",
+        ),
+        ForeignKeyConstraint(
+            ["link_id"],
+            ["character_source_links.id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="fk_user_favorite_links_link_id",
+        ),
+        Index("idx_user_favorite_links_link_id", "link_id"),
+    )
+
+    # Composite PK; FK constraints (with CASCADE) live in __table_args__ —
+    # do NOT add foreign_key= to the Fields (duplicates the FK sans CASCADE).
+    user_id: int = Field(primary_key=True)
+    link_id: int = Field(primary_key=True)
+
+    # 0-based within the user's characters list. Gaps after deletes are
+    # harmless (order-by stays correct); reorder rewrites 0..n-1.
+    position: int
+
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
+    )
+
+    # Relationships intentionally omitted (house style).
+
+
+class UserFavoriteTags(SQLModel, table=True):
+    """A user's favorite source/artist tags, ordered by position per type."""
+
+    __tablename__ = "user_favorite_tags"
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id"],
+            ["users.user_id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="fk_user_favorite_tags_user_id",
+        ),
+        ForeignKeyConstraint(
+            ["tag_id"],
+            ["tags.tag_id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="fk_user_favorite_tags_tag_id",
+        ),
+        Index("idx_user_favorite_tags_tag_id", "tag_id"),
+    )
+
+    user_id: int = Field(primary_key=True)
+    tag_id: int = Field(primary_key=True)
+
+    # 0-based within that tag-type's list (sources and artists order
+    # independently even though they share this table).
+    position: int
+
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
+    )

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -2,12 +2,13 @@
 Pydantic schemas for User endpoints
 """
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, EmailStr, Field, StrictBool, computed_field, field_validator
 
 from app.models.user import UserBase
 from app.schemas.base import UTCDatetime, UTCDatetimeOptional
+from app.schemas.tag import LinkedTag, LinkPictureInfo
 
 # Canonical set of allowed theme presets. Adding a new preset requires:
 # 1) appending the id here, 2) adding the matching entry to the frontend
@@ -336,3 +337,45 @@ class AcknowledgeWarningsResponse(BaseModel):
 
     acknowledged_count: int
     message: str
+
+
+# ===== Profile Favorite Tags Schemas =====
+
+
+class FavoriteCharacterEntry(BaseModel):
+    """One favorited character combo on a user's public favorites"""
+
+    link_id: int
+    position: int
+    character: LinkedTag
+    source: LinkedTag
+    picture: LinkPictureInfo | None = None
+
+
+class FavoriteTagEntry(BaseModel):
+    """One favorited source/artist tag on a user's public favorites"""
+
+    position: int
+    tag: LinkedTag
+
+
+class UserFavoriteTagsResponse(BaseModel):
+    """A user's public favorites, grouped and position-ordered"""
+
+    characters: list[FavoriteCharacterEntry]
+    sources: list[FavoriteTagEntry]
+    artists: list[FavoriteTagEntry]
+
+
+class FavoriteTagCreate(BaseModel):
+    """Add-favorite body: exactly one of tag_id (source/artist) or link_id"""
+
+    tag_id: int | None = None
+    link_id: int | None = None
+
+
+class FavoriteOrderUpdate(BaseModel):
+    """Atomic per-category reorder: ids must be a permutation of the set"""
+
+    category: Literal["characters", "sources", "artists"]
+    ids: list[int]

--- a/tests/api/v1/test_user_favorite_tags.py
+++ b/tests/api/v1/test_user_favorite_tags.py
@@ -1,5 +1,6 @@
 """Tests for profile favorite tags (grouped GET + own-only mutations)."""
 
+import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -159,3 +160,190 @@ class TestGetFavoriteTags:
         await db_session.refresh(other)
         response = await client.get(f"/api/v1/users/{other.user_id}/favorite-tags")
         assert response.json() == {"characters": [], "sources": [], "artists": []}
+
+
+class TestAddFavorite:
+    async def test_add_tag_and_link_happy_paths(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        ids = await _seed(db_session)
+        headers = await _login(client)
+        src = await client.post(
+            "/api/v1/users/me/favorite-tags", json={"tag_id": SRC_A}, headers=headers
+        )
+        assert src.status_code == 201, src.text
+        assert src.json()["tag"]["tag_id"] == SRC_A
+
+        art = await client.post(
+            "/api/v1/users/me/favorite-tags", json={"tag_id": ARTIST_A}, headers=headers
+        )
+        assert art.status_code == 201
+        assert art.json()["position"] == 0  # artists order independently of sources
+
+        combo = await client.post(
+            "/api/v1/users/me/favorite-tags", json={"link_id": ids["link_a"]}, headers=headers
+        )
+        assert combo.status_code == 201
+        body = combo.json()
+        assert body["link_id"] == ids["link_a"]
+        assert body["character"]["title"] == "fav char"
+        assert body["picture"]["image_id"] == IMG_PIC
+
+    @pytest.mark.parametrize(
+        ("payload", "status", "fragment"),
+        [
+            ({"tag_id": 999999}, 404, "Tag not found"),
+            ({"link_id": 999999}, 404, "Link not found"),
+            ({"tag_id": THEME_A}, 400, "Source or Artist"),
+            ({"tag_id": CHAR_A}, 400, "Source or Artist"),
+            ({"tag_id": SRC_ALIAS}, 400, "alias"),
+            ({}, 400, "exactly one"),
+            ({"tag_id": SRC_A, "link_id": 1}, 400, "exactly one"),
+        ],
+    )
+    async def test_add_rejections(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        payload: dict[str, int],
+        status: int,
+        fragment: str,
+    ) -> None:
+        await _seed(db_session)
+        headers = await _login(client)
+        response = await client.post(
+            "/api/v1/users/me/favorite-tags", json=payload, headers=headers
+        )
+        assert response.status_code == status, response.text
+        assert fragment in response.json()["detail"]
+
+    # The 409 path rolls back a failed commit (IntegrityError on the duplicate
+    # PK) -- same as create_character_source_link's duplicate-link 409 -- which
+    # SQLAlchemy flags on fixture teardown. Expected consequence of that
+    # pattern, not a defect; named explicitly so the suite's output stays
+    # clean without hiding anything else.
+    @pytest.mark.filterwarnings(
+        "ignore:transaction already deassociated from connection:sqlalchemy.exc.SAWarning"
+    )
+    async def test_duplicate_409_and_anonymous_401(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        await _seed(db_session)
+        headers = await _login(client)
+        first = await client.post(
+            "/api/v1/users/me/favorite-tags", json={"tag_id": SRC_A}, headers=headers
+        )
+        assert first.status_code == 201
+        dupe = await client.post(
+            "/api/v1/users/me/favorite-tags", json={"tag_id": SRC_A}, headers=headers
+        )
+        assert dupe.status_code == 409
+        anon = await client.post("/api/v1/users/me/favorite-tags", json={"tag_id": SRC_A})
+        assert anon.status_code == 401
+
+    async def test_cap_is_per_category(self, client: AsyncClient, db_session: AsyncSession) -> None:
+        ids = await _seed(db_session)
+        # Fill sources to the cap directly (20 extra source tags).
+        uid = ids["user_id"]
+        for i in range(20):
+            tag_id = 9900 + i
+            db_session.add(Tags(tag_id=tag_id, type=TagType.SOURCE, title=f"cap src {i}"))
+            await db_session.flush()
+            db_session.add(UserFavoriteTags(user_id=uid, tag_id=tag_id, position=i))
+        await db_session.commit()
+        headers = await _login(client)
+        over = await client.post(
+            "/api/v1/users/me/favorite-tags", json={"tag_id": SRC_A}, headers=headers
+        )
+        assert over.status_code == 400
+        assert "20" in over.json()["detail"]
+        # A full sources list must NOT block artists (independent caps).
+        artist_ok = await client.post(
+            "/api/v1/users/me/favorite-tags", json={"tag_id": ARTIST_A}, headers=headers
+        )
+        assert artist_ok.status_code == 201
+
+
+class TestRemoveFavorite:
+    async def test_remove_both_kinds_and_404(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        ids = await _seed(db_session)
+        await _favorite_all(db_session, ids)
+        headers = await _login(client)
+        assert (
+            await client.delete(f"/api/v1/users/me/favorite-tags/tag/{SRC_A}", headers=headers)
+        ).status_code == 204
+        assert (
+            await client.delete(
+                f"/api/v1/users/me/favorite-tags/link/{ids['link_a']}", headers=headers
+            )
+        ).status_code == 204
+        assert (
+            await client.delete(f"/api/v1/users/me/favorite-tags/tag/{SRC_A}", headers=headers)
+        ).status_code == 404
+
+    async def test_cascade_from_tag_and_link_deletion(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        ids = await _seed(db_session)
+        await _favorite_all(db_session, ids)
+        link = (
+            await db_session.execute(
+                select(CharacterSourceLinks).where(
+                    CharacterSourceLinks.id == ids["link_a"]  # type: ignore[arg-type]
+                )
+            )
+        ).scalar_one()
+        await db_session.delete(link)
+        tag = (
+            await db_session.execute(
+                select(Tags).where(Tags.tag_id == ARTIST_A)  # type: ignore[arg-type]
+            )
+        ).scalar_one()
+        await db_session.delete(tag)
+        await db_session.commit()
+        response = await client.get(f"/api/v1/users/{ids['user_id']}/favorite-tags")
+        body = response.json()
+        assert [c["link_id"] for c in body["characters"]] == [ids["link_b"]]
+        assert body["artists"] == []
+
+
+class TestReorder:
+    async def test_reorder_rewrites_positions(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        ids = await _seed(db_session)
+        await _favorite_all(db_session, ids)
+        headers = await _login(client)
+        response = await client.put(
+            "/api/v1/users/me/favorite-tags/order",
+            json={"category": "characters", "ids": [ids["link_b"], ids["link_a"]]},
+            headers=headers,
+        )
+        assert response.status_code == 204, response.text
+        got = await client.get(f"/api/v1/users/{ids['user_id']}/favorite-tags")
+        assert [c["link_id"] for c in got.json()["characters"]] == [ids["link_b"], ids["link_a"]]
+
+    @pytest.mark.parametrize(
+        "ids_builder",
+        [
+            lambda d: [d["link_a"]],  # missing an id
+            lambda d: [d["link_a"], d["link_a"]],  # duplicate
+            lambda d: [d["link_a"], d["link_b"], 999],  # foreign id
+            lambda d: [SRC_A, ARTIST_A],  # wrong category's ids
+        ],
+    )
+    async def test_reorder_requires_permutation(
+        self, client: AsyncClient, db_session: AsyncSession, ids_builder
+    ) -> None:
+        ids = await _seed(db_session)
+        await _favorite_all(db_session, ids)
+        headers = await _login(client)
+        response = await client.put(
+            "/api/v1/users/me/favorite-tags/order",
+            json={"category": "characters", "ids": ids_builder(ids)},
+            headers=headers,
+        )
+        assert response.status_code == 400
+        assert "permutation" in response.json()["detail"]

--- a/tests/api/v1/test_user_favorite_tags.py
+++ b/tests/api/v1/test_user_favorite_tags.py
@@ -1,0 +1,161 @@
+"""Tests for profile favorite tags (grouped GET + own-only mutations)."""
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus, TagType
+from app.core.security import get_password_hash
+from app.models.character_source_link import CharacterSourceLinks
+from app.models.character_source_link_picture import CharacterSourceLinkPictures
+from app.models.image import Images
+from app.models.tag import Tags
+from app.models.tag_link import TagLinks
+from app.models.user import Users
+from app.models.user_favorite import UserFavoriteLinks, UserFavoriteTags
+
+CHAR_A = 9801  # linked to SRC_A and SRC_B (two combos)
+SRC_A = 9803
+SRC_B = 9804
+ARTIST_A = 9805
+THEME_A = 9806  # never favoritable
+SRC_ALIAS = 9807  # alias of SRC_A — rejected on write
+IMG_PIC = 9811  # picture source for the (CHAR_A, SRC_A) link
+
+
+async def _seed(db: AsyncSession) -> dict[str, int]:
+    """Tags, two links (one with a picture), one favoriting user. Returns ids."""
+    db.add(Tags(tag_id=CHAR_A, type=TagType.CHARACTER, title="fav char"))
+    db.add(Tags(tag_id=SRC_A, type=TagType.SOURCE, title="fav source A"))
+    db.add(Tags(tag_id=SRC_B, type=TagType.SOURCE, title="fav source B"))
+    db.add(Tags(tag_id=ARTIST_A, type=TagType.ARTIST, title="fav artist"))
+    db.add(Tags(tag_id=THEME_A, type=TagType.THEME, title="fav theme"))
+    db.add(Tags(tag_id=SRC_ALIAS, type=TagType.SOURCE, title="fav source A alias", alias_of=SRC_A))
+    db.add(
+        Images(
+            image_id=IMG_PIC,
+            user_id=1,
+            ext="jpg",
+            status=ImageStatus.ACTIVE,
+            width=1000,
+            height=1000,
+        )
+    )
+    user = Users(
+        username="fav_user",
+        password=get_password_hash("Password123!"),
+        password_type="bcrypt",
+        salt="",
+        email="fav_user@example.com",
+        active=1,
+        admin=0,
+    )
+    db.add(user)
+    await db.flush()
+    db.add(TagLinks(tag_id=CHAR_A, image_id=IMG_PIC, user_id=1))
+    db.add(TagLinks(tag_id=SRC_A, image_id=IMG_PIC, user_id=1))
+    link_a = CharacterSourceLinks(character_tag_id=CHAR_A, source_tag_id=SRC_A)
+    link_b = CharacterSourceLinks(character_tag_id=CHAR_A, source_tag_id=SRC_B)
+    db.add(link_a)
+    db.add(link_b)
+    await db.flush()
+    assert link_a.id is not None and link_b.id is not None and user.user_id is not None
+    db.add(
+        CharacterSourceLinkPictures(
+            link_id=link_a.id,
+            image_id=IMG_PIC,
+            crop_x=0.1,
+            crop_y=0.1,
+            crop_w=0.5,
+            crop_h=0.5,
+        )
+    )
+    await db.commit()
+    return {"link_a": link_a.id, "link_b": link_b.id, "user_id": user.user_id}
+
+
+async def _login(
+    client: AsyncClient, username: str = "fav_user", password: str = "Password123!"
+) -> dict[str, str]:
+    response = await client.post(
+        "/api/v1/auth/login", json={"username": username, "password": password}
+    )
+    assert response.status_code == 200, response.text
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+async def _favorite_all(db: AsyncSession, ids: dict[str, int]) -> None:
+    """Directly seed favorites: both combos, one source, one artist."""
+    uid = ids["user_id"]
+    db.add(UserFavoriteLinks(user_id=uid, link_id=ids["link_a"], position=0))
+    db.add(UserFavoriteLinks(user_id=uid, link_id=ids["link_b"], position=1))
+    db.add(UserFavoriteTags(user_id=uid, tag_id=SRC_A, position=0))
+    db.add(UserFavoriteTags(user_id=uid, tag_id=ARTIST_A, position=0))
+    await db.commit()
+
+
+class TestGetFavoriteTags:
+    async def test_grouped_shape_order_and_picture(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        ids = await _seed(db_session)
+        await _favorite_all(db_session, ids)
+        response = await client.get(f"/api/v1/users/{ids['user_id']}/favorite-tags")
+        assert response.status_code == 200, response.text
+        body = response.json()
+
+        chars = body["characters"]
+        assert [c["link_id"] for c in chars] == [ids["link_a"], ids["link_b"]]
+        assert chars[0]["character"]["title"] == "fav char"
+        assert chars[0]["source"]["title"] == "fav source A"
+        assert chars[0]["picture"]["image_id"] == IMG_PIC
+        assert chars[0]["picture"]["thumbnail_url"].endswith(".webp")
+        assert chars[1]["picture"] is None  # link_b has no picture
+
+        assert [s["tag"]["tag_id"] for s in body["sources"]] == [SRC_A]
+        assert [a["tag"]["tag_id"] for a in body["artists"]] == [ARTIST_A]
+
+    async def test_picture_omitted_when_image_leaves_public_status(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        ids = await _seed(db_session)
+        await _favorite_all(db_session, ids)
+        image = (
+            await db_session.execute(
+                select(Images).where(Images.image_id == IMG_PIC)  # type: ignore[arg-type]
+            )
+        ).scalar_one()
+        image.status = ImageStatus.DEACTIVATED
+        await db_session.commit()
+        response = await client.get(f"/api/v1/users/{ids['user_id']}/favorite-tags")
+        assert response.json()["characters"][0]["picture"] is None
+
+    async def test_empty_and_missing_user(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        ids = await _seed(db_session)
+        response = await client.get(f"/api/v1/users/{ids['user_id']}/favorite-tags")
+        assert response.status_code == 200
+        assert response.json() == {"characters": [], "sources": [], "artists": []}
+        missing = await client.get("/api/v1/users/999999/favorite-tags")
+        assert missing.status_code == 404
+
+    async def test_cross_user_isolation(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        ids = await _seed(db_session)
+        await _favorite_all(db_session, ids)
+        other = Users(
+            username="fav_other",
+            password=get_password_hash("Password123!"),
+            password_type="bcrypt",
+            salt="",
+            email="fav_other@example.com",
+            active=1,
+            admin=0,
+        )
+        db_session.add(other)
+        await db_session.commit()
+        await db_session.refresh(other)
+        response = await client.get(f"/api/v1/users/{other.user_id}/favorite-tags")
+        assert response.json() == {"characters": [], "sources": [], "artists": []}

--- a/tests/api/v1/test_user_favorite_tags.py
+++ b/tests/api/v1/test_user_favorite_tags.py
@@ -14,6 +14,7 @@ from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
 from app.models.user_favorite import UserFavoriteLinks, UserFavoriteTags
+from tests.transient_conflict import _flaky_commit, _snapshot_conflict_error
 
 CHAR_A = 9801  # linked to SRC_A and SRC_B (two combos)
 SRC_A = 9803
@@ -263,6 +264,74 @@ class TestAddFavorite:
         )
         assert artist_ok.status_code == 201
 
+    @pytest.mark.needs_commit
+    async def test_add_tag_retries_on_transient_conflict_and_lands_once(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """ADR-0004: a transient snapshot conflict at commit is retried, not
+        surfaced as a 500 — and the retried unit re-derives its INSERT rather
+        than replaying a stale one, so exactly one row lands.
+
+        needs_commit: retry_on_transient_conflict's rollback between attempts
+        needs the seeded user row to be durably committed (not just
+        savepoint-released) to survive re-fetch on the retry, as in production.
+        """
+        ids = await _seed(db_session)
+        headers = await _login(client)
+
+        commit_patch, calls = _flaky_commit(1, _snapshot_conflict_error("user_favorite_tags"))
+        with commit_patch:
+            response = await client.post(
+                "/api/v1/users/me/favorite-tags", json={"tag_id": SRC_A}, headers=headers
+            )
+
+        assert response.status_code == 201, response.text
+        assert len(calls) >= 2  # failed attempt + successful retry
+        rows = (
+            (
+                await db_session.execute(
+                    select(UserFavoriteTags).where(
+                        UserFavoriteTags.user_id == ids["user_id"],  # type: ignore[arg-type]
+                        UserFavoriteTags.tag_id == SRC_A,  # type: ignore[arg-type]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+
+    @pytest.mark.needs_commit
+    async def test_add_link_retries_on_transient_conflict_and_lands_once(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        ids = await _seed(db_session)
+        headers = await _login(client)
+
+        commit_patch, calls = _flaky_commit(1, _snapshot_conflict_error("user_favorite_links"))
+        with commit_patch:
+            response = await client.post(
+                "/api/v1/users/me/favorite-tags",
+                json={"link_id": ids["link_a"]},
+                headers=headers,
+            )
+
+        assert response.status_code == 201, response.text
+        assert len(calls) >= 2
+        rows = (
+            (
+                await db_session.execute(
+                    select(UserFavoriteLinks).where(
+                        UserFavoriteLinks.user_id == ids["user_id"],  # type: ignore[arg-type]
+                        UserFavoriteLinks.link_id == ids["link_a"],  # type: ignore[arg-type]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+
 
 class TestRemoveFavorite:
     async def test_remove_both_kinds_and_404(
@@ -347,3 +416,32 @@ class TestReorder:
         )
         assert response.status_code == 400
         assert "permutation" in response.json()["detail"]
+
+    @pytest.mark.needs_commit
+    async def test_reorder_retries_on_transient_conflict(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """Same ADR-0004 coverage as user_profile_update's confirmed 1020
+        site: a transient conflict on the position UPDATEs is retried, and
+        the retried unit re-fetches its rows rather than reusing stale ones.
+
+        needs_commit: same reason as the add-favorite retry tests — the
+        seeded favorites must be durably committed to survive the internal
+        rollback between attempts.
+        """
+        ids = await _seed(db_session)
+        await _favorite_all(db_session, ids)
+        headers = await _login(client)
+
+        commit_patch, calls = _flaky_commit(1, _snapshot_conflict_error("user_favorite_links"))
+        with commit_patch:
+            response = await client.put(
+                "/api/v1/users/me/favorite-tags/order",
+                json={"category": "characters", "ids": [ids["link_b"], ids["link_a"]]},
+                headers=headers,
+            )
+
+        assert response.status_code == 204, response.text
+        assert len(calls) >= 2
+        got = await client.get(f"/api/v1/users/{ids['user_id']}/favorite-tags")
+        assert [c["link_id"] for c in got.json()["characters"]] == [ids["link_b"], ids["link_a"]]


### PR DESCRIPTION
Chunk 5 of WhiteKitten's character↔source ideas (API side): MAL-style public profile favorites — favorite character combos (per `character_source_links` row, carrying chunk-4 link pictures), favorite sources, favorite artists. Design + implementation plan live in the frontend repo: `docs/plans/2026-Q3/2026-08-18-profile-favorite-tags-{design,impl}.md`.

## What

- Two new tables: `user_favorite_links` (PK (user_id, link_id)) and `user_favorite_tags` (PK (user_id, tag_id)), both with `position` for manual ordering and CASCADE from users/tags/links — favorites clean themselves up, no orphan handling. Category (source vs artist) derives from `tags.type`; no stored kind column.
- `GET /users/{user_id}/favorite-tags` — public, grouped `{characters, sources, artists}`, position-ordered; character entries embed the link's picture via the shared `thumbnail_url_for` with the same read-time public-status re-check the tag-detail embed uses.
- `POST /users/me/favorite-tags` (`tag_id` XOR `link_id`; validates type SOURCE/ARTIST, refuses aliases naming the canonical, enforces a per-category cap of 20, appends at the end, 409 on duplicate via the house IntegrityError pattern); `DELETE .../tag/{id}` + `.../link/{id}`; `PUT .../order` (strict-permutation atomic reorder, positions rewritten 0..n−1).
- No special permissions — users curate only their own; no audit rows (personal curation, not moderation).

## Notes

- **Carries a migration** (two additive tables). Deploy order: this PR before the FE PR; on prod run `make prod-migrate` before rollout.
- Additive API surface — existing clients unaffected.
- The FE consumer (profile sections, `/users/{id}/favorite-tags` management page, tag-page star toggles) follows in a frontend PR.

## Testing

- 21 tests in `tests/api/v1/test_user_favorite_tags.py`: grouped GET (shape/order/picture embed/deactivation degradation/isolation), POST matrix (types, alias, XOR, caps-per-category, 409, 401), DELETEs, CASCADE, reorder incl. four non-permutation rejections.
- Full `make pytest`: 2598 passed, exit 0. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CA4okLo3e4xG9uRjnRKXag