### PR TITLE
fix(nginx): serve stub_status on a loopback-published port for Datadog

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -132,9 +132,18 @@ services:
       # only runs in prod and its public URL is fixed. The .conf glob
       # in nginx.conf picks it up automatically.
       - ./docker/nginx/conf.d/wiki.conf:/etc/nginx/conf.d/wiki.conf:ro
+      # stub_status on :8081 for the Datadog nginx check. Same .conf glob
+      # picks it up. Published to 127.0.0.1 only — see ports below.
+      - ./docker/nginx/conf.d/stub-status.conf:/etc/nginx/conf.d/stub-status.conf:ro
       # LE certs land here via the certbot service. Read-only for nginx;
       # certbot has it RW.
       - ./docker/certbot/conf:/etc/letsencrypt:ro
+    ports:
+      # Appended to the base file's 80/443. Bound to loopback so the status
+      # endpoint is reachable by dd-agent on this host and by nothing off it;
+      # docker is the boundary rather than an nginx allow/deny on a bridge
+      # subnet that can change.
+      - "127.0.0.1:8081:8081"
     depends_on:
       - api
       - frontend

--- a/docker/nginx/conf.d/stub-status.conf
+++ b/docker/nginx/conf.d/stub-status.conf
@@ -1,0 +1,38 @@
+# =============================================================================
+# stub_status endpoint for the Datadog nginx check (host-local ONLY)
+# =============================================================================
+# Auto-included at http level by the /etc/nginx/conf.d/*.conf glob in
+# nginx.conf.
+#
+# Why its own port rather than a location on the public vhost: the check runs
+# as dd-agent on the host and reaches the container through docker-proxy, so
+# nginx sees a docker-bridge source address, not 127.0.0.1. An
+# `allow 127.0.0.1; deny all;` block on :80 would reject it, and widening the
+# allow to the bridge subnet ties the ACL to a subnet that can change. Binding
+# the published port to 127.0.0.1 on the host instead makes docker itself the
+# boundary: nothing off-box can route to it.
+#
+# Not 8080: that port is the SSR API proxy, deliberately unpublished so
+# external clients cannot reach it even with a spoofed Host header. Publishing
+# 8080 to reuse it here would undo that.
+#
+# Published in docker-compose.prod.yml as 127.0.0.1:8081:8081.
+# =============================================================================
+server {
+    listen 8081;
+    server_name _;
+
+    # The check polls every 15s; that is 5,760 lines a day of no value, and
+    # alloy tails this directory into Loki.
+    access_log off;
+
+    location = /nginx_status {
+        stub_status;
+    }
+
+    # Anything else on this port is a mistake — do not fall through to a
+    # default handler that might serve real content.
+    location / {
+        return 404;
+    }
+}


### PR DESCRIPTION
## Problem

The Datadog nginx check has failed **6,532 consecutive times** since it was configured — 0 metric samples, `Last Successful Execution Date: Never`.

It polls `http://localhost/nginx_status`, which matches no `server_name`, falls through to the default vhost, redirects to `https://e-shuushuu.net` and 404s. `stub_status` was never configured anywhere in `docker/`, so the endpoint it was written against did not exist.

```
Instance ID: nginx:3c99f6380abf9d72 [ERROR]
Total Runs: 6,532
Metric Samples: Last Run: 0, Total: 0
Last Successful Execution Date : Never
Error: 404 Client Error: Not Found for url: https://e-shuushuu.net/nginx_status
```

## Approach

Serve `stub_status` from its own server block on `:8081`, published as `127.0.0.1:8081` so docker is the boundary and nothing off-box can route to it.

A `location` on `:80` does not work: dd-agent runs on the host and reaches the container through docker-proxy, so nginx sees a **docker-bridge source address rather than `127.0.0.1`**, and an `allow 127.0.0.1; deny all;` block would reject it. Widening the allow to the bridge subnet would tie the ACL to a subnet that can change.

**Not reusing `:8080`** — that is the SSR API proxy, deliberately unpublished so external clients cannot reach it even with a spoofed `Host` header. Publishing it to save a port would undo that.

## Verification

- Merged compose config **appends** this to the base file's 80/443 rather than replacing them — both remain on `0.0.0.0`, 8081 on `127.0.0.1`
- The server block passes `nginx -t`

## Scope

Worth being explicit about the payoff: `stub_status` carries connection and request counts with **no status-code breakdown**. This fixes a permanently red check and gives connection metrics. It is not 5xx alerting — that is #TBD (`feat/grafana-5xx-alert`), which reads the access logs via Loki.

Takes effect only once the nginx container is recreated, which briefly drops 80/443.

The paired ansible change (pointing the check at the new endpoint) is already on `main` in the iac repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)