### PR TITLE
Publish postgres on 0.0.0.0 like mariadb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,9 +65,10 @@ services:
       -c effective_cache_size=${POSTGRES_EFFECTIVE_CACHE_SIZE:-4GB}
       -c max_connections=200
     ports:
-      # localhost-only: host access is for dev tooling (pytest --pg, psql);
-      # containers reach it in-network as postgres:5432
-      - "127.0.0.1:5432:5432"
+      # Published like mariadb's 3306: dev is reached from other machines on
+      # the local network. Prod never runs this service (stubbed with
+      # ports overridden empty in docker-compose.prod.yml).
+      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/docs/plans/2026-Q3/2026-08-21-pg-compose-topology-impl.md
+++ b/docs/plans/2026-Q3/2026-08-21-pg-compose-topology-impl.md
@@ -9,8 +9,10 @@
    conventions: pinned `${POSTGRES_IMAGE:-postgres:17.11}`, env-var
    credentials with dev defaults, tuning knobs
    (`POSTGRES_SHARED_BUFFERS`/`EFFECTIVE_CACHE_SIZE`), named `postgres_data`
-   volume, `pg_isready` healthcheck, resource limits, **localhost-only** port
-   publish (dev tooling; containers use `postgres:5432` in-network). Dev
+   volume, `pg_isready` healthcheck, resource limits, and a `5432:5432`
+   publish matching mariadb's 3306 (dev is reached from other machines on the
+   LAN; containers use `postgres:5432` in-network, and prod stubs the service
+   with ports overridden empty). Dev
    override adds `-dev` container/volume names and an api `depends_on`.
    Prod is unaffected: its DB tier is native/out-of-stack
    (`docker-compose.prod.yml` stubs it and passes `DATABASE_URL` through).


### PR DESCRIPTION
One-liner follow-up to #356: the LAN-accessible port binding (user-requested — dev is reached from other machines on the local network) was applied and verified on the live stack during that PR's work but missed the branch commits, so the merged base file still had `127.0.0.1:5432`. Prod is unaffected (the prod overlay stubs the service with `ports: !override []`). Plan-doc wording updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhULr3gzY2uk1kJQoPENvH