### PR TITLE
Port counter-maintenance triggers to Postgres

### DIFF
--- a/app/core/pg_schema.py
+++ b/app/core/pg_schema.py
@@ -13,6 +13,8 @@ from sqlalchemy import MetaData, text
 from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.sql.elements import quoted_name
 
+from app.core.pg_triggers import install_counter_triggers
+
 # citext has no length modifier, so the VARCHAR(n) caps these columns have on
 # MariaDB move to CHECK constraints (Postgres-only: a CHECK in the models'
 # __table_args__ would change the MariaDB DDL and break schema-sync). ADR-0008.
@@ -61,3 +63,4 @@ async def build_pg_schema(conn: AsyncConnection) -> None:
     await conn.run_sync(SQLModel.metadata.create_all)
     for ddl in _LENGTH_CHECKS:
         await conn.execute(text(ddl))
+    await install_counter_triggers(conn)

--- a/app/core/pg_triggers.py
+++ b/app/core/pg_triggers.py
@@ -1,0 +1,199 @@
+"""Counter-maintenance triggers for Postgres.
+
+Ports the MariaDB trigger set (migrations 2cd4e874e956, 5721ccce6a85,
+ec5c5fa4e3e5) that maintains the denormalized counters:
+
+- ``tags.usage_count``            <- tag_links INSERT/DELETE
+- ``images.favorites``            <- favorites INSERT/DELETE/UPDATE (re-point)
+- ``users.favorites``             <- favorites INSERT/DELETE/UPDATE (re-point)
+- ``users.image_posts``           <- images INSERT/DELETE/UPDATE (re-point)
+- ``images.posts``/``last_post``  <- posts INSERT/UPDATE/DELETE, soft-delete aware
+- ``users.posts``                 <- posts INSERT/UPDATE/DELETE, soft-delete aware
+
+Layout differs from MariaDB deliberately: one function per (source table,
+event) covering every counter that event touches, instead of one trigger per
+target table — same semantics, fewer objects, and each event's full effect
+reads in one place.
+
+Semantics note: Postgres fires these on FK-cascaded deletes, which InnoDB
+does not. The counter drift MariaDB accumulates when an image is deleted
+(cascaded tag_links/favorites/posts rows never fire its triggers) does not
+occur here; the UPDATE a cascade-fired trigger aims at the row being deleted
+is a harmless no-op.
+
+The DDL is idempotent (CREATE OR REPLACE FUNCTION + DROP TRIGGER IF EXISTS)
+so it can be applied to a live database as well as a fresh bootstrap. Until a
+Postgres Alembic baseline exists, installation happens in build_pg_schema;
+the baseline migration inherits this file's SQL when it lands.
+"""
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+
+def _trigger(name: str, event: str, table: str, body: str) -> tuple[str, str, str]:
+    # Three separate statements: asyncpg refuses multiple commands in one
+    # prepared statement (the semicolons inside $$..$$ are fine).
+    return (
+        f"""
+        CREATE OR REPLACE FUNCTION {name}() RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+        {body}
+        RETURN NULL;
+        END $$
+        """,
+        f"DROP TRIGGER IF EXISTS {name} ON {table}",
+        f"""
+        CREATE TRIGGER {name} AFTER {event} ON {table}
+            FOR EACH ROW EXECUTE FUNCTION {name}()
+        """,
+    )
+
+
+_TRIGGER_TRIOS = (
+    _trigger(
+        "tag_links_counters_insert",
+        "INSERT",
+        "tag_links",
+        "UPDATE tags SET usage_count = usage_count + 1 WHERE tag_id = NEW.tag_id;",
+    ),
+    _trigger(
+        "tag_links_counters_delete",
+        "DELETE",
+        "tag_links",
+        "UPDATE tags SET usage_count = GREATEST(0, usage_count - 1) WHERE tag_id = OLD.tag_id;",
+    ),
+    _trigger(
+        "favorites_counters_insert",
+        "INSERT",
+        "favorites",
+        """
+        UPDATE images SET favorites = favorites + 1 WHERE image_id = NEW.image_id;
+        UPDATE users SET favorites = favorites + 1 WHERE user_id = NEW.user_id;
+        """,
+    ),
+    _trigger(
+        "favorites_counters_delete",
+        "DELETE",
+        "favorites",
+        """
+        UPDATE images SET favorites = favorites - 1 WHERE image_id = OLD.image_id;
+        UPDATE users SET favorites = favorites - 1 WHERE user_id = OLD.user_id;
+        """,
+    ),
+    _trigger(
+        "favorites_counters_update",
+        "UPDATE",
+        "favorites",
+        """
+        IF OLD.image_id IS DISTINCT FROM NEW.image_id THEN
+            UPDATE images SET favorites = favorites - 1 WHERE image_id = OLD.image_id;
+            UPDATE images SET favorites = favorites + 1 WHERE image_id = NEW.image_id;
+        END IF;
+        IF OLD.user_id IS DISTINCT FROM NEW.user_id THEN
+            UPDATE users SET favorites = favorites - 1 WHERE user_id = OLD.user_id;
+            UPDATE users SET favorites = favorites + 1 WHERE user_id = NEW.user_id;
+        END IF;
+        """,
+    ),
+    _trigger(
+        "images_counters_insert",
+        "INSERT",
+        "images",
+        "UPDATE users SET image_posts = image_posts + 1 WHERE user_id = NEW.user_id;",
+    ),
+    _trigger(
+        "images_counters_delete",
+        "DELETE",
+        "images",
+        "UPDATE users SET image_posts = image_posts - 1 WHERE user_id = OLD.user_id;",
+    ),
+    _trigger(
+        "images_counters_update",
+        "UPDATE",
+        "images",
+        """
+        IF OLD.user_id IS DISTINCT FROM NEW.user_id THEN
+            UPDATE users SET image_posts = image_posts - 1 WHERE user_id = OLD.user_id;
+            UPDATE users SET image_posts = image_posts + 1 WHERE user_id = NEW.user_id;
+        END IF;
+        """,
+    ),
+    # posts triggers are soft-delete aware: only rows with deleted = false
+    # count, and images.last_post tracks MAX(date) of the visible rows.
+    _trigger(
+        "posts_counters_insert",
+        "INSERT",
+        "posts",
+        """
+        IF NOT NEW.deleted THEN
+            UPDATE images SET posts = posts + 1, last_post = NEW.date
+                WHERE image_id = NEW.image_id;
+            UPDATE users SET posts = posts + 1 WHERE user_id = NEW.user_id;
+        END IF;
+        """,
+    ),
+    _trigger(
+        "posts_counters_update",
+        "UPDATE",
+        "posts",
+        """
+        IF OLD.deleted = false AND NEW.deleted = true THEN
+            UPDATE images
+            SET posts = posts - 1,
+                last_post = (SELECT MAX(date) FROM posts
+                             WHERE image_id = NEW.image_id AND NOT deleted)
+            WHERE image_id = NEW.image_id;
+            UPDATE users SET posts = posts - 1 WHERE user_id = NEW.user_id;
+        ELSIF OLD.deleted = true AND NEW.deleted = false THEN
+            UPDATE images
+            SET posts = posts + 1,
+                last_post = (SELECT MAX(date) FROM posts
+                             WHERE image_id = NEW.image_id AND NOT deleted)
+            WHERE image_id = NEW.image_id;
+            UPDATE users SET posts = posts + 1 WHERE user_id = NEW.user_id;
+        ELSE
+            IF OLD.image_id IS DISTINCT FROM NEW.image_id THEN
+                UPDATE images
+                SET posts = posts - 1,
+                    last_post = (SELECT MAX(date) FROM posts
+                                 WHERE image_id = OLD.image_id AND NOT deleted)
+                WHERE image_id = OLD.image_id;
+                UPDATE images
+                SET posts = posts + 1,
+                    last_post = (SELECT MAX(date) FROM posts
+                                 WHERE image_id = NEW.image_id AND NOT deleted)
+                WHERE image_id = NEW.image_id;
+            END IF;
+            IF OLD.user_id IS DISTINCT FROM NEW.user_id THEN
+                UPDATE users SET posts = posts - 1 WHERE user_id = OLD.user_id;
+                UPDATE users SET posts = posts + 1 WHERE user_id = NEW.user_id;
+            END IF;
+        END IF;
+        """,
+    ),
+    _trigger(
+        "posts_counters_delete",
+        "DELETE",
+        "posts",
+        """
+        IF NOT OLD.deleted THEN
+            UPDATE images
+            SET posts = posts - 1,
+                last_post = (SELECT MAX(date) FROM posts
+                             WHERE image_id = OLD.image_id AND NOT deleted)
+            WHERE image_id = OLD.image_id;
+            UPDATE users SET posts = posts - 1 WHERE user_id = OLD.user_id;
+        END IF;
+        """,
+    ),
+)
+
+
+_TRIGGER_DDL: tuple[str, ...] = tuple(stmt for trio in _TRIGGER_TRIOS for stmt in trio)
+
+
+async def install_counter_triggers(conn: AsyncConnection) -> None:
+    """Install (or refresh) the counter triggers. Idempotent."""
+    for ddl in _TRIGGER_DDL:
+        await conn.execute(text(ddl))

--- a/docs/plans/2026-Q3/2026-08-21-pg-counter-triggers-design.md
+++ b/docs/plans/2026-Q3/2026-08-21-pg-counter-triggers-design.md
@@ -1,0 +1,43 @@
+# Postgres counter triggers — design
+
+**Date:** 2026-08-21
+**Follows:** docs/plans/2026-Q3/2026-08-20-tests-on-postgres-design.md (the counters decision it deferred)
+
+## Motivation
+
+Six denormalized counter families (`tags.usage_count`, `images.favorites`,
+`users.favorites`, `users.image_posts`, `images.posts`+`last_post`,
+`users.posts`) are maintained by MariaDB triggers that exist only in the
+migration chain. On the Postgres side (create_all schema) they were frozen at
+migrated values, and their tests were `mariadb_only`-skipped as the placeholder
+for this decision.
+
+## Decision: port the triggers to PL/pgSQL
+
+Options weighed:
+
+- **Port triggers (chosen).** Zero app changes; every write path covered,
+  including the ones app code never sees. The clincher: InnoDB triggers do NOT
+  fire on FK-cascaded deletes, and the image-delete endpoint relies purely on
+  CASCADE — so prod MariaDB silently drifts `usage_count`/`users.favorites`/
+  `users.posts` on every image deletion (the backfill scripts are the de-facto
+  reconciliation). Postgres triggers DO fire on cascades, so the port is
+  strictly more correct than parity. The cascade-fired UPDATE aimed at the
+  row being deleted is a harmless no-op.
+- **App-side recompute** (the tag_type_flags pattern) is visible and
+  dialect-free but must enumerate every write path and every cascade site,
+  now and forever; one missed path is silent drift. Rejected as the primary
+  mechanism; the recompute/backfill helpers remain the reconciliation tools.
+- **Count-on-read** cannot serve the hot sorts (usage_count over 235k tags,
+  posts at feed scale). Rejected.
+
+## Shape
+
+`app/core/pg_triggers.py`: one PL/pgSQL function per (source table, event) —
+11 triggers — each covering every counter that event touches; idempotent DDL
+(CREATE OR REPLACE + DROP TRIGGER IF EXISTS) so it applies to live databases
+and fresh bootstraps alike. Installed by `build_pg_schema` (POC DB + every
+test database); the future Postgres Alembic baseline inherits this SQL.
+Behavior matches the MariaDB set verbatim, including the soft-delete-aware
+posts pair and its `last_post = MAX(date)` recompute; the un-skipped
+`TestTagUsageCount` and alias-usage-count tests are the acceptance suite.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -28,6 +28,7 @@ Exceptions block is maintained by hand and is preserved across regeneration.
 
 | Date | Effort | Docs |
 | --- | --- | --- |
+| 2026-08-21 | Postgres counter triggers — design | [design](2026-Q3/2026-08-21-pg-counter-triggers-design.md) |
 | 2026-08-20 | Tests on Postgres — design | [design](2026-Q3/2026-08-20-tests-on-postgres-design.md) · [impl](2026-Q3/2026-08-20-tests-on-postgres-impl.md) |
 | 2026-08-20 | Postgres Proof-of-Concept Implementation Plan | [impl](2026-Q3/2026-08-20-postgres-poc-impl.md) |
 | 2026-08-18 | For You v2: favorites as a live input + daily rotation | [design](2026-Q3/2026-08-18-for-you-favorites-rotation-design.md) · [impl](2026-Q3/2026-08-18-for-you-favorites-rotation-impl.md) |
@@ -108,4 +109,4 @@ Exceptions block is maintained by hand and is preserved across regeneration.
 | 2025-11-23 | Avatar Upload Feature Design | [design](2025-Q4/2025-11-23-avatar-upload-design.md) |
 | 2025-11-22 | Image Reporting and Review System Design | [design](2025-Q4/2025-11-22-image-reporting-review-design.md) |
 
-64 efforts, 95 documents.
+65 efforts, 96 documents.

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -2539,13 +2539,12 @@ class TestOwnerStatusChangeSyncsMlSuggestions:
 
 
 @pytest.mark.api
-# mariadb_only: usage_count is maintained by DB triggers, which exist only in
-# the MariaDB migration chain. These become the acceptance tests for whatever
-# mechanism the Postgres counters decision picks (see the tests-on-postgres
-# design doc's deferred list).
-@pytest.mark.mariadb_only
 class TestTagUsageCount:
-    """Tests for automatic tag usage_count updates via database triggers."""
+    """Tests for automatic tag usage_count updates via database triggers.
+
+    Both backends: the MariaDB migration chain and the Postgres bootstrap
+    (app/core/pg_triggers.py) each install the triggers under test.
+    """
 
     async def test_tag_usage_count_increments_on_add(
         self,

--- a/tests/api/v1/test_tags.py
+++ b/tests/api/v1/test_tags.py
@@ -3182,11 +3182,6 @@ class TestUpdateTag:
         alias_ext_links = result.all()
         assert len(alias_ext_links) == 0
 
-    # mariadb_only: the recalculation under test counts real tag_links rows,
-    # but its baseline values come from the INSERT/DELETE triggers that exist
-    # only in the MariaDB migration chain (see the counters decision in the
-    # tests-on-postgres design doc).
-    @pytest.mark.mariadb_only
     async def test_setting_alias_updates_usage_counts(
         self, client: AsyncClient, db_session: AsyncSession
     ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,12 @@ def pytest_configure(config):
         "migration-chain comparison, the affinity guard); skipped when the session "
         "backend is Postgres. See docs/plans/2026-Q3/2026-08-20-tests-on-postgres-design.md.",
     )
+    config.addinivalue_line(
+        "markers",
+        "postgres_only: marks tests of Postgres-defined behavior (e.g. triggers firing "
+        "on FK-cascaded deletes, which InnoDB does not do); skipped when the session "
+        "backend is MariaDB.",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -108,6 +114,13 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "mariadb_only" in item.keywords or "schema_sync" in item.keywords:
                 item.add_marker(skip_mariadb)
+    else:
+        skip_postgres = pytest.mark.skip(
+            reason="Postgres-defined behavior (postgres_only); session backend is MariaDB"
+        )
+        for item in items:
+            if "postgres_only" in item.keywords:
+                item.add_marker(skip_postgres)
 
     if not config.getoption("--schema-sync"):
         skip_schema_sync = pytest.mark.skip(reason="need --schema-sync option to run")

--- a/tests/integration/test_counter_cascades.py
+++ b/tests/integration/test_counter_cascades.py
@@ -1,0 +1,86 @@
+"""Counters must survive FK-cascaded deletes on Postgres.
+
+The selling point of the trigger port (app/core/pg_triggers.py, PR #353):
+deleting an image cascades away its tag_links/favorites/posts rows, and on
+Postgres the counter triggers fire for those cascaded deletes. InnoDB does
+not fire triggers on cascades, so on MariaDB these counters silently drift on
+every image deletion — which is why this test is postgres_only: it asserts
+the *correct* behavior, which only Postgres exhibits.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Comments, Images, Tags, Users
+from app.models.favorite import Favorites
+from app.models.tag_link import TagLinks
+
+pytestmark = [pytest.mark.integration, pytest.mark.postgres_only]
+
+
+async def _counters(db: AsyncSession, user_id: int, tag_id: int) -> dict[str, int]:
+    user = (
+        await db.execute(
+            select(Users.posts, Users.image_posts, Users.favorites).where(  # type: ignore[call-overload]
+                Users.user_id == user_id
+            )
+        )
+    ).one()
+    usage_count = (
+        await db.execute(select(Tags.usage_count).where(Tags.tag_id == tag_id))  # type: ignore[call-overload]
+    ).scalar_one()
+    return {
+        "user_posts": user.posts,
+        "user_image_posts": user.image_posts,
+        "user_favorites": user.favorites,
+        "tag_usage_count": usage_count,
+    }
+
+
+async def test_image_delete_cascade_maintains_counters(
+    db_session: AsyncSession, test_user, test_image, test_tag
+):
+    """Deleting an image must decrement every counter its cascaded rows fed."""
+    # Plain ints up front: expire_all() below invalidates the ORM objects, and
+    # touching an expired attribute lazy-loads synchronously (MissingGreenlet).
+    user_id = test_user.user_id
+    image_id = test_image.image_id
+    tag_id = test_tag.tag_id
+
+    # Attach a tag, a favorite, and a comment to the image; the insert
+    # triggers bump the counters.
+    db_session.add(TagLinks(image_id=image_id, tag_id=tag_id, user_id=user_id))
+    db_session.add(Favorites(image_id=image_id, user_id=user_id, fav_date=datetime.now(UTC)))
+    db_session.add(
+        Comments(
+            image_id=image_id,
+            user_id=user_id,
+            post_text="cascade probe",
+            date=datetime.now(UTC),
+            update_count=0,
+        )
+    )
+    await db_session.commit()
+
+    db_session.expire_all()  # trigger writes bypass the identity map
+    before = await _counters(db_session, user_id, tag_id)
+    assert before["tag_usage_count"] >= 1
+    assert before["user_favorites"] >= 1
+    assert before["user_posts"] >= 1
+    assert before["user_image_posts"] >= 1
+
+    # The same statement the image-delete endpoint issues: the tag_link,
+    # favorite, and comment rows go away via FK CASCADE, not via app code.
+    await db_session.execute(delete(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
+    await db_session.commit()
+
+    db_session.expire_all()
+    after = await _counters(db_session, user_id, tag_id)
+    assert after["tag_usage_count"] == before["tag_usage_count"] - 1
+    assert after["user_favorites"] == before["user_favorites"] - 1
+    assert after["user_posts"] == before["user_posts"] - 1
+    # images_counters_delete fires on the image row itself (not a cascade).
+    assert after["user_image_posts"] == before["user_image_posts"] - 1


### PR DESCRIPTION
## Summary

Settles the counters decision from the tests-on-postgres design doc: the six denormalized counter families (`tags.usage_count`, `images.favorites`, `users.favorites`, `users.image_posts`, `images.posts`+`last_post`, `users.posts`) are now maintained on Postgres by PL/pgSQL twins of the MariaDB trigger set.

Plan: docs/plans/2026-Q3/2026-08-21-pg-counter-triggers-design.md

## Why port rather than app-side maintenance

The deciding fact: **InnoDB triggers don't fire on FK-cascaded deletes**, and the image-delete endpoint relies purely on CASCADE — so prod MariaDB already silently drifts `usage_count`/`users.favorites`/`users.posts` on every image deletion (the backfill scripts are the de-facto reconciliation). Postgres triggers *do* fire on cascades, so the port is strictly more correct than parity, with zero app changes and no write path left uncovered. App-side recompute would have required auditing ~10+ write paths plus every cascade site, forever. Full option analysis in the design doc.

## Shape

- `app/core/pg_triggers.py` — one function per (source table, event), 11 triggers, faithful to the MariaDB bodies including the soft-delete-aware posts pair and its `last_post = MAX(date)` recompute. Idempotent DDL (applies to live DBs and fresh bootstraps; the future PG Alembic baseline inherits this SQL).
- Installed by `build_pg_schema` → every test database and the POC bootstrap get them; also applied to the live dev DB (verified: tag-link insert bumped `school uniform` 153,999 → 154,000, rolled back cleanly).
- The `TestTagUsageCount` and alias-usage-count tests drop `mariadb_only` and pass on both backends.

## Verification

- Postgres: **2,618 passed, 27 skipped** (4 counter tests moved from skipped to passing)
- MariaDB: **2,638 passed, 7 skipped** with `--schema-sync` — untouched
- `mypy` clean; live-DB trigger probe verified with rollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhULr3gzY2uk1kJQoPENvH