### PR TITLE
feat(images): list images marked as reposts of an image

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -75,6 +75,8 @@ from app.models.image_status_history import ImageStatusHistory
 from app.models.ml_tag_suggestion import MlTagSuggestions
 from app.models.permissions import UserGroups
 from app.schemas.audit import (
+    ImageRepostListResponse,
+    ImageRepostResponse,
     ImageReviewListResponse,
     ImageReviewPublicResponse,
     ImageStatusHistoryListResponse,
@@ -1944,6 +1946,70 @@ async def get_image_status_history(
         per_page=pagination.per_page,
         items=items,
     )
+
+
+@router.get("/{image_id}/reposts", response_model=ImageRepostListResponse)
+async def get_image_reposts(
+    image_id: Annotated[int, Path(description="Image ID")],
+    db: AsyncSession = Depends(get_db),
+) -> ImageRepostListResponse:
+    """
+    Get the images currently marked as reposts of this image.
+
+    Derived from the live `replacement_id` pointer on the images row, not from
+    image_status_history, which never recorded replacement_id. The status filter
+    is required: restoring a repost historically left replacement_id set, so
+    hundreds of non-repost rows still point at an original.
+
+    Public: REPOST is a publicly visible status, and the repost's own page
+    already links to the original. Unpaginated — a handful of reposts per image.
+    """
+    # Verify image exists
+    image_result = await db.execute(select(Images).where(Images.image_id == image_id))  # type: ignore[arg-type]
+    if not image_result.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    # Eager load user groups for UserSummary; outer join because status_user_id
+    # is NULL on legacy rows.
+    query = (
+        select(Images, Users)
+        .outerjoin(Users, Images.status_user_id == Users.user_id)  # type: ignore[arg-type]
+        .options(
+            selectinload(Users.user_groups).selectinload(UserGroups.group)  # type: ignore[arg-type]
+        )
+        .where(
+            Images.replacement_id == image_id,  # type: ignore[arg-type]
+            Images.status == ImageStatus.REPOST,  # type: ignore[arg-type]
+        )
+        .order_by(
+            desc(Images.status_updated),  # type: ignore[arg-type]
+            desc(Images.image_id),  # type: ignore[arg-type]
+        )
+    )
+
+    rows = (await db.execute(query)).all()
+
+    items = [
+        ImageRepostResponse(
+            image_id=repost.image_id,
+            user=(
+                UserSummary(
+                    user_id=user.user_id,
+                    username=user.username,
+                    avatar=user.avatar,
+                    avatar_in_r2=user.avatar_in_r2,
+                    user_title=user.user_title,
+                    groups=user.groups,
+                )
+                if user
+                else None
+            ),
+            marked_at=repost.status_updated,
+        )
+        for repost, user in rows
+    ]
+
+    return ImageRepostListResponse(total=len(items), items=items)
 
 
 def get_review_outcome_label(outcome: int) -> str:

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -13,7 +13,7 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-from app.schemas.base import UTCDatetime
+from app.schemas.base import UTCDatetime, UTCDatetimeOptional
 from app.schemas.common import UserSummary
 from app.schemas.tag import LinkedTag
 
@@ -194,6 +194,28 @@ class ImageStatusHistoryListResponse(BaseModel):
     page: int
     per_page: int
     items: list[ImageStatusHistoryResponse]
+
+
+# =============================================================================
+# Image Reposts
+# =============================================================================
+
+
+class ImageRepostResponse(BaseModel):
+    """An image currently marked as a repost of some other image."""
+
+    image_id: int
+    user: UserSummary | None = None
+    marked_at: UTCDatetimeOptional = None
+
+    model_config = {"from_attributes": True}
+
+
+class ImageRepostListResponse(BaseModel):
+    """List of images marked as reposts of one original."""
+
+    total: int
+    items: list[ImageRepostResponse]
 
 
 # =============================================================================

--- a/tests/api/v1/test_image_reposts_endpoint.py
+++ b/tests/api/v1/test_image_reposts_endpoint.py
@@ -1,0 +1,268 @@
+"""
+Tests for GET /images/{image_id}/reposts endpoint.
+
+Returns the images whose live `replacement_id` points at this image and whose
+status is still REPOST. Derived from the images row, not image_status_history —
+the history table never recorded replacement_id and has no rows for the legacy
+reposts.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import ImageStatus
+from app.models.image import Images
+from app.models.user import Users
+from app.services.image_status import change_image_status
+
+
+async def _make_user(db_session: AsyncSession, username: str) -> Users:
+    user = Users(
+        username=username,
+        password="hashed",
+        password_type="bcrypt",
+        salt="",
+        email=f"{username}@example.com",
+        active=1,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+async def _make_image(
+    db_session: AsyncSession,
+    owner: Users,
+    slug: str,
+    *,
+    status: int = ImageStatus.ACTIVE,
+    replacement_id: int | None = None,
+    status_user_id: int | None = None,
+    status_updated: datetime | None = None,
+) -> Images:
+    image = Images(
+        filename=slug,
+        ext="jpg",
+        md5_hash=f"{slug}{'0' * 32}"[:32],
+        user_id=owner.user_id,
+        width=100,
+        height=100,
+        filesize=1000,
+        status=status,
+        replacement_id=replacement_id,
+        status_user_id=status_user_id,
+        status_updated=status_updated,
+    )
+    db_session.add(image)
+    await db_session.commit()
+    await db_session.refresh(image)
+    return image
+
+
+@pytest.mark.api
+class TestGetImageReposts:
+    """Tests for GET /images/{image_id}/reposts endpoint."""
+
+    async def test_returns_404_for_nonexistent_image(self, client: AsyncClient) -> None:
+        """Should return 404 for a nonexistent image."""
+        response = await client.get("/api/v1/images/99999999/reposts")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Image not found"
+
+    async def test_returns_empty_list_when_no_reposts(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """An image nothing points at should return an empty list."""
+        owner = await _make_user(db_session, "repostsempty")
+        original = await _make_image(db_session, owner, "repostsempty")
+
+        response = await client.get(f"/api/v1/images/{original.image_id}/reposts")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["total"] == 0
+        assert data["items"] == []
+
+    async def test_returns_repost_with_user_and_marked_at(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """A repost pointing at the original is listed with its marking user and time."""
+        owner = await _make_user(db_session, "repostsowner")
+        marker = await _make_user(db_session, "repostsmarker")
+        original = await _make_image(db_session, owner, "repostsorig")
+        repost = await _make_image(
+            db_session,
+            owner,
+            "repostsdupe",
+            status=ImageStatus.REPOST,
+            replacement_id=original.image_id,
+            status_user_id=marker.user_id,
+            status_updated=datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC),
+        )
+
+        response = await client.get(f"/api/v1/images/{original.image_id}/reposts")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+
+        item = data["items"][0]
+        assert item["image_id"] == repost.image_id
+        assert item["user"] is not None
+        assert item["user"]["user_id"] == marker.user_id
+        assert item["user"]["username"] == "repostsmarker"
+        assert item["marked_at"] is not None
+
+        # The repost itself has nothing pointing at it.
+        response = await client.get(f"/api/v1/images/{repost.image_id}/reposts")
+        assert response.status_code == 200
+        assert response.json()["total"] == 0
+
+    async def test_excludes_stale_replacement_pointer(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """An image with a leftover replacement_id but a non-REPOST status is excluded.
+
+        Prod has hundreds of these: restoring a repost to ACTIVE historically left
+        replacement_id set. They are not reposts and must not be listed.
+        """
+        owner = await _make_user(db_session, "repostsstale")
+        original = await _make_image(db_session, owner, "repostsstaleorig")
+        await _make_image(
+            db_session,
+            owner,
+            "repostsstalerestored",
+            status=ImageStatus.ACTIVE,
+            replacement_id=original.image_id,
+            status_user_id=owner.user_id,
+            status_updated=datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC),
+        )
+
+        response = await client.get(f"/api/v1/images/{original.image_id}/reposts")
+        assert response.status_code == 200
+        assert response.json()["total"] == 0
+
+    async def test_excludes_repost_of_a_different_original(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """A repost pointing at another image is not listed here."""
+        owner = await _make_user(db_session, "repostsother")
+        original = await _make_image(db_session, owner, "repostsotherA")
+        elsewhere = await _make_image(db_session, owner, "repostsotherB")
+        await _make_image(
+            db_session,
+            owner,
+            "repostsotherC",
+            status=ImageStatus.REPOST,
+            replacement_id=elsewhere.image_id,
+            status_user_id=owner.user_id,
+            status_updated=datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC),
+        )
+
+        response = await client.get(f"/api/v1/images/{original.image_id}/reposts")
+        assert response.status_code == 200
+        assert response.json()["total"] == 0
+
+        response = await client.get(f"/api/v1/images/{elsewhere.image_id}/reposts")
+        assert response.status_code == 200
+        assert response.json()["total"] == 1
+
+    async def test_ordered_newest_marked_first(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """Reposts are ordered by marking time, most recent first."""
+        owner = await _make_user(db_session, "repostsorder")
+        original = await _make_image(db_session, owner, "repostsorderorig")
+        older = await _make_image(
+            db_session,
+            owner,
+            "repostsorderold",
+            status=ImageStatus.REPOST,
+            replacement_id=original.image_id,
+            status_user_id=owner.user_id,
+            status_updated=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+        )
+        newer = await _make_image(
+            db_session,
+            owner,
+            "repostsordernew",
+            status=ImageStatus.REPOST,
+            replacement_id=original.image_id,
+            status_user_id=owner.user_id,
+            status_updated=datetime(2026, 6, 7, 8, 9, 10, tzinfo=UTC),
+        )
+
+        response = await client.get(f"/api/v1/images/{original.image_id}/reposts")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["total"] == 2
+        assert [item["image_id"] for item in data["items"]] == [newer.image_id, older.image_id]
+
+    async def test_handles_null_status_user(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """A repost with no recorded marking user returns a null user."""
+        owner = await _make_user(db_session, "repostsnulluser")
+        original = await _make_image(db_session, owner, "repostsnullorig")
+        repost = await _make_image(
+            db_session,
+            owner,
+            "repostsnulldupe",
+            status=ImageStatus.REPOST,
+            replacement_id=original.image_id,
+            status_user_id=None,
+            status_updated=datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC),
+        )
+
+        response = await client.get(f"/api/v1/images/{original.image_id}/reposts")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["total"] == 1
+        assert data["items"][0]["image_id"] == repost.image_id
+        assert data["items"][0]["user"] is None
+
+    async def test_reflects_real_marking_and_restore_path(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """Marking and restoring through change_image_status adds then removes the row."""
+        owner = await _make_user(db_session, "repostsservice")
+        actor = await _make_user(db_session, "repostsserviceactor")
+        original = await _make_image(db_session, owner, "repostssvcorig")
+        repost = await _make_image(db_session, owner, "repostssvcdupe")
+
+        await change_image_status(
+            db_session,
+            repost,
+            actor,
+            new_status=ImageStatus.REPOST,
+            replacement_id=original.image_id,
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{original.image_id}/reposts")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["items"][0]["image_id"] == repost.image_id
+        assert data["items"][0]["user"]["username"] == "repostsserviceactor"
+        assert data["items"][0]["marked_at"] is not None
+
+        await change_image_status(
+            db_session,
+            repost,
+            actor,
+            new_status=ImageStatus.ACTIVE,
+            reason="not actually a repost",
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{original.image_id}/reposts")
+        assert response.status_code == 200
+        assert response.json()["total"] == 0


### PR DESCRIPTION
## Summary

- New public endpoint `GET /api/v1/images/{image_id}/reposts`: the images whose live `replacement_id` points at this image and whose status is still REPOST, with the marking user (`status_user_id`) and `status_updated` as `marked_at`. Newest first, unpaginated (prod maximum is 7 per original).
- Derived from the `images` row rather than `image_status_history` on purpose: the history table never recorded `replacement_id`, and it holds rows for only ~127 of the ~25.8k reposts (legacy markings predate it). Agreed with the user that this should not write new history rows.
- The `status == REPOST` filter is load-bearing: 308 non-repost prod rows still carry a stale `replacement_id` from restores.

## Consumer

The frontend renders these on the original image's history page as "Image #N marked as a repost of this image" (frontend PR to follow; it needs the regenerated types from this endpoint).

## Tests

8 tests in `tests/api/v1/test_image_reposts_endpoint.py`, run green on both MariaDB and Postgres. One exercises the real `change_image_status` mark-then-restore path. Mutation-checked: dropping the status filter or flipping the order each fail a test. mypy at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bqqJxyVL3L1huxvuSZFjm