### PR TITLE
fix(nginx): block scraper signatures and dead legacy paths at the edge

### DIFF
--- a/docker/nginx/frontend-production.conf.template
+++ b/docker/nginx/frontend-production.conf.template
@@ -3,18 +3,6 @@
 # Certificates are issued via DNS-01 (Cloudflare API), so no /.well-known
 # webroot path is needed on port 80 — port 80 is HTTPS-redirect only.
 #
-# Scraper signatures that hit the site in hourly waves (2026-09-05): frozen,
-# long-obsolete Chrome versions (132/133 were current in early 2025; 99/101/107
-# in 2022) that no auto-updating browser still reports. During a wave they were
-# ~70% of page loads, and each page fans out to ~9 api calls from SSR, which is
-# what pinned the single-core api at 100%. Blocking here keeps them off the
-# frontend and api; the requests still reach this box. Edit the list here; the
-# check itself is the `if ($block_stale_ua)` in the 443 server block below.
-map $http_user_agent $block_stale_ua {
-    default 0;
-    "~Chrome/(99|101|107|132|133)\.0\." 1;
-}
-
 # HTTP server - redirect everything to HTTPS
 server {
     listen 80;
@@ -95,17 +83,24 @@ server {
 
     client_max_body_size 100M;
 
-    # See the $block_stale_ua map at the top of this file.
-    if ($block_stale_ua) {
-        return 403;
-    }
-
-    # Dead legacy URLs: phpBB (/forums/*) and the PHP-era /index.php. The
-    # frontend has no routes for them and 404s only after running the full
-    # layout load (3 api calls, 2 Redis connections per hit), and bots hammer
-    # them at thousands per minute. 410 tells crawlers the content is gone.
+    # Dead legacy URLs. phpBB lived at /forums/; the frontend has no route
+    # for it and 404s only after running the full layout load (3 api calls,
+    # 2 Redis connections per hit), and bots hammer it at thousands per
+    # minute. 410 tells crawlers the content is gone.
     location ^~ /forums/ { return 410; }
-    location ^~ /index.php { return 410; }
+
+    # MediaWiki URL forms from when the wiki lived at the apex:
+    # /index.php/<Title> and /index.php?title=<Title>&... still get thousands
+    # of hits per wave (mostly Special:RecentChanges). wiki.e-shuushuu.net
+    # serves both forms, so send them there with the query string intact.
+    # Anything else at /index.php is the dead PHP-era site.
+    location ~ "^/index\.php/(.+)$" { return 301 https://wiki.e-shuushuu.net/index.php/$1$is_args$args; }
+    location = /index.php {
+        if ($arg_title) {
+            return 301 https://wiki.e-shuushuu.net/index.php$is_args$args;
+        }
+        return 410;
+    }
 
     # API proxy to FastAPI backend
     location /api/ {

--- a/docker/nginx/frontend-production.conf.template
+++ b/docker/nginx/frontend-production.conf.template
@@ -3,6 +3,18 @@
 # Certificates are issued via DNS-01 (Cloudflare API), so no /.well-known
 # webroot path is needed on port 80 — port 80 is HTTPS-redirect only.
 #
+# Scraper signatures that hit the site in hourly waves (2026-09-05): frozen,
+# long-obsolete Chrome versions (132/133 were current in early 2025; 99/101/107
+# in 2022) that no auto-updating browser still reports. During a wave they were
+# ~70% of page loads, and each page fans out to ~9 api calls from SSR, which is
+# what pinned the single-core api at 100%. Blocking here keeps them off the
+# frontend and api; the requests still reach this box. Edit the list here; the
+# check itself is the `if ($block_stale_ua)` in the 443 server block below.
+map $http_user_agent $block_stale_ua {
+    default 0;
+    "~Chrome/(99|101|107|132|133)\.0\." 1;
+}
+
 # HTTP server - redirect everything to HTTPS
 server {
     listen 80;
@@ -82,6 +94,18 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
 
     client_max_body_size 100M;
+
+    # See the $block_stale_ua map at the top of this file.
+    if ($block_stale_ua) {
+        return 403;
+    }
+
+    # Dead legacy URLs: phpBB (/forums/*) and the PHP-era /index.php. The
+    # frontend has no routes for them and 404s only after running the full
+    # layout load (3 api calls, 2 Redis connections per hit), and bots hammer
+    # them at thousands per minute. 410 tells crawlers the content is gone.
+    location ^~ /forums/ { return 410; }
+    location ^~ /index.php { return 410; }
 
     # API proxy to FastAPI backend
     location /api/ {


### PR DESCRIPTION
## Why

Follow-up to #377. The hourly scraper waves (every :00-:10 UTC today) pin the single-core api process at 100% CPU (sampler: 101-103% for 8 minutes, Postgres never above 4 active backends) and trip the nginx 5xx alert every hour. Cloudflare WAF custom rules would be the right place to stop this, but they aren't available on the account's plan, so this does the same thing at nginx.

Fingerprints, from nginx logs of the 16:00, 17:00, 18:00 and 19:00 waves:

- **Stale Chrome UAs.** 70% of the damaging wave's page loads report `Chrome/132.0.0.0` or `Chrome/133.0.0.0` (current in Jan-Feb 2025); the second-style wave adds `Chrome/99`, `/101`, `/107` (2022). In a quiet 30-minute window, 757 IPs used these UAs and made 5,066 page requests; 5% of them made a browser-side api call, versus 19% of all other clients. Each page load fans out to ~9 api calls from SSR, so cutting these is what brings the wave under one core.
- **Dead legacy paths.** `/forums/*.php` (phpBB) and `/index.php` have no frontend route; SvelteKit 404s them only after the root layout load runs (`meta/config` + two `banners/current`, the latter opening a fresh Redis connection each). They were 12-15k requests per 3-minute wave.

## What

- `map $http_user_agent $block_stale_ua` at http level (top of the template), `if ($block_stale_ua) { return 403; }` in the 443 server block. The version list lives in the map so it's a one-line edit to tune or drop.
- `location ^~ /forums/` and `location ^~ /index.php` return 410. `/image/N` and `/wiki/*` were already nginx-level 301s.

The internal :8080 SSR server block is untouched (its client UA is `node`).

## Verified

Rendered the template with the container's `envsubst` allowlist inside `shuushuu-nginx-prod` and ran `nginx -t` against it with the real certs and includes: syntax ok, test successful.

## Trade-off to decide

The UA block will also refuse any real human still on a 19-month-old Chrome. The data above says that population is small and mostly bots, but it is not zero. If you'd rather not, drop the `if` block and keep the 410s; the 410s alone remove the second-style wave and the Redis churn but probably not the CPU saturation.

## Deploy

Template is bind-mounted, so after merging and pulling on the prod checkout either `make prod-restart nginx` (few seconds of downtime) or, zero-downtime:

```
docker exec shuushuu-nginx-prod sh -c 'envsubst "\${STORAGE_PATH},\${NGINX_HOST},\${NGINX_PORT}" < /etc/nginx/conf.d/frontend.conf.template > /etc/nginx/conf.d/default.conf && nginx -t && nginx -s reload'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
