### PR TITLE
fix(pg-migration): pass --userns=host so pgloader runs under userns-remap

### DIFF
--- a/docs/postgres-cutover-runbook.md
+++ b/docs/postgres-cutover-runbook.md
@@ -1,8 +1,9 @@
 # Postgres cutover runbook
 
 Migrating production from MariaDB to Postgres. Every step here was executed
-at prod scale (46.5M rows) against the dev restore on 2026-08-20/21; the
-sharp edges are annotated with what they cost when first hit. The executable
+at prod scale against the dev restore on 2026-08-20/21, and end-to-end from
+kyouko into the prod target on 2026-08-21 (52.3M rows); the sharp edges are
+annotated with what they cost when first hit. The executable
 half lives in `scripts/pg_migration/` (`migrate.py` + the pgloader template).
 
 Related decisions: ADR-0008 (citext), ADR-0009 (counter triggers), ADR-0010
@@ -11,9 +12,16 @@ Related decisions: ADR-0008 (citext), ADR-0009 (counter triggers), ADR-0010
 ## 0. Rehearse first
 
 Run this entire runbook against a scratch target database before the real
-window. All tooling is idempotent — a failed step reruns safely. Rehearsal
-wall-clock at current scale: schema ~5s, load ~7 min, post ~4 min, validate
-~2 min.
+window. All tooling is idempotent — a failed step reruns safely.
+
+Rehearse on the machine that will run the real migration, not just against a
+representative source: the 2026-08-21 rehearsal was the first to run from
+kyouko, and it immediately failed on a docker/userns incompatibility (step 6)
+that every earlier rehearsal elsewhere had missed. A rehearsal that skips the
+real host does not cover the host.
+
+Wall-clock, kyouko → tomoyo at 52.3M rows / 2.4 GB: `load` 3m10s, the other
+four steps ~41s combined, ~3m50s for `all`.
 
 ## 1. Prerequisites
 
@@ -120,7 +128,9 @@ validate (per-table source-vs-target counts; exits non-zero on any diff).
 Steps can be rerun individually; `prep` + `load` restart a botched copy from
 clean. The pgloader settings in the template are load-bearing — concurrency 1
 (thread race), small batches (heap exhaustion on wide rows), docker `-t`
-(SBCL /dev/tty crash); don't "optimize" them without re-rehearsing.
+(SBCL /dev/tty crash), docker `--userns=host` (a daemon with `userns-remap`
+refuses `--network host`, and the remapped container root cannot read the
+0600 load file); don't "optimize" them without re-rehearsing.
 
 The rendered load file and pgloader log land in `/tmp/pg-migration-*/`
 (mode 0700) and contain both database URLs **with credentials** — remove

--- a/scripts/pg_migration/migrate.py
+++ b/scripts/pg_migration/migrate.py
@@ -145,6 +145,12 @@ def load() -> None:
                 "run",
                 "--rm",
                 "-t",
+                # --userns=host is required, not a convenience: a daemon with
+                # userns-remap enabled refuses --network host outright, and
+                # without it the remapped container root cannot read the 0600
+                # load file below (it holds both URLs, credentials included, so
+                # loosening the mode is not the trade to make).
+                "--userns=host",
                 "--network",
                 "host",
                 "-v",


### PR DESCRIPTION
## Problem

`load()` ran pgloader with `docker run --network host`. A daemon configured with `"userns-remap": "default"` — which is kyouko's config, the machine that runs the migration — refuses that outright:

```
docker: Error response from daemon: cannot share the host's network namespace
when user namespaces are enabled
```

The load died on contact. Every earlier rehearsal ran against a dev restore from somewhere else, so nothing had exercised the actual migration host, and this would have surfaced mid-window with writes already frozen.

## Why not just drop `--network host`

That was my first instinct, and it's wrong. Both databases are on the LAN, so bridge networking reaches them fine — I verified that. But with userns-remap still active, container root maps to a subuid that cannot read the rendered load file:

```
$ docker run --rm -v <0600 file>:/f:ro alpine cat /f
cat: can't open '/f': Permission denied
```

That file is mode 0600 because it holds both database URLs with credentials. Relaxing it to satisfy the sandbox trades a real secret for a cosmetic fix. `--userns=host` resolves the network refusal *and* keeps the file readable at 0600, so it belongs with `-t` in the load-bearing set rather than reading as an incidental flag — hence the comment at the call site.

## Verification

Full `migrate.py all`, prod MariaDB → prod Postgres target, after the fix:

- 52,323,759 rows / 2.4 GB, `load` 3m10s, `all` 3m50s
- all 44 tables match source exactly; `bans` loads empty as documented
- `validate: 44 tables match, all triggers enabled` — first run of the trigger assertion from 784ae63 against a real loaded database
- 0 sequences behind `max(pk)`; citext matched a fully case-swapped username (ADR-0008)

Load superuser granted for the run and revoked after; `/tmp/pg-migration-*` removed.

## Runbook

`--userns=host` recorded with the other load-bearing flags in §6. Stale wall-clock figures in §0 replaced with measured ones (the old `load ~7 min` / `post ~4 min` predate this dataset and were measured elsewhere). §0 also now says directly that rehearsing on a representative source is not enough — rehearse on the host that will run the migration, since that omission is exactly what hid this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
