### PR TITLE
feat(db): FK coverage for the historically FK-less user-reference columns

### DIFF
--- a/alembic/versions/28e56662b975_add_user_reference_fk_constraints.py
+++ b/alembic/versions/28e56662b975_add_user_reference_fk_constraints.py
@@ -1,0 +1,90 @@
+"""add user reference fk constraints
+
+MariaDB half of the pair (ADR-0010) for alembic_pg
+0003_add_user_reference_fks: FK coverage for the historically FK-less
+user-reference columns. Membership and grant links die with the
+user/group/perm; donations outlive the donor (SET NULL).
+user_tag_affinity stays FK-less by design — its nightly staging-table swap
+(CREATE TABLE ... LIKE) would shed any FK.
+
+Unlike the Postgres half there is nothing to drop: these tables never had
+any FK on this chain. The data fixes mirror the PG half and are no-ops on
+chain-built (empty) databases.
+
+InnoDB requires exact type matches across an FK, and the legacy parents
+(users.user_id, groups.group_id, perms.perm_id) are INT UNSIGNED while the
+junction columns were signed int(11) — so those move to INT UNSIGNED first
+(values are all positive; donations.user_id is already unsigned). The
+models keep plain (signed) ints: a create_all schema is signed on BOTH
+sides of these FKs and therefore self-consistent; the full signed/unsigned
+audit is tracked in
+docs/plans/2026-Q2/2026-06-10-schema-sync-signed-unsigned-drift.md.
+
+Revision ID: 28e56662b975
+Revises: 10eef13f525a
+Create Date: 2026-08-29 17:06:59.135451
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "28e56662b975"
+down_revision: str | Sequence[str] | None = "10eef13f525a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# (name, table, column, referent table, referent column, ondelete)
+_FKS = [
+    ("fk_user_groups_user_id", "user_groups", "user_id", "users", "user_id", "CASCADE"),
+    ("fk_user_groups_group_id", "user_groups", "group_id", "groups", "group_id", "CASCADE"),
+    ("fk_user_perms_user_id", "user_perms", "user_id", "users", "user_id", "CASCADE"),
+    ("fk_user_perms_perm_id", "user_perms", "perm_id", "perms", "perm_id", "CASCADE"),
+    ("fk_donations_user_id", "donations", "user_id", "users", "user_id", "SET NULL"),
+]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Detach donations from deleted users; the rows themselves are kept.
+    op.execute(
+        "UPDATE donations SET user_id = NULL WHERE user_id IS NOT NULL "
+        "AND NOT EXISTS (SELECT 1 FROM users WHERE users.user_id = donations.user_id)"
+    )
+    # Defensive orphan sweep before the CASCADE FKs can be validated.
+    op.execute(
+        "DELETE FROM user_groups WHERE NOT EXISTS "
+        "(SELECT 1 FROM users WHERE users.user_id = user_groups.user_id) "
+        "OR NOT EXISTS (SELECT 1 FROM groups WHERE groups.group_id = user_groups.group_id)"
+    )
+    op.execute(
+        "DELETE FROM user_perms WHERE NOT EXISTS "
+        "(SELECT 1 FROM users WHERE users.user_id = user_perms.user_id) "
+        "OR NOT EXISTS (SELECT 1 FROM perms WHERE perms.perm_id = user_perms.perm_id)"
+    )
+
+    # Match the unsigned legacy parents before InnoDB will accept the FKs.
+    op.execute(
+        "ALTER TABLE user_groups "
+        "MODIFY user_id INT UNSIGNED NOT NULL, MODIFY group_id INT UNSIGNED NOT NULL"
+    )
+    op.execute(
+        "ALTER TABLE user_perms "
+        "MODIFY user_id INT UNSIGNED NOT NULL, MODIFY perm_id INT UNSIGNED NOT NULL"
+    )
+
+    for name, table, column, ref_table, ref_column, ondelete in _FKS:
+        op.create_foreign_key(
+            name, table, ref_table, [column], [ref_column], ondelete=ondelete, onupdate="CASCADE"
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # The NULLed donations.user_id values are not recoverable.
+    for name, table, _column, _ref_table, _ref_column, _ondelete in _FKS:
+        op.drop_constraint(name, table, type_="foreignkey")
+    op.execute("ALTER TABLE user_groups MODIFY user_id INT NOT NULL, MODIFY group_id INT NOT NULL")
+    op.execute("ALTER TABLE user_perms MODIFY user_id INT NOT NULL, MODIFY perm_id INT NOT NULL")

--- a/alembic_pg/versions/0003_add_user_reference_fks.py
+++ b/alembic_pg/versions/0003_add_user_reference_fks.py
@@ -1,0 +1,72 @@
+"""FK coverage for the historically FK-less user-reference columns.
+
+These tables predate FK discipline (the legacy PHP schema had none):
+user_groups/user_perms rows either outlived their user as orphans or — for
+user_groups.group_id — were guarded only by an unnamed NO ACTION constraint
+that vetoed group deletion outright. Decision (2026-08-29, follow-up to
+PR #370): membership and grant links die with the user/group/perm; donations
+outlive the donor (SET NULL). user_tag_affinity stays FK-less by design —
+its nightly staging-table swap would shed any FK (see
+app/services/user_tag_affinity.py).
+
+Data fixes first: prod had 41 donations pointing at deleted users (NULLed —
+irreversible, which is also what SET NULL would have done); the orphan
+deletes are defensive no-ops (prod counts were 0).
+
+Revision ID: 0003_add_user_reference_fks
+Revises: 0002_drop_redundant_fk_twins
+Create Date: 2026-08-29
+"""
+
+from alembic import op
+
+revision = "0003_add_user_reference_fks"
+down_revision = "0002_drop_redundant_fk_twins"
+branch_labels = None
+depends_on = None
+
+# (name, table, column, referent table, referent column, ondelete)
+_FKS = [
+    ("fk_user_groups_user_id", "user_groups", "user_id", "users", "user_id", "CASCADE"),
+    ("fk_user_groups_group_id", "user_groups", "group_id", "groups", "group_id", "CASCADE"),
+    ("fk_user_perms_user_id", "user_perms", "user_id", "users", "user_id", "CASCADE"),
+    ("fk_user_perms_perm_id", "user_perms", "perm_id", "perms", "perm_id", "CASCADE"),
+    ("fk_donations_user_id", "donations", "user_id", "users", "user_id", "SET NULL"),
+]
+
+
+def upgrade() -> None:
+    # Detach donations from deleted users; the rows themselves are kept.
+    op.execute(
+        "UPDATE donations SET user_id = NULL WHERE user_id IS NOT NULL "
+        "AND NOT EXISTS (SELECT 1 FROM users WHERE users.user_id = donations.user_id)"
+    )
+    # Defensive orphan sweep before the CASCADE FKs can be validated.
+    op.execute(
+        "DELETE FROM user_groups WHERE NOT EXISTS "
+        "(SELECT 1 FROM users WHERE users.user_id = user_groups.user_id) "
+        "OR NOT EXISTS (SELECT 1 FROM groups WHERE groups.group_id = user_groups.group_id)"
+    )
+    op.execute(
+        "DELETE FROM user_perms WHERE NOT EXISTS "
+        "(SELECT 1 FROM users WHERE users.user_id = user_perms.user_id) "
+        "OR NOT EXISTS (SELECT 1 FROM perms WHERE perms.perm_id = user_perms.perm_id)"
+    )
+
+    # The baseline's stray on user_groups.group_id: unnamed, NO ACTION, and the
+    # only FK these tables had. Replaced by fk_user_groups_group_id below.
+    op.drop_constraint("user_groups_group_id_fkey", "user_groups", type_="foreignkey")
+
+    for name, table, column, ref_table, ref_column, ondelete in _FKS:
+        op.create_foreign_key(
+            name, table, ref_table, [column], [ref_column], ondelete=ondelete, onupdate="CASCADE"
+        )
+
+
+def downgrade() -> None:
+    # The NULLed donations.user_id values are not recoverable.
+    for name, table, _column, _ref_table, _ref_column, _ondelete in _FKS:
+        op.drop_constraint(name, table, type_="foreignkey")
+    op.create_foreign_key(
+        "user_groups_group_id_fkey", "user_groups", "groups", ["group_id"], ["group_id"]
+    )

--- a/app/api/v1/donations.py
+++ b/app/api/v1/donations.py
@@ -114,6 +114,15 @@ async def create_donation(
     ):
         raise HTTPException(status_code=403, detail="DONATIONS_CREATE permission required")
 
+    # fk_donations_user_id would refuse a dangling reference anyway, but as a
+    # 500; check up front so the caller gets a proper 404.
+    if body.user_id is not None:
+        user_exists = await db.scalar(
+            select(Users.user_id).where(Users.user_id == body.user_id)  # type: ignore[call-overload]
+        )
+        if user_exists is None:
+            raise HTTPException(status_code=404, detail="User not found")
+
     donation = Donations(
         amount=body.amount,
         nick=body.nick,

--- a/app/models/misc.py
+++ b/app/models/misc.py
@@ -209,7 +209,8 @@ class DonationBase(SQLModel):
     """
     Base model for Donations table.
 
-    This is a simple tracking table with no foreign key relationships.
+    This is a simple tracking table; user_id links the donor when known
+    and survives their deletion (ON DELETE SET NULL on the table model).
     Note: Original table has no primary key, but we need one for SQLModel.
     """
 
@@ -231,7 +232,17 @@ class Donations(DonationBase, table=True):
 
     __tablename__ = "donations"
 
-    __table_args__ = (Index("idx_date", "date"),)
+    __table_args__ = (
+        # Donations outlive the donor: deleting a user detaches, never deletes.
+        ForeignKeyConstraint(
+            ["user_id"],
+            ["users.user_id"],
+            ondelete="SET NULL",
+            onupdate="CASCADE",
+            name="fk_donations_user_id",
+        ),
+        Index("idx_date", "date"),
+    )
 
     # SQLModel requires a primary key, but original table has none
     # We'll make this auto-increment for new inserts

--- a/app/models/permissions.py
+++ b/app/models/permissions.py
@@ -143,7 +143,7 @@ class UserGroupBase(SQLModel):
     """
 
     user_id: int = Field(primary_key=True)
-    group_id: int = Field(primary_key=True, foreign_key="groups.group_id")
+    group_id: int = Field(primary_key=True)
 
 
 class UserGroups(UserGroupBase, table=True):
@@ -154,6 +154,27 @@ class UserGroups(UserGroupBase, table=True):
     """
 
     __tablename__ = "user_groups"
+
+    # FKs are declared here ONLY — never add foreign_key= to the Field()s above:
+    # that emits a second, unnamed constraint whose implicit NO ACTION vetoes the
+    # ON DELETE rule declared here (PR #370; guarded by
+    # tests/integration/test_fk_constraint_names.py).
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id"],
+            ["users.user_id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="fk_user_groups_user_id",
+        ),
+        ForeignKeyConstraint(
+            ["group_id"],
+            ["groups.group_id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="fk_user_groups_group_id",
+        ),
+    )
 
     # Relationship to Groups (requires explicit eager loading via selectinload/joinedload)
     group: Groups = Relationship(
@@ -188,7 +209,23 @@ class UserPerms(UserPermBase, table=True):
 
     __tablename__ = "user_perms"
 
-    # Note: No foreign key constraints in schema, but logically references users and perms
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id"],
+            ["users.user_id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="fk_user_perms_user_id",
+        ),
+        ForeignKeyConstraint(
+            ["perm_id"],
+            ["perms.perm_id"],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+            name="fk_user_perms_perm_id",
+        ),
+    )
+
     # Note: Relationships are intentionally omitted.
     # Foreign keys are sufficient for queries, and omitting relationships avoids:
     # - Circular import issues

--- a/tests/api/v1/test_donations.py
+++ b/tests/api/v1/test_donations.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.permissions import Permission
@@ -105,14 +106,16 @@ class TestListDonations:
         data = response.json()
         assert data["donations"][0]["username"] == "testuser"
 
-    async def test_username_null_when_no_user(self, client: AsyncClient, db_session: AsyncSession):
-        """Username is null when user_id has no matching user."""
-        db_session.add(Donations(amount=10, user_id=0, nick="Anonymous"))
-        await db_session.commit()
+    async def test_dangling_user_id_is_impossible(self, db_session: AsyncSession):
+        """A donation can no longer reference a nonexistent user.
 
-        response = await client.get("/api/v1/donations")
-        data = response.json()
-        assert data["donations"][0]["username"] is None
+        The legacy PHP data used user_id=0 as an anonymous sentinel;
+        fk_donations_user_id forbids dangling references, so anonymous
+        donations carry user_id NULL instead (next test).
+        """
+        db_session.add(Donations(amount=10, user_id=0, nick="Anonymous"))
+        with pytest.raises(IntegrityError):
+            await db_session.commit()
 
     async def test_username_null_when_no_user_id(
         self, client: AsyncClient, db_session: AsyncSession
@@ -282,17 +285,31 @@ class TestCreateDonation:
         self, client: AsyncClient, user_with_donations_create: tuple[Users, str]
     ):
         """Creates donation with all fields."""
-        _, token = user_with_donations_create
+        user, token = user_with_donations_create
         response = await client.post(
             "/api/v1/donations",
-            json={"amount": 50, "nick": "Generous", "user_id": 123},
+            json={"amount": 50, "nick": "Generous", "user_id": user.user_id},
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 201
         data = response.json()
         assert data["amount"] == 50
         assert data["nick"] == "Generous"
-        assert data["user_id"] == 123
+        assert data["user_id"] == user.user_id
+
+    async def test_create_nonexistent_user_returns_404(
+        self, client: AsyncClient, user_with_donations_create: tuple[Users, str]
+    ):
+        """A user_id with no matching user is rejected up front —
+        fk_donations_user_id would refuse it anyway, but as a 500."""
+        _, token = user_with_donations_create
+        response = await client.post(
+            "/api/v1/donations",
+            json={"amount": 50, "user_id": 999999999},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "User not found"
 
     async def test_create_naive_date_returns_422(
         self, client: AsyncClient, user_with_donations_create: tuple[Users, str]

--- a/tests/integration/test_fk_constraint_names.py
+++ b/tests/integration/test_fk_constraint_names.py
@@ -99,3 +99,68 @@ async def test_one_fk_constraint_per_column_set(db_session: AsyncSession) -> Non
             "one carrying ON DELETE — and drop the redundant constraint in an "
             "alembic_pg migration.\n\n" + "\n".join(duplicates)
         )
+
+
+# The FK coverage decided 2026-08-29 (users cleanup after PR #370): membership
+# and grant links die with the user/group/perm; donations outlive the donor.
+# user_tag_affinity stays FK-less BY DESIGN — its nightly staging-table swap
+# (CREATE TABLE ... LIKE, app/services/user_tag_affinity.py) does not copy FKs,
+# so one added here would silently vanish at the next rebuild.
+_EXPECTED_USER_REFERENCE_FKS = [
+    ("user_groups", "user_id", "users", "CASCADE"),
+    ("user_groups", "group_id", "groups", "CASCADE"),
+    ("user_perms", "user_id", "users", "CASCADE"),
+    ("user_perms", "perm_id", "perms", "CASCADE"),
+    ("donations", "user_id", "users", "SET NULL"),
+]
+
+
+@pytest.mark.integration
+@pytest.mark.postgres_only  # asserts on pg_constraint; Postgres is the system
+# of record for delete behavior post-cutover
+async def test_user_reference_fks_have_delete_rules(db_session: AsyncSession) -> None:
+    """
+    The historically FK-less user-reference columns must be constrained.
+
+    These tables predate FK discipline (the legacy PHP schema had none), so
+    user deletion either left orphans (user_perms, donations) or was vetoed
+    by an unnamed NO ACTION constraint (user_groups.group_id). Each expected
+    FK must exist, follow the fk_<table>_<column> naming convention, and
+    carry the agreed ON DELETE rule.
+    """
+    result = await db_session.execute(
+        text(
+            """
+            SELECT conrelid::regclass::text,
+                   (SELECT att.attname FROM pg_attribute att
+                     WHERE att.attrelid = conrelid AND att.attnum = conkey[1]),
+                   confrelid::regclass::text,
+                   conname,
+                   CASE confdeltype WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
+                        WHEN 'r' THEN 'RESTRICT' WHEN 'd' THEN 'SET DEFAULT'
+                        ELSE 'NO ACTION' END
+            FROM pg_constraint
+            WHERE contype = 'f' AND connamespace = 'public'::regnamespace
+              AND cardinality(conkey) = 1
+            """
+        )
+    )
+    actual = {(t, col): (ref, name, rule) for t, col, ref, name, rule in result}
+
+    problems: list[str] = []
+    for table, column, ref_table, on_delete in _EXPECTED_USER_REFERENCE_FKS:
+        found = actual.get((table, column))
+        if found is None:
+            problems.append(f"{table}.{column}: no FK (expected -> {ref_table} {on_delete})")
+            continue
+        ref, name, rule = found
+        if ref != ref_table or rule != on_delete:
+            problems.append(
+                f"{table}.{column}: {name} -> {ref} ON DELETE {rule} "
+                f"(expected -> {ref_table} {on_delete})"
+            )
+        elif name != f"fk_{table}_{column}":
+            problems.append(f"{table}.{column}: named {name}, expected fk_{table}_{column}")
+
+    if problems:
+        pytest.fail("User-reference FK constraints missing or wrong:\n" + "\n".join(problems))


### PR DESCRIPTION
Follow-up to #370: the columns that had **no** FK at all.

## Decision

| Column | Rule | Why |
|---|---|---|
| `user_groups.user_id` | CASCADE | membership dies with the user |
| `user_groups.group_id` | CASCADE | …and with the group (was an unnamed NO ACTION stray from the PG baseline that vetoed group deletion; `group_perms` already cascades) |
| `user_perms.user_id` | CASCADE | grant dies with the user |
| `user_perms.perm_id` | CASCADE | …and with the perm |
| `donations.user_id` | SET NULL | **donations outlive the donor** — the record is kept, the dead pointer cleared |
| `user_tag_affinity.*` | none | FK-less **by design**: the nightly staging-table swap (`CREATE TABLE … LIKE`, `app/services/user_tag_affinity.py`) doesn't copy FKs, so one added here would silently vanish at the next rebuild; orphans self-heal within 24h |

Prod data: every CASCADE target had **0 orphans**; `donations` had 41 rows pointing at deleted users, which the migration NULLs (irreversible — and exactly what SET NULL would have done).

## Shape

ADR-0010 pair: `alembic_pg` **0003** (drops the stray, adds 5 named FKs) + **28e56662b975** on the MariaDB chain. The MariaDB half additionally moves the junction columns to `INT UNSIGNED` — InnoDB requires exact type matches and the legacy parents are unsigned. Models keep plain signed ints: a create_all schema is signed on *both* sides of these FKs and therefore self-consistent; the whole-schema signedness audit remains tracked in `docs/plans/2026-Q2/2026-06-10-schema-sync-signed-unsigned-drift.md`, and `test_column_types_match` is scoped to the report/review family so no new drift is flagged.

## What the FK flushed out

- `test_username_null_when_no_user` fabricated a dangling `user_id=0` donation (the legacy PHP anonymous sentinel). Repurposed: it now asserts that state is impossible.
- `POST /donations` stored any `user_id` unvalidated — a nonexistent user surfaced as an FK-violation 500. Now checked up front → `404 "User not found"` (codebase convention), with a new test.

## TDD

`test_user_reference_fks_have_delete_rules` (catalog-level, asserts existence + naming convention + ON DELETE rule for all five) — red on the chain before the migrations, green after.

## Gates

- PG suite: **2652 passed** + `--schema-sync` (models == chain)
- MariaDB suite: **2665 passed** + `--schema-sync`
- ruff + mypy clean

## After merge

`make prod-migrate` (now correctly targeting the PG chain via #371) applies 0003. The MariaDB half only ever runs on chain-built test databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)