### PR TITLE
fix(pg): drop the duplicate FK twins that veto every ON DELETE rule

### DIFF
--- a/alembic_pg/versions/0002_drop_redundant_fk_twins.py
+++ b/alembic_pg/versions/0002_drop_redundant_fk_twins.py
@@ -1,0 +1,80 @@
+"""Drop the redundant unnamed-FK twins the baseline inherited.
+
+The models declared 34 foreign keys twice — ``Field(foreign_key=...)`` plus a
+named ``ForeignKeyConstraint`` carrying the intended ON DELETE — and the
+baseline's create_all capture faithfully rendered both. Postgres enforces
+both, and the auto-named twin defaults to NO ACTION, which vetoes the named
+constraint's CASCADE/SET NULL on every delete. The models now declare each FK
+once (the named constraint); this drops the twins so the chain matches.
+
+Guarded by tests/integration/test_fk_constraint_names.py
+(test_one_fk_constraint_per_column_set).
+
+Revision ID: 0002_drop_redundant_fk_twins
+Revises: 0001_pg_baseline
+Create Date: 2026-08-29
+"""
+
+from alembic import op
+
+revision = "0002_drop_redundant_fk_twins"
+down_revision = "0001_pg_baseline"
+branch_labels = None
+depends_on = None
+
+# (constraint, table, column, referent table, referent column) — the unnamed
+# FOREIGN KEY clauses in 0001_pg_baseline.sql, under the names Postgres
+# auto-assigned them. Each has a named fk_* twin that stays.
+_REDUNDANT_TWINS = [
+    ("bans_banned_by_fkey", "bans", "banned_by", "users", "user_id"),
+    ("bans_user_id_fkey", "bans", "user_id", "users", "user_id"),
+    ("favorites_image_id_fkey", "favorites", "image_id", "images", "image_id"),
+    ("favorites_user_id_fkey", "favorites", "user_id", "users", "user_id"),
+    ("group_perms_group_id_fkey", "group_perms", "group_id", "groups", "group_id"),
+    ("group_perms_perm_id_fkey", "group_perms", "perm_id", "perms", "perm_id"),
+    ("image_ratings_image_id_fkey", "image_ratings", "image_id", "images", "image_id"),
+    ("image_ratings_user_id_fkey", "image_ratings", "user_id", "users", "user_id"),
+    ("images_replacement_id_fkey", "images", "replacement_id", "images", "image_id"),
+    ("images_status_user_id_fkey", "images", "status_user_id", "users", "user_id"),
+    ("images_user_id_fkey", "images", "user_id", "users", "user_id"),
+    ("news_user_id_fkey", "news", "user_id", "users", "user_id"),
+    ("posts_last_updated_user_id_fkey", "posts", "last_updated_user_id", "users", "user_id"),
+    ("posts_user_id_fkey", "posts", "user_id", "users", "user_id"),
+    ("privmsgs_from_user_id_fkey", "privmsgs", "from_user_id", "users", "user_id"),
+    ("privmsgs_to_user_id_fkey", "privmsgs", "to_user_id", "users", "user_id"),
+    ("quicklinks_user_id_fkey", "quicklinks", "user_id", "users", "user_id"),
+    ("refresh_tokens_user_id_fkey", "refresh_tokens", "user_id", "users", "user_id"),
+    ("tag_external_links_tag_id_fkey", "tag_external_links", "tag_id", "tags", "tag_id"),
+    ("tag_history_image_id_fkey", "tag_history", "image_id", "images", "image_id"),
+    ("tag_history_tag_id_fkey", "tag_history", "tag_id", "tags", "tag_id"),
+    ("tag_history_user_id_fkey", "tag_history", "user_id", "users", "user_id"),
+    ("tag_links_image_id_fkey", "tag_links", "image_id", "images", "image_id"),
+    ("tag_links_tag_id_fkey", "tag_links", "tag_id", "tags", "tag_id"),
+    ("tag_links_user_id_fkey", "tag_links", "user_id", "users", "user_id"),
+    ("tags_alias_of_fkey", "tags", "alias_of", "tags", "tag_id"),
+    ("tags_inheritedfrom_id_fkey", "tags", "inheritedfrom_id", "tags", "tag_id"),
+    ("tags_user_id_fkey", "tags", "user_id", "users", "user_id"),
+    ("user_banner_pins_banner_id_fkey", "user_banner_pins", "banner_id", "banners", "banner_id"),
+    ("user_banner_pins_user_id_fkey", "user_banner_pins", "user_id", "users", "user_id"),
+    (
+        "user_banner_preferences_user_id_fkey",
+        "user_banner_preferences",
+        "user_id",
+        "users",
+        "user_id",
+    ),
+    ("user_suspensions_actioned_by_fkey", "user_suspensions", "actioned_by", "users", "user_id"),
+    ("user_suspensions_user_id_fkey", "user_suspensions", "user_id", "users", "user_id"),
+    ("users_bookmark_fkey", "users", "bookmark", "images", "image_id"),
+]
+
+
+def upgrade() -> None:
+    for constraint, table, _column, _ref_table, _ref_column in _REDUNDANT_TWINS:
+        op.drop_constraint(constraint, table, type_="foreignkey")
+
+
+def downgrade() -> None:
+    # Restores the exact baseline state: unnamed clauses default to NO ACTION.
+    for constraint, table, column, ref_table, ref_column in _REDUNDANT_TWINS:
+        op.create_foreign_key(constraint, table, ref_table, [column], [ref_column])

--- a/app/models/ban.py
+++ b/app/models/ban.py
@@ -98,7 +98,7 @@ class Bans(BanBase, table=True):
     ban_id: int | None = Field(default=None, primary_key=True)
 
     # Public reference - user being banned
-    user_id: int = Field(foreign_key="users.user_id")
+    user_id: int
 
     # Override to add server default
     date: datetime | None = Field(
@@ -110,7 +110,7 @@ class Bans(BanBase, table=True):
     expires: datetime | None = Field(default=None, sa_column=Column(UtcDateTime, nullable=True))
 
     # Internal fields
-    banned_by: int | None = Field(default=None, foreign_key="users.user_id")
+    banned_by: int | None = Field(default=None)
     ip: str | None = Field(default=None, max_length=15)
 
     # Note: Relationships (e.g., user, banned_by_user) are intentionally omitted.

--- a/app/models/ban.py
+++ b/app/models/ban.py
@@ -70,11 +70,11 @@ class Bans(BanBase, table=True):
 
     __tablename__ = "bans"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["banned_by"],

--- a/app/models/character_source_link.py
+++ b/app/models/character_source_link.py
@@ -48,11 +48,11 @@ class CharacterSourceLinks(CharacterSourceLinkBase, table=True):
 
     __tablename__ = "character_source_links"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["character_tag_id"],

--- a/app/models/comment.py
+++ b/app/models/comment.py
@@ -69,11 +69,11 @@ class Comments(CommentBase, table=True):
 
     __tablename__ = "posts"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["image_id"],

--- a/app/models/comment.py
+++ b/app/models/comment.py
@@ -114,7 +114,7 @@ class Comments(CommentBase, table=True):
     post_id: int | None = Field(default=None, primary_key=True)
 
     # User reference (public)
-    user_id: int = Field(foreign_key="users.user_id")
+    user_id: int
 
     # Public timestamp
     date: datetime = Field(
@@ -131,7 +131,7 @@ class Comments(CommentBase, table=True):
     last_updated: datetime | None = Field(
         default=None, sa_column=Column(UtcDateTime, nullable=True)
     )
-    last_updated_user_id: int | None = Field(default=None, foreign_key="users.user_id")
+    last_updated_user_id: int | None = Field(default=None)
 
     # Relationships
     # Load user info for displaying comment author

--- a/app/models/favorite.py
+++ b/app/models/favorite.py
@@ -30,8 +30,8 @@ class FavoriteBase(SQLModel):
     """
 
     # Composite primary key (order matches schema: user_id, image_id)
-    user_id: int = Field(foreign_key="users.user_id", primary_key=True)
-    image_id: int = Field(foreign_key="images.image_id", primary_key=True)
+    user_id: int = Field(primary_key=True)
+    image_id: int = Field(primary_key=True)
 
     # Public timestamp
     fav_date: datetime = Field(

--- a/app/models/favorite.py
+++ b/app/models/favorite.py
@@ -57,11 +57,11 @@ class Favorites(FavoriteBase, table=True):
 
     __tablename__ = "favorites"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["image_id"],

--- a/app/models/image.py
+++ b/app/models/image.py
@@ -172,11 +172,11 @@ class Images(ImageBase, table=True):
     model_config = ConfigDict(validate_assignment=True)  # type: ignore
     __tablename__ = "images"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["replacement_id"],

--- a/app/models/image.py
+++ b/app/models/image.py
@@ -220,7 +220,7 @@ class Images(ImageBase, table=True):
     image_id: int | None = Field(default=None, primary_key=True)
 
     # User reference (public)
-    user_id: int = Field(foreign_key="users.user_id")
+    user_id: int
 
     # Public status/stats fields
     locked: int = Field(default=0)
@@ -249,7 +249,7 @@ class Images(ImageBase, table=True):
     large: int = Field(default=0)
 
     # Internal moderation fields
-    status_user_id: int | None = Field(default=None, foreign_key="users.user_id")
+    status_user_id: int | None = Field(default=None)
     status_updated: datetime | None = Field(
         default=None, sa_column=Column(UtcDateTime, nullable=True)
     )
@@ -257,7 +257,7 @@ class Images(ImageBase, table=True):
 
     # Internal metadata
     total_pixels: Decimal | None = Field(default=None)
-    replacement_id: int | None = Field(default=None, foreign_key="images.image_id")
+    replacement_id: int | None = Field(default=None)
 
     # Deactivation detail (set when status == DEACTIVATED)
     reason_category: int | None = Field(default=None)

--- a/app/models/image_rating.py
+++ b/app/models/image_rating.py
@@ -52,11 +52,11 @@ class ImageRatings(ImageRatingBase, table=True):
 
     __tablename__ = "image_ratings"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["image_id"],

--- a/app/models/image_rating.py
+++ b/app/models/image_rating.py
@@ -32,8 +32,8 @@ class ImageRatingBase(SQLModel):
     """
 
     # Composite primary key
-    user_id: int = Field(foreign_key="users.user_id", primary_key=True)
-    image_id: int = Field(foreign_key="images.image_id", primary_key=True)
+    user_id: int = Field(primary_key=True)
+    image_id: int = Field(primary_key=True)
 
     # Rating value (0-10 or similar scale)
     rating: int = Field(default=0)

--- a/app/models/misc.py
+++ b/app/models/misc.py
@@ -102,7 +102,7 @@ class UserBannerPreferences(UserBannerPreferencesBase, table=True):
         ),
     )
 
-    user_id: int = Field(primary_key=True, foreign_key="users.user_id")
+    user_id: int = Field(primary_key=True)
 
 
 class UserBannerPinsBase(SQLModel):
@@ -136,8 +136,8 @@ class UserBannerPins(UserBannerPinsBase, table=True):
     )
 
     id: int | None = Field(default=None, primary_key=True)
-    user_id: int = Field(foreign_key="users.user_id")
-    banner_id: int = Field(foreign_key="banners.banner_id")
+    user_id: int
+    banner_id: int
 
 
 # ===== EvaTheme =====
@@ -302,7 +302,7 @@ class Quicklinks(QuicklinkBase, table=True):
     quicklink_id: int | None = Field(default=None, primary_key=True)
 
     # Override to add foreign key
-    user_id: int | None = Field(default=None, foreign_key="users.user_id")
+    user_id: int | None = Field(default=None)
 
     # Note: Relationships are intentionally omitted.
     # Foreign keys are sufficient for queries, and omitting relationships avoids:

--- a/app/models/news.py
+++ b/app/models/news.py
@@ -73,7 +73,7 @@ class News(NewsBase, table=True):
     news_id: int | None = Field(default=None, primary_key=True)
 
     # User reference (public or internal depending on use case)
-    user_id: int = Field(foreign_key="users.user_id")
+    user_id: int
 
     # Override to add server default
     date: datetime | None = Field(

--- a/app/models/news.py
+++ b/app/models/news.py
@@ -53,11 +53,11 @@ class News(NewsBase, table=True):
 
     __tablename__ = "news"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["user_id"],

--- a/app/models/permissions.py
+++ b/app/models/permissions.py
@@ -92,8 +92,8 @@ class GroupPermBase(SQLModel):
     Junction table linking groups to permissions with a permission value.
     """
 
-    group_id: int = Field(foreign_key="groups.group_id", primary_key=True)
-    perm_id: int = Field(foreign_key="perms.perm_id", primary_key=True)
+    group_id: int = Field(primary_key=True)
+    perm_id: int = Field(primary_key=True)
     permvalue: int | None = Field(default=None)
 
 

--- a/app/models/privmsg.py
+++ b/app/models/privmsg.py
@@ -93,8 +93,8 @@ class Privmsgs(PrivmsgBase, table=True):
     privmsg_id: int | None = Field(default=None, primary_key=True)
 
     # Override to add foreign keys
-    from_user_id: int = Field(foreign_key="users.user_id")
-    to_user_id: int = Field(foreign_key="users.user_id")
+    from_user_id: int
+    to_user_id: int
 
     # Message status
     viewed: int = Field(default=0)

--- a/app/models/privmsg.py
+++ b/app/models/privmsg.py
@@ -64,11 +64,11 @@ class Privmsgs(PrivmsgBase, table=True):
 
     __tablename__ = "privmsgs"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["from_user_id"],

--- a/app/models/refresh_token.py
+++ b/app/models/refresh_token.py
@@ -50,7 +50,7 @@ class RefreshTokens(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
 
     # User reference
-    user_id: int = Field(foreign_key="users.user_id")
+    user_id: int
 
     # Token (hashed for security - never store plaintext!)
     token_hash: str = Field(max_length=255, unique=True, index=True)

--- a/app/models/tag.py
+++ b/app/models/tag.py
@@ -75,11 +75,11 @@ class Tags(TagBase, table=True):
 
     __tablename__ = "tags"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["alias_of"],

--- a/app/models/tag.py
+++ b/app/models/tag.py
@@ -124,11 +124,11 @@ class Tags(TagBase, table=True):
     usage_count: int = Field(default=0, ge=0)
 
     # Public relationship fields
-    alias_of: int | None = Field(default=None, foreign_key="tags.tag_id")
-    inheritedfrom_id: int | None = Field(default=None, foreign_key="tags.tag_id")
+    alias_of: int | None = Field(default=None)
+    inheritedfrom_id: int | None = Field(default=None)
 
     # Internal fields
-    user_id: int | None = Field(default=None, foreign_key="users.user_id")
+    user_id: int | None = Field(default=None)
 
     # Note: Relationships are intentionally omitted.
     # Foreign keys are sufficient for queries, and omitting relationships avoids:

--- a/app/models/tag_external_link.py
+++ b/app/models/tag_external_link.py
@@ -67,7 +67,7 @@ class TagExternalLinks(TagExternalLinkBase, table=True):
     link_id: int | None = Field(default=None, primary_key=True)
 
     # Foreign key
-    tag_id: int = Field(foreign_key="tags.tag_id", index=True)
+    tag_id: int = Field(index=True)
 
     # Timestamp
     date_added: datetime = Field(

--- a/app/models/tag_external_link.py
+++ b/app/models/tag_external_link.py
@@ -46,11 +46,11 @@ class TagExternalLinks(TagExternalLinkBase, table=True):
 
     __tablename__ = "tag_external_links"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["tag_id"],

--- a/app/models/tag_history.py
+++ b/app/models/tag_history.py
@@ -56,11 +56,11 @@ class TagHistory(TagHistoryBase, table=True):
 
     __tablename__ = "tag_history"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["image_id"],

--- a/app/models/tag_history.py
+++ b/app/models/tag_history.py
@@ -94,8 +94,8 @@ class TagHistory(TagHistoryBase, table=True):
     tag_history_id: int | None = Field(default=None, primary_key=True)
 
     # Override to add foreign keys
-    image_id: int | None = Field(default=None, foreign_key="images.image_id")
-    tag_id: int | None = Field(default=None, foreign_key="tags.tag_id")
+    image_id: int | None = Field(default=None)
+    tag_id: int | None = Field(default=None)
 
     # Override to add server default
     date: datetime | None = Field(
@@ -104,7 +104,7 @@ class TagHistory(TagHistoryBase, table=True):
     )
 
     # Internal field
-    user_id: int | None = Field(default=None, foreign_key="users.user_id")
+    user_id: int | None = Field(default=None)
 
     # Note: Relationships are intentionally omitted.
     # Foreign keys are sufficient for queries, and omitting relationships avoids:

--- a/app/models/tag_link.py
+++ b/app/models/tag_link.py
@@ -36,8 +36,8 @@ class TagLinkBase(SQLModel):
     """
 
     # Junction table primary keys
-    tag_id: int = Field(foreign_key="tags.tag_id", primary_key=True)
-    image_id: int = Field(foreign_key="images.image_id", primary_key=True)
+    tag_id: int = Field(primary_key=True)
+    image_id: int = Field(primary_key=True)
 
 
 class TagLinks(TagLinkBase, table=True):
@@ -95,7 +95,7 @@ class TagLinks(TagLinkBase, table=True):
     )
 
     # Internal field
-    user_id: int | None = Field(default=None, foreign_key="users.user_id")
+    user_id: int | None = Field(default=None)
 
     # Relationship to tag
     tag: Tags = Relationship(

--- a/app/models/tag_link.py
+++ b/app/models/tag_link.py
@@ -55,11 +55,11 @@ class TagLinks(TagLinkBase, table=True):
 
     __tablename__ = "tag_links"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["image_id"],

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -194,7 +194,7 @@ class Users(UserBase, table=True):
 
     # References
     forum_id: int | None = Field(default=None)
-    bookmark: int | None = Field(default=None, foreign_key="images.image_id")
+    bookmark: int | None = Field(default=None)
 
     # Relationship to UserGroups for eager loading groups
     user_groups: list[UserGroups] = Relationship(

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -81,11 +81,11 @@ class Users(UserBase, table=True):
 
     __tablename__ = "users"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["bookmark"],

--- a/app/models/user_suspension.py
+++ b/app/models/user_suspension.py
@@ -66,13 +66,13 @@ class UserSuspensions(SQLModel, table=True):
     suspension_id: int | None = Field(default=None, primary_key=True)
 
     # User being suspended/reactivated
-    user_id: int = Field(foreign_key="users.user_id")
+    user_id: int
 
     # Action type
     action: str = Field(max_length=20)  # SuspensionAction.SUSPENDED or SuspensionAction.REACTIVATED
 
     # Who performed the action
-    actioned_by: int | None = Field(default=None, foreign_key="users.user_id")
+    actioned_by: int | None = Field(default=None)
 
     # When the action occurred
     actioned_at: datetime = Field(

--- a/app/models/user_suspension.py
+++ b/app/models/user_suspension.py
@@ -33,11 +33,11 @@ class UserSuspensions(SQLModel, table=True):
 
     __tablename__ = "user_suspensions"
 
-    # NOTE: __table_args__ is partially redundant with Field(foreign_key=...) declarations below.
-    # However, it's kept for explicit CASCADE behavior and named constraints that SQLModel's
-    # Field() cannot express. Be aware: if using Alembic migrations to manage schema changes,
-    # these definitions may drift from the actual database structure over time. When in doubt,
-    # treat Alembic migrations as the source of truth for production schema.
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s below:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py). When in doubt, treat Alembic
+    # migrations as the source of truth for production schema.
     __table_args__ = (
         ForeignKeyConstraint(
             ["user_id"],

--- a/tests/integration/test_fk_constraint_names.py
+++ b/tests/integration/test_fk_constraint_names.py
@@ -13,7 +13,8 @@ actual names alembic produced on a fresh schema.
 """
 
 import pytest
-from sqlalchemy import create_engine, inspect
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tests.conftest import TEST_DATABASE_URL_SYNC
 
@@ -50,4 +51,51 @@ def test_all_fks_use_fk_prefix_convention():
             "FK constraints without explicit fk_-prefixed names found. "
             "Add `name=` to the ForeignKeyConstraint(...) in the migration "
             "that created the table. Convention: fk_<table>_<column>.\n\n" + "\n".join(failures)
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.postgres_only  # guards the PG chain against doubled FK enforcement;
+# on MariaDB the chain never rendered model metadata, so the hazard doesn't exist
+async def test_one_fk_constraint_per_column_set(db_session: AsyncSession) -> None:
+    """
+    Each FK column set must be enforced by exactly ONE constraint.
+
+    Regression guard for the doubled model declarations
+    (``Field(foreign_key=...)`` alongside a named ``ForeignKeyConstraint``)
+    that the frozen PG baseline rendered as 34 duplicate pairs: a named
+    ``fk_*`` carrying the intended ON DELETE plus an auto-named ``*_fkey``
+    defaulting to NO ACTION — and NO ACTION vetoes the cascade, so every
+    ON DELETE rule involved was silently dead. Asserts on ``pg_constraint``
+    directly: a models-vs-chain diff (test_pg_schema_sync) compares two
+    renderings of the same metadata and is structurally blind to this class.
+    """
+    result = await db_session.execute(
+        text(
+            """
+            SELECT conrelid::regclass::text AS child_table,
+                   (SELECT string_agg(att.attname, ',' ORDER BY cols.ord)
+                      FROM unnest(pg_constraint.conkey)
+                           WITH ORDINALITY AS cols(attnum, ord)
+                      JOIN pg_attribute att
+                        ON att.attrelid = pg_constraint.conrelid
+                       AND att.attnum = cols.attnum) AS child_columns,
+                   string_agg(conname, ', ' ORDER BY conname) AS constraint_names
+            FROM pg_constraint
+            WHERE contype = 'f' AND connamespace = 'public'::regnamespace
+            GROUP BY conrelid, conkey, confrelid, confkey
+            HAVING count(*) > 1
+            ORDER BY 1, 2
+            """
+        )
+    )
+    duplicates = [f"{table}({columns}): {names}" for table, columns, names in result]
+
+    if duplicates:
+        pytest.fail(
+            "Duplicate FK constraints found (same child columns, same parent). "
+            "The declaration is doubled: drop the `foreign_key=` from the "
+            "Field() — the named ForeignKeyConstraint in __table_args__ is the "
+            "one carrying ON DELETE — and drop the redundant constraint in an "
+            "alembic_pg migration.\n\n" + "\n".join(duplicates)
         )


### PR DESCRIPTION
## Problem

`DELETE FROM users WHERE user_id = 846335` fails on `refresh_tokens_user_id_fkey` despite `fk_refresh_tokens_user_id` declaring `ON DELETE CASCADE`. Root cause: 34 FKs are enforced **twice** in the PG schema — the named `fk_*` with the intended `ON DELETE`, plus an auto-named `*_fkey` twin defaulting to `NO ACTION`. Postgres enforces both, and `NO ACTION` aborts the delete first, so every `ON DELETE CASCADE`/`SET NULL` involving users/images/tags/groups/perms/banners children was silently dead.

## How it happened

The models declared each FK twice since 2025-11 (`Field(foreign_key=...)` **and** a named `ForeignKeyConstraint`). MariaDB never saw the twins — its schema descends from the PHP era plus hand-written migrations. The PG baseline (`gen_pg_baseline.py`, #f58a140) was the first time the full metadata was rendered into a real schema: create_all faithfully emitted both declarations → 62 named + 57 unnamed FKs, now live in prod.

Neither guard caught it: `test_pg_schema_sync` diffs two renderings of the *same* metadata, and `test_schema_sync`'s cascade test keys FKs by column set, collapsing twins (and was scoped to 3 unaffected tables).

## Fix

- **Models**: drop the redundant `foreign_key=` from the 34 doubled declarations; the named `ForeignKeyConstraint` (which carries `ondelete`) stays. `user_groups.group_id` keeps its inline FK — it has no named twin.
- **Migration** `alembic_pg` 0002: drops the 34 auto-named constraints; downgrade restores them verbatim (unnamed = `NO ACTION`), returning to the exact baseline state.
- **Test** (TDD, red first on the chain-built DB): catalog-level assertion in `test_fk_constraint_names.py` that each FK column set is enforced by exactly one constraint — the only vantage point structurally able to see this class.

## Gates

- New test: red (34 duplicates) → green after fix
- `test_pg_schema_sync --schema-sync`: passed (models == chain)
- PG suite on CI-mirroring postgres:18 + redis: **2619 passed**
- MariaDB suite: **2661 passed**; `test_schema_sync --schema-sync`: 3 passed
- ruff + mypy clean

## After merge

Prod PG is at `0001_pg_baseline` — run `alembic -c alembic.pg.ini upgrade head` to drop the twins there.

Not in scope (pre-existing in both engines): `user_groups.user_id`, `user_perms.*`, `donations.user_id`, `user_tag_affinity.*` have no FK at all and need an orphan sweep before one can be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)