### PR TITLE
Postgres proof-of-concept: API runs against PostgreSQL 17

### DIFF
--- a/app/api/v1/comments.py
+++ b/app/api/v1/comments.py
@@ -127,7 +127,12 @@ async def list_comments(
     searching = bool(search_text and search_text.strip())
     if searching:
         reject_unindexable_comment_search(search_text, search_mode)  # type: ignore[arg-type]
-        query = apply_comment_text_search(query, search_text, search_mode)  # type: ignore[arg-type]
+        query = apply_comment_text_search(
+            query,
+            search_text,  # type: ignore[arg-type]
+            search_mode,
+            use_fulltext=db.get_bind().dialect.name != "postgresql",
+        )
     # Only the text-search path can degrade to an unindexed scan; None makes the
     # bound a no-op so plain image_ids/user_id listings are untouched.
     search_timeout = COMMENT_SEARCH_TIMEOUT_SECONDS if searching else None

--- a/app/api/v1/comments.py
+++ b/app/api/v1/comments.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import selectinload
 from app.api.dependencies import CommentSortParams, PaginationParams
 from app.config import AdminActionType, ReportStatus
 from app.core.auth import get_current_user
-from app.core.database import get_db, statement_timeout
+from app.core.database import get_db, is_postgres, statement_timeout
 from app.core.permissions import Permission, has_permission
 from app.core.redis import get_redis
 from app.models import Comments, Images, Users
@@ -131,7 +131,7 @@ async def list_comments(
             query,
             search_text,  # type: ignore[arg-type]
             search_mode,
-            use_fulltext=db.get_bind().dialect.name != "postgresql",
+            use_fulltext=not is_postgres(db),
         )
     # Only the text-search path can degrade to an unindexed scan; None makes the
     # bound a no-op so plain image_ids/user_id listings are untouched.

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -817,7 +817,12 @@ async def list_images(
         if commenter is not None:
             query = query.where(Comments.user_id == commenter)  # type: ignore[arg-type]
         if commentsearch is not None:
-            query = apply_comment_text_search(query, commentsearch, commentsearch_mode)
+            query = apply_comment_text_search(
+                query,
+                commentsearch,
+                commentsearch_mode,
+                use_fulltext=db.get_bind().dialect.name != "postgresql",
+            )
     elif hascomments is True:
         # Use posts counter field (fast indexed lookup)
         query = query.where(Images.posts > 0)  # type: ignore[arg-type]

--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -48,7 +48,7 @@ from app.config import (
     settings,
 )
 from app.core.auth import CurrentUser, VerifiedUser, get_current_user, get_optional_current_user
-from app.core.database import get_db, statement_timeout
+from app.core.database import get_db, is_postgres, statement_timeout
 from app.core.db_retry import retry_on_transient_conflict
 from app.core.logging import get_logger
 from app.core.permission_deps import require_permission
@@ -821,7 +821,7 @@ async def list_images(
                 query,
                 commentsearch,
                 commentsearch_mode,
-                use_fulltext=db.get_bind().dialect.name != "postgresql",
+                use_fulltext=not is_postgres(db),
             )
     elif hascomments is True:
         # Use posts counter field (fast indexed lookup)

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -671,6 +671,10 @@ async def list_tags(
     # Track whether we're using fulltext search and what query string
     fulltext_query_str: str | None = None
 
+    # Postgres has no MySQL FULLTEXT; its LIKE is also case-sensitive (the
+    # MariaDB columns are *_ci), so the fallback uses ILIKE.
+    use_fulltext = db.get_bind().dialect.name != "postgresql"
+
     if search:
         # Hybrid search strategy:
         # - Queries < 3 chars: Use LIKE (autocomplete, prefix matching)
@@ -683,7 +687,21 @@ async def list_tags(
             # Short query: prefix match with LIKE (e.g., "sa" -> "sakura")
             # Escape LIKE special characters to prevent unintended wildcard matching
             escaped_search = _escape_like_pattern(search)
-            query = query.where(Tags.title.like(f"{escaped_search}%"))  # type: ignore[union-attr]
+            prefix_pattern = f"{escaped_search}%"
+            query = query.where(
+                Tags.title.like(prefix_pattern)  # type: ignore[union-attr]
+                if use_fulltext
+                else Tags.title.ilike(prefix_pattern)  # type: ignore[union-attr]
+            )
+        elif not use_fulltext:
+            # Postgres: no index tokenizer to mirror — AND of case-insensitive
+            # contains matches per word keeps word-order independence.
+            # fulltext_query_str stays None so relevance ordering below takes
+            # the LIKE branch (built on portable lower() comparisons).
+            for word in search.split():
+                query = query.where(
+                    Tags.title.ilike(f"%{_escape_like_pattern(word)}%")  # type: ignore[union-attr]
+                )
         else:
             # Long query: word-order independent full-text search with wildcard expansion
             # Split search into words and add wildcard to each word to match partial terms

--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -31,7 +31,7 @@ from sqlalchemy.orm import aliased, selectinload
 from app.api.dependencies import ImageSortParams, PaginationParams, TagSortParams
 from app.config import ImageStatus, TagAuditActionType, TagType
 from app.core.auth import get_current_user, get_optional_current_user
-from app.core.database import get_db
+from app.core.database import get_db, is_postgres
 from app.core.permission_deps import require_permission
 from app.core.permissions import Permission
 from app.core.redis import get_redis
@@ -673,7 +673,7 @@ async def list_tags(
 
     # Postgres has no MySQL FULLTEXT; its LIKE is also case-sensitive (the
     # MariaDB columns are *_ci), so the fallback uses ILIKE.
-    use_fulltext = db.get_bind().dialect.name != "postgresql"
+    use_fulltext = not is_postgres(db)
 
     if search:
         # Hybrid search strategy:

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -4,8 +4,10 @@ Database configuration and session management
 
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
 
 from sqlalchemy import text as sql_text
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import declarative_base
 
@@ -13,6 +15,14 @@ from app.config import settings
 
 # Create declarative base for models
 Base = declarative_base()
+
+# Ensure all connections use UTC timezone for consistent datetime handling;
+# each driver spells the session setting differently.
+_connect_args: dict[str, Any] = (
+    {"server_settings": {"timezone": "UTC"}}
+    if make_url(settings.DATABASE_URL).get_backend_name() == "postgresql"
+    else {"init_command": "SET time_zone = '+00:00'"}
+)
 
 # Create async engine
 engine = create_async_engine(
@@ -22,8 +32,7 @@ engine = create_async_engine(
     max_overflow=settings.DB_MAX_OVERFLOW,
     pool_pre_ping=True,  # Verify connections before using
     pool_recycle=3600,  # Recycle connections every hour (MariaDB wait_timeout is 8 hours)
-    # Ensure all connections use UTC timezone for consistent datetime handling
-    connect_args={"init_command": "SET time_zone = '+00:00'"},
+    connect_args=_connect_args,
 )
 
 # Create async session factory
@@ -77,7 +86,8 @@ async def statement_timeout(db: AsyncSession, seconds: float | None) -> AsyncIte
     the limit should sit well clear of the slowest legitimate query so it never
     fires on real traffic. MariaDB's `max_statement_time` is per *statement*, so
     a request issuing several still has a total ceiling of the limit times the
-    statement count.
+    statement count. Postgres's `statement_timeout` behaves the same way (but
+    is set in milliseconds).
 
     Restoring on exit is not optional. Connections are pooled and returned to the
     pool without resetting session variables, so a limit left set would silently
@@ -91,10 +101,19 @@ async def statement_timeout(db: AsyncSession, seconds: float | None) -> AsyncIte
         yield
         return
 
-    # float() coerces the value: SET does not take bind parameters, so this is
-    # interpolated, and the coercion is what keeps that safe.
-    await db.execute(sql_text(f"SET SESSION max_statement_time = {float(seconds)}"))
-    try:
-        yield
-    finally:
-        await db.execute(sql_text("SET SESSION max_statement_time = DEFAULT"))
+    # int()/float() coerce the value: SET does not take bind parameters, so this
+    # is interpolated, and the coercion is what keeps that safe.
+    if db.get_bind().dialect.name == "postgresql":
+        # Postgres takes milliseconds and its DEFAULT restores the session's
+        # configured value, matching the MariaDB restore semantics below.
+        await db.execute(sql_text(f"SET statement_timeout = {int(seconds * 1000)}"))
+        try:
+            yield
+        finally:
+            await db.execute(sql_text("SET statement_timeout = DEFAULT"))
+    else:
+        await db.execute(sql_text(f"SET SESSION max_statement_time = {float(seconds)}"))
+        try:
+            yield
+        finally:
+            await db.execute(sql_text("SET SESSION max_statement_time = DEFAULT"))

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -45,6 +45,15 @@ AsyncSessionLocal = async_sessionmaker(
 )
 
 
+def is_postgres(db: AsyncSession) -> bool:
+    """Whether this session is bound to Postgres — the dialect-branch switch.
+
+    (The MariaDB-only guard in user_tag_affinity deliberately tests
+    `!= "mysql"` instead: it must also refuse any third dialect.)
+    """
+    return db.get_bind().dialect.name == "postgresql"
+
+
 async def get_db() -> AsyncGenerator[AsyncSession]:
     """
     Dependency for getting async database sessions.
@@ -103,7 +112,7 @@ async def statement_timeout(db: AsyncSession, seconds: float | None) -> AsyncIte
 
     # int()/float() coerce the value: SET does not take bind parameters, so this
     # is interpolated, and the coercion is what keeps that safe.
-    if db.get_bind().dialect.name == "postgresql":
+    if is_postgres(db):
         # Postgres takes milliseconds and its DEFAULT restores the session's
         # configured value, matching the MariaDB restore semantics below.
         await db.execute(sql_text(f"SET statement_timeout = {int(seconds * 1000)}"))

--- a/app/models/admin_action.py
+++ b/app/models/admin_action.py
@@ -15,8 +15,7 @@ see git history for `prune_admin_actions`.)
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import ForeignKeyConstraint, Index, text
-from sqlalchemy.dialects.mysql import JSON
+from sqlalchemy import JSON, ForeignKeyConstraint, Index, text
 from sqlmodel import Column, Field, SQLModel
 
 from app.models.types import UnsignedInt, UtcDateTime
@@ -102,7 +101,7 @@ class AdminActions(SQLModel, table=True):
     # Timestamp (indexed for time-ordered lookups)
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/ban.py
+++ b/app/models/ban.py
@@ -103,7 +103,7 @@ class Bans(BanBase, table=True):
     # Override to add server default
     date: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Override to attach UtcDateTime column type

--- a/app/models/character_source_link.py
+++ b/app/models/character_source_link.py
@@ -95,7 +95,7 @@ class CharacterSourceLinks(CharacterSourceLinkBase, table=True):
     # Timestamp
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/character_source_link_picture.py
+++ b/app/models/character_source_link_picture.py
@@ -69,7 +69,7 @@ class CharacterSourceLinkPictures(CharacterSourceLinkPictureBase, table=True):
 
     set_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Relationships intentionally omitted (house style — see

--- a/app/models/comment.py
+++ b/app/models/comment.py
@@ -118,7 +118,7 @@ class Comments(CommentBase, table=True):
 
     # Public timestamp
     date: datetime = Field(
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()"))
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP"))
     )
 
     # Public update tracking

--- a/app/models/comment_report.py
+++ b/app/models/comment_report.py
@@ -76,7 +76,7 @@ class CommentReports(CommentReportBase, table=True):
 
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     reviewed_by: int | None = Field(

--- a/app/models/favorite.py
+++ b/app/models/favorite.py
@@ -36,7 +36,7 @@ class FavoriteBase(SQLModel):
     # Public timestamp
     fav_date: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/generated.py.backup
+++ b/app/models/generated.py.backup
@@ -45,14 +45,14 @@ class Banners(Base):
     event_id: Mapped[int] = mapped_column(INTEGER(11), nullable=False, server_default=text("0"))
     active: Mapped[int] = mapped_column(TINYINT(1), nullable=False, server_default=text("1"))
     date: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
 
 
 t_donations = Table(
     "donations",
     Base.metadata,
-    Column("date", DateTime, nullable=False, server_default=text("current_timestamp()")),
+    Column("date", DateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     Column("user_id", INTEGER(10)),
     Column("nick", String(30)),
     Column("amount", INTEGER(3)),
@@ -154,7 +154,7 @@ class Images(Base):
     reviewed: Mapped[int] = mapped_column(TINYINT(1), nullable=False, server_default=text("0"))
     change_id: Mapped[int] = mapped_column(INTEGER(10), nullable=False, server_default=text("0"))
     date_added: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
     status_user_id: Mapped[int | None] = mapped_column(INTEGER(10))
     status_updated: Mapped[datetime.datetime | None] = mapped_column(DateTime)
@@ -294,7 +294,7 @@ class Users(Base):
 
     user_id: Mapped[int] = mapped_column(INTEGER(10), primary_key=True)
     date_joined: Mapped[datetime.datetime] = mapped_column(
-        DateTime, nullable=False, server_default=text("current_timestamp()")
+        DateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")
     )
     active: Mapped[int] = mapped_column(TINYINT(1), nullable=False, server_default=text("0"))
     admin: Mapped[int] = mapped_column(TINYINT(1), nullable=False, server_default=text("0"))
@@ -343,7 +343,7 @@ class Users(Base):
     )
     forum_id: Mapped[int | None] = mapped_column(MEDIUMINT(8))
     last_login: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
     bookmark: Mapped[int | None] = mapped_column(INTEGER(10))
     location: Mapped[str | None] = mapped_column(String(100))
@@ -435,7 +435,7 @@ class Bans(Base):
     reason: Mapped[str | None] = mapped_column(TINYTEXT)
     message: Mapped[str | None] = mapped_column(String(255))
     date: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
     expires: Mapped[datetime.datetime | None] = mapped_column(DateTime)
 
@@ -468,7 +468,7 @@ class Favorites(Base):
     user_id: Mapped[int] = mapped_column(INTEGER(10), primary_key=True)
     image_id: Mapped[int] = mapped_column(INTEGER(10), primary_key=True)
     fav_date: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
 
     image: Mapped["Images"] = relationship("Images", back_populates="favorites_")
@@ -527,7 +527,7 @@ class ImageRatings(Base):
     image_id: Mapped[int] = mapped_column(INTEGER(10), primary_key=True)
     rating: Mapped[int] = mapped_column(TINYINT(2), nullable=False, server_default=text("0"))
     date: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
 
     image: Mapped["Images"] = relationship("Images", back_populates="image_ratings")
@@ -563,7 +563,7 @@ class ImageReports(Base):
     category: Mapped[int | None] = mapped_column(TINYINT(3))
     text_: Mapped[str | None] = mapped_column("text", Text)
     date: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
 
     image: Mapped["Images"] = relationship("Images", back_populates="image_reports")
@@ -618,7 +618,7 @@ class News(Base):
     title: Mapped[str | None] = mapped_column(String(128))
     news_text: Mapped[str | None] = mapped_column(Text)
     date: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
     edited: Mapped[datetime.datetime | None] = mapped_column(DateTime)
 
@@ -660,7 +660,7 @@ class Posts(Base):
     useragent: Mapped[str] = mapped_column(String(255), nullable=False, server_default=text("''"))
     ip: Mapped[str] = mapped_column(String(15), nullable=False, server_default=text("''"))
     date: Mapped[datetime.datetime] = mapped_column(
-        DateTime, nullable=False, server_default=text("current_timestamp()")
+        DateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")
     )
     update_count: Mapped[int] = mapped_column(INTEGER(3), nullable=False, server_default=text("0"))
     post_text: Mapped[str] = mapped_column(Text, nullable=False)
@@ -708,7 +708,7 @@ class Privmsgs(Base):
     cardpath: Mapped[str] = mapped_column(String(255), nullable=False, server_default=text("''"))
     text_: Mapped[str | None] = mapped_column("text", Text)
     date: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
 
     from_user: Mapped["Users"] = relationship(
@@ -771,7 +771,7 @@ class Tags(Base):
 
     tag_id: Mapped[int] = mapped_column(INTEGER(10), primary_key=True)
     date_added: Mapped[datetime.datetime] = mapped_column(
-        DateTime, nullable=False, server_default=text("current_timestamp()")
+        DateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")
     )
     type: Mapped[int] = mapped_column(TINYINT(1), nullable=False, server_default=text("1"))
     title: Mapped[str | None] = mapped_column(String(150))
@@ -821,15 +821,15 @@ class UserSessions(Base):
     session_id: Mapped[str] = mapped_column(String(50), primary_key=True, server_default=text("''"))
     user_id: Mapped[int] = mapped_column(INTEGER(10), nullable=False)
     last_used: Mapped[datetime.datetime] = mapped_column(
-        DateTime, nullable=False, server_default=text("current_timestamp()")
+        DateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")
     )
     ip: Mapped[str] = mapped_column(String(16), nullable=False, server_default=text("''"))
     last_view_date: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
     lastpage: Mapped[str | None] = mapped_column(String(200))
     last_search: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
 
     user: Mapped["Users"] = relationship("Users", back_populates="user_sessions")
@@ -870,7 +870,7 @@ class TagHistory(Base):
     user_id: Mapped[int | None] = mapped_column(INTEGER(10))
     action: Mapped[str | None] = mapped_column(CHAR(1))
     date: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
 
     image: Mapped[Optional["Images"]] = relationship("Images", back_populates="tag_history")
@@ -910,7 +910,7 @@ class TagLinks(Base):
     image_id: Mapped[int] = mapped_column(INTEGER(10), primary_key=True)
     user_id: Mapped[int | None] = mapped_column(INTEGER(10))
     date_linked: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime, server_default=text("current_timestamp()")
+        DateTime, server_default=text("CURRENT_TIMESTAMP")
     )
 
     image: Mapped["Images"] = relationship("Images", back_populates="tag_links")

--- a/app/models/image.py
+++ b/app/models/image.py
@@ -232,7 +232,7 @@ class Images(ImageBase, table=True):
     # Public timestamp
     date_added: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Internal tracking fields (privacy-sensitive)

--- a/app/models/image_rating.py
+++ b/app/models/image_rating.py
@@ -78,7 +78,7 @@ class ImageRatings(ImageRatingBase, table=True):
     # Public timestamp
     date: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/image_report.py
+++ b/app/models/image_report.py
@@ -97,7 +97,7 @@ class ImageReports(ImageReportBase, table=True):
     # Public timestamp
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Review tracking

--- a/app/models/image_report_tag_suggestion.py
+++ b/app/models/image_report_tag_suggestion.py
@@ -62,5 +62,5 @@ class ImageReportTagSuggestions(ImageReportTagSuggestionBase, table=True):
 
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )

--- a/app/models/image_review.py
+++ b/app/models/image_review.py
@@ -138,7 +138,7 @@ class ImageReviews(ImageReviewBase, table=True):
     # Timestamps
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
     closed_at: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
 

--- a/app/models/image_status_history.py
+++ b/app/models/image_status_history.py
@@ -92,5 +92,5 @@ class ImageStatusHistory(ImageStatusHistoryBase, table=True):
     # Timestamp
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )

--- a/app/models/misc.py
+++ b/app/models/misc.py
@@ -70,7 +70,7 @@ class Banners(BannerBase, table=True):
     # Timestamp
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
 
 
@@ -214,7 +214,7 @@ class DonationBase(SQLModel):
     """
 
     date: datetime = Field(
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()"))
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP"))
     )
     user_id: int | None = Field(default=None)
     nick: str | None = Field(default=None, max_length=30)

--- a/app/models/ml_tag_suggestion.py
+++ b/app/models/ml_tag_suggestion.py
@@ -62,7 +62,7 @@ class MlTagSuggestions(MlTagSuggestionBase, table=True):
     )
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
     reviewed_at: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
     reviewed_by_user_id: int | None = Field(

--- a/app/models/news.py
+++ b/app/models/news.py
@@ -78,7 +78,7 @@ class News(NewsBase, table=True):
     # Override to add server default
     date: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Override to attach UtcDateTime column type

--- a/app/models/privmsg.py
+++ b/app/models/privmsg.py
@@ -104,7 +104,7 @@ class Privmsgs(PrivmsgBase, table=True):
     # Public timestamp
     date: datetime = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/refresh_token.py
+++ b/app/models/refresh_token.py
@@ -62,7 +62,7 @@ class RefreshTokens(SQLModel, table=True):
 
     # Expiration
     created_at: datetime = Field(
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()"))
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP"))
     )
     expires_at: datetime = Field(sa_column=Column(UtcDateTime, nullable=False))
 

--- a/app/models/review_vote.py
+++ b/app/models/review_vote.py
@@ -102,7 +102,7 @@ class ReviewVotes(ReviewVoteBase, table=True):
     # Timestamp
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/tag.py
+++ b/app/models/tag.py
@@ -18,7 +18,7 @@ from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, SQLModel
 
 from app.config import TagType
-from app.models.types import UtcDateTime
+from app.models.types import UtcDateTime, ci_string
 
 
 class TagBase(SQLModel):
@@ -32,7 +32,8 @@ class TagBase(SQLModel):
     """
 
     # Basic information
-    title: str | None = Field(default=None, max_length=255)
+    # ci_string: title matching/dedupe is case-insensitive on both dialects
+    title: str | None = Field(default=None, max_length=255, sa_type=ci_string(255))  # type: ignore[call-overload]
     desc: str | None = Field(default=None, max_length=200)
     type: int = Field(
         default=TagType.THEME,

--- a/app/models/tag.py
+++ b/app/models/tag.py
@@ -115,7 +115,7 @@ class Tags(TagBase, table=True):
     # Public timestamp
     date_added: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Usage count (number of images with this tag)

--- a/app/models/tag_audit_log.py
+++ b/app/models/tag_audit_log.py
@@ -148,7 +148,7 @@ class TagAuditLog(TagAuditLogBase, table=True):
     # Timestamp
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Note: Relationships are intentionally omitted.

--- a/app/models/tag_external_link.py
+++ b/app/models/tag_external_link.py
@@ -72,7 +72,7 @@ class TagExternalLinks(TagExternalLinkBase, table=True):
     # Timestamp
     date_added: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Dead link tracking

--- a/app/models/tag_history.py
+++ b/app/models/tag_history.py
@@ -100,7 +100,7 @@ class TagHistory(TagHistoryBase, table=True):
     # Override to add server default
     date: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Internal field

--- a/app/models/tag_link.py
+++ b/app/models/tag_link.py
@@ -91,7 +91,7 @@ class TagLinks(TagLinkBase, table=True):
     # Public timestamp
     date_linked: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Internal field

--- a/app/models/tag_mapping.py
+++ b/app/models/tag_mapping.py
@@ -40,5 +40,5 @@ class TagMappings(TagMappingBase, table=True):
     )
     created_at: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )

--- a/app/models/types.py
+++ b/app/models/types.py
@@ -20,13 +20,26 @@ on Postgres.
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import DateTime, Integer, SmallInteger
+from sqlalchemy import DateTime, Integer, SmallInteger, String
 from sqlalchemy.dialects.mysql import INTEGER, SMALLINT
-from sqlalchemy.types import TypeDecorator
+from sqlalchemy.dialects.postgresql import CITEXT
+from sqlalchemy.types import TypeDecorator, TypeEngine
 
 # Shared type instances, not classes — use as Column(UnsignedInt, ...); don't call them.
 UnsignedInt = INTEGER(unsigned=True).with_variant(Integer(), "postgresql")
 UnsignedSmallInt = SMALLINT(unsigned=True).with_variant(SmallInteger(), "postgresql")
+
+
+def ci_string(length: int) -> TypeEngine[str]:
+    """VARCHAR(length) on MariaDB; citext on Postgres.
+
+    For natural-key columns (username, email, tag title) whose comparisons were
+    case-insensitive on MariaDB via utf8mb4_unicode_ci. Postgres compares
+    case-sensitively by default, which breaks login/uniqueness semantics; the
+    citext variant restores them at the type level. citext has no length
+    modifier — the length cap on Postgres is application validation only.
+    """
+    return String(length).with_variant(CITEXT(), "postgresql")
 
 
 class UtcDateTime(TypeDecorator[datetime]):

--- a/app/models/types.py
+++ b/app/models/types.py
@@ -8,21 +8,25 @@ tzinfo=UTC on read. Naive datetimes are rejected on bind to avoid ambiguous
 UnsignedInt: INT UNSIGNED, matching the legacy schema's ID columns. Models must
 declare the same signedness as the migrations, or create_all-built schemas
 (schema-sync tests) fail FK creation with errno 150 (signed PK <- unsigned FK).
+Postgres has no unsigned ints, so the variant maps to plain INTEGER there
+(values in these columns stay well under the signed 32-bit ceiling today; a
+real data migration must re-verify that).
 
 UnsignedSmallInt: SMALLINT UNSIGNED, same rationale, for the ml_models
-dictionary table (small enough to fit SMALLINT) and its FKs.
+dictionary table (small enough to fit SMALLINT) and its FKs. Plain SMALLINT
+on Postgres.
 """
 
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import DateTime
+from sqlalchemy import DateTime, Integer, SmallInteger
 from sqlalchemy.dialects.mysql import INTEGER, SMALLINT
 from sqlalchemy.types import TypeDecorator
 
 # Shared type instances, not classes — use as Column(UnsignedInt, ...); don't call them.
-UnsignedInt = INTEGER(unsigned=True)
-UnsignedSmallInt = SMALLINT(unsigned=True)
+UnsignedInt = INTEGER(unsigned=True).with_variant(Integer(), "postgresql")
+UnsignedSmallInt = SMALLINT(unsigned=True).with_variant(SmallInteger(), "postgresql")
 
 
 class UtcDateTime(TypeDecorator[datetime]):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import Column, ForeignKeyConstraint, Index, text
 from sqlmodel import Field, Relationship, SQLModel
 
-from app.models.types import UtcDateTime
+from app.models.types import UtcDateTime, ci_string
 
 if TYPE_CHECKING:
     from app.models.permissions import UserGroups
@@ -34,7 +34,8 @@ class UserBase(SQLModel):
     """
 
     # Basic information
-    username: str = Field(max_length=30)
+    # ci_string: login and uniqueness are case-insensitive on both dialects
+    username: str = Field(max_length=30, sa_type=ci_string(30))  # type: ignore[call-overload]
 
     # Public profile
     location: str | None = Field(default=None, max_length=100)
@@ -146,7 +147,8 @@ class Users(UserBase, table=True):
     )
 
     # Contact info (privacy-sensitive)
-    email: str = Field(max_length=120)
+    # ci_string: lookups (password reset) and uniqueness are case-insensitive
+    email: str = Field(max_length=120, sa_type=ci_string(120))  # type: ignore[call-overload]
     email_verified: bool = Field(default=False)
     email_verification_token: str | None = Field(default=None, max_length=64)
     email_verification_sent_at: datetime | None = Field(

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -120,11 +120,11 @@ class Users(UserBase, table=True):
     # Public timestamps
     date_joined: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     )
     last_login: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )
     last_active: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
 

--- a/app/models/user_favorite.py
+++ b/app/models/user_favorite.py
@@ -51,7 +51,7 @@ class UserFavoriteLinks(SQLModel, table=True):
 
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     )
 
     # Relationships intentionally omitted (house style).
@@ -89,5 +89,5 @@ class UserFavoriteTags(SQLModel, table=True):
 
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     )

--- a/app/models/user_suspension.py
+++ b/app/models/user_suspension.py
@@ -76,7 +76,7 @@ class UserSuspensions(SQLModel, table=True):
 
     # When the action occurred
     actioned_at: datetime = Field(
-        sa_column=Column(UtcDateTime, nullable=False, server_default=text("current_timestamp()"))
+        sa_column=Column(UtcDateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP"))
     )
 
     # Suspension details (only for SuspensionAction.SUSPENDED action)

--- a/app/models/user_tag_affinity.py
+++ b/app/models/user_tag_affinity.py
@@ -38,5 +38,5 @@ class UserTagAffinity(SQLModel, table=True):
     affinity: float = Field(sa_column=Column(Float, nullable=False))
     updated_at: datetime | None = Field(
         default=None,
-        sa_column=Column(UtcDateTime, nullable=True, server_default=text("current_timestamp()")),
+        sa_column=Column(UtcDateTime, nullable=True, server_default=text("CURRENT_TIMESTAMP")),
     )

--- a/app/services/ml_raw_store.py
+++ b/app/services/ml_raw_store.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.dialects.mysql import insert as mysql_insert
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
@@ -190,7 +191,10 @@ async def ingest_raw_predictions(
     total_inserted = 0
     for start in range(0, len(rows), _BATCH_SIZE):
         batch = rows[start : start + _BATCH_SIZE]
-        stmt = mysql_insert(MlRawPredictions).values(batch).prefix_with("IGNORE")
+        if db.get_bind().dialect.name == "postgresql":
+            stmt: Any = pg_insert(MlRawPredictions).values(batch).on_conflict_do_nothing()
+        else:
+            stmt = mysql_insert(MlRawPredictions).values(batch).prefix_with("IGNORE")
         res = await db.execute(stmt)
         total_inserted += res.rowcount  # type: ignore[attr-defined]
 

--- a/app/services/ml_raw_store.py
+++ b/app/services/ml_raw_store.py
@@ -16,6 +16,7 @@ from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.database import is_postgres
 from app.core.logging import get_logger
 from app.models.ml_raw_prediction import MlExternalTags, MlModels, MlRawPredictions
 
@@ -191,7 +192,7 @@ async def ingest_raw_predictions(
     total_inserted = 0
     for start in range(0, len(rows), _BATCH_SIZE):
         batch = rows[start : start + _BATCH_SIZE]
-        if db.get_bind().dialect.name == "postgresql":
+        if is_postgres(db):
             stmt: Any = pg_insert(MlRawPredictions).values(batch).on_conflict_do_nothing()
         else:
             stmt = mysql_insert(MlRawPredictions).values(batch).prefix_with("IGNORE")

--- a/app/services/repost.py
+++ b/app/services/repost.py
@@ -8,6 +8,7 @@ from the repost to the original image, then cleans up the repost.
 from sqlalchemy import TextClause, delete, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.database import is_postgres
 from app.models.favorite import Favorites
 from app.models.image import Images
 from app.models.image_rating import ImageRatings
@@ -28,7 +29,7 @@ def _copy_to_original_sql(
         f"INTO {table} ({insert_cols}) "
         f"SELECT {select_cols} FROM {table} WHERE image_id = :repost_id"
     )
-    if db.get_bind().dialect.name == "postgresql":
+    if is_postgres(db):
         return text(f"INSERT {base} ON CONFLICT DO NOTHING")
     return text(f"INSERT IGNORE {base}")
 

--- a/app/services/repost.py
+++ b/app/services/repost.py
@@ -5,7 +5,7 @@ When an image is marked as a repost, migrates favorites, ratings, and tags
 from the repost to the original image, then cleans up the repost.
 """
 
-from sqlalchemy import delete, func, select, text, update
+from sqlalchemy import TextClause, delete, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.favorite import Favorites
@@ -15,6 +15,22 @@ from app.models.ml_tag_suggestion import MlTagSuggestions
 from app.models.tag_link import TagLinks
 from app.services.ml_suggestion_review import approve_pending_suggestions_for_links
 from app.services.tag_type_flags import refresh_images_tag_type_flags
+
+
+def _copy_to_original_sql(
+    db: AsyncSession, table: str, insert_cols: str, select_cols: str
+) -> TextClause:
+    """INSERT-or-skip-duplicates, copying `table` rows from the repost to the original.
+
+    MariaDB spells "skip duplicates" INSERT IGNORE; Postgres ON CONFLICT DO NOTHING.
+    """
+    base = (
+        f"INTO {table} ({insert_cols}) "
+        f"SELECT {select_cols} FROM {table} WHERE image_id = :repost_id"
+    )
+    if db.get_bind().dialect.name == "postgresql":
+        return text(f"INSERT {base} ON CONFLICT DO NOTHING")
+    return text(f"INSERT IGNORE {base}")
 
 
 async def _tag_ids_for(db: AsyncSession, image_id: int) -> set[int]:
@@ -51,10 +67,8 @@ async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession
     fav_count_before = before_fav.scalar() or 0
 
     await db.execute(
-        text(
-            "INSERT IGNORE INTO favorites (user_id, image_id, fav_date) "
-            "SELECT user_id, :original_id, fav_date FROM favorites "
-            "WHERE image_id = :repost_id"
+        _copy_to_original_sql(
+            db, "favorites", "user_id, image_id, fav_date", "user_id, :original_id, fav_date"
         ),
         {"original_id": original_id, "repost_id": repost_id},
     )
@@ -96,10 +110,11 @@ async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession
     rat_count_before = before_rat.scalar() or 0
 
     await db.execute(
-        text(
-            "INSERT IGNORE INTO image_ratings (user_id, image_id, rating, date) "
-            "SELECT user_id, :original_id, rating, date FROM image_ratings "
-            "WHERE image_id = :repost_id"
+        _copy_to_original_sql(
+            db,
+            "image_ratings",
+            "user_id, image_id, rating, date",
+            "user_id, :original_id, rating, date",
         ),
         {"original_id": original_id, "repost_id": repost_id},
     )
@@ -140,10 +155,11 @@ async def migrate_repost_data(repost_id: int, original_id: int, db: AsyncSession
     tags_moved = len(moved_tag_ids)
 
     await db.execute(
-        text(
-            "INSERT IGNORE INTO tag_links (tag_id, image_id, date_linked, user_id) "
-            "SELECT tag_id, :original_id, date_linked, user_id FROM tag_links "
-            "WHERE image_id = :repost_id"
+        _copy_to_original_sql(
+            db,
+            "tag_links",
+            "tag_id, image_id, date_linked, user_id",
+            "tag_id, :original_id, date_linked, user_id",
         ),
         {"original_id": original_id, "repost_id": repost_id},
     )

--- a/app/services/tag_type_flags.py
+++ b/app/services/tag_type_flags.py
@@ -9,6 +9,8 @@ from collections.abc import Collection
 from sqlalchemy import bindparam, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.database import is_postgres
+
 # Single set-based recompute over a set of image_ids. MariaDB multi-table UPDATE;
 # MAX(t.type = N) is a boolean aggregate (1 if any tag of that type, else 0).
 _RECOMPUTE_SQL = text(
@@ -76,7 +78,7 @@ async def refresh_images_tag_type_flags(db: AsyncSession, image_ids: Collection[
     if not ids:
         return
     await db.flush()
-    sql = _RECOMPUTE_SQL_PG if db.get_bind().dialect.name == "postgresql" else _RECOMPUTE_SQL
+    sql = _RECOMPUTE_SQL_PG if is_postgres(db) else _RECOMPUTE_SQL
     await db.execute(sql, {"ids": ids})
 
 

--- a/app/services/tag_type_flags.py
+++ b/app/services/tag_type_flags.py
@@ -33,6 +33,33 @@ _RECOMPUTE_SQL = text(
     """
 ).bindparams(bindparam("ids", expanding=True))
 
+# Postgres twin: UPDATE ... FROM instead of the multi-table UPDATE JOIN, and
+# bool_or instead of MAX over a 0/1 comparison. The subquery LEFT JOINs from
+# images so every requested id gets an agg row (all-NULL flags when untagged),
+# preserving the MariaDB version's reset-to-false behavior via COALESCE.
+_RECOMPUTE_SQL_PG = text(
+    """
+    UPDATE images
+    SET has_theme = COALESCE(agg.ht, FALSE),
+        has_source = COALESCE(agg.hs, FALSE),
+        has_artist = COALESCE(agg.ha, FALSE),
+        has_character = COALESCE(agg.hc, FALSE)
+    FROM (
+        SELECT i2.image_id,
+               bool_or(t.type = 1) AS ht,
+               bool_or(t.type = 2) AS hs,
+               bool_or(t.type = 3) AS ha,
+               bool_or(t.type = 4) AS hc
+        FROM images i2
+        LEFT JOIN tag_links tl ON tl.image_id = i2.image_id
+        LEFT JOIN tags t ON t.tag_id = tl.tag_id
+        WHERE i2.image_id IN :ids
+        GROUP BY i2.image_id
+    ) AS agg
+    WHERE images.image_id = agg.image_id
+    """
+).bindparams(bindparam("ids", expanding=True))
+
 
 async def refresh_images_tag_type_flags(db: AsyncSession, image_ids: Collection[int]) -> None:
     """Recompute the 4 tag-type presence flags for the given images from tag_links.
@@ -49,7 +76,8 @@ async def refresh_images_tag_type_flags(db: AsyncSession, image_ids: Collection[
     if not ids:
         return
     await db.flush()
-    await db.execute(_RECOMPUTE_SQL, {"ids": ids})
+    sql = _RECOMPUTE_SQL_PG if db.get_bind().dialect.name == "postgresql" else _RECOMPUTE_SQL
+    await db.execute(sql, {"ids": ids})
 
 
 async def refresh_image_tag_type_flags(db: AsyncSession, image_id: int) -> None:

--- a/app/services/user_tag_affinity.py
+++ b/app/services/user_tag_affinity.py
@@ -97,6 +97,11 @@ async def refresh_user_tag_affinity(
     ``< 0`` as "skipped") without touching any tables if another refresh already
     holds the lock.
     """
+    if db.get_bind().dialect.name != "mysql":
+        raise NotImplementedError(
+            "refresh_user_tag_affinity is MariaDB-only (GET_LOCK, ENGINE=InnoDB "
+            "helper tables); see docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md"
+        )
     db_name = (await db.execute(text("SELECT DATABASE()"))).scalar()
     lock_name = f"{_LOCK_PREFIX}:{db_name}"
     locked = (await db.execute(text("SELECT GET_LOCK(:n, 0)"), {"n": lock_name})).scalar()

--- a/app/utils/comment_search.py
+++ b/app/utils/comment_search.py
@@ -256,8 +256,16 @@ def apply_comment_text_search(
     """
     effective_mode = mode or "all_words"
 
+    def contains(pattern: str) -> Any:
+        # MariaDB LIKE is case-insensitive via utf8mb4_unicode_ci; Postgres
+        # LIKE is not, so the no-fulltext (Postgres) path must use ILIKE to
+        # keep the same matching semantics.
+        if use_fulltext:
+            return Comments.post_text.like(pattern, escape="\\")  # type: ignore[attr-defined]
+        return Comments.post_text.ilike(pattern, escape="\\")  # type: ignore[attr-defined]
+
     if effective_mode == "like":
-        return query.where(Comments.post_text.like(like_pattern(raw), escape="\\"))  # type: ignore[attr-defined]
+        return query.where(contains(like_pattern(raw)))
 
     if use_fulltext:
         if effective_mode == "boolean":
@@ -283,8 +291,8 @@ def apply_comment_text_search(
             sql_text("MATCH(post_text) AGAINST(:comment_q IN BOOLEAN MODE)")
         ).params(comment_q=parsed.boolean_query)
     for term in parsed.like_terms:
-        query = query.where(Comments.post_text.like(like_pattern(term), escape="\\"))  # type: ignore[attr-defined]
+        query = query.where(contains(like_pattern(term)))
     for term in parsed.not_like_terms:
         # post_text is NOT NULL (verified), so NOT LIKE needs no NULL guard.
-        query = query.where(~Comments.post_text.like(like_pattern(term), escape="\\"))  # type: ignore[attr-defined]
+        query = query.where(~contains(like_pattern(term)))
     return query

--- a/app/utils/comment_search.py
+++ b/app/utils/comment_search.py
@@ -166,8 +166,13 @@ def _is_indexable(token: str) -> bool:
     return len(token) >= MIN_TOKEN_SIZE and token.isascii() and token.lower() not in STOPWORDS
 
 
-def parse_comment_search(raw: str) -> CommentSearchQuery:
-    """Split a user's search string into fulltext and LIKE predicates."""
+def parse_comment_search(raw: str, *, index_visible: bool = True) -> CommentSearchQuery:
+    """Split a user's search string into fulltext and LIKE predicates.
+
+    With ``index_visible=False`` (Postgres POC: there is no fulltext index at
+    all) every term lands on the LIKE lists and ``boolean_query`` stays empty;
+    negation and quoted phrases keep their meaning.
+    """
     parsed = CommentSearchQuery()
     positives: list[str] = []
     negatives: list[str] = []
@@ -183,7 +188,7 @@ def parse_comment_search(raw: str) -> CommentSearchQuery:
             if not phrase:
                 continue
             tokens = _WORD_RE.findall(phrase)
-            if tokens and all(_is_indexable(t) for t in tokens):
+            if index_visible and tokens and all(_is_indexable(t) for t in tokens):
                 # Phrase search stays token-based, matching fulltext semantics
                 # (punctuation and repeated spaces are not significant).
                 quoted = '"' + " ".join(tokens) + '"'
@@ -193,7 +198,7 @@ def parse_comment_search(raw: str) -> CommentSearchQuery:
             continue
 
         for token in _WORD_RE.findall(term):
-            if _is_indexable(token):
+            if index_visible and _is_indexable(token):
                 (negatives if negated else positives).append(token)
             else:
                 (parsed.not_like_terms if negated else parsed.like_terms).append(token)
@@ -226,12 +231,21 @@ def reject_unindexable_comment_search(raw: str, mode: str | None) -> None:
         )
 
 
-def apply_comment_text_search(query: Select[Any], raw: str, mode: str | None) -> Select[Any]:
+def apply_comment_text_search(
+    query: Select[Any], raw: str, mode: str | None, *, use_fulltext: bool = True
+) -> Select[Any]:
     """Add comment-text predicates to `query`.
 
     `query` must already select from / join the Comments table. The bind
     parameter is named `comment_q` so it cannot collide with a caller's own
     parameters.
+
+    ``use_fulltext=False`` (Postgres POC: no MATCH/AGAINST) routes every mode
+    except the explicit ``like`` mode through the parsed path with
+    ``index_visible=False``, so all predicates become (NOT) LIKE. The legacy
+    ``boolean``/``natural`` modes degrade gracefully there: `-term` and quoted
+    phrases keep their meaning, `+`/`*` operators are dropped and terms are
+    simply ANDed.
 
     Callers are expected to skip calling this at all for a blank/whitespace-only
     `raw` -- that means "not searching," not "search for nothing" (see the
@@ -242,20 +256,21 @@ def apply_comment_text_search(query: Select[Any], raw: str, mode: str | None) ->
     """
     effective_mode = mode or "all_words"
 
-    if effective_mode == "boolean":
-        return query.where(sql_text("MATCH(post_text) AGAINST(:comment_q IN BOOLEAN MODE)")).params(
-            comment_q=raw
-        )
-
-    if effective_mode == "natural":
-        return query.where(
-            sql_text("MATCH(post_text) AGAINST(:comment_q IN NATURAL LANGUAGE MODE)")
-        ).params(comment_q=raw)
-
     if effective_mode == "like":
         return query.where(Comments.post_text.like(like_pattern(raw), escape="\\"))  # type: ignore[attr-defined]
 
-    parsed = parse_comment_search(raw)
+    if use_fulltext:
+        if effective_mode == "boolean":
+            return query.where(
+                sql_text("MATCH(post_text) AGAINST(:comment_q IN BOOLEAN MODE)")
+            ).params(comment_q=raw)
+
+        if effective_mode == "natural":
+            return query.where(
+                sql_text("MATCH(post_text) AGAINST(:comment_q IN NATURAL LANGUAGE MODE)")
+            ).params(comment_q=raw)
+
+    parsed = parse_comment_search(raw, index_visible=use_fulltext)
     if parsed.is_empty:
         # Nothing searchable in a non-blank input (e.g. "!!!"): no comment can
         # ever match, so this must return zero rows. A blank/whitespace-only

--- a/docker-compose.postgres-api.yml
+++ b/docker-compose.postgres-api.yml
@@ -1,0 +1,23 @@
+# Point the dev-stack api (and arq-worker) at the Postgres POC container
+# instead of MariaDB. Opt-in third compose file — plain `docker compose up -d`
+# reverts to MariaDB. See docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md.
+#
+#   docker compose -f docker-compose.postgres.yml up -d          # the DB itself
+#   docker compose -f docker-compose.yml -f docker-compose.override.yml \
+#     -f docker-compose.postgres-api.yml up -d --no-deps api arq-worker
+#   docker compose stop mariadb                                  # optional
+#
+# The POC postgres is a separate compose project, so the api reaches it through
+# the published host port via the host gateway.
+services:
+  api:
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://shuushuu:pg_dev_password@host.docker.internal:5432/shuushuu
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  arq-worker:
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://shuushuu:pg_dev_password@host.docker.internal:5432/shuushuu
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,27 @@
+# Postgres proof-of-concept — deliberately a separate compose project so it
+# never touches the main dev stack. See docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md.
+#   docker compose -f docker-compose.postgres.yml up -d
+#   docker compose -f docker-compose.postgres.yml down -v   # discard the POC data
+name: shuushuu-postgres-poc
+
+services:
+  postgres:
+    image: postgres:17
+    container_name: shuushuu-postgres-poc
+    environment:
+      POSTGRES_DB: shuushuu
+      POSTGRES_USER: shuushuu
+      POSTGRES_PASSWORD: pg_dev_password
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_poc_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U shuushuu -d shuushuu"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  postgres_poc_data:
+    driver: local

--- a/docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md
+++ b/docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md
@@ -357,6 +357,19 @@ git add scripts/postgres_poc.py
 git commit -m "feat(postgres-poc): schema setup + e2e smoke script"
 ```
 
+### Task 7 (addendum, same day): citext for natural keys
+
+Live testing confirmed the case-sensitivity risk immediately: login with a
+differently-cased username worked on MariaDB (`utf8mb4_unicode_ci`) and failed
+on Postgres. Decision for the POC: `citext` on exactly the three natural-key
+columns whose comparisons the legacy collation was load-bearing for —
+`users.username`, `users.email`, `tags.title` — via `ci_string(length)` in
+`app/models/types.py` (`String(n)` on MariaDB, `CITEXT` variant on Postgres;
+DDL verified identical on MariaDB, schema-sync green). `scripts/postgres_poc.py
+setup` now creates the extension before `create_all`. Everything else stays
+case-sensitive on Postgres. citext drops the length modifier on the PG side;
+the cap remains as application validation.
+
 ### Task 6: Full verification and PR
 
 - [ ] **Step 1: mypy everything touched**

--- a/docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md
+++ b/docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md
@@ -1,0 +1,383 @@
+# Postgres Proof-of-Concept Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Get the API booting and serving its core read/write paths against a real PostgreSQL container, with MariaDB remaining the default everywhere, to validate the 2026-06-10 feasibility analysis with running code.
+
+**Architecture:** All changes are dialect-aware branches keyed off the SQLAlchemy engine/bind dialect name, so one codebase serves both databases; nothing MariaDB-facing changes behavior. Schema on Postgres is built by `SQLModel.metadata.create_all()` (the Alembic chain reset is deferred, per the feasibility doc). Verification is a smoke script that runs the real FastAPI app in-process via httpx's ASGI transport against the real Postgres container — no mocks.
+
+**Tech Stack:** postgres:17 (docker compose, standalone project), asyncpg, SQLAlchemy 2.0 `with_variant`, httpx ASGI transport.
+
+**Spec:** docs/plans/2026-Q2/2026-06-10-postgres-migration-feasibility.md
+
+## Global Constraints
+
+- MariaDB stays the default: no behavior change on the `mysql` dialect; the full existing test suite must stay green on MariaDB.
+- `app/` stays at zero mypy errors; any touched `scripts/` file must be mypy-clean.
+- Smallest reasonable change per site: dialect branch or `with_variant`, not rewrites.
+- Deferred (out of scope, recorded here deliberately): Alembic chain reset / Postgres baseline migration, the 8+ counter triggers (counters simply don't self-maintain on PG in this POC), data migration, case-insensitivity (citext/ICU) work, running the pytest suite against Postgres, `scripts/db_utils.py`, `tests/conftest.py` rework.
+
+## Explicitly deferred sites (guarded, not ported)
+
+`app/services/user_tag_affinity.py` (batch taste-profile rebuild: `GET_LOCK`, `SELECT DATABASE()`, temp-table dance) is cron/batch-only and is NOT ported. It gets a loud guard raising `NotImplementedError` on non-mysql dialects so a PG run fails immediately and explicitly rather than mid-flow.
+
+---
+
+### Task 1: Postgres container + asyncpg dependency
+
+**Files:**
+- Create: `docker-compose.postgres.yml`
+- Modify: `pyproject.toml` (via `uv add`)
+
+**Interfaces:**
+- Produces: a Postgres 17 server on `localhost:5432`, database `shuushuu`, user `shuushuu`, password `pg_dev_password`; the `postgresql+asyncpg://` driver installed. All later tasks assume the URL `postgresql+asyncpg://shuushuu:pg_dev_password@localhost:5432/shuushuu`.
+
+- [ ] **Step 1: Add asyncpg**
+
+Run: `uv add asyncpg`
+Expected: `asyncpg>=0.30` lands in `[project.dependencies]` and `uv.lock`.
+
+- [ ] **Step 2: Write the compose file**
+
+```yaml
+# Postgres proof-of-concept — deliberately a separate compose project so it
+# never touches the main dev stack. See docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md.
+#   docker compose -f docker-compose.postgres.yml up -d
+#   docker compose -f docker-compose.postgres.yml down -v   # discard the POC data
+name: shuushuu-postgres-poc
+
+services:
+  postgres:
+    image: postgres:17
+    container_name: shuushuu-postgres-poc
+    environment:
+      POSTGRES_DB: shuushuu
+      POSTGRES_USER: shuushuu
+      POSTGRES_PASSWORD: pg_dev_password
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_poc_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U shuushuu -d shuushuu"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  postgres_poc_data:
+    driver: local
+```
+
+- [ ] **Step 3: Verify the container comes up healthy**
+
+Run: `docker compose -f docker-compose.postgres.yml up -d && docker compose -f docker-compose.postgres.yml ps`
+Expected: `shuushuu-postgres-poc` healthy.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker-compose.postgres.yml pyproject.toml uv.lock
+git commit -m "feat(postgres-poc): postgres 17 compose project + asyncpg"
+```
+
+### Task 2: Dialect-aware engine config and statement timeout
+
+**Files:**
+- Modify: `app/core/database.py`
+
+**Interfaces:**
+- Consumes: `settings.DATABASE_URL` (may now be `postgresql+asyncpg://...`).
+- Produces: `engine` that connects on either dialect with UTC session timezone; `statement_timeout(db, seconds)` works on both dialects with unchanged signature.
+
+- [ ] **Step 1: Branch connect_args on the URL's backend**
+
+Replace the engine construction so the MariaDB `init_command` is only passed to mysql drivers, and asyncpg gets its `server_settings` equivalent:
+
+```python
+from sqlalchemy.engine import make_url
+
+_url = make_url(settings.DATABASE_URL)
+_is_postgres = _url.get_backend_name() == "postgresql"
+
+# Both branches pin the session timezone to UTC; each driver spells it differently.
+_connect_args: dict[str, Any] = (
+    {"server_settings": {"timezone": "UTC"}}
+    if _is_postgres
+    else {"init_command": "SET time_zone = '+00:00'"}
+)
+
+engine = create_async_engine(
+    settings.DATABASE_URL,
+    echo=settings.DB_ECHO,
+    pool_size=settings.DB_POOL_SIZE,
+    max_overflow=settings.DB_MAX_OVERFLOW,
+    pool_pre_ping=True,  # Verify connections before using
+    pool_recycle=3600,  # Recycle connections every hour (MariaDB wait_timeout is 8 hours)
+    connect_args=_connect_args,
+)
+```
+
+(`Any` is already importable; add `from typing import Any` if not present.)
+
+- [ ] **Step 2: Branch statement_timeout on the bind dialect**
+
+MariaDB's `max_statement_time` takes seconds; Postgres's `statement_timeout` takes milliseconds. Keep the restore-on-exit contract identical:
+
+```python
+    if seconds is None:
+        yield
+        return
+
+    if db.get_bind().dialect.name == "postgresql":
+        # int() coerces the value: SET does not take bind parameters, so this is
+        # interpolated, and the coercion is what keeps that safe.
+        await db.execute(sql_text(f"SET statement_timeout = {int(seconds * 1000)}"))
+        try:
+            yield
+        finally:
+            await db.execute(sql_text("SET statement_timeout = DEFAULT"))
+    else:
+        # float() coerces the value (same interpolation-safety rationale).
+        await db.execute(sql_text(f"SET SESSION max_statement_time = {float(seconds)}"))
+        try:
+            yield
+        finally:
+            await db.execute(sql_text("SET SESSION max_statement_time = DEFAULT"))
+```
+
+- [ ] **Step 3: Verify types and MariaDB regression**
+
+Run: `uv run mypy app/core/database.py` and `uv run pytest tests/ -x -q -n 4` (MariaDB suite).
+Expected: mypy clean; suite green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/core/database.py
+git commit -m "feat(postgres-poc): dialect-aware engine config and statement timeout"
+```
+
+### Task 3: Portable column types (unsigned ints, JSON, server defaults)
+
+**Files:**
+- Modify: `app/models/types.py`, `app/models/admin_action.py`, all `app/models/*.py` with `server_default=text("current_timestamp()")`
+
+**Interfaces:**
+- Produces: `UnsignedInt` / `UnsignedSmallInt` that compile as `INTEGER`/`SMALLINT` on Postgres (values here never exceed signed 32-bit today; the feasibility doc's data-migration check still applies before any real cutover); `AdminActions.details` as a portable JSON column; every timestamp `server_default` valid on both dialects.
+
+- [ ] **Step 1: with_variant the unsigned types**
+
+In `app/models/types.py`:
+
+```python
+from sqlalchemy import DateTime, Integer, SmallInteger
+from sqlalchemy.dialects.mysql import INTEGER, SMALLINT
+
+# Shared type instances, not classes — use as Column(UnsignedInt, ...); don't call them.
+# Postgres has no unsigned ints; the variant maps to plain INTEGER/SMALLINT there.
+UnsignedInt = INTEGER(unsigned=True).with_variant(Integer(), "postgresql")
+UnsignedSmallInt = SMALLINT(unsigned=True).with_variant(SmallInteger(), "postgresql")
+```
+
+Update the module docstring's UnsignedInt/UnsignedSmallInt paragraphs to mention the Postgres variant.
+
+- [ ] **Step 2: Portable JSON in admin_action.py**
+
+Replace `from sqlalchemy.dialects.mysql import JSON` with the generic `from sqlalchemy import JSON` (both compile to `JSON` DDL on MariaDB; the generic type compiles to `JSON` on Postgres).
+
+- [ ] **Step 3: Normalize server defaults**
+
+Replace every `text("current_timestamp()")` in `app/models/` with `text("CURRENT_TIMESTAMP")` — the empty-parens spelling is a MariaDB-ism that Postgres rejects; the bare keyword is valid DDL on both, and MariaDB normalizes both to the same stored default (so `alembic` autogen and the schema-sync test see no difference; `alembic/env.py` does not enable `compare_server_default`).
+
+```bash
+grep -rl 'text("current_timestamp()")' app/models/ | xargs sed -i 's/text("current_timestamp()")/text("CURRENT_TIMESTAMP")/g'
+```
+
+- [ ] **Step 4: Verify — schema-sync test is the real gate**
+
+Run: `uv run mypy app/models/` then `MYSQL_ROOT_PASSWORD=dev_root_password uv run pytest tests/integration/test_schema_sync.py -q`
+Expected: mypy clean; schema-sync green (proves MariaDB DDL is unchanged in effect).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/
+git commit -m "feat(postgres-poc): portable column types and server defaults"
+```
+
+### Task 4: Dialect branches for raw-SQL sites
+
+Audit result (2026-08-20, supersedes the June doc's narrower list):
+
+| Site | MySQL-ism | Reached from | Disposition |
+|---|---|---|---|
+| `app/utils/comment_search.py` | `MATCH ... AGAINST` (3 modes) | GET /comments, GET /images comment search | dialect branch → LIKE path |
+| `app/api/v1/tags.py` `list_tags` | `MATCH ... AGAINST` + tokenizer sim | GET /tags?search= | dialect branch → ILIKE per word |
+| `app/services/tag_type_flags.py` | multi-table `UPDATE ... JOIN`, `MAX(bool)` | tag add/remove request paths | dialect branch → `UPDATE ... FROM` + `bool_or` |
+| `app/services/repost.py` | `INSERT IGNORE ... SELECT` ×3 | mark-repost admin path | shared helper → `ON CONFLICT DO NOTHING` |
+| `app/services/ml_raw_store.py` | `mysql_insert().prefix_with("IGNORE")` | ML ingest (arq/scripts) | dialect branch → `pg_insert().on_conflict_do_nothing()` |
+| `app/services/user_tag_affinity.py` | `GET_LOCK`, `SELECT DATABASE()`, `CREATE TABLE ... ENGINE=InnoDB` | nightly cron / manual script | guard: `NotImplementedError` on non-mysql |
+| `app/services/recommendations.py` | none — standard SQL (seeding is Python `random.Random`) | GET for-you feed | works as-is |
+| `app/core/database.py` `statement_timeout` | `SET SESSION max_statement_time` | search endpoints | done in Task 2 |
+
+**Files:**
+- Modify: `app/utils/comment_search.py`, `app/api/v1/comments.py:130`, `app/api/v1/images.py:820`, `app/api/v1/tags.py` (search block in `list_tags`), `app/services/tag_type_flags.py`, `app/services/repost.py`, `app/services/ml_raw_store.py`, `app/services/user_tag_affinity.py`
+- Test: `tests/unit/test_comment_search.py`
+
+**Interfaces:**
+- Produces: `parse_comment_search(raw, *, index_visible: bool = True)` — with `index_visible=False` every token lands on the LIKE lists and `boolean_query` stays empty; `apply_comment_text_search(query, raw, mode, *, use_fulltext: bool = True)` — with `use_fulltext=False` all modes except explicit `"like"` go through the parsed path with `index_visible=False`. Callers compute `use_fulltext=db.get_bind().dialect.name != "postgresql"`.
+
+- [ ] **Step 1 (TDD): failing unit tests for the parse mode**
+
+```python
+class TestParseWithoutIndex:
+    """index_visible=False (Postgres: no fulltext index) — everything rides LIKE."""
+
+    def test_indexable_token_goes_to_like(self):
+        parsed = parse_comment_search("birthday", index_visible=False)
+        assert parsed.boolean_query == ""
+        assert parsed.like_terms == ["birthday"]
+
+    def test_negation_still_works(self):
+        parsed = parse_comment_search("happy -birthday", index_visible=False)
+        assert parsed.like_terms == ["happy"]
+        assert parsed.not_like_terms == ["birthday"]
+
+    def test_quoted_phrase_becomes_single_like_term(self):
+        parsed = parse_comment_search('"happy birthday"', index_visible=False)
+        assert parsed.boolean_query == ""
+        assert parsed.like_terms == ["happy birthday"]
+```
+
+Run: `uv run pytest tests/unit/test_comment_search.py -q` — expect the new tests to FAIL (unexpected keyword argument).
+
+- [ ] **Step 2: implement `index_visible` + `use_fulltext`, wire the two callers, verify green**
+
+In `parse_comment_search`, gate the indexable checks: phrases use `if index_visible and tokens and all(_is_indexable(t) ...)`, bare tokens use `if index_visible and _is_indexable(token)`. In `apply_comment_text_search(query, raw, mode, *, use_fulltext=True)`: when `use_fulltext` is false, `"boolean"`/`"natural"`/default all take the parsed path with `index_visible=False` (`"like"` unchanged — negation and phrases survive; `+`/`*` operators degrade to plain ANDed words). Callers add the keyword: `apply_comment_text_search(query, s, mode, use_fulltext=db.get_bind().dialect.name != "postgresql")`.
+
+- [ ] **Step 3: tags.py search branch**
+
+At the top of the `if search:` block compute `use_fulltext = db.get_bind().dialect.name != "postgresql"`; short-query branch uses `.ilike` instead of `.like` when not `use_fulltext`; the ≥3-char branch gets a preceding `elif not use_fulltext:` arm — `for word in search.split(): query = query.where(Tags.title.ilike(f"%{_escape_like_pattern(word)}%"))` — leaving `fulltext_query_str` None so relevance ordering falls into the existing LIKE branch (which is already built on portable `lower()` comparisons).
+
+- [ ] **Step 4: tag_type_flags PG twin**
+
+```python
+_RECOMPUTE_SQL_PG = text(
+    """
+    UPDATE images
+    SET has_theme = COALESCE(agg.ht, FALSE),
+        has_source = COALESCE(agg.hs, FALSE),
+        has_artist = COALESCE(agg.ha, FALSE),
+        has_character = COALESCE(agg.hc, FALSE)
+    FROM (
+        SELECT i2.image_id,
+               bool_or(t.type = 1) AS ht,
+               bool_or(t.type = 2) AS hs,
+               bool_or(t.type = 3) AS ha,
+               bool_or(t.type = 4) AS hc
+        FROM images i2
+        LEFT JOIN tag_links tl ON tl.image_id = i2.image_id
+        LEFT JOIN tags t ON t.tag_id = tl.tag_id
+        WHERE i2.image_id IN :ids
+        GROUP BY i2.image_id
+    ) AS agg
+    WHERE images.image_id = agg.image_id
+    """
+).bindparams(bindparam("ids", expanding=True))
+```
+
+`refresh_images_tag_type_flags` picks by `db.get_bind().dialect.name`.
+
+- [ ] **Step 5: repost helper + ml_raw_store branch**
+
+repost.py: replace the three literals with one helper —
+
+```python
+def _copy_to_original_sql(db: AsyncSession, table: str, insert_cols: str, select_cols: str) -> TextClause:
+    """INSERT-or-skip-duplicates, copying `table` rows from the repost to the original."""
+    base = (
+        f"INTO {table} ({insert_cols}) "
+        f"SELECT {select_cols} FROM {table} WHERE image_id = :repost_id"
+    )
+    if db.get_bind().dialect.name == "postgresql":
+        return text(f"INSERT {base} ON CONFLICT DO NOTHING")
+    return text(f"INSERT IGNORE {base}")
+```
+
+ml_raw_store.py:
+
+```python
+if db.get_bind().dialect.name == "postgresql":
+    stmt: Any = pg_insert(MlRawPredictions).values(batch).on_conflict_do_nothing()
+else:
+    stmt = mysql_insert(MlRawPredictions).values(batch).prefix_with("IGNORE")
+```
+
+- [ ] **Step 6: user_tag_affinity guard**
+
+First statement of `refresh_user_tag_affinity`:
+
+```python
+    if db.get_bind().dialect.name != "mysql":
+        raise NotImplementedError(
+            "refresh_user_tag_affinity is MariaDB-only (GET_LOCK, ENGINE=InnoDB "
+            "helper tables); see docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md"
+        )
+```
+
+- [ ] **Step 7: verify**
+
+Run: `uv run mypy app/` (clean), `MYSQL_ROOT_PASSWORD=dev_root_password uv run pytest tests/ -q -n 4` (green on MariaDB).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/ tests/unit/test_comment_search.py
+git commit -m "feat(postgres-poc): dialect branches for raw-SQL sites"
+```
+
+### Task 5: POC setup + smoke script
+
+**Files:**
+- Create: `scripts/postgres_poc.py`
+
+**Interfaces:**
+- Consumes: the Task 1 container URL (override via `POSTGRES_POC_DATABASE_URL`); `app.main.app`; `SQLModel.metadata`.
+- Produces: `uv run python scripts/postgres_poc.py setup` (create schema) and `uv run python scripts/postgres_poc.py smoke` (seed + exercise the real app in-process, printing a pass/fail table and exiting non-zero on failure).
+
+The script has two subcommands. `setup`: `DROP SCHEMA public CASCADE` + `CREATE SCHEMA public` (drop_all can't untangle the FK cycles without CASCADE), dedupe the two cross-table index-name collisions (`idx_date`, `idx_tag_id` — MySQL scopes index names per table, Postgres per schema), then `SQLModel.metadata.create_all` with models registered by importing `app.main` (the models package `__init__` misses some modules, e.g. `user_suspension`). `smoke`: seed permissions + a bcrypt login user + tag + image directly via the ORM, then run the real app in-process (httpx `ASGITransport`, real Redis from the dev stack, no dependency overrides) through: `/health`, login, `/auth/me`, images list + detail, tags list, `GET /tags?search=` (exercises the Task 4 ILIKE branch), comment create, comments list, `GET /comments?search_text=` (exercises the comment-search LIKE branch — the param is `search_text`, not `search`). Prints a PASS/FAIL table; exit 1 on any failure.
+
+- [ ] **Step 1: write the script as specified above** (`scripts/postgres_poc.py`, mypy-clean)
+- [ ] **Step 2: run it** — `setup` then `smoke`; all checks PASS
+- [ ] **Step 3: commit**
+
+```bash
+git add scripts/postgres_poc.py
+git commit -m "feat(postgres-poc): schema setup + e2e smoke script"
+```
+
+### Task 6: Full verification and PR
+
+- [ ] **Step 1: mypy everything touched**
+
+Run: `uv run mypy app/ && uv run mypy scripts/postgres_poc.py`
+Expected: clean.
+
+- [ ] **Step 2: Full MariaDB suite**
+
+Run: `MYSQL_ROOT_PASSWORD=dev_root_password uv run pytest tests/ -q -n 4`
+Expected: green — proves the POC changed nothing for MariaDB.
+
+- [ ] **Step 3: End-to-end POC run**
+
+```bash
+docker compose -f docker-compose.postgres.yml up -d
+uv run python scripts/postgres_poc.py setup
+uv run python scripts/postgres_poc.py smoke
+```
+Expected: all smoke checks pass against Postgres.
+
+- [ ] **Step 4: PR**
+
+Push `feat/postgres-poc`, open PR with the smoke output and the discussion items (redesign opportunities) in the body.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -28,6 +28,7 @@ Exceptions block is maintained by hand and is preserved across regeneration.
 
 | Date | Effort | Docs |
 | --- | --- | --- |
+| 2026-08-20 | Postgres Proof-of-Concept Implementation Plan | [impl](2026-Q3/2026-08-20-postgres-poc-impl.md) |
 | 2026-08-18 | For You v2: favorites as a live input + daily rotation | [design](2026-Q3/2026-08-18-for-you-favorites-rotation-design.md) · [impl](2026-Q3/2026-08-18-for-you-favorites-rotation-impl.md) |
 | 2026-08-17 | Bundled feed comments (`include_comments` on the images list) | [design](2026-Q3/2026-08-17-bundled-feed-comments-design.md) · [impl](2026-Q3/2026-08-17-bundled-feed-comments-impl.md) |
 | 2026-08-01 | External Artist Identity (pixiv IDs without alias tags) | [design](2026-Q3/2026-08-01-external-artist-identity-design.md) · [impl](2026-Q3/2026-08-01-external-artist-identity-impl.md) |
@@ -106,4 +107,4 @@ Exceptions block is maintained by hand and is preserved across regeneration.
 | 2025-11-23 | Avatar Upload Feature Design | [design](2025-Q4/2025-11-23-avatar-upload-design.md) |
 | 2025-11-22 | Image Reporting and Review System Design | [design](2025-Q4/2025-11-22-image-reporting-review-design.md) |
 
-62 efforts, 92 documents.
+63 efforts, 93 documents.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "aiosmtplib>=5.1.1",
     "onnxruntime>=1.26.0",  # 1.26.0 is the first release with Python 3.14 wheels
     "numpy>=2.4.1",
+    "asyncpg>=0.31.0",
 ]
 
 [dependency-groups]

--- a/scripts/postgres_poc.py
+++ b/scripts/postgres_poc.py
@@ -68,6 +68,17 @@ async def setup() -> int:
         # username/email/tag-title columns need it (see types.ci_string).
         await conn.execute(text("CREATE EXTENSION IF NOT EXISTS citext"))
         await conn.run_sync(SQLModel.metadata.create_all)
+        # citext has no length modifier, so the VARCHAR(n) caps these columns
+        # had on MariaDB move to CHECK constraints (Postgres-only: a CHECK in
+        # the models' __table_args__ would change the MariaDB DDL and break
+        # schema-sync; a real migration would put these in the PG baseline).
+        for ddl in (
+            "ALTER TABLE users ADD CONSTRAINT ck_users_username_len"
+            " CHECK (char_length(username) <= 30)",
+            "ALTER TABLE users ADD CONSTRAINT ck_users_email_len CHECK (char_length(email) <= 120)",
+            "ALTER TABLE tags ADD CONSTRAINT ck_tags_title_len CHECK (char_length(title) <= 255)",
+        ):
+            await conn.execute(text(ddl))
     async with engine.connect() as conn:
         count = (
             await conn.execute(

--- a/scripts/postgres_poc.py
+++ b/scripts/postgres_poc.py
@@ -1,0 +1,321 @@
+"""Postgres proof-of-concept: build the schema and smoke-test the real API.
+
+Part of docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md. Runs the real
+FastAPI app in-process (httpx ASGI transport, no dependency overrides, real
+Redis from the dev stack) against the Postgres container from
+docker-compose.postgres.yml. MariaDB is untouched.
+
+    docker compose -f docker-compose.postgres.yml up -d
+    uv run python scripts/postgres_poc.py setup   # drop + create_all schema
+    uv run python scripts/postgres_poc.py smoke   # seed + exercise endpoints
+
+The database URL can be overridden with POSTGRES_POC_DATABASE_URL.
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from collections import defaultdict
+from typing import Any
+
+DEFAULT_URL = "postgresql+asyncpg://shuushuu:pg_dev_password@localhost:5432/shuushuu"
+
+# Must be set before any app.* import: app.config caches settings at import
+# time and app.core.database builds the engine from them.
+os.environ["DATABASE_URL"] = os.environ.get("POSTGRES_POC_DATABASE_URL", DEFAULT_URL)
+
+SMOKE_USERNAME = "pocuser"
+SMOKE_PASSWORD = "poc-password-123"  # noqa: S105 - throwaway POC credential
+
+
+def _dedupe_index_names(metadata: Any) -> None:
+    """Rename index names that repeat across tables.
+
+    MySQL scopes index names per table; Postgres per schema. The legacy schema
+    reuses a few names (idx_date, idx_tag_id), which is fine on MariaDB but a
+    DuplicateTableError on Postgres. POC-only shim: a real migration would
+    normalize the names in a Postgres baseline migration instead.
+    """
+    by_name = defaultdict(list)
+    for table in metadata.tables.values():
+        for index in table.indexes:
+            by_name[index.name].append((table, index))
+    for entries in by_name.values():
+        if len(entries) > 1:
+            for table, index in entries:
+                index.name = f"{table.name}_{index.name}"
+
+
+async def setup() -> int:
+    """Drop and recreate the full schema on the POC database via create_all."""
+    from sqlalchemy import text
+    from sqlmodel import SQLModel
+
+    # app.main, not app.models: the models package __init__ does not import
+    # every model module (e.g. user_suspension), but the app wiring does.
+    import app.main  # noqa: F401  (registers all tables on SQLModel.metadata)
+    from app.core.database import engine
+
+    _dedupe_index_names(SQLModel.metadata)
+    async with engine.begin() as conn:
+        # DROP SCHEMA CASCADE instead of drop_all: the FK graph has cycles
+        # that Postgres won't untangle without CASCADE (MySQL drop_all just
+        # disables FK checks).
+        await conn.execute(text("DROP SCHEMA public CASCADE"))
+        await conn.execute(text("CREATE SCHEMA public"))
+        await conn.run_sync(SQLModel.metadata.create_all)
+    async with engine.connect() as conn:
+        count = (
+            await conn.execute(
+                text("SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public'")
+            )
+        ).scalar()
+    await engine.dispose()
+    print(f"setup: created {count} tables on {os.environ['DATABASE_URL']}")
+    return 0
+
+
+async def _seed() -> tuple[int, int]:
+    """Seed a login-capable user, a tag, and an image. Idempotent."""
+    from sqlalchemy import select
+
+    from app.core.database import AsyncSessionLocal
+    from app.core.permission_sync import sync_permissions
+    from app.core.security import get_password_hash
+    from app.models.image import Images
+    from app.models.tag import Tags
+    from app.models.user import Users
+
+    async with AsyncSessionLocal() as db:
+        await sync_permissions(db)
+
+        user = (
+            await db.execute(select(Users).where(Users.username == SMOKE_USERNAME))  # type: ignore[arg-type]
+        ).scalar_one_or_none()
+        if user is None:
+            user = Users(
+                username=SMOKE_USERNAME,
+                password=get_password_hash(SMOKE_PASSWORD),
+                password_type="bcrypt",
+                salt="pocsalt123456789",
+                email="poc@example.com",
+                active=1,
+            )
+            db.add(user)
+            await db.commit()
+            await db.refresh(user)
+
+        image = (
+            await db.execute(select(Images).where(Images.filename == "poc-image-001"))  # type: ignore[arg-type]
+        ).scalar_one_or_none()
+        if image is None:
+            image = Images(
+                filename="poc-image-001",
+                ext="jpg",
+                original_filename="poc.jpg",
+                md5_hash="d41d8cd98f00b204e9800998ecf8427e",
+                filesize=123456,
+                width=1920,
+                height=1080,
+                caption="Postgres POC seed image",
+                rating=0.0,
+                user_id=user.user_id,
+                status=1,
+                locked=False,
+            )
+            db.add(image)
+
+        tag = (
+            await db.execute(select(Tags).where(Tags.title == "poc tag"))  # type: ignore[arg-type]
+        ).scalar_one_or_none()
+        if tag is None:
+            db.add(Tags(title="poc tag", type=1, user_id=user.user_id))
+
+        await db.commit()
+
+        image_id = (
+            await db.execute(select(Images.image_id).where(Images.filename == "poc-image-001"))  # type: ignore[call-overload]
+        ).scalar_one()
+        assert user.user_id is not None
+        return user.user_id, image_id
+
+
+async def _service_checks(
+    results: list[tuple[str, bool, str]], user_id: int, image_id: int
+) -> None:
+    """Run the dialect-branched service SQL that the endpoint checks don't reach.
+
+    Real session, real Postgres — proves the PG twins of the tag-type-flags
+    recompute and the repost INSERT ... ON CONFLICT actually execute.
+    """
+    from sqlalchemy import select
+
+    from app.core.database import AsyncSessionLocal
+    from app.models.image import Images
+    from app.models.tag import Tags
+    from app.models.tag_link import TagLinks
+    from app.services.repost import migrate_repost_data
+    from app.services.tag_type_flags import refresh_images_tag_type_flags
+
+    async def run(name: str, coro: Any) -> None:
+        try:
+            await coro
+            results.append((name, True, "ok"))
+        except Exception as exc:  # noqa: BLE001 - a failing check must not stop the run
+            results.append((name, False, f"{type(exc).__name__}: {str(exc)[:200]}"))
+
+    async with AsyncSessionLocal() as db:
+
+        async def flags_check() -> None:
+            tag_id = (
+                await db.execute(select(Tags.tag_id).where(Tags.title == "poc tag"))  # type: ignore[call-overload]
+            ).scalar_one()
+            link = (
+                await db.execute(
+                    select(TagLinks).where(
+                        TagLinks.image_id == image_id,  # type: ignore[arg-type]
+                        TagLinks.tag_id == tag_id,
+                    )
+                )
+            ).scalar_one_or_none()
+            if link is None:
+                db.add(TagLinks(image_id=image_id, tag_id=tag_id))
+            await refresh_images_tag_type_flags(db, [image_id])
+            await db.commit()
+            has_theme = (
+                await db.execute(
+                    select(Images.has_theme).where(Images.image_id == image_id)  # type: ignore[call-overload]
+                )
+            ).scalar_one()
+            assert has_theme, "has_theme not set by recompute"
+
+        async def repost_check() -> None:
+            repost = Images(
+                filename="poc-image-repost",
+                ext="jpg",
+                original_filename="poc2.jpg",
+                md5_hash="e41d8cd98f00b204e9800998ecf8427f",
+                filesize=1,
+                width=1,
+                height=1,
+                caption="Postgres POC repost",
+                rating=0.0,
+                user_id=user_id,
+                status=1,
+                locked=False,
+            )
+            db.add(repost)
+            await db.commit()
+            await db.refresh(repost)
+            assert repost.image_id is not None
+            counts = await migrate_repost_data(repost.image_id, image_id, db)
+            await db.commit()
+            assert counts["tags_moved"] == 0  # repost had no tags; the SQL still ran
+
+        await run("service: tag_type_flags recompute (PG SQL)", flags_check())
+        await run("service: repost migrate (ON CONFLICT SQL)", repost_check())
+
+
+async def smoke() -> int:
+    """Exercise the real app against Postgres and report per-check results."""
+    from httpx import ASGITransport, AsyncClient
+
+    from app.core.database import engine
+    from app.main import app
+
+    user_id, image_id = await _seed()
+
+    results: list[tuple[str, bool, str]] = []
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://poc") as client:
+
+        async def check(name: str, coro: Any, expect: int) -> Any:
+            try:
+                response = await coro
+            except Exception as exc:  # noqa: BLE001 - a failing check must not stop the run
+                results.append((name, False, f"{type(exc).__name__}: {exc}"))
+                return None
+            ok = response.status_code == expect
+            detail = f"HTTP {response.status_code}"
+            if not ok:
+                detail += f" (expected {expect}): {response.text[:200]}"
+            results.append((name, ok, detail))
+            return response if ok else None
+
+        await check("GET /health", client.get("/health"), 200)
+
+        login = await check(
+            "POST /api/v1/auth/login",
+            client.post(
+                "/api/v1/auth/login",
+                json={"username": SMOKE_USERNAME, "password": SMOKE_PASSWORD},
+            ),
+            200,
+        )
+        headers = {}
+        if login is not None:
+            headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+            await check("GET /api/v1/auth/me", client.get("/api/v1/auth/me", headers=headers), 200)
+
+        await check("GET /api/v1/images", client.get("/api/v1/images"), 200)
+        await check(f"GET /api/v1/images/{image_id}", client.get(f"/api/v1/images/{image_id}"), 200)
+        await check("GET /api/v1/tags", client.get("/api/v1/tags"), 200)
+        await check(
+            "GET /api/v1/tags?search= (DB fallback)",
+            client.get("/api/v1/tags", params={"search": "poc"}),
+            200,
+        )
+
+        if headers:
+            await check(
+                "POST /api/v1/comments",
+                client.post(
+                    "/api/v1/comments",
+                    json={"image_id": image_id, "post_text": "Postgres POC comment"},
+                    headers=headers,
+                ),
+                201,
+            )
+        await check(
+            "GET /api/v1/comments?image_id",
+            client.get("/api/v1/comments", params={"image_id": image_id}),
+            200,
+        )
+        await check(
+            "GET /api/v1/comments?search_text= (DB fallback)",
+            client.get("/api/v1/comments", params={"search_text": "postgres"}),
+            200,
+        )
+        if headers:
+            await check(
+                "GET /api/v1/images/recommended (cold start)",
+                client.get("/api/v1/images/recommended", headers=headers),
+                200,
+            )
+
+    await _service_checks(results, user_id, image_id)
+
+    await engine.dispose()
+
+    width = max(len(name) for name, _, _ in results)
+    failed = 0
+    for name, ok, detail in results:
+        status = "PASS" if ok else "FAIL"
+        failed += 0 if ok else 1
+        print(f"{status}  {name:<{width}}  {detail}")
+    print(f"\n{len(results) - failed}/{len(results)} checks passed")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["setup", "smoke"])
+    args = parser.parse_args()
+    if args.command == "setup":
+        return asyncio.run(setup())
+    return asyncio.run(smoke())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/postgres_poc.py
+++ b/scripts/postgres_poc.py
@@ -64,6 +64,9 @@ async def setup() -> int:
         # disables FK checks).
         await conn.execute(text("DROP SCHEMA public CASCADE"))
         await conn.execute(text("CREATE SCHEMA public"))
+        # citext lives in public, so the DROP SCHEMA above removed it; the
+        # username/email/tag-title columns need it (see types.ci_string).
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS citext"))
         await conn.run_sync(SQLModel.metadata.create_all)
     async with engine.connect() as conn:
         count = (

--- a/tests/unit/test_comment_search.py
+++ b/tests/unit/test_comment_search.py
@@ -108,6 +108,29 @@ class TestParseCommentSearch:
         assert parsed.like_terms == ["The"]
 
 
+class TestParseWithoutIndex:
+    """index_visible=False (Postgres POC: no fulltext index) — everything rides LIKE.
+
+    See docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md.
+    """
+
+    def test_indexable_token_goes_to_like(self):
+        parsed = parse_comment_search("birthday", index_visible=False)
+        assert parsed.boolean_query == ""
+        assert parsed.like_terms == ["birthday"]
+
+    def test_negation_still_works(self):
+        parsed = parse_comment_search("happy -birthday", index_visible=False)
+        assert parsed.boolean_query == ""
+        assert parsed.like_terms == ["happy"]
+        assert parsed.not_like_terms == ["birthday"]
+
+    def test_quoted_phrase_becomes_single_like_term(self):
+        parsed = parse_comment_search('"happy birthday"', index_visible=False)
+        assert parsed.boolean_query == ""
+        assert parsed.like_terms == ["happy birthday"]
+
+
 class TestLikePattern:
     def test_wraps_in_wildcards(self):
         assert like_pattern("cat") == "%cat%"

--- a/tests/unit/test_comment_search.py
+++ b/tests/unit/test_comment_search.py
@@ -5,8 +5,13 @@ recorded in
 <shuushuu-frontend-repo>/docs/plans/2026-Q3/2026-08-10-comment-search-and-semantics-impl.md.
 """
 
+from sqlalchemy import select
+from sqlalchemy.dialects import mysql, postgresql
+
+from app.models import Comments
 from app.utils.comment_search import (
     CommentSearchQuery,
+    apply_comment_text_search,
     like_pattern,
     parse_comment_search,
 )
@@ -129,6 +134,41 @@ class TestParseWithoutIndex:
         parsed = parse_comment_search('"happy birthday"', index_visible=False)
         assert parsed.boolean_query == ""
         assert parsed.like_terms == ["happy birthday"]
+
+
+class TestAppliedPredicateDialect:
+    """The LIKE predicates must be case-insensitive on both dialects.
+
+    MariaDB's utf8mb4_unicode_ci makes LIKE case-insensitive by collation;
+    Postgres LIKE is case-sensitive, so the no-fulltext path must emit ILIKE
+    (measured: 'birthday' matched 2790 comments on MariaDB but only 1936 on
+    Postgres with plain LIKE).
+    """
+
+    def test_postgres_fallback_uses_ilike(self):
+        query = apply_comment_text_search(select(Comments), "birthday", None, use_fulltext=False)
+        sql = str(query.compile(dialect=postgresql.dialect()))
+        assert "ILIKE" in sql
+        assert "MATCH" not in sql
+
+    def test_postgres_like_mode_uses_ilike(self):
+        query = apply_comment_text_search(select(Comments), "birthday", "like", use_fulltext=False)
+        sql = str(query.compile(dialect=postgresql.dialect()))
+        assert "ILIKE" in sql
+
+    def test_postgres_negated_term_uses_ilike(self):
+        query = apply_comment_text_search(
+            select(Comments), "-birthday cake", None, use_fulltext=False
+        )
+        sql = str(query.compile(dialect=postgresql.dialect()))
+        assert "NOT ILIKE" in sql
+
+    def test_mysql_path_is_unchanged(self):
+        query = apply_comment_text_search(select(Comments), "happy bd", None)
+        sql = str(query.compile(dialect=mysql.dialect()))
+        assert "MATCH" in sql
+        assert "LIKE" in sql
+        assert "lower(" not in sql  # plain LIKE: collation handles case there
 
 
 class TestLikePattern:

--- a/uv.lock
+++ b/uv.lock
@@ -223,6 +223,30 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2403,6 +2427,7 @@ dependencies = [
     { name = "aiosmtplib" },
     { name = "alembic" },
     { name = "arq" },
+    { name = "asyncpg" },
     { name = "bcrypt" },
     { name = "fastapi", extra = ["standard"] },
     { name = "feedgenerator" },
@@ -2446,6 +2471,7 @@ requires-dist = [
     { name = "aiosmtplib", specifier = ">=5.1.1" },
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "arq", specifier = ">=0.27.0" },
+    { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0,<=0.136.1" },
     { name = "feedgenerator", specifier = ">=2.2.1" },


### PR DESCRIPTION
## Summary

Proof of concept validating the [2026-06-10 Postgres feasibility analysis](docs/plans/2026-Q2/2026-06-10-postgres-migration-feasibility.md) with running code: the API boots and serves its core read/write/search paths against a real PostgreSQL 17 container. **MariaDB stays the default** — every change is a dialect branch keyed off the engine/bind dialect, and the full MariaDB suite is untouched-green.

Plan: docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md

## What's in it

- `docker-compose.postgres.yml` — postgres:17 as a separate compose project (own volume/name; can't touch the dev stack) + `asyncpg`
- Dialect-aware engine config (UTC session setup) and `statement_timeout` (ms vs s, same restore semantics)
- Portable column types: `with_variant` for the unsigned ints, generic `JSON`, `CURRENT_TIMESTAMP` server defaults (MariaDB normalizes both spellings identically — schema-sync green)
- Dialect branches for the raw-SQL sites: comment search and tag search degrade to (I)LIKE on PG; tag_type_flags gets an `UPDATE … FROM` + `bool_or` twin; repost copies use `ON CONFLICT DO NOTHING`; ml_raw_store uses `pg_insert().on_conflict_do_nothing()`; the MariaDB-only `user_tag_affinity` rebuild now fails loudly on other dialects
- `scripts/postgres_poc.py` — `setup` (schema via create_all) and `smoke` (real app in-process, real Redis, no mocks/overrides)

## Verification

- MariaDB: full suite **2631 passed**, schema-sync (opt-in flag) green, `mypy app/` clean
- Postgres: smoke **13/13** — health, login/me (bcrypt + refresh token), images list/detail, tags list/search fallback, comment create/list/search fallback, recommended feed (cold start), tag-type-flags recompute SQL, repost migration SQL

## Deliberately deferred (per POC scope)

Alembic PG baseline (schema comes from `create_all`), the 8+ counter triggers (counters don't self-maintain on PG), data migration, case-collation strategy, running the pytest suite against PG, `scripts/db_utils.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhULr3gzY2uk1kJQoPENvH