### PR TITLE
fix(tags): rank linked characters/sources by shared images

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -73,6 +73,7 @@ from app.schemas.tag import (
     TagWithStats,
 )
 from app.schemas.tag_suggestion_stats import TagSuggestionStatsResponse, TagSuggestionUserStats
+from app.services.character_source_counts import get_shared_image_counts
 from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 from app.services.search import sync_tag_delete_to_search, sync_tag_to_search
 from app.services.tag_type_flags import refresh_images_tag_type_flags
@@ -1056,7 +1057,7 @@ async def get_characters_for_source(
     )
 
 
-def _linked_tag_entry(row: Any) -> dict[str, Any]:
+def _linked_tag_entry(row: Any, shared_counts: dict[int, int]) -> dict[str, Any]:
     """Build a LinkedTagWithPicture dict from a get_tag relationship row."""
     (
         tag_id,
@@ -1079,6 +1080,8 @@ def _linked_tag_entry(row: Any) -> dict[str, Any]:
         "type": tag_type,
         "usage_count": usage_count,
         "link_id": link_id,
+        # Absent from the map means the two tags never co-occur.
+        "shared_image_count": shared_counts.get(tag_id, 0),
     }
     # Re-checked at read time: an image deactivated after being chosen must
     # not leak through the embed — the card falls back to its placeholder.
@@ -1094,10 +1097,21 @@ def _linked_tag_entry(row: Any) -> dict[str, Any]:
     return entry
 
 
+def _rank_by_shared_images(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Order linked-tag entries by shared image count, most first.
+
+    The caller's query already ordered them by title, and Python's sort is
+    stable, so title remains the tiebreaker without repeating the collation
+    here.
+    """
+    return sorted(entries, key=lambda entry: -entry["shared_image_count"])
+
+
 @router.get("/{tag_id}", response_model=TagWithStats)
 async def get_tag(
     tag_id: Annotated[int, Path(description="Tag ID")],
     db: AsyncSession = Depends(get_db),
+    redis_client: redis.Redis = Depends(get_redis),  # type: ignore[type-arg]
     current_user: Users | None = Depends(get_optional_current_user),
 ) -> TagWithStats:
     """
@@ -1219,8 +1233,8 @@ async def get_tag(
     characters: list[dict[str, Any]] = []
 
     if tag.type == TagType.CHARACTER:
-        # Get all sources linked to this character
-        # Sorted by usage_count descending with title as tiebreaker
+        # Get all sources linked to this character, ranked by how many images
+        # carry both tags (see _rank_by_shared_images) with title as tiebreaker
         sources_result = await db.execute(
             select(  # type: ignore[call-overload]
                 Tags.tag_id,
@@ -1247,13 +1261,16 @@ async def get_tag(
             )
             .outerjoin(Images, Images.image_id == CharacterSourceLinkPictures.image_id)
             .where(CharacterSourceLinks.character_tag_id == tag_id)
-            .order_by(desc(Tags.usage_count), Tags.title)  # type: ignore[arg-type]
+            .order_by(Tags.title)
         )
-        sources = [_linked_tag_entry(row) for row in sources_result.all()]
+        shared_counts = await get_shared_image_counts(db, tag_id, "source", redis_client)
+        sources = _rank_by_shared_images(
+            [_linked_tag_entry(row, shared_counts) for row in sources_result.all()]
+        )
 
     elif tag.type == TagType.SOURCE:
-        # Get all characters linked to this source
-        # Sorted by usage_count descending with title as tiebreaker
+        # Get all characters linked to this source, ranked by how many images
+        # carry both tags (see _rank_by_shared_images) with title as tiebreaker
         characters_result = await db.execute(
             select(  # type: ignore[call-overload]
                 Tags.tag_id,
@@ -1280,9 +1297,12 @@ async def get_tag(
             )
             .outerjoin(Images, Images.image_id == CharacterSourceLinkPictures.image_id)
             .where(CharacterSourceLinks.source_tag_id == tag_id)
-            .order_by(desc(Tags.usage_count), Tags.title)  # type: ignore[arg-type]
+            .order_by(Tags.title)
         )
-        characters = [_linked_tag_entry(row) for row in characters_result.all()]
+        shared_counts = await get_shared_image_counts(db, tag_id, "character", redis_client)
+        characters = _rank_by_shared_images(
+            [_linked_tag_entry(row, shared_counts) for row in characters_result.all()]
+        )
 
     return TagWithStats(
         tag_id=tag.tag_id or 0,

--- a/app/schemas/tag.py
+++ b/app/schemas/tag.py
@@ -161,6 +161,10 @@ class LinkedTagWithPicture(LinkedTag):
 
     link_id: int
     picture: LinkPictureInfo | None = None
+    # Images carrying both this tag and the one being viewed - what the list is
+    # ordered by. Raw tag_links intersection, so it is comparable to
+    # usage_count rather than to the status-aware total_image_count.
+    shared_image_count: int = 0
 
 
 class TagWithStats(TagResponse):

--- a/app/services/character_source_counts.py
+++ b/app/services/character_source_counts.py
@@ -1,0 +1,79 @@
+"""TTL-cached image counts shared between a tag and its character-source links.
+
+A source page ranks its linked characters, and a character page its linked
+sources, by how many images carry *both* tags — not by the linked tag's global
+``usage_count``, which floats a big-franchise character to the top of a source
+it barely appears in (Charlotte: 841 images total, 8 of them Genshin Impact).
+
+The count is a raw ``tag_links`` intersection: no status filter, no repost
+filter, no tag hierarchy — the same semantics as the ``usage_count`` it
+replaces for ordering, and the reason it can be cached once for every viewer.
+The join has to expand every tag on every image of the anchor tag, which costs
+~140ms on the largest source in the corpus (Pokémon: 1006 linked characters
+over 16.5k images) and a few ms on a typical one, so the result is cached.
+"""
+
+import json
+from typing import Literal
+
+import redis.asyncio as redis
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.models.character_source_link import CharacterSourceLinks
+from app.models.tag_link import TagLinks
+
+# TTL-only - no per-mutation invalidation. Adding or removing one tag moves one
+# count by one, which almost never reorders the list, so a quarter-hour of lag
+# is not worth coupling the cache to every tag_links write.
+SHARED_COUNT_TTL = 900
+
+LinkedSide = Literal["character", "source"]
+
+
+def _cache_key(anchor_tag_id: int, linked_side: LinkedSide) -> str:
+    return f"csl:shared:{linked_side[0]}:{anchor_tag_id}"
+
+
+async def get_shared_image_counts(
+    db: AsyncSession,
+    anchor_tag_id: int,
+    linked_side: LinkedSide,
+    redis_client: redis.Redis | None = None,  # type: ignore[type-arg]
+) -> dict[int, int]:
+    """Map linked tag_id -> images carrying both it and ``anchor_tag_id``.
+
+    ``linked_side`` names the side of the link being counted: ``"character"``
+    when viewing a source, ``"source"`` when viewing a character. Tags linked
+    to the anchor but sharing no image are absent from the map, so callers
+    should read it with a ``0`` default.
+    """
+    key = _cache_key(anchor_tag_id, linked_side)
+    if redis_client is not None:
+        cached = await redis_client.get(key)
+        if cached is not None:
+            return {int(tag_id): count for tag_id, count in json.loads(cached).items()}
+
+    if linked_side == "character":
+        linked_col = CharacterSourceLinks.character_tag_id
+        anchor_col = CharacterSourceLinks.source_tag_id
+    else:
+        linked_col = CharacterSourceLinks.source_tag_id
+        anchor_col = CharacterSourceLinks.character_tag_id
+
+    anchor_links = aliased(TagLinks)
+    linked_links = aliased(TagLinks)
+    query = (
+        select(linked_links.tag_id, func.count())  # type: ignore[call-overload]
+        .select_from(anchor_links)
+        .join(linked_links, linked_links.image_id == anchor_links.image_id)
+        .join(CharacterSourceLinks, linked_col == linked_links.tag_id)
+        .where(anchor_links.tag_id == anchor_tag_id, anchor_col == anchor_tag_id)
+        .group_by(linked_links.tag_id)
+    )
+    counts: dict[int, int] = dict((await db.execute(query)).all())  # type: ignore[arg-type]
+
+    if redis_client is not None:
+        await redis_client.setex(key, SHARED_COUNT_TTL, json.dumps(counts))
+    return counts

--- a/tests/api/v1/test_character_source_links.py
+++ b/tests/api/v1/test_character_source_links.py
@@ -9,17 +9,22 @@ These tests cover the /api/v1/character-source-links endpoints including:
 Uses TDD approach - these tests are written before the endpoints are implemented.
 """
 
+import json
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import TagType
+from app.config import ImageStatus, TagType
 from app.core.security import get_password_hash
 from app.models.character_source_link import CharacterSourceLinks
+from app.models.image import Images
 from app.models.permissions import Perms, UserPerms
 from app.models.tag import Tags
+from app.models.tag_link import TagLinks
 from app.models.user import Users
+from app.services.character_source_counts import _cache_key
 
 # =============================================================================
 # Fixtures
@@ -987,11 +992,13 @@ class TestLinkedTagUsageCount:
         for char in data["characters"]:
             assert "usage_count" in char
 
-        # Verify sorted by usage_count descending (char1 should be first with 100)
-        assert data["characters"][0]["usage_count"] == 100
+        # Neither character shares an image with the source, so the order here
+        # is the alphabetical tiebreaker, not usage_count (see
+        # TestLinkedTagSharedImageCount for the ranking rule).
         assert data["characters"][0]["title"] == "Character A"
-        assert data["characters"][1]["usage_count"] == 50
+        assert data["characters"][0]["usage_count"] == 100
         assert data["characters"][1]["title"] == "Character B"
+        assert data["characters"][1]["usage_count"] == 50
 
     async def test_character_tag_sources_include_usage_count(
         self,
@@ -1031,11 +1038,11 @@ class TestLinkedTagUsageCount:
         for source in data["sources"]:
             assert "usage_count" in source
 
-        # Verify sorted by usage_count descending (source1 should be first with 200)
-        assert data["sources"][0]["usage_count"] == 200
+        # As above: no shared images, so this is the alphabetical tiebreaker.
         assert data["sources"][0]["title"] == "Source A"
-        assert data["sources"][1]["usage_count"] == 75
+        assert data["sources"][0]["usage_count"] == 200
         assert data["sources"][1]["title"] == "Source B"
+        assert data["sources"][1]["usage_count"] == 75
 
     async def test_aliases_include_usage_count(
         self,
@@ -1079,14 +1086,14 @@ class TestLinkedTagUsageCount:
         assert data["aliases"][1]["title"] == "Alias B"
         assert data["aliases"][1]["usage_count"] == 25
 
-    async def test_characters_sorted_by_usage_count_with_title_tiebreaker(
+    async def test_characters_with_no_shared_images_sorted_by_title(
         self,
         client: AsyncClient,
         db_session: AsyncSession,
         source_tag: Tags,
     ):
-        """Test that characters with same usage_count are sorted by title."""
-        # Create characters with same usage count
+        """Test that characters sharing no images with the source sort by title."""
+        # Same usage count, and neither is on any of the source's images
         char_b = Tags(title="Character B", type=TagType.CHARACTER, usage_count=100)
         char_a = Tags(title="Character A", type=TagType.CHARACTER, usage_count=100)
         db_session.add_all([char_b, char_a])
@@ -1111,6 +1118,229 @@ class TestLinkedTagUsageCount:
         assert response.status_code == 200
         data = response.json()
 
-        # Same usage_count, should be sorted alphabetically by title
+        # Tied at zero shared images, so sorted alphabetically by title
         assert data["characters"][0]["title"] == "Character A"
         assert data["characters"][1]["title"] == "Character B"
+
+
+# =============================================================================
+# Shared-image-count ordering
+# =============================================================================
+
+# Distinct id ranges so the seed helpers below never collide with other fixtures.
+_SIC_IMG_BASE = 971000
+
+
+async def _tag_images(
+    db: AsyncSession, tag_ids: list[int], first_image_id: int, count: int
+) -> None:
+    """Create ``count`` active images and link every tag in ``tag_ids`` to each."""
+    for offset in range(count):
+        image_id = first_image_id + offset
+        db.add(
+            Images(
+                image_id=image_id,
+                user_id=1,
+                ext="jpg",
+                status=ImageStatus.ACTIVE,
+                width=800,
+                height=600,
+            )
+        )
+    # Flush so the image rows exist before the tag_links rows referencing them.
+    await db.flush()
+    for offset in range(count):
+        for tag_id in tag_ids:
+            db.add(TagLinks(tag_id=tag_id, image_id=first_image_id + offset))
+    await db.flush()
+
+
+@pytest.mark.api
+class TestLinkedTagSharedImageCount:
+    """Linked characters/sources rank by images shared with the tag being viewed.
+
+    The old ordering used the linked tag's global usage_count, which floated
+    big-franchise characters to the top of a source they barely appear in.
+    """
+
+    async def test_characters_rank_by_images_shared_with_the_source(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        source_tag: Tags,
+    ):
+        """A character with more total images but fewer on this source ranks lower."""
+        # Sorts first by title and has the higher usage_count, so ranking it
+        # second can only come from the shared count.
+        broad = Tags(title="Aaa Broad", type=TagType.CHARACTER)
+        focused = Tags(title="Zzz Focused", type=TagType.CHARACTER)
+        db_session.add_all([broad, focused])
+        await db_session.flush()
+
+        # Broad: 3 images, 1 of them also tagged with the source.
+        await _tag_images(db_session, [broad.tag_id, source_tag.tag_id], _SIC_IMG_BASE, 1)
+        await _tag_images(db_session, [broad.tag_id], _SIC_IMG_BASE + 10, 2)
+        # Focused: 2 images, both also tagged with the source.
+        await _tag_images(db_session, [focused.tag_id, source_tag.tag_id], _SIC_IMG_BASE + 20, 2)
+
+        db_session.add_all(
+            [
+                CharacterSourceLinks(
+                    character_tag_id=broad.tag_id, source_tag_id=source_tag.tag_id
+                ),
+                CharacterSourceLinks(
+                    character_tag_id=focused.tag_id, source_tag_id=source_tag.tag_id
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/tags/{source_tag.tag_id}")
+        assert response.status_code == 200
+        characters = response.json()["characters"]
+
+        assert [c["title"] for c in characters] == ["Zzz Focused", "Aaa Broad"]
+        assert [c["shared_image_count"] for c in characters] == [2, 1]
+        # The global count is still reported, and still favours the loser.
+        assert [c["usage_count"] for c in characters] == [2, 3]
+
+    async def test_sources_rank_by_images_shared_with_the_character(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        character_tag: Tags,
+    ):
+        """Same rule in reverse: sources on a character page."""
+        broad = Tags(title="Aaa Broad Source", type=TagType.SOURCE)
+        focused = Tags(title="Zzz Focused Source", type=TagType.SOURCE)
+        db_session.add_all([broad, focused])
+        await db_session.flush()
+
+        await _tag_images(db_session, [broad.tag_id, character_tag.tag_id], _SIC_IMG_BASE + 100, 1)
+        await _tag_images(db_session, [broad.tag_id], _SIC_IMG_BASE + 110, 2)
+        await _tag_images(
+            db_session, [focused.tag_id, character_tag.tag_id], _SIC_IMG_BASE + 120, 2
+        )
+
+        db_session.add_all(
+            [
+                CharacterSourceLinks(
+                    character_tag_id=character_tag.tag_id, source_tag_id=broad.tag_id
+                ),
+                CharacterSourceLinks(
+                    character_tag_id=character_tag.tag_id, source_tag_id=focused.tag_id
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/tags/{character_tag.tag_id}")
+        assert response.status_code == 200
+        sources = response.json()["sources"]
+
+        assert [s["title"] for s in sources] == ["Zzz Focused Source", "Aaa Broad Source"]
+        assert [s["shared_image_count"] for s in sources] == [2, 1]
+
+    async def test_equal_shared_counts_fall_back_to_title(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        source_tag: Tags,
+    ):
+        """Characters tied on shared count are ordered alphabetically."""
+        char_b = Tags(title="Character B", type=TagType.CHARACTER)
+        char_a = Tags(title="Character A", type=TagType.CHARACTER)
+        db_session.add_all([char_b, char_a])
+        await db_session.flush()
+
+        await _tag_images(db_session, [char_a.tag_id, source_tag.tag_id], _SIC_IMG_BASE + 200, 2)
+        await _tag_images(db_session, [char_b.tag_id, source_tag.tag_id], _SIC_IMG_BASE + 210, 2)
+
+        db_session.add_all(
+            [
+                CharacterSourceLinks(
+                    character_tag_id=char_a.tag_id, source_tag_id=source_tag.tag_id
+                ),
+                CharacterSourceLinks(
+                    character_tag_id=char_b.tag_id, source_tag_id=source_tag.tag_id
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/tags/{source_tag.tag_id}")
+        assert response.status_code == 200
+        characters = response.json()["characters"]
+
+        assert [c["title"] for c in characters] == ["Character A", "Character B"]
+        assert [c["shared_image_count"] for c in characters] == [2, 2]
+
+    async def test_character_sharing_no_images_reports_zero(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        source_tag: Tags,
+    ):
+        """A linked character that appears on none of the source's images counts zero."""
+        char = Tags(title="Unseen Character", type=TagType.CHARACTER)
+        db_session.add(char)
+        await db_session.flush()
+        await _tag_images(db_session, [char.tag_id], _SIC_IMG_BASE + 300, 1)
+        db_session.add(
+            CharacterSourceLinks(character_tag_id=char.tag_id, source_tag_id=source_tag.tag_id)
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/tags/{source_tag.tag_id}")
+        assert response.status_code == 200
+        assert response.json()["characters"][0]["shared_image_count"] == 0
+
+    async def test_shared_counts_are_written_to_the_cache(
+        self,
+        client_real_redis: AsyncClient,
+        redis_client,
+        db_session: AsyncSession,
+        source_tag: Tags,
+    ):
+        """A cold request stores the computed count map under the source's key."""
+        char = Tags(title="Cached Character", type=TagType.CHARACTER)
+        db_session.add(char)
+        await db_session.flush()
+        await _tag_images(db_session, [char.tag_id, source_tag.tag_id], _SIC_IMG_BASE + 400, 2)
+        db_session.add(
+            CharacterSourceLinks(character_tag_id=char.tag_id, source_tag_id=source_tag.tag_id)
+        )
+        await db_session.commit()
+
+        response = await client_real_redis.get(f"/api/v1/tags/{source_tag.tag_id}")
+        assert response.status_code == 200
+        assert response.json()["characters"][0]["shared_image_count"] == 2
+
+        cached = await redis_client.get(_cache_key(source_tag.tag_id, "character"))
+        assert cached is not None
+        assert json.loads(cached) == {str(char.tag_id): 2}
+
+    async def test_cached_shared_counts_are_used_instead_of_querying(
+        self,
+        client_real_redis: AsyncClient,
+        redis_client,
+        db_session: AsyncSession,
+        source_tag: Tags,
+    ):
+        """A populated key is trusted: the response reports the cached count."""
+        char = Tags(title="Cached Character", type=TagType.CHARACTER)
+        db_session.add(char)
+        await db_session.flush()
+        # One image actually shared - the cache will claim otherwise.
+        await _tag_images(db_session, [char.tag_id, source_tag.tag_id], _SIC_IMG_BASE + 500, 1)
+        db_session.add(
+            CharacterSourceLinks(character_tag_id=char.tag_id, source_tag_id=source_tag.tag_id)
+        )
+        await db_session.commit()
+        await redis_client.set(
+            _cache_key(source_tag.tag_id, "character"), json.dumps({str(char.tag_id): 42})
+        )
+
+        response = await client_real_redis.get(f"/api/v1/tags/{source_tag.tag_id}")
+        assert response.status_code == 200
+        assert response.json()["characters"][0]["shared_image_count"] == 42


### PR DESCRIPTION
On a source tag page the linked characters were ordered by the character tag's global `usage_count`, not by how many of that source's images the character actually appears on. On Genshin Impact that put Charlotte (841 images total, 8 of them Genshin) and Layla (668 / 39) above Ganyu (290 / 290) — and since the page truncates to 20 with a "Show all" button, the characters people want were pushed off the visible list. Character pages had the same bug in reverse, ordering sources by the source's global count.

## Change

Both lists now rank by the number of images carrying **both** tags, exposed as a new `shared_image_count` field on `LinkedTagWithPicture`. Title stays the tiebreaker (the SQL query still orders by title and the Python re-rank is stable).

The count is a raw `tag_links` intersection — no status, repost or hierarchy filtering. That keeps it comparable to the `usage_count` it replaces for ordering, and makes it identical for every viewer, which is what lets it be cached: `app/services/character_source_counts.py` follows the existing `feed_count_cache` pattern (TTL-only, no per-mutation invalidation, 15 min).

## Cost

Measured on the dev restore (prod-scale, Postgres 18), warm:

| source | linked chars | images | uncached co-occurrence query |
|---|---|---|---|
| Pokémon (290) | 1006 | 16.5k | ~140ms |
| Touhou (186) | 190 | 87k | ~135ms |
| Genshin Impact (216485) | 104 | 4.4k | ~5ms |

With the cache, warm request latency on those pages is unchanged from before this PR; the query runs at most once per 15 minutes per tag.

## Verification

- New `TestLinkedTagSharedImageCount` covers both directions, the zero case, the title tiebreaker, and both sides of the cache (real Redis, real DB).
- Three pre-existing tests in `TestLinkedTagUsageCount` asserted a usage_count ordering that no longer holds. They passed unchanged (their fixtures have no `tag_links`, so everything ties at zero and falls to the title tiebreaker) but their names and comments were misleading, so those were corrected rather than left claiming to test ordering they no longer test.
- Full suite: 2660 passed. `mypy app/` clean.
- Verified against the dev restore: the Genshin Impact page now leads with Ganyu, Raiden Shogun, Lumine, Dehya.

Frontend companion PR removes the client-side re-sort that would otherwise undo this: anonymousobject/shuushuu-frontend#403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1D9tqn9mPti4x6RCBjGpq