### PR TITLE
fix(ci): cancel superseded runs on a newer push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main, dev]
   pull_request:
 
+# Supersede in-flight runs when a newer commit lands on the same ref. Without
+# this a quick follow-up push left the first run going to completion alongside
+# the second, verifying a commit nobody was waiting on any more.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint & Format Check

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# Cancel an in-progress review when a newer commit lands on the same PR, so we
+# don't burn quota reviewing a superseded diff or post duplicate comment sets.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   review:
     name: Claude Review


### PR DESCRIPTION
## Why

Noticed while auditing Actions usage: push a commit, push a second one right after, and the first run here keeps going to completion alongside the second.

That's real, and it's because **neither workflow in this repo declares a `concurrency` group**. Measured over Aug 1–19:

| | shuushuu-frontend | shuushuu-api |
|---|---:|---:|
| Superseded runs cancelled | 17 of 17 | **0** |
| Runs cancelled all month | 20 | **0** |
| Redundant compute | 0 min | ~13 min |

The eight superseded runs that ran on regardless:

```
CI                main                      kept running 0.8 min after next push
Claude PR Review  docs/plans-reorg          kept running 3.1 min
Claude PR Review  chore/scripts-mypy-clean  kept running 1.3 min
CI                chore/scripts-mypy-clean  kept running 1.1 min
Claude PR Review  chore/db-tooling          kept running 1.2 min
Claude PR Review  chore/ruff-all-paths      kept running 3.0 min
CI                fix/forum-review          kept running 1.1 min
Claude PR Review  fix/forum-review          kept running 1.7 min
```

## What changed

The same four lines the frontend already uses, on `CI` and `Claude PR Review`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Grouping on `github.workflow` keeps CI and the review workflow independent — a new push supersedes the previous CI run and the previous review run, but the two never cancel each other.

`pr-agent.yml` is left alone; it's `workflow_dispatch`-only and disabled.

## Worth being clear about the payoff

**This saves no money.** This repo is public, so its Actions minutes are free — that's why the quota problem that started this audit is entirely a frontend issue. The wins here are feedback latency, and not reading Claude review comments written against a diff that's already been replaced.

One consequence to be aware of: on a rapid series of pushes to `main`, only the last commit gets a full CI run. That's the frontend's existing behaviour too. If you'd rather every `main` commit stay verified, `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` keeps the supersession on PR branches only — say the word and I'll switch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpyUCvsCCafcj2d5ZGFHx4