### PR TITLE
feat(grafana): alert on sustained nginx 5xx, paged via Pushover

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -281,9 +281,16 @@ services:
       - GF_ANALYTICS_REPORTING_ENABLED=false
       - GF_ANALYTICS_CHECK_FOR_UPDATES=false
       - GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES=false
-    # No env_file — only GRAFANA_ADMIN_PASSWORD is needed, and it is already
+      # Resolved by the pushover contact point in
+      # provisioning/alerting/contact-points.yaml, which is git-tracked and so
+      # references $PUSHOVER_* rather than carrying the values. Rendered into
+      # .env by the ansible compose_project role from vault/monitoring.yml.
+      - PUSHOVER_API_TOKEN=${PUSHOVER_API_TOKEN}
+      - PUSHOVER_USER_KEY=${PUSHOVER_USER_KEY}
+    # No env_file — only the variables enumerated above are needed, and they are
     # substituted via ${VAR} in `environment:` (sourced from .env at compose level).
     # This avoids leaking unrelated DB/Redis/etc. credentials into the Grafana container.
+    # Adding an env_file to save enumerating two lines would quietly undo that.
     volumes:
       - grafana_data:/var/lib/grafana
       - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro

--- a/docker/grafana/provisioning/alerting/contact-points.yaml
+++ b/docker/grafana/provisioning/alerting/contact-points.yaml
@@ -1,0 +1,37 @@
+# Grafana contact points.
+#
+# The whole ./docker/grafana/provisioning tree is already mounted read-only
+# into the container, so this directory is picked up with no compose volume
+# change.
+#
+# This file is git-tracked. The secrets MUST stay as $VAR references —
+# never inline the literal token or user key here. They reach the container
+# via the grafana service's environment: block in docker-compose.prod.yml,
+# rendered into .env by the ansible compose_project role from
+# vault/monitoring.yml.
+#
+# Grafana expands $VAR in provisioning files, but coverage for *alerting*
+# provisioning specifically has been inconsistent across versions. The
+# failure is silent: a contact point holding the literal string
+# "$PUSHOVER_API_TOKEN" looks perfectly healthy in the UI and only reveals
+# itself when an alert fails to deliver. Confirm with Alerting → Contact
+# points → Test after deploying; a phone notification is the only real proof.
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: pushover
+    receivers:
+      - uid: pushover_primary
+        type: pushover
+        settings:
+          apiToken: $PUSHOVER_API_TOKEN
+          userKey: $PUSHOVER_USER_KEY
+          # priority 1 = high: bypasses Pushover's quiet hours. This rule
+          # only fires on a sustained fault, so it should wake someone.
+          priority: "1"
+          # retry/expire apply to priority 2 (emergency) only; harmless at
+          # priority 1 and left in place so raising the priority later does
+          # not also require remembering to add them.
+          retry: "60"
+          expire: "3600"

--- a/docker/grafana/provisioning/alerting/rules.yaml
+++ b/docker/grafana/provisioning/alerting/rules.yaml
@@ -1,0 +1,96 @@
+# Grafana alert rules.
+#
+# Why this exists rather than a Datadog monitor: the Datadog agent ingests no
+# logs from either host (logs_enabled is unset), and its nginx check reports
+# stub_status only — connection and request counts, with no status-code
+# breakdown. Loki already has the nginx access logs. A bug served roughly 130
+# errors an hour for sixteen hours without tripping anything.
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: http-errors
+    folder: Alerts
+    interval: 1m
+    rules:
+      - uid: nginx_5xx_rate
+        title: nginx 5xx errors
+        condition: threshold
+
+        # 10m, against a 5m query window. Deploys recreate the api container
+        # and produce a burst of 5xx while it is down — the fix deploy that
+        # motivated this rule generated ~43 in a few seconds on SSR routes.
+        # That burst stays visible for 5 minutes and then decays, so
+        # requiring the condition to hold for 10 rides out a deploy without
+        # suppressing a genuine sustained fault.
+        for: 10m
+
+        # Load-bearing. Zero 5xx is the healthy state, and a Loki range query
+        # matching nothing returns no series at all — which Grafana treats as
+        # NoData, not as zero. Left at the default this rule pages
+        # continuously while the site is perfectly healthy, and gets muted
+        # within a day.
+        noDataState: OK
+
+        # If the query itself breaks (Loki down, datasource misconfigured),
+        # alert rather than fail open — a silent 5xx alarm is the thing this
+        # rule exists to prevent.
+        execErrState: Alerting
+
+        annotations:
+          # Deliberately not a numbered container name: docker-rollout
+          # increments it on every deploy (already -33 -> -34), so a hardcoded
+          # one is stale by the time anyone reads the alert.
+          summary: >-
+            nginx is serving 5xx responses. Check the api logs with
+            `docker compose -f docker-compose.yml -f docker-compose.prod.yml
+            logs --tail=200 api` — tracebacks there are raw text, not
+            structlog, so level-based queries will not surface them. If the
+            burst coincides with a deploy it will decay on its own; this rule
+            waits 10m precisely so it does not page for that.
+        labels:
+          severity: warning
+
+        # Attaches the contact point to this rule directly, in preference to
+        # provisioning a root notification policy — that would replace the
+        # default tree wholesale and silently change routing for anything
+        # added later.
+        notification_settings:
+          receiver: pushover
+
+        data:
+          - refId: query
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: loki
+            model:
+              refId: query
+              queryType: instant
+              # The regexp parser, not a `|= " 500 "` substring filter: the
+              # substring form misses 502 and 503 entirely, and false-positives
+              # on any response whose byte count happens to be 500.
+              expr: >-
+                sum(count_over_time({container_name="shuushuu-nginx-prod"}
+                | regexp `" (?P<status>\d{3}) \d+ `
+                | status=~`5..` [5m]))
+
+          - refId: threshold
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: threshold
+              type: threshold
+              expression: query
+              conditions:
+                # >5 per 5m. The incident that motivated this produced ~134
+                # HTTP 500s an hour, about 11 per five-minute window — an
+                # intuitive round threshold of 20 would have sat above the
+                # real incident and never fired. 5 leaves headroom over the
+                # healthy baseline of zero while catching a fault that size
+                # comfortably.
+                - evaluator:
+                    type: gt
+                    params: [5]


### PR DESCRIPTION
## Problem

A bug served roughly **130 errors an hour for sixteen hours** without tripping anything.

Datadog cannot cover this without new plumbing: it ingests no logs from either host (`logs_enabled` is unset), and its nginx check reports `stub_status` only — connection and request counts, no status-code breakdown. Repairing that check (#364) would not have caught this bug and will not catch the next one. Loki already has the access logs.

## What this adds

- `docker/grafana/provisioning/alerting/contact-points.yaml` — Pushover receiver
- `docker/grafana/provisioning/alerting/rules.yaml` — the 5xx rule
- Two environment entries on the grafana service

The provisioning tree is already mounted read-only into the container, so `alerting/` is picked up with no compose volume change.

## The two tunables are load-bearing

**Threshold: >5 per 5m.** The incident produced ~134 500s an hour, about 11 per five-minute window. An intuitive round threshold of 20 would have sat *above* the real fault and never fired. Five leaves headroom over the healthy baseline of zero.

**Duration: 10m.** Deploys recreate the api container and burst 5xx while nginx has nothing to reach. The query's 5m window keeps that burst visible for 5 minutes before it decays, so 10m rides out a deploy without suppressing a sustained fault.

**`noDataState: OK`** decides whether this survives contact with production. Zero 5xx is the healthy state, and a Loki query matching nothing returns *no series* — which Grafana treats as NoData, not zero. Left at the default, this pages continuously while the site is perfectly healthy and gets muted within a day.

The query uses the `regexp` parser rather than a `|= " 500 "` substring filter: the substring form misses 502 and 503 entirely and false-positives on any response whose byte count happens to be 500.

## Verification

Ran the LogQL against **live Loki** before committing. It returned `13` over 5m — because an api redeploy was three minutes old: 13 502s from the container gap, plus 3 500s that were also transient (`/api/v1/images.atom` returns 200 now).

So the exact burst `for: 10m` exists to absorb happened during validation. Useful confirmation that 20 would have been the wrong threshold and that the duration matters.

Also verified: both files parse as YAML with the LogQL intact through round-tripping, and the merged compose config substitutes both variables with no `env_file` introduced.

## Secrets

`$PUSHOVER_*` references only — this path is git-tracked and the values must never be inlined. They reach the container through two **explicitly enumerated** environment entries rather than an `env_file`, preserving the existing decision to keep unrelated database and Redis credentials out of Grafana. Values are rendered into `.env` by the ansible `compose_project` role from `vault/monitoring.yml` (already on `main` in iac).

## Verify after deploy

Grafana expands `$VAR` in provisioning files, but coverage for **alerting** provisioning specifically has been inconsistent across versions, and the failure is silent — a contact point holding the literal string `$PUSHOVER_API_TOKEN` looks perfectly healthy in the UI.

**Alerting → Contact points → Test.** A phone notification is the only real proof. Then confirm the rule shows *Normal* rather than *Error*, and force a real firing — an alert that has never fired is not an alert.

The annotation deliberately avoids naming a numbered container: docker-rollout increments it every deploy and it had already moved from `-33` to `-34`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)