### PR TITLE
fix(prod): raise nofile ulimit for api and arq-worker containers

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -180,6 +180,15 @@ services:
     # !reset drops the base service's container_name from the merged config.
     container_name: !reset null
     user: "1003:1003"  # shuushuu user — matches storage directory ownership
+    # Docker's default soft nofile limit is 1024 (containerd LimitNOFILESoft).
+    # The single uvicorn process exhausted it under scraper bursts on 2026-09-05
+    # (OSError: [Errno 24] Too many open files → nginx 502s for every request,
+    # including healthchecks and image serving). Raise the ceiling so descriptor
+    # exhaustion can't be the first thing to fail under load.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     command: uv run --no-project uvicorn app.main:app --host 0.0.0.0 --port 8000
     # No host port publish: two replicas can't bind the same host port during a
     # rollout, and nginx reaches the api over the compose network (api:8000), so
@@ -218,6 +227,12 @@ services:
     # double-run anything.
     container_name: !reset null
     user: "1003:1003"  # shuushuu user — matches storage directory ownership
+    # Same 1024 default as api; the worker opens per-job DB/Redis/httpx
+    # connections, so give it the same headroom.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     ports: []
     environment:
       - DATABASE_URL=${DATABASE_URL}


### PR DESCRIPTION
## Why

Prod 5xx alerts today (2026-09-05) at 16:00, 17:00 and 18:00 UTC. Each wave is ~10 minutes of distributed scraper traffic (tens of thousands of IPs, ~1 request each, frozen Chrome/132-133 user agents, dead legacy paths like `/forums/*.php` and `/index.php` plus real `/images/N` pages), pushing nginx from ~1.2k to ~15k req/min. The frontend's root layout fans each page out to 3+ API calls (`meta/config`, two `banners/current`), and `banners/current` opens a fresh Redis connection per call.

The api container runs one uvicorn process with **soft nofile = 1024** (Docker/containerd default `LimitNOFILESoft=1024`; hard is 524288). Within a minute of each wave the process logs hundreds of

```
OSError: [Errno 24] Too many open files
redis.exceptions.ConnectionError: Error 24 connecting to 10.42.0.11:6379. Too many open files.
```

per minute. libuv's EMFILE path accepts-and-closes new connections, so nginx logs `recv() failed (104: Connection reset by peer) while reading response header from upstream` and returns 502 for everything proxied to the api, including image serving and healthchecks. The frontend's SSR fetches fail the same way, so `/images/N` renders as a 500 page. ~3,700 5xx per wave.

## What

`ulimits.nofile` = 65536 for `api` and `arq-worker` in `docker-compose.prod.yml`. Verified the merged config renders both entries with `docker compose config`. The frontend image already runs at 524288.

## What this does not fix

- No load shedding: under a wave, requests queue on the 20+10 asyncpg pool (p50 8s, p99 28s, 30s pool timeouts). Candidates: `uvicorn --limit-concurrency`, more workers (PG `max_connections` is 100, 32 in use), and blocking the dead legacy paths / stale UAs at Cloudflare.
- `get_redis` in `app/core/redis.py` still builds a new client per request.
- The api's own 5xx never reach Loki as `request_complete` (the middleware only logs on the non-exception path), so `{service="api", level=~"error|critical"}` was silent through the whole incident.

## Deploy

`make prod-deploy api` (zero-downtime rollout). `arq-worker` needs its own rollout to pick up the limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
