### PR TITLE
fix(deploy): prod-migrate must run the Postgres chain, not the MariaDB one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN sha256sum uv.lock | awk '{print $1}' > /app/.uv-lock-hash
 # Copy only what's needed for runtime (explicit allowlist)
 COPY app/ ./app/
 COPY alembic/ ./alembic/
+COPY alembic_pg/ ./alembic_pg/
+COPY alembic.pg.ini ./
 COPY scripts/ ./scripts/
 
 # Install the project itself (cheap; deps are already in the venv).

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,11 @@ prod-build-frontend: check-env-prod
 	$(COMPOSE_PROD) build --no-cache frontend
 
 # Apply database migrations as an explicit, gated step. Run this BEFORE
-# prod-deploy when a release includes a migration. Migrations must be
+# prod-deploy when a release includes a migration. The -c alembic.pg.ini is
+# load-bearing: a bare `alembic upgrade head` resolves via pyproject
+# [tool.alembic] to the legacy MariaDB chain (alembic/) and silently no-ops
+# against the retired MariaDB instead of prod Postgres (bit us 2026-08-29,
+# release of PR #370). Migrations must be
 # backward-compatible (expand/contract): during the rollout the old and new app
 # versions briefly run against the same DB at once, so a column the old code
 # still reads must not disappear yet. Defer destructive (contract) changes to a
@@ -209,7 +213,7 @@ prod-migrate: check-env-prod
 	# migration code even if prod-migrate is run on its own. The duplicate
 	# build is a cache-cheap no-op.
 	$(COMPOSE_PROD) build api
-	$(COMPOSE_PROD) run --rm --no-deps api uv run --no-project alembic upgrade head
+	$(COMPOSE_PROD) run --rm --no-deps api uv run --no-project alembic -c alembic.pg.ini upgrade head
 
 # Zero-downtime deploy: build the app image(s), then roll each service one at a
 # time. docker-rollout starts a new replica, waits for its healthcheck, then


### PR DESCRIPTION
## Problem

Running `make prod-migrate` for the PR #370 release reported success but applied nothing: the target runs a bare `alembic upgrade head`, which resolves through pyproject `[tool.alembic]` to `script_location = "alembic"` — the legacy **MariaDB** chain, connecting via `DATABASE_URL_SYNC` to the retired-but-still-running MariaDB, which is already at head. A silent no-op against the wrong engine, while prod Postgres stayed at `0001_pg_baseline` with all 34 duplicate FK twins live.

A second gap made the correct invocation impossible in-container: the Dockerfile's runtime allowlist copies `alembic/` but never `alembic_pg/` or `alembic.pg.ini`. The PG baseline (f58a140) added the parallel chain so existing alembic invocations stayed untouched — prod-migrate being one of the invocations that then never learned about it.

## Fix

- `prod-migrate` runs `alembic -c alembic.pg.ini upgrade head`; the PG chain's env.py resolves the container's `DATABASE_URL` — the same async PG URL the app itself uses, so the migrator can no longer target a different database than the application.
- Dockerfile ships `alembic_pg/` + `alembic.pg.ini`.
- Comment on the target records why `-c` is load-bearing.

## Verification

Built the image and ran the exact prod-migrate command in offline mode (`upgrade head --sql`): renders `0001_pg_baseline` + all 34 `DROP CONSTRAINT`s of `0002_drop_redundant_fk_twins`.

The 0002 catch-up on prod is being applied from the host checkout (`uv run alembic -c alembic.pg.ini upgrade head`), same path that stamped the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)