### PR TITLE
fix(users): escape LIKE metacharacters in username search

### DIFF
--- a/app/api/v1/tags.py
+++ b/app/api/v1/tags.py
@@ -78,6 +78,7 @@ from app.services.character_source_counts import get_shared_image_counts
 from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 from app.services.search import sync_tag_delete_to_search, sync_tag_to_search
 from app.services.tag_type_flags import refresh_images_tag_type_flags
+from app.utils.like_escape import escape_like_pattern
 
 SUGGESTION_STATS_MIN_THRESHOLD = 5
 
@@ -215,11 +216,6 @@ FULLTEXT_WORD_DELIMITERS = frozenset(" \n\t;:!?.'\"`()[]{}|&/\\,-=~")
 
 # Pre-computed translation table for efficient delimiter replacement (used by str.translate)
 _DELIMITER_TRANS_TABLE = str.maketrans(dict.fromkeys(FULLTEXT_WORD_DELIMITERS, " "))
-
-
-def _escape_like_pattern(value: str) -> str:
-    """Escape special LIKE pattern characters (% and _) in a search value."""
-    return value.replace("%", r"\%").replace("_", r"\_")
 
 
 def _sanitize_fulltext_term(term: str) -> str:
@@ -696,7 +692,7 @@ async def list_tags(
         if len(search) < 3:
             # Short query: prefix match with LIKE (e.g., "sa" -> "sakura")
             # Escape LIKE special characters to prevent unintended wildcard matching
-            escaped_search = _escape_like_pattern(search)
+            escaped_search = escape_like_pattern(search)
             prefix_pattern = f"{escaped_search}%"
             query = query.where(
                 Tags.title.like(prefix_pattern)  # type: ignore[union-attr]
@@ -710,7 +706,7 @@ async def list_tags(
             # the LIKE branch (built on portable lower() comparisons).
             for word in search.split():
                 query = query.where(
-                    Tags.title.ilike(f"%{_escape_like_pattern(word)}%")  # type: ignore[union-attr]
+                    Tags.title.ilike(f"%{escape_like_pattern(word)}%")  # type: ignore[union-attr]
                 )
         else:
             # Long query: word-order independent full-text search with wildcard expansion
@@ -760,7 +756,7 @@ async def list_tags(
                 # All terms were stopwords or too short - fall back to LIKE prefix search
                 # This handles edge cases like searching for "The" or "A" or "The A"
                 # Escape LIKE special characters to prevent unintended wildcard matching
-                escaped_search = _escape_like_pattern(search)
+                escaped_search = escape_like_pattern(search)
                 query = query.where(Tags.title.like(f"{escaped_search}%"))  # type: ignore[union-attr]
     if type_id is not None:
         query = query.where(Tags.type == type_id)  # type: ignore[arg-type]

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -96,6 +96,7 @@ from app.services.tag_context import stamp_context_sources
 from app.services.turnstile import verify_turnstile_token
 from app.services.user import build_user_private_response
 from app.tasks.queue import enqueue_job
+from app.utils.like_escape import escape_like_pattern
 
 logger = get_logger(__name__)
 
@@ -121,8 +122,10 @@ async def list_users(
 
     # Apply search filter
     if search:
-        # Case-insensitive match - include substring matches
-        query = query.where(func.lower(Users.username).like(f"%{search.lower()}%"))
+        # Case-insensitive match - include substring matches. Escape LIKE
+        # metacharacters so % and _ in the search term are treated literally.
+        escaped_search = escape_like_pattern(search.lower())
+        query = query.where(func.lower(Users.username).like(f"%{escaped_search}%"))
 
     # Count total
     count_query = select(func.count()).select_from(query.subquery())
@@ -158,13 +161,14 @@ async def list_users(
     # Apply sorting. If a search is present, order by relevance first
     if search:
         s_lower = search.lower()
+        escaped_s_lower = escape_like_pattern(s_lower)
         relevance = case(
             (
                 func.lower(Users.username) == s_lower,
                 0,
             ),
             (
-                func.lower(Users.username).like(f"{s_lower}%"),
+                func.lower(Users.username).like(f"{escaped_s_lower}%"),
                 1,
             ),
             else_=2,

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -2,6 +2,7 @@
 Utility functions
 """
 
+from app.utils.like_escape import escape_like_pattern
 from app.utils.markdown import (
     clean_user_input,
     normalize_legacy_entities,
@@ -11,6 +12,7 @@ from app.utils.markdown import (
 
 __all__ = [
     "clean_user_input",
+    "escape_like_pattern",
     "normalize_legacy_entities",
     "parse_markdown",
     "strip_markdown",

--- a/app/utils/comment_search.py
+++ b/app/utils/comment_search.py
@@ -28,6 +28,7 @@ from sqlalchemy import Select, false
 from sqlalchemy import text as sql_text
 
 from app.models import Comments
+from app.utils.like_escape import escape_like_pattern
 
 # Must match innodb_ft_min_token_size on the server. Anything shorter is
 # absent from the index, so `+ab` matches nothing at all.
@@ -151,8 +152,7 @@ def like_pattern(term: str) -> str:
     Without this a search for `100%` degrades into "match anything". Backslash
     is escaped first so it cannot double-escape the wildcards added after it.
     """
-    escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    return f"%{escaped}%"
+    return f"%{escape_like_pattern(term)}%"
 
 
 def _is_indexable(token: str) -> bool:

--- a/app/utils/like_escape.py
+++ b/app/utils/like_escape.py
@@ -2,5 +2,10 @@
 
 
 def escape_like_pattern(value: str) -> str:
-    """Escape special LIKE pattern characters (% and _) in a search value."""
-    return value.replace("%", r"\%").replace("_", r"\_")
+    """Escape special LIKE pattern characters (\\, % and _) in a search value.
+
+    Backslash is escaped first so it cannot double-escape the % and _
+    escapes added after it, or combine with a wildcard a caller appends to
+    the result into an unintended escape sequence.
+    """
+    return value.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")

--- a/app/utils/like_escape.py
+++ b/app/utils/like_escape.py
@@ -1,0 +1,6 @@
+"""Escaping for SQL LIKE pattern metacharacters."""
+
+
+def escape_like_pattern(value: str) -> str:
+    """Escape special LIKE pattern characters (% and _) in a search value."""
+    return value.replace("%", r"\%").replace("_", r"\_")

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -399,6 +399,46 @@ class TestListUsers:
         assert "a_bcdef" in usernames
         assert "aXbdecoy" not in usernames
 
+    async def test_list_users_search_backslash_escaped(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A literal backslash in the search term must be escaped first, so it
+        cannot desync from the % and _ escapes or from the wildcards this
+        endpoint appends around the term."""
+        backslash_user = Users(
+            username="back\\slash",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="backslash@example.com",
+            active=1,
+        )
+        # Without the actual backslash character, would only match if the
+        # database silently dropped the raw backslash instead of escaping it.
+        decoy = Users(
+            username="backslash",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="backslashdecoy@example.com",
+            active=1,
+        )
+        db_session.add_all([backslash_user, decoy])
+        await db_session.commit()
+
+        response = await client.get("/api/v1/users", params={"search": "back\\slash"})
+        assert response.status_code == 200
+        data = response.json()
+        usernames = [u["username"] for u in data["users"]]
+        assert usernames == ["back\\slash"]
+
+        # A trailing backslash must not desync from the wildcard this endpoint
+        # appends after the term and must not degrade into matching everyone.
+        trailing_response = await client.get("/api/v1/users", params={"search": "abc\\"})
+        assert trailing_response.status_code == 200
+        trailing_data = trailing_response.json()
+        assert trailing_data["users"] == []
+
     async def test_list_users_search_empty_returns_all(
         self, client: AsyncClient, db_session: AsyncSession
     ):

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -278,6 +278,127 @@ class TestListUsers:
         assert "Ran" in usernames
         assert usernames[0] == "Ran"
 
+    async def test_list_users_search_literal_underscore_no_wildcard(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A literal `_` in the search term must not match arbitrary characters."""
+        test_users = [
+            ("under_score", "underscore@example.com"),
+            ("underXscore", "underxscore@example.com"),
+        ]
+        for username, email in test_users:
+            user = Users(
+                username=username,
+                password=get_password_hash("TestPassword123!"),
+                password_type="bcrypt",
+                salt="",
+                email=email,
+                active=1,
+            )
+            db_session.add(user)
+        await db_session.commit()
+
+        response = await client.get("/api/v1/users", params={"search": "under_score"})
+        assert response.status_code == 200
+        data = response.json()
+        usernames = [u["username"] for u in data["users"]]
+        assert usernames == ["under_score"]
+
+    async def test_list_users_search_literal_percent(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A literal `%` in the search term must match only usernames containing it."""
+        test_users = [
+            ("100%", "hundredpercent@example.com"),
+            ("100", "hundred@example.com"),
+            ("100abc", "hundredabc@example.com"),
+        ]
+        for username, email in test_users:
+            user = Users(
+                username=username,
+                password=get_password_hash("TestPassword123!"),
+                password_type="bcrypt",
+                salt="",
+                email=email,
+                active=1,
+            )
+            db_session.add(user)
+        await db_session.commit()
+
+        response = await client.get("/api/v1/users", params={"search": "100%"})
+        assert response.status_code == 200
+        data = response.json()
+        usernames = [u["username"] for u in data["users"]]
+        assert usernames == ["100%"]
+
+    async def test_list_users_search_bare_percent_no_match_all(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """A bare `%` must not act as a wildcard matching every user."""
+        test_users = [
+            ("percentuser1", "percentuser1@example.com"),
+            ("percentuser2", "percentuser2@example.com"),
+        ]
+        for username, email in test_users:
+            user = Users(
+                username=username,
+                password=get_password_hash("TestPassword123!"),
+                password_type="bcrypt",
+                salt="",
+                email=email,
+                active=1,
+            )
+            db_session.add(user)
+        await db_session.commit()
+
+        response = await client.get("/api/v1/users", params={"search": "%"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 0
+        assert data["users"] == []
+
+    async def test_list_users_search_relevance_ordering_with_escaped_term(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Relevance ordering (exact match first, prefix next) must still work
+        when the search term contains characters that need LIKE-escaping."""
+        exact = Users(
+            username="a_b",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="exact_ab@example.com",
+            active=1,
+        )
+        prefix = Users(
+            username="a_bcdef",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="prefix_ab@example.com",
+            active=1,
+        )
+        # Would have matched under the old unescaped interpretation of "_" as
+        # a single-character wildcard, but must not match now that it's literal.
+        wildcard_decoy = Users(
+            username="aXbdecoy",
+            password=get_password_hash("TestPassword123!"),
+            password_type="bcrypt",
+            salt="",
+            email="decoy_ab@example.com",
+            active=1,
+        )
+        db_session.add_all([exact, prefix, wildcard_decoy])
+        await db_session.commit()
+
+        response = await client.get("/api/v1/users", params={"search": "a_b"})
+        assert response.status_code == 200
+        data = response.json()
+        usernames = [u["username"] for u in data["users"]]
+        assert usernames[0] == "a_b"
+        assert "a_bcdef" in usernames
+        assert "aXbdecoy" not in usernames
+
     async def test_list_users_search_empty_returns_all(
         self, client: AsyncClient, db_session: AsyncSession
     ):


### PR DESCRIPTION
Closes #351

## Summary
- `GET /api/v1/users?search=` pasted the raw search term into LIKE patterns, so `%` and `_` acted as SQL wildcards in both the filter (`app/api/v1/users.py`) and the relevance-ordering block: `100%` searched for `100`, a bare `%` matched every user, and `_` matched any single character (`anonymous_object` also matched `anonymousXobject`).
- Every other search path already escaped these (`tags.py`'s `_escape_like_pattern`, `app/utils/comment_search.py`'s `like_pattern`), but `users.py` never got the same treatment.
- Fix: lifted the escaping logic into a shared `app/utils/like_escape.py::escape_like_pattern`, so `tags.py` and `users.py` both call one implementation instead of `users.py` growing a third private copy.
- `users.py` now escapes the search term before building both the substring-match filter and the prefix-match relevance-ordering pattern (the exact-match relevance branch is an `==` comparison, not a `LIKE`, so it needed no change).
- Behavior is identical on MariaDB and Postgres: no call site passes an explicit `ESCAPE` clause, matching the existing `tags.py` pattern, since both engines default `LIKE`'s escape character to backslash.

**Follow-up from review:** the helper lifted from `tags.py` only escaped `%` and `_`, not backslash — the issue text's claim that both existing helpers escaped backslash was wrong for the `tags.py` one. A raw backslash in a search term passed through unescaped, and the database silently drops a backslash before an ordinary character rather than treating it as literal, so a search for a backslash-containing username instead matched *other* usernames that merely contained the surrounding substring (and a trailing backslash could swallow the closing `%` this endpoint appends into an unintended escape sequence). `escape_like_pattern` now escapes backslash first, matching what `app/utils/comment_search.py::like_pattern` already did — which made that function's own escaping redundant, so it now calls the shared helper too (`return f"%{escape_like_pattern(term)}%"`), keeping its docstring. All three search paths (`tags.py`, `users.py`, `comment_search.py`) now share one escaping implementation.

## Test plan
- Added failing-first tests in `tests/api/v1/test_users.py::TestListUsers` covering: a literal `_` no longer matching an arbitrary character, a literal `%` being searchable, a bare `%` no longer matching every user, relevance ordering (exact match first, prefix next) still working with an escaped term including a decoy that would only match under the old broken wildcard interpretation, and a literal backslash in the search term correctly finding a backslash-containing username (plus a decoy proving it isn't just a dropped-character coincidence) with a trailing backslash not desyncing from the appended wildcard.
- Confirmed each new test failed against the pre-fix code, then passed after the corresponding fix.
- `uv run pytest tests/api/v1/test_users.py -k search`, `tests/api/v1/test_tags.py -k search`, and the comment-search suites (`test_comments.py`, `test_images.py::*comment*`, `tests/unit/test_comment_search.py`) — all passing, confirming the consolidation didn't regress tag or comment search.
- Full suite: `uv run pytest -n 4 --dist loadgroup` against the Postgres test DB — 2780 passed, 33 skipped, 0 failed.
- `uv run mypy app/`: no issues found in 174 source files.
- `uv run ruff check` / `uv run ruff format --check` on touched files: clean.

Nothing was left out; both call sites in `users.py` mentioned in the issue are fixed, and the escaping helper now matches the strongest of the two implementations that existed before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SU6KhFCrbutgMxi7AjtyuR
