### PR TITLE
fix(tag-history): break same-second ties on the editor first

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1750,19 +1750,28 @@ async def get_image_tag_history(
     # Merge in memory and sort by date desc, then a deterministic tiebreak. The
     # row count loaded here is bounded by the image's own tag activity (its current
     # tag_links plus its tag_history rows), which is small in practice — the same
-    # load-all-then-sort approach the user-history endpoint uses. The tiebreak is
-    # (source, id): tag_id for link events vs tag_history_id for history events live
-    # in separate ordinal lanes (0/1) so identical timestamps still order the same
-    # way across requests (the two id spaces are unrelated and could collide).
-    # Both date columns default to current_timestamp; the aware sentinel keeps the
-    # sort total if one is ever null.
+    # load-all-then-sort approach the user-history endpoint uses.
+    #
+    # The tiebreak is (editor, source, id). Editor leads because both date columns
+    # default to current_timestamp, so one save's events all share a second: without
+    # it a second editor's event sorts between two of the first editor's purely on
+    # id, and one save reads as two. Then (source, id): tag_id for link events vs
+    # tag_history_id for history events live in separate ordinal lanes (0/1) so
+    # identical timestamps still order the same way across requests (the two id
+    # spaces are unrelated and could collide). The aware sentinel keeps the sort
+    # total if a date is ever null, and 0 stands in for an unknown editor.
     epoch = datetime(1, 1, 1, tzinfo=UTC)
-    events: list[tuple[datetime, int, int, ImageTagHistoryResponse]] = []
+
+    def editor_id(user: Users | None) -> int:
+        return user.user_id if user is not None and user.user_id is not None else 0
+
+    events: list[tuple[datetime, int, int, int, ImageTagHistoryResponse]] = []
 
     for link, tag, user in link_rows:
         events.append(
             (
                 link.date_linked or epoch,
+                editor_id(user),
                 0,  # source lane: link events
                 link.tag_id or 0,
                 ImageTagHistoryResponse(
@@ -1789,6 +1798,7 @@ async def get_image_tag_history(
         events.append(
             (
                 history.date or epoch,
+                editor_id(user),
                 1,  # source lane: history events
                 history.tag_history_id or 0,
                 ImageTagHistoryResponse(
@@ -1803,11 +1813,11 @@ async def get_image_tag_history(
             )
         )
 
-    events.sort(key=lambda e: (e[0], e[1], e[2]), reverse=True)
+    events.sort(key=lambda e: (e[0], e[1], e[2], e[3]), reverse=True)
 
     total = len(events)
     start = pagination.offset
-    items = [event[3] for event in events[start : start + pagination.per_page]]
+    items = [event[4] for event in events[start : start + pagination.per_page]]
 
     return ImageTagHistoryListResponse(
         total=total,

--- a/tests/api/v1/test_image_tag_history_endpoint.py
+++ b/tests/api/v1/test_image_tag_history_endpoint.py
@@ -5,6 +5,8 @@ Tests that image tag history (tags added/removed to a specific image) can be ret
 with proper pagination, tag info (LinkedTag), and user info.
 """
 
+from datetime import UTC, datetime
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -686,3 +688,99 @@ class TestGetImageTagHistory:
 
         # User should be null
         assert data["items"][0]["user"] is None
+
+    async def test_same_second_edits_keep_each_editor_together(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """Within one second, an editor's events must not be split by another editor.
+
+        tag_links.date_linked defaults to CURRENT_TIMESTAMP, so every link one save
+        writes shares a wall-clock second. Breaking that tie on tag_id alone lets a
+        second editor's link sort between two of the first editor's, which reads as
+        the first editor having edited twice.
+        """
+        editor = Users(
+            username="samesecondeditor",
+            password="hashed",
+            password_type="bcrypt",
+            salt="",
+            email="samesecondeditor@example.com",
+            active=1,
+        )
+        other = Users(
+            username="samesecondother",
+            password="hashed",
+            password_type="bcrypt",
+            salt="",
+            email="samesecondother@example.com",
+            active=1,
+        )
+        db_session.add_all([editor, other])
+        await db_session.commit()
+        await db_session.refresh(editor)
+        await db_session.refresh(other)
+
+        image = Images(
+            filename="samesecond1",
+            ext="jpg",
+            md5_hash="samesecondmd5111111111111111111",
+            user_id=editor.user_id,
+            width=100,
+            height=100,
+            filesize=1000,
+        )
+        db_session.add(image)
+        await db_session.commit()
+        await db_session.refresh(image)
+
+        # tag_id is auto-increment, so creating them in this order puts the other
+        # editor's tag between the first editor's two under a tag_id tiebreak.
+        lower = Tags(title="same second lower", type=TagType.THEME)
+        middle = Tags(title="same second middle", type=TagType.THEME)
+        upper = Tags(title="same second upper", type=TagType.THEME)
+        db_session.add_all([lower, middle, upper])
+        await db_session.commit()
+        await db_session.refresh(lower)
+        await db_session.refresh(middle)
+        await db_session.refresh(upper)
+
+        linked_at = datetime(2013, 1, 26, 21, 11, 11, tzinfo=UTC)
+        db_session.add_all(
+            [
+                TagLinks(
+                    image_id=image.image_id,
+                    tag_id=lower.tag_id,
+                    user_id=editor.user_id,
+                    date_linked=linked_at,
+                ),
+                TagLinks(
+                    image_id=image.image_id,
+                    tag_id=middle.tag_id,
+                    user_id=other.user_id,
+                    date_linked=linked_at,
+                ),
+                TagLinks(
+                    image_id=image.image_id,
+                    tag_id=upper.tag_id,
+                    user_id=editor.user_id,
+                    date_linked=linked_at,
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{image.image_id}/tag-history")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data["items"]) == 3
+
+        # Collapse the response into runs of consecutive editors: an editor that
+        # appears in two runs is one whose single save was split apart.
+        editors = [item["user"]["user_id"] for item in data["items"]]
+        runs = [
+            user_id
+            for position, user_id in enumerate(editors)
+            if position == 0 or editors[position - 1] != user_id
+        ]
+        assert len(runs) == len(set(runs)), f"an editor was split across runs: {editors}"


### PR DESCRIPTION
Closes #362.

`GET /api/v1/images/{id}/tag-history` sorted merged events on `(date, source_lane, id)` — where `id` is `tag_id` for the `tag_links`-derived "added" events. Nothing in the tiebreak was the editor.

`date_linked` defaults to `CURRENT_TIMESTAMP`, so every link one save writes shares a wall-clock second. Two people tagging an image in the same second interleaved purely by `tag_id`, so one editor's single save came back split around the other's. Image 116009 at `2013-01-26 21:11:11` served `anonymous_object`, `tw`, then three more `anonymous_object` rows.

## Fix

Editor joins the tiebreak ahead of the lane and id, with `0` standing in for an unknown editor (the `Users` join is an outer join). The lane/id tiebreak is unchanged and still keeps the two unrelated id spaces from colliding.

## Test

`test_same_second_edits_keep_each_editor_together` — three `tag_links` sharing one explicit `date_linked`, with the second editor's `tag_id` between the first editor's two, which is the real 116009 shape. It collapses the response into runs of consecutive editors and asserts no editor appears in two runs.

Written first; failed with `an editor was split across runs: [4, 5, 4]`.

## Verification

Against the real 116009 row in the dev DB, at that second:

- before — `(2, 'Mai')`, `(10, 'Izumi Konata')`, `(2, 'Hisen-Ko')`, `(2, 'Felicia')`, `(2, 'Chun-Li')`
- after — `(10, 'Izumi Konata')`, `(2, 'Mai')`, `(2, 'Hisen-Ko')`, `(2, 'Felicia')`, `(2, 'Chun-Li')`

No split editors anywhere in that image's 39 events.

`uv run pytest tests/api/v1/`: 1434 passed, 4 skipped (pre-existing). `uv run mypy app/api/v1/images.py`: clean. ruff check + format: clean.

## Frontend

No response model changed — ordering only — so the generated types need no regeneration.

`<shuushuu-frontend-repo>` #402 fixes the consumer side of the same bug (its history page grouped by adjacency, so the split editor produced a duplicate each-key and hydration threw, blanking the route). That fix stands on its own — the frontend can't depend on this ordering, and the deployed API won't carry this yet. With both applied, image 116009 renders identically to frontend-only: 17 groups, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZjH4obi8fBWhuyDTEEmRP