### PR TITLE
fix(pg-migration): fail validate on triggers the load left disabled

### DIFF
--- a/app/core/pg_triggers.py
+++ b/app/core/pg_triggers.py
@@ -197,3 +197,35 @@ async def install_counter_triggers(conn: AsyncConnection) -> None:
     """Install (or refresh) the counter triggers. Idempotent."""
     for ddl in _TRIGGER_DDL:
         await conn.execute(text(ddl))
+
+
+_DISABLED_TRIGGERS_SQL = text(
+    """
+    SELECT c.relname, t.tgname
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND NOT t.tgisinternal
+      AND t.tgenabled <> 'O'
+    ORDER BY c.relname, t.tgname
+    """
+)
+
+
+async def disabled_triggers(conn: AsyncConnection) -> list[str]:
+    """Return ``table.trigger`` for each disabled user trigger, sorted.
+
+    Empty means every trigger this module installs is live. A non-empty result
+    after a migration means pgloader's ``disable triggers`` never got reversed
+    (see tests/integration/test_pg_trigger_state.py) and the counters are inert
+    — repair with ``ALTER TABLE ... ENABLE TRIGGER USER`` before taking writes.
+
+    ``tgenabled`` is 'O' when a trigger fires for origin/local writes, the state
+    every trigger here is created in; 'D' is disabled, and the replica-only
+    states ('R'/'A') would be just as wrong for counters. Internal triggers are
+    excluded because they belong to FK constraints, which ``migrate.py post``
+    rebuilds outright.
+    """
+    rows = await conn.execute(_DISABLED_TRIGGERS_SQL)
+    return [f"{table}.{trigger}" for table, trigger in rows]

--- a/docs/postgres-cutover-runbook.md
+++ b/docs/postgres-cutover-runbook.md
@@ -18,8 +18,14 @@ wall-clock at current scale: schema ~5s, load ~7 min, post ~4 min, validate
 ## 1. Prerequisites
 
 - Postgres 18 with the `citext` extension available (bundled contrib; present
-  in the official image and every managed provider). The migration connects
-  as a superuser or owner (needed by `disable triggers` during load).
+  in the official image, in Debian/Ubuntu's `postgresql-18` package, and in
+  every managed provider).
+- The load must connect as a **superuser** — owner is not enough. pgloader's
+  `disable triggers` toggles FK-internal triggers, which only a superuser may
+  do. Grant it for the window and revoke after step 7 (`ALTER ROLE <user>
+  SUPERUSER;` / `NOSUPERUSER`); nothing needs it afterwards, since the app owns
+  its own tables and `citext` is a trusted extension the owner creates in
+  step 3.
 - Docker on the machine running the migration (`dimitri/pgloader:latest`),
   network reach to both databases, and this repo checked out at the cutover
   revision with `uv sync` done.
@@ -112,7 +118,15 @@ those directories once the window closes: `rm -rf /tmp/pg-migration-*`.
 
 Counts are necessary, not sufficient — every smoke check passed while comment
 search was silently missing case-variant rows; a source-vs-target *count
-comparison on the same query* is what caught it. Minimum manual checks:
+comparison on the same query* is what caught it.
+
+`validate` now also fails on any user trigger the load left disabled — the one
+failure counts structurally cannot see, since a database with inert counter
+triggers matches row-for-row (ADR-0009; the check lives in
+`app.core.pg_triggers.disabled_triggers`). Repair is `ALTER TABLE ... ENABLE
+TRIGGER USER`, which owner rights cover, then rerun `validate`.
+
+Minimum manual checks:
 
 - Login with a deliberately wrong-cased username (citext, ADR-0008).
 - The same search (`?search_text=...`) on both stacks: target count ≥ source
@@ -121,6 +135,8 @@ comparison on the same query* is what caught it. Minimum manual checks:
 - Favorite + unfavorite an image; comment; add/remove a tag — counters must
   move (triggers).
 - `SELECT last_value FROM images_image_id_seq` vs `MAX(image_id)`.
+
+Once these pass, revoke the load superuser (step 1) before opening the flip.
 
 ## 8. Flip
 

--- a/scripts/pg_migration/migrate.py
+++ b/scripts/pg_migration/migrate.py
@@ -212,6 +212,8 @@ async def post() -> None:
 
 
 async def validate() -> None:
+    from app.core.pg_triggers import disabled_triggers
+
     source = create_async_engine(SOURCE_SA_URL)
     target = _target_engine()
 
@@ -252,11 +254,26 @@ async def validate() -> None:
     for table in sorted(target_tables - source_tables - set(_EXCLUDED)):
         print(f"NOTE {table:<34} exists only in target (loads empty)")
 
+    # Counts can't see this: pgloader's `disable triggers` takes the counter
+    # triggers down with the FK internals, and only the FKs get rebuilt (post).
+    # A load that died partway leaves the counters inert on a database whose
+    # every row count matches.
+    async with target.connect() as conn:
+        inert = await disabled_triggers(conn)
+    for name in inert:
+        print(f"DOWN {name:<34} trigger disabled")
+
     await source.dispose()
     await target.dispose()
     if mismatched:
         sys.exit(f"validate: count mismatch in {len(mismatched)} table(s): {mismatched}")
-    print(f"validate: {len(common)} tables match")
+    if inert:
+        sys.exit(
+            f"validate: {len(inert)} trigger(s) left disabled by the load — counters "
+            "would silently stop updating. Re-enable them (ALTER TABLE ... ENABLE "
+            "TRIGGER USER, owner is enough) and rerun validate before taking writes."
+        )
+    print(f"validate: {len(common)} tables match, all triggers enabled")
 
 
 def main() -> None:

--- a/tests/integration/test_pg_trigger_state.py
+++ b/tests/integration/test_pg_trigger_state.py
@@ -1,0 +1,53 @@
+"""A disabled counter trigger must be detectable, not silent.
+
+pgloader loads with ``disable triggers`` (scripts/pg_migration/shuushuu.load.template),
+which issues ``ALTER TABLE ... DISABLE TRIGGER ALL`` and so takes the counter
+triggers down along with the FK internals. ``migrate.py post`` drops and re-adds
+every FK constraint, so those come back enabled no matter how the load went —
+but nothing re-enables the *user* triggers this module installs. A load that
+dies partway can therefore leave the counters silently inert on a database that
+passes every row-count check in ``migrate.py validate``.
+
+The cutover runbook's fix is to assert on trigger state before the window
+closes; this covers the query that assertion runs.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.pg_triggers import disabled_triggers
+
+pytestmark = [pytest.mark.integration, pytest.mark.postgres_only]
+
+
+async def test_reports_nothing_on_a_healthy_schema(db_session: AsyncSession) -> None:
+    """The chain-built schema installs every trigger enabled."""
+    assert await disabled_triggers(await db_session.connection()) == []
+
+
+async def test_detects_a_disabled_counter_trigger(db_session: AsyncSession) -> None:
+    """The exact state a half-finished pgloader run leaves behind."""
+    await db_session.execute(
+        text("ALTER TABLE tag_links DISABLE TRIGGER tag_links_counters_insert")
+    )
+
+    assert await disabled_triggers(await db_session.connection()) == [
+        "tag_links.tag_links_counters_insert"
+    ]
+
+
+async def test_reports_every_disabled_trigger_not_just_the_first(
+    db_session: AsyncSession,
+) -> None:
+    """``DISABLE TRIGGER ALL`` hits whole tables at a time, so the check must
+    enumerate rather than short-circuit on the first hit."""
+    await db_session.execute(text("ALTER TABLE tag_links DISABLE TRIGGER ALL"))
+
+    found = await disabled_triggers(await db_session.connection())
+
+    assert found == sorted(found), "results must be ordered for stable reporting"
+    assert set(found) == {
+        "tag_links.tag_links_counters_insert",
+        "tag_links.tag_links_counters_delete",
+    }


### PR DESCRIPTION
## Problem

pgloader loads with `disable triggers` (`scripts/pg_migration/shuushuu.load.template`), which issues `ALTER TABLE ... DISABLE TRIGGER ALL` and so takes the ADR-0009 counter triggers down alongside the FK internals.

`post()` drops and re-adds every FK constraint, so those come back enabled no matter how the load went. Nothing re-enables the **user** triggers. A load that dies partway therefore leaves the counters inert on a database that passes `validate` cleanly — a database with dead counter triggers matches the source row-for-row, so counts structurally cannot see it.

The failure mode is silent: counters stop updating under live traffic. The runbook's §7 manual check (favorite/unfavorite, counters must move) would catch it, but only for the one table you poke, and only if you remember.

## Change

- `app.core.pg_triggers.disabled_triggers(conn)` — returns sorted `table.trigger` for every disabled user trigger in `public`. Lives next to `install_counter_triggers` because that module owns the trigger set. Excludes `tgisinternal` (FK constraints, which `post()` rebuilds outright) and treats anything but `tgenabled = 'O'` as broken, so the replica-only states `'R'`/`'A'` fail too.
- `validate()` prints a `DOWN <name>` line per hit and exits non-zero. Repair is `ENABLE TRIGGER USER`, which needs only owner rights, so it stays available after the load superuser is revoked.

## Runbook correction

§1 said the migration "connects as a superuser **or owner**." That's wrong, and it's what let this hide — owner cannot toggle FK-internal triggers, so the load genuinely requires superuser. §1 now states that as its own prerequisite, granted for the window and revoked after §7 rather than before, so the privilege outlives any repair that needs it. §7 documents that `validate` covers trigger state.

## Testing

`tests/integration/test_pg_trigger_state.py`, 3 tests, `postgres_only`:

- healthy chain-built schema reports nothing
- a single disabled trigger is caught by name
- `DISABLE TRIGGER ALL` on a table reports both of that table's triggers, in sorted order, rather than short-circuiting on the first

Run against a real `postgres:18.6` with the schema built from the `alembic_pg` chain — no mocks. Red first (ImportError), then green; `test_counter_cascades.py` still passes. Skips cleanly on the MariaDB default. mypy and ruff clean.

`validate()` itself is not exercised end-to-end here: it needs a live MariaDB source alongside the PG target, and the only MariaDB with real data is prod, where the per-table `COUNT(*)` sweep across 46.5M rows isn't worth firing off for this. The wiring is verified to load and be reachable; the query is covered by the tests above. It gets its real run at rehearsal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
