### PR TITLE
feat(prod): run the api with 4 uvicorn workers and a concurrency cap

### DIFF
--- a/app/core/permission_sync.py
+++ b/app/core/permission_sync.py
@@ -10,6 +10,7 @@ source of truth for permissions. On startup, it:
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.database import is_postgres
 from app.core.logging import get_logger
 from app.core.permissions import Permission
 from app.models.permissions import Perms
@@ -37,7 +38,7 @@ async def sync_permissions(db: AsyncSession) -> None:
     # has no unique constraint, so two workers that both read before either
     # commits would both insert the same row. A transaction-scoped advisory
     # lock serializes them; the commit below releases it.
-    if db.get_bind().dialect.name == "postgresql":
+    if is_postgres(db):
         await db.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": _SYNC_LOCK_KEY})
 
     # Get all existing permissions from DB

--- a/app/core/permission_sync.py
+++ b/app/core/permission_sync.py
@@ -7,7 +7,7 @@ source of truth for permissions. On startup, it:
 - Warns about orphan permissions in DB but not in enum
 """
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
@@ -15,6 +15,9 @@ from app.core.permissions import Permission
 from app.models.permissions import Perms
 
 logger = get_logger(__name__)
+
+# Any fixed value; it only has to agree between the processes that run the sync.
+_SYNC_LOCK_KEY = 0x5045524D  # "PERM"
 
 
 async def sync_permissions(db: AsyncSession) -> None:
@@ -29,6 +32,13 @@ async def sync_permissions(db: AsyncSession) -> None:
         db: Database session
     """
     enum_titles = {p.value for p in Permission}
+
+    # uvicorn runs this once per worker at startup, concurrently. perms.title
+    # has no unique constraint, so two workers that both read before either
+    # commits would both insert the same row. A transaction-scoped advisory
+    # lock serializes them; the commit below releases it.
+    if db.get_bind().dialect.name == "postgresql":
+        await db.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": _SYNC_LOCK_KEY})
 
     # Get all existing permissions from DB
     result = await db.execute(select(Perms))

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -189,7 +189,12 @@ services:
       nofile:
         soft: 65536
         hard: 65536
-    command: uv run --no-project uvicorn app.main:app --host 0.0.0.0 --port 8000
+    # 4 workers: the host has 8 cores and one uvicorn process saturates a
+    # single core under scraper waves (2026-09-05). --limit-concurrency caps
+    # in-flight requests per worker so a saturated worker answers 503 in
+    # milliseconds instead of queueing thousands of connections into 30 s
+    # pool timeouts and nginx 504s.
+    command: uv run --no-project uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 4 --limit-concurrency 64
     # No host port publish: two replicas can't bind the same host port during a
     # rollout, and nginx reaches the api over the compose network (api:8000), so
     # the publish was debug-only. Use `docker compose exec api …` for host access.
@@ -199,6 +204,11 @@ services:
       - REDIS_URL=${REDIS_URL}
       - ARQ_REDIS_URL=${ARQ_REDIS_URL}
       - IQDB_HOST=iqdb
+      # Per-worker asyncpg pool. 4 workers x (8 + 4) = 48 connections, which
+      # with arq-worker's pool stays under Postgres max_connections=100.
+      # Peak active backends observed under load was 4.
+      - DB_POOL_SIZE=8
+      - DB_MAX_OVERFLOW=4
       - PYTHONDONTWRITEBYTECODE=1
     volumes:
       - ${STORAGE_PATH:-/shuushuu/images}:${STORAGE_PATH:-/shuushuu/images}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -204,8 +204,10 @@ services:
       - REDIS_URL=${REDIS_URL}
       - ARQ_REDIS_URL=${ARQ_REDIS_URL}
       - IQDB_HOST=iqdb
-      # Per-worker asyncpg pool. 4 workers x (8 + 4) = 48 connections, which
-      # with arq-worker's pool stays under Postgres max_connections=100.
+      # Per-worker asyncpg pool. 4 workers x (8 + 4) = 48 connections per
+      # container. docker-rollout runs two api replicas during a deploy, so the
+      # worst case is 96 here plus arq-worker's default 30, which fits under
+      # Postgres max_connections=200 (raised from 100 on 2026-09-06 for this).
       # Peak active backends observed under load was 4.
       - DB_POOL_SIZE=8
       - DB_MAX_OVERFLOW=4

--- a/tests/unit/test_permission_sync.py
+++ b/tests/unit/test_permission_sync.py
@@ -136,4 +136,3 @@ class TestSyncPermissions:
             async with AsyncSession(engine) as session:
                 await session.execute(delete(Perms).where(Perms.title == race_title))
                 await session.commit()
-

--- a/tests/unit/test_permission_sync.py
+++ b/tests/unit/test_permission_sync.py
@@ -93,3 +93,47 @@ class TestSyncPermissions:
         count_after_second = len(result.scalars().all())
 
         assert count_after_first == count_after_second
+
+    async def test_concurrent_syncs_insert_each_missing_permission_once(
+        self, engine, monkeypatch: pytest.MonkeyPatch
+    ):
+        """uvicorn runs one sync per worker at startup, concurrently. Two workers
+        that both read before either commits must not both insert the same
+        permission (perms.title has no unique constraint)."""
+        import asyncio
+        from enum import StrEnum
+
+        from sqlalchemy import delete, func
+
+        from app.core import permission_sync
+        from app.core.permission_sync import sync_permissions
+
+        if engine.dialect.name != "postgresql":
+            pytest.skip("cross-process serialization is Postgres-only")
+
+        race_title = "race_test_permission"
+        # Every real member plus one nothing has seeded, so both syncs see
+        # exactly one permission as missing and nothing as orphaned.
+        fake = StrEnum(
+            "FakePermission",
+            {**{m.name: m.value for m in Permission}, "RACE_TEST": race_title},
+        )
+        fake.description = property(lambda self: "Exists only for this test")  # type: ignore[attr-defined]
+        monkeypatch.setattr(permission_sync, "Permission", fake)
+
+        async def run_sync() -> None:
+            async with AsyncSession(engine) as session:
+                await sync_permissions(session)
+
+        try:
+            await asyncio.gather(run_sync(), run_sync())
+            async with AsyncSession(engine) as session:
+                count = await session.scalar(
+                    select(func.count()).select_from(Perms).where(Perms.title == race_title)
+                )
+            assert count == 1
+        finally:
+            async with AsyncSession(engine) as session:
+                await session.execute(delete(Perms).where(Perms.title == race_title))
+                await session.commit()
+


### PR DESCRIPTION
## Why

Follow-up to #377. The sampler on the 19:00 and 22:00 UTC scraper waves showed the single uvicorn process pinned at 100% of one core for 8-10 minutes per wave while Postgres never had more than 4 active backends. Every request held its pool connection while parked waiting for CPU (21-28 "idle in transaction"), so the pool timed out at 30 s and nginx answered 504. Raising the descriptor limit alone (#377) turned fast resets into slow timeouts: ~7,100 5xx at 22:00 versus ~3,000 before. The host has 8 cores.

## What

`docker-compose.prod.yml`, api service:
- `--workers 4`. Each worker loads the ML model; container RSS went from 1.3 GB to 3.4 GB.
- `--limit-concurrency 64` per worker. A saturated worker answers 503 in milliseconds instead of queueing thousands of connections.
- `DB_POOL_SIZE=8`, `DB_MAX_OVERFLOW=4` per worker: 48 connections max per api container. Review pointed out that docker-rollout runs two api replicas during a deploy, so the worst case is 96 plus arq-worker's default 30 = 126, over the old `max_connections=100`. Raised `max_connections` to 200 on tomoyo on 2026-09-06; the compose comment records the budget.

`app/core/permission_sync.py`: with four workers starting at once, `sync_permissions` (select-then-insert, no unique constraint on `perms.title`) could insert a newly added permission twice. A transaction-scoped Postgres advisory lock before the read serializes the workers; the existing commit releases it. Test written first: two concurrent syncs against real sessions with one permission missing must yield one row. Red before the lock (both inserted), green after.

## Applied live first (22:23 UTC) and measured on the 23:00 wave

| | 22:00 wave (1 worker, 65536 fds) | 23:00 wave (this change) |
|---|---|---|
| Requests in the window | ~48,000 | ~49,500 |
| nginx 5xx | ~7,100 (2,800 of them 504) | 542, all in the first minute (527 of them 503 from the cap) |
| Pool timeouts / ASGI exceptions | ~5,100 | 0 |
| API CPU | 100% of one core, sustained | peak 219% of 400% |
| Connections open to the API | up to 3,850 | up to 308 |
| Postgres active backends | max 4, 21-28 idle in transaction | max 9 |
| Grafana `nginx 5xx errors` | Alerting 22:11 | Pending 23:00, Normal 23:06, never fired |

Unit suite on the branch: 828 passed, 11 skipped (the pre-existing local-Redis skips). mypy clean on touched files.

## Notes

- This is already what prod runs; merging and pulling on the prod checkout just makes the tree clean. No further rollout needed.
- Startup log now shows the `orphan_permission` warnings (`checkdupes`, `editimgfilename`) four times, once per worker. They pre-date this change.
- Each worker's ONNX session defaults its intra-op thread count to the core count. Only `/analyze` runs inference in the api, so it hasn't mattered; worth a look if upload-time inference ever contends with request handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

