### PR TITLE
fix(images): reposts review follow-ups

### DIFF
--- a/app/api/v1/images.py
+++ b/app/api/v1/images.py
@@ -1969,6 +1969,14 @@ async def get_image_reposts(
     if not image_result.scalar_one_or_none():
         raise HTTPException(status_code=404, detail="Image not found")
 
+    # Nullable sort column: MariaDB places NULLs last on a DESC sort, Postgres
+    # places them first. A legacy repost with no status_updated belongs at the
+    # bottom on both. MariaDB has no NULLS LAST syntax, so this is Postgres-only
+    # by construction (same pattern as the user list in app/api/v1/users.py).
+    status_updated_desc: Any = desc(Images.status_updated)  # type: ignore[arg-type]
+    if is_postgres(db):
+        status_updated_desc = status_updated_desc.nullslast()
+
     # Eager load user groups for UserSummary; outer join because status_user_id
     # is NULL on legacy rows.
     query = (
@@ -1980,9 +1988,12 @@ async def get_image_reposts(
         .where(
             Images.replacement_id == image_id,  # type: ignore[arg-type]
             Images.status == ImageStatus.REPOST,  # type: ignore[arg-type]
+            # Prod holds a couple of rows that point at themselves, from before
+            # the service rejected a self-repost. An image is not its own repost.
+            Images.image_id != image_id,  # type: ignore[arg-type]
         )
         .order_by(
-            desc(Images.status_updated),  # type: ignore[arg-type]
+            status_updated_desc,
             desc(Images.image_id),  # type: ignore[arg-type]
         )
     )

--- a/tests/api/v1/test_image_reposts_endpoint.py
+++ b/tests/api/v1/test_image_reposts_endpoint.py
@@ -94,6 +94,7 @@ class TestGetImageReposts:
         owner = await _make_user(db_session, "repostsowner")
         marker = await _make_user(db_session, "repostsmarker")
         original = await _make_image(db_session, owner, "repostsorig")
+        marked_at = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
         repost = await _make_image(
             db_session,
             owner,
@@ -101,7 +102,7 @@ class TestGetImageReposts:
             status=ImageStatus.REPOST,
             replacement_id=original.image_id,
             status_user_id=marker.user_id,
-            status_updated=datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC),
+            status_updated=marked_at,
         )
 
         response = await client.get(f"/api/v1/images/{original.image_id}/reposts")
@@ -116,7 +117,7 @@ class TestGetImageReposts:
         assert item["user"] is not None
         assert item["user"]["user_id"] == marker.user_id
         assert item["user"]["username"] == "repostsmarker"
-        assert item["marked_at"] is not None
+        assert item["marked_at"] == marked_at.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         # The repost itself has nothing pointing at it.
         response = await client.get(f"/api/v1/images/{repost.image_id}/reposts")
@@ -175,18 +176,14 @@ class TestGetImageReposts:
     async def test_ordered_newest_marked_first(
         self, client: AsyncClient, db_session: AsyncSession
     ) -> None:
-        """Reposts are ordered by marking time, most recent first."""
+        """Reposts are ordered by marking time, most recent first.
+
+        The newer-marked repost is inserted FIRST, so it gets the LOWER image_id.
+        The `image_id DESC` tiebreak alone would then return them in the wrong
+        order, so this only passes if `status_updated DESC` is actually applied.
+        """
         owner = await _make_user(db_session, "repostsorder")
         original = await _make_image(db_session, owner, "repostsorderorig")
-        older = await _make_image(
-            db_session,
-            owner,
-            "repostsorderold",
-            status=ImageStatus.REPOST,
-            replacement_id=original.image_id,
-            status_user_id=owner.user_id,
-            status_updated=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
-        )
         newer = await _make_image(
             db_session,
             owner,
@@ -196,6 +193,16 @@ class TestGetImageReposts:
             status_user_id=owner.user_id,
             status_updated=datetime(2026, 6, 7, 8, 9, 10, tzinfo=UTC),
         )
+        older = await _make_image(
+            db_session,
+            owner,
+            "repostsorderold",
+            status=ImageStatus.REPOST,
+            replacement_id=original.image_id,
+            status_user_id=owner.user_id,
+            status_updated=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+        )
+        assert newer.image_id < older.image_id  # autoincrement opposes marking order
 
         response = await client.get(f"/api/v1/images/{original.image_id}/reposts")
         assert response.status_code == 200
@@ -203,6 +210,67 @@ class TestGetImageReposts:
         data = response.json()
         assert data["total"] == 2
         assert [item["image_id"] for item in data["items"]] == [newer.image_id, older.image_id]
+
+    async def test_null_marked_at_sorts_last_on_both_dialects(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """A repost with no status_updated sorts below a dated one on every backend.
+
+        MariaDB puts NULLs last on a DESC sort; Postgres puts them first by
+        default. The NULL repost is inserted SECOND, so it holds the HIGHER
+        image_id: the `image_id DESC` tiebreak alone would float it to the top,
+        so this fails on Postgres unless NULLs are explicitly ordered last.
+        """
+        owner = await _make_user(db_session, "repostsnullsort")
+        original = await _make_image(db_session, owner, "repostsnullsortorig")
+        dated = await _make_image(
+            db_session,
+            owner,
+            "repostsnullsortdated",
+            status=ImageStatus.REPOST,
+            replacement_id=original.image_id,
+            status_user_id=owner.user_id,
+            status_updated=datetime(2026, 6, 7, 8, 9, 10, tzinfo=UTC),
+        )
+        undated = await _make_image(
+            db_session,
+            owner,
+            "repostsnullsortundated",
+            status=ImageStatus.REPOST,
+            replacement_id=original.image_id,
+            status_user_id=owner.user_id,
+            status_updated=None,
+        )
+        assert dated.image_id < undated.image_id  # tiebreak alone would invert this
+
+        response = await client.get(f"/api/v1/images/{original.image_id}/reposts")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["total"] == 2
+        assert [item["image_id"] for item in data["items"]] == [dated.image_id, undated.image_id]
+        assert data["items"][1]["marked_at"] is None
+
+    async def test_excludes_self_referencing_repost(
+        self, client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """A REPOST row pointing at itself is not a repost of itself.
+
+        Prod holds a couple of these, left over from before the service rejected
+        a self-repost. They must not show up on their own page.
+        """
+        owner = await _make_user(db_session, "repostsself")
+        image = await _make_image(db_session, owner, "repostsselfimg")
+        image.status = ImageStatus.REPOST
+        image.replacement_id = image.image_id
+        image.status_user_id = owner.user_id
+        image.status_updated = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+        db_session.add(image)
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/images/{image.image_id}/reposts")
+        assert response.status_code == 200
+        assert response.json()["total"] == 0
 
     async def test_handles_null_status_user(
         self, client: AsyncClient, db_session: AsyncSession


### PR DESCRIPTION
Closes #375

Four review follow-ups on `GET /images/{id}/reposts` (added by #374):

1. **Nullable sort key differs by dialect.** `ORDER BY status_updated DESC` placed NULLs last on MariaDB but first on Postgres. Applied the existing `is_postgres(db)` + `.nullslast()` pattern from `app/api/v1/users.py:146-156`. Verified with a new test, `test_null_marked_at_sorts_last_on_both_dialects`, which inserts the NULL-`status_updated` row *after* the dated one (giving it the higher `image_id`) so the `image_id DESC` tiebreak alone would float it to the top — it only passes with the `nullslast()` fix applied.
2. **Self-reference guard.** Added `Images.image_id != image_id` to the filter so a `REPOST` row pointing at itself (prod has 2, predating the service's self-repost check) isn't listed as its own repost. Verified with a new test, `test_excludes_self_referencing_repost`.
3. **`test_ordered_newest_marked_first` couldn't fail.** It inserted the older row first, so the `image_id DESC` tiebreak alone produced the expected order regardless of the `status_updated` sort. Rewrote it to insert the newer-marked row first (giving it the *lower* `image_id`), so the tiebreak alone now produces the wrong order. **Proof it now guards the ordering:** I temporarily removed the `status_updated` sort key from the query and reran this test plus `test_null_marked_at_sorts_last_on_both_dialects` — both failed (`assert [3, 2] == [2, 3]` and `assert [6, 5] == [5, 6]`) — then reverted the temporary change and confirmed both pass again with the real ordering restored.
4. **`marked_at` was only asserted `is not None`.** `test_returns_repost_with_user_and_marked_at` now compares it to the constructed `status_updated`'s serialized value. The new NULL-`status_updated` test above also asserts `marked_at` is `null` for the undated row, covering the optional serialization path.

## Test plan
- [x] `tests/api/v1/test_image_reposts_endpoint.py` — 10 passed (was 8; added 2)
- [x] Deliberate-failure proof for item 3 (see above), then reverted
- [x] `tests/api/v1/test_images.py` + `tests/api/v1/test_users.py` — 274 passed, 2 skipped (pre-existing MariaDB-only skips)
- [x] Full suite: `uv run pytest -n 4 --dist loadgroup` — 2777 passed, 33 skipped (all pre-existing: MariaDB-only tests on the Postgres session backend, missing ML model files, etc.), pristine output
- [x] `uv run mypy app/` — clean, 173 source files
- [x] `uv run ruff check` / `ruff format --check` on touched files — clean

Built from the partial, unverified WIP on `wip/reposts-review-fixes` (commit 9220b5e) as reference material; rewritten via TDD on this branch rather than cherry-picked. `wip/reposts-review-fixes` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SU6KhFCrbutgMxi7AjtyuR