### PR TITLE
fix(images): include sort column in DISTINCT select list for comment filters

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -988,11 +988,22 @@ async def list_images(
     # Subquery: Apply all filters, sort, and limit to get matching image_ids
     # When comment filters are used with JOIN, apply distinct() to avoid duplicate rows
     # (one image can have multiple comments)
-    image_id_subquery = (
-        query.with_only_columns(Images.image_id.label("image_id"))  # type: ignore[union-attr]
-    )
     # Only need distinct when we JOIN with Comments (commenter or commentsearch filters)
-    if commenter is not None or commentsearch is not None:
+    needs_distinct = commenter is not None or commentsearch is not None
+
+    subquery_columns = [Images.image_id.label("image_id")]  # type: ignore[union-attr]
+    if needs_distinct and sort_column.key != "image_id":
+        # Postgres rejects an ORDER BY expression that is absent from a SELECT
+        # DISTINCT select list; MySQL permits it, which is why this only broke
+        # after the cutover. Adding the sort column cannot change which rows
+        # survive DISTINCT: it comes from Images, so it is constant per
+        # image_id and (image_id, sort_column) collapses exactly as image_id
+        # alone. Sorts whose get_column() already resolves to image_id
+        # (image_id, date_added) satisfy the rule and must not add a duplicate.
+        subquery_columns.append(sort_column)
+
+    image_id_subquery = query.with_only_columns(*subquery_columns)
+    if needs_distinct:
         image_id_subquery = image_id_subquery.distinct()
 
     imageset = (

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -8,6 +8,7 @@ These tests cover the /api/v1/images endpoints including:
 """
 
 from datetime import UTC, datetime
+from decimal import Decimal
 
 import pytest
 from httpx import AsyncClient
@@ -2837,6 +2838,77 @@ class TestCommentFilters:
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 0
+
+    @pytest.mark.parametrize("sort_by", ["favorites", "last_post", "total_pixels"])
+    async def test_filter_by_commenter_with_non_id_sort(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        sample_image_data: dict,
+        sort_by: str,
+    ):
+        """Comment filters must work with sorts that are not image_id.
+
+        The commenter/commentsearch path JOINs Comments and applies DISTINCT to
+        the id subquery. Postgres requires every ORDER BY expression to appear in
+        a SELECT DISTINCT select list; MySQL does not. Sorts whose get_column()
+        resolves to image_id (image_id, date_added) hid this — every other sort
+        raised InvalidColumnReferenceError and returned 500 in production.
+        """
+        from app.models import Comments
+
+        user = Users(
+            username=f"sortcommenter_{sort_by}",
+            email=f"sc_{sort_by}@test.com",
+            password="testpass",
+            password_type="bcrypt",
+            salt="testsalt0000003",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        # Two images the user commented on, with different sort-column values so
+        # the ordering assertion below is meaningful rather than incidental.
+        low_data = sample_image_data.copy()
+        low_data.update({"filename": f"low_{sort_by}", "md5_hash": f"lo{sort_by:>014}"[:32]})
+        high_data = sample_image_data.copy()
+        high_data.update({"filename": f"high_{sort_by}", "md5_hash": f"hi{sort_by:>014}"[:32]})
+        low, high = Images(**low_data), Images(**high_data)
+        db_session.add_all([low, high])
+        await db_session.flush()
+
+        low_value, high_value = {
+            "favorites": (1, 99),
+            "last_post": (
+                datetime(2020, 1, 1, tzinfo=UTC),
+                datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+            # decimal(6,3) unsigned megapixels in prod — keep inside the range.
+            "total_pixels": (Decimal("0.100"), Decimal("200.000")),
+        }[sort_by]
+        setattr(low, sort_by, low_value)
+        setattr(high, sort_by, high_value)
+
+        db_session.add_all(
+            [
+                Comments(image_id=low.image_id, user_id=user.id, post_text="a"),
+                Comments(image_id=high.image_id, user_id=user.id, post_text="b"),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get(
+            f"/api/v1/images?commenter={user.id}&sort_by={sort_by}&sort_order=DESC"
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["total"] == 2
+        # DISTINCT must not drop or duplicate rows, and the sort must be honored.
+        assert [img["filename"] for img in data["images"]] == [
+            f"high_{sort_by}",
+            f"low_{sort_by}",
+        ]
 
     async def test_filter_by_comment_text_like_search(
         self, client: AsyncClient, db_session: AsyncSession, sample_image_data: dict


### PR DESCRIPTION
## Problem

`GET /comments?commenter=N` has returned **HTTP 500 since the Postgres cutover**:

```
asyncpg.exceptions.InvalidColumnReferenceError:
  for SELECT DISTINCT, ORDER BY expressions must appear in select list
```

The commenter/commentsearch path JOINs `Comments` and applies `DISTINCT` to the image_id subquery, then orders by `sort_by.get_column(Images)`. MySQL permits ordering by a column outside the `DISTINCT` select list; Postgres rejects it. The query shape worked for years and broke on contact with the new backend.

Only two of six sorts were safe, because `get_column()` maps both to `image_id`, which is already selected:

| `sort_by` | `get_column()` | before |
|---|---|---|
| `image_id`, `date_added` | `image_id` | 200 |
| `favorites`, `last_post`, `total_pixels`, `bayesian_rating` | own column | **500** |

## Impact

Loki puts the first occurrence in the **02Z hour on 2026-08-22 — the cutover hour** (01:52 UTC) — with nothing before it, and ~300–500 log events/hour since. That matches nginx's ~134 HTTP 500s/hour. **1,742 of 1,746** total 500s were this endpoint.

This was invisible to routine error checks: the traceback prints as raw multi-line text rather than structlog JSON, so it carries no `"level": "error"` field and does not show up in the usual queries. Worth knowing independently of this fix.

## Change

Add the sort column to the select list when `DISTINCT` applies. This cannot change which rows survive — the column comes from `Images`, so it is constant per `image_id`, and `(image_id, sort_column)` collapses exactly as `image_id` alone does. Sorts already resolving to `image_id` are skipped so no duplicate column is emitted.

I considered replacing the `Comments` JOIN with `EXISTS`, which removes the need for `DISTINCT` entirely and is likely faster. That's the better end state, but it restructures a hot path while production is actively throwing 500s, so it belongs in its own change.

## Testing

Red first: all three parametrizations failed with the exact production SQL and error. Green after, on **both backends**:

- Postgres 18.6: 184 passed
- MariaDB: 186 passed

The test is not `postgres_only` — it asserts correct behavior on either backend, so it guards the MariaDB path through the transition window too. It covers `favorites`, `last_post`, and `total_pixels`, and asserts ordering as well as status, so a fix that returned 200 with the sort silently dropped would still fail.

(`total_pixels` is `decimal(6,3) unsigned` megapixels in prod, real range 0–206 — the test uses values inside that range after an out-of-range first attempt failed on MariaDB.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
