### PR TITLE
test: stub the arq pool so pytest can never enqueue into the prod queue

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,8 @@ os.environ.setdefault("BCRYPT_ROUNDS", "4")
 
 from collections.abc import AsyncGenerator
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -671,6 +673,46 @@ async def mock_redis():
     mock.pipeline.return_value = pipeline_mock
 
     return mock
+
+
+class _StubArqPool:
+    """In-memory stand-in for the arq Redis pool.
+
+    Records (function_name, args, kwargs) so tests can assert on enqueued jobs
+    without patching enqueue_job in each route module.
+    """
+
+    def __init__(self) -> None:
+        self.jobs: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    async def enqueue_job(
+        self,
+        function_name: str,
+        *args: Any,
+        _job_id: str | None = None,
+        _defer_by: float | None = None,
+        **kwargs: Any,
+    ) -> SimpleNamespace:
+        self.jobs.append((function_name, args, kwargs))
+        return SimpleNamespace(job_id=_job_id or f"stub-job-{len(self.jobs)}")
+
+    async def close(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def stub_arq_pool(monkeypatch: pytest.MonkeyPatch) -> _StubArqPool:
+    """Replace the arq pool so no test can enqueue into a real queue.
+
+    Prod runs from this same checkout (env_file: .env), so ARQ_REDIS_URL points
+    at the production queue; on 2026-08-29 a pytest run enqueued jobs there and
+    the prod worker emailed real users. get_queue() returns the cached
+    app.tasks.queue._pool when set, so seeding it with a stub short-circuits
+    pool creation for every enqueue_job call site.
+    """
+    pool = _StubArqPool()
+    monkeypatch.setattr("app.tasks.queue._pool", pool)
+    return pool
 
 
 def _test_redis_db() -> int:

--- a/tests/test_arq_queue_guard.py
+++ b/tests/test_arq_queue_guard.py
@@ -1,0 +1,29 @@
+"""Tests for the conftest guard that keeps arq jobs out of real queues.
+
+Prod runs from this same checkout (env_file: .env), so settings.ARQ_REDIS_URL
+points at the production queue. On 2026-08-29 a pytest run enqueued PM
+notification and password-reset jobs there, and the prod worker resolved the
+small pytest-DB IDs against prod data and emailed real users. The autouse
+stub_arq_pool fixture in conftest.py replaces the arq pool for every test;
+these tests pin that guard in place.
+"""
+
+from app.config import settings
+from app.tasks.queue import enqueue_job
+
+
+async def test_enqueue_job_never_reaches_a_real_queue(monkeypatch):
+    # Without the autouse stub, enqueue_job builds a pool from
+    # settings.ARQ_REDIS_URL; point it somewhere unreachable so that failure
+    # mode returns None here instead of enqueuing into a live queue.
+    monkeypatch.setattr(settings, "ARQ_REDIS_URL", "redis://127.0.0.1:1/15")
+
+    job_id = await enqueue_job("send_pm_notification", privmsg_id=123)
+
+    assert job_id is not None
+
+
+async def test_stub_pool_captures_enqueued_jobs(stub_arq_pool):
+    await enqueue_job("send_pm_notification", privmsg_id=123)
+
+    assert stub_arq_pool.jobs == [("send_pm_notification", (), {"privmsg_id": 123})]


### PR DESCRIPTION
## Problem

Prod runs from this same checkout (`env_file: .env`), so `settings.ARQ_REDIS_URL` points at the production arq queue (tomoyo, db 1). `tests/conftest.py` redirects the database (`TEST_DATABASE_URL`) and the cache Redis (per-worker high DB numbers), but nothing ever touched the arq pool — `app/tasks/queue.py` builds it straight from settings.

On 2026-08-29 (20:36–21:14 UTC) pytest runs pushed real jobs into the prod queue. The prod worker resolved the small pytest-DB IDs against **prod** data and emailed real users:

- PM notification emails for privmsgs 2/3/4 — messages from **May 2005** (this is what brought Manick back to the site after 10+ years)
- ~5 bogus "Reset your password" emails to user 5 (dead tokens, but alarming)
- Image jobs (`sync_image_status_job`, `recalculate_rating_job`) also leaked but were no-ops since both re-derive state from the current prod DB

## Fix

An autouse `stub_arq_pool` fixture seeds `app.tasks.queue._pool` with an in-memory stub, short-circuiting pool creation for every `enqueue_job` call site (route modules bind `enqueue_job` at import, so patching at the pool level is the one place that covers them all). The stub records `(function_name, args, kwargs)` so tests can assert on enqueued jobs without per-module patching; existing `patch("app.api.v1.….enqueue_job")` tests shadow it and still pass.

## Verification

- TDD: red run showed `enqueue_job` building a real pool from `ARQ_REDIS_URL`; green with the fixture in place
- Full suite serially: 2621 passed, 1 pre-existing failure (`test_pg_trigger_state`, superuser-only `DISABLE TRIGGER`, already in lastfailed before this change)
- Prod worker logs (Loki) show **zero** job starts during the full-suite run, vs. 129 during the incident window
- `mypy tests/conftest.py tests/test_arq_queue_guard.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)