### PR TITLE
Postgres 18

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ MARIADB_PASSWORD=change_this_password
 
 # Used by docker-compose for the Postgres container (the transition target,
 # ADR-0010 / docs/postgres-cutover-runbook.md). Pin the image deliberately.
-POSTGRES_IMAGE=postgres:17.11
+POSTGRES_IMAGE=postgres:18.6
 POSTGRES_DB=shuushuu
 POSTGRES_USER=shuushuu
 POSTGRES_PASSWORD=change_this_password

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17
+        image: postgres:18
         env:
           POSTGRES_USER: shuushuu
           POSTGRES_PASSWORD: shuushuu_ci_password
@@ -166,7 +166,7 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
-          --tmpfs /var/lib/postgresql/data:rw
+          --tmpfs /var/lib/postgresql:rw
 
       redis:
         image: redis:7-alpine

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,7 +30,7 @@ services:
 
   # Same treatment for the transition-target Postgres: prod's Postgres (like
   # MariaDB) lives natively on the DB tier, reached via DATABASE_URL. Without
-  # this stub a prod `up -d` would start a real postgres:17 container with
+  # this stub a prod `up -d` would start a real postgres container with
   # whatever POSTGRES_* creds the prod .env holds.
   postgres:
     image: busybox:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
   postgres:
     # Pin like mariadb above: bump POSTGRES_IMAGE in .env deliberately; a
     # floating major tag drifts dev away from whatever prod's DB tier runs.
-    image: ${POSTGRES_IMAGE:-postgres:17.11}
+    image: ${POSTGRES_IMAGE:-postgres:18.6}
     container_name: shuushuu-postgres
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-shuushuu}
@@ -70,7 +70,12 @@ services:
       # ports overridden empty in docker-compose.prod.yml).
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # postgres:18 images moved the volume mount point to /var/lib/postgresql
+      # (PGDATA lives in a versioned subdir, e.g. .../18/docker). Mounting the
+      # old .../data path would silently put the cluster OUTSIDE this volume —
+      # the exact data-not-where-config-claims failure class from the POC
+      # incident (see the pg-compose-topology plan doc).
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-shuushuu} -d ${POSTGRES_DB:-shuushuu}"]
       interval: 10s

--- a/docs/postgres-cutover-runbook.md
+++ b/docs/postgres-cutover-runbook.md
@@ -17,7 +17,7 @@ wall-clock at current scale: schema ~5s, load ~7 min, post ~4 min, validate
 
 ## 1. Prerequisites
 
-- Postgres 17 with the `citext` extension available (bundled contrib; present
+- Postgres 18 with the `citext` extension available (bundled contrib; present
   in the official image and every managed provider). The migration connects
   as a superuser or owner (needed by `disable triggers` during load).
 - Docker on the machine running the migration (`dimitri/pgloader:latest`),


### PR DESCRIPTION
## Summary

Moves the transition target from Postgres 17 to **18 (pinned 18.6)** across the living surfaces: compose service, CI job, `.env.example`, runbook prerequisite. 17 was a POC-day default that propagated, never a decision — 18 has been stable since Sept 2025, buys a year of support runway (EOL 2030 vs 2029), and its async I/O and B-tree skip scans target exactly our hot paths (feed scans, multicolumn index sorts). Now is the cheapest possible moment: prod's Postgres doesn't exist yet, and dev rebuilds from MariaDB by script.

## The load-bearing change

`postgres:18` images moved the volume mount point to `/var/lib/postgresql`, with PGDATA in a versioned subdir (`.../18/docker`). The compose mount and CI tmpfs are updated to the new path — carrying the old `.../data` mount forward would have silently placed the cluster **outside** the named volume, the exact data-not-where-config-claims failure class from the topology PR's incident. The comment in the compose file documents this for the next reader.

Historical docs (plan docs, ADRs) keep their 17 references as point-in-time records.

## Verification (all on 18.6)

- Fresh initdb: `PGDATA` confirmed **inside** `postgres_data_dev` (`/v/18/docker/PG_VERSION`)
- From-scratch migration (`migrate.py all`): preflight → load → post → **44/44 tables validated**
- Persistence: 7.9GB and full counts (1.1M images, 11 triggers, 119 FKs) survive `--force-recreate`; server reports PostgreSQL 18.6
- App: api + nginx serving 1,086,611 images
- Full PG suite with `--schema-sync`: **2,620 passed, 27 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhULr3gzY2uk1kJQoPENvH