### PR TITLE
fix(redis): share one connection pool per process instead of per request

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -54,6 +54,13 @@ class Settings(BaseSettings):
     # Redis
     REDIS_URL: str = Field(default="redis://localhost:6379/0")
     CACHE_TTL: int = 300  # 5 minutes
+    # Cap on the shared per-process redis.asyncio.ConnectionPool (created once
+    # in the app lifespan, see app/core/redis.py). 64 matches --limit-concurrency
+    # in docker-compose.prod.yml: a fully loaded worker can't ask Redis for more
+    # connections than uvicorn will let it run requests concurrently. Beyond the
+    # cap, redis-py raises a clear ConnectionError("Too many connections")
+    # instead of letting a burst open unbounded sockets (see #381).
+    REDIS_MAX_CONNECTIONS: int = Field(default=64, ge=1)
 
     # Meilisearch
     MEILISEARCH_URL: str = Field(default="http://localhost:7700")

--- a/app/core/redis.py
+++ b/app/core/redis.py
@@ -1,20 +1,39 @@
 from collections.abc import AsyncGenerator
 
 import redis.asyncio as redis
+from fastapi import Request
 
 from app.config import settings
 
 
-async def get_redis() -> AsyncGenerator[redis.Redis]:  # type: ignore[type-arg]
+def create_redis_pool() -> redis.ConnectionPool:  # type: ignore[type-arg]
     """
-    Dependency for getting async redis connection.
+    Build the process-wide Redis connection pool.
+
+    Called once per process in the app lifespan (app/main.py) and stored on
+    app.state.redis_pool, so every get_redis() dependency resolution shares it
+    instead of paying a TCP connect per request (see #381).
     """
-    client = redis.from_url(
+    return redis.ConnectionPool.from_url(
         str(settings.REDIS_URL),
         encoding="utf-8",
         decode_responses=True,
+        max_connections=settings.REDIS_MAX_CONNECTIONS,
     )
+
+
+async def get_redis(request: Request) -> AsyncGenerator[redis.Redis]:  # type: ignore[type-arg]
+    """
+    Dependency for getting an async redis connection.
+
+    Binds to the shared per-process pool at app.state.redis_pool (created in
+    the app lifespan) instead of opening a new connection per request.
+    Closing the yielded client does not close the shared pool -- redis-py
+    only auto-closes a pool it created internally; a pool passed in
+    explicitly (as here) is left for its owner (the lifespan) to dispose of.
+    """
+    client = redis.Redis(connection_pool=request.app.state.redis_pool)
     try:
         yield client
     finally:
-        await client.close()
+        await client.aclose()  # type: ignore[attr-defined]  # stub lags runtime; aclose is correct

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,7 @@ from app.core.logging import (
     set_request_context,
 )
 from app.core.permission_sync import sync_permissions
+from app.core.redis import create_redis_pool
 from app.core.security import verify_access_token
 from app.services.ml_runtime import warm_load_if_enabled
 from app.tasks.queue import close_queue
@@ -120,6 +121,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         version="2.0.0",
     )
 
+    # Shared Redis connection pool: one per process, reused by every
+    # get_redis() dependency resolution instead of opening a fresh TCP
+    # connection per request (#381).
+    app.state.redis_pool = create_redis_pool()
+
     # Sync permissions: ensure database matches Permission enum
     async with AsyncSessionLocal() as db:
         await sync_permissions(db)
@@ -161,6 +167,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     if meilisearch_client:
         await meilisearch_client.aclose()
     await close_queue()  # Close arq pool
+    await app.state.redis_pool.disconnect()
 
 
 # Create FastAPI application

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -738,6 +738,19 @@ def _test_redis_db() -> int:
 
 
 @pytest.fixture
+def test_redis_url() -> str:
+    """Redis DSN for the same host/port/db as the `redis_client` fixture.
+
+    For tests that need a URL string (e.g. app.core.redis.create_redis_pool)
+    rather than a ready-made client.
+    """
+    host = os.getenv("TEST_REDIS_HOST", "localhost")
+    port = int(os.getenv("TEST_REDIS_PORT", "6379"))
+    db = _test_redis_db()
+    return f"redis://{host}:{port}/{db}"
+
+
+@pytest.fixture
 async def redis_client():
     """Real Redis client for tests that require Redis functionality.
 

--- a/tests/unit/test_redis_pool.py
+++ b/tests/unit/test_redis_pool.py
@@ -1,0 +1,116 @@
+"""Tests for the shared per-process Redis connection pool (#381).
+
+Before this, app.core.redis.get_redis called redis.from_url(...) on every
+dependency resolution and closed the client in `finally`, so every request
+that depended on it paid a fresh TCP connect -- the dominant cause of the
+"Too many open files" errors during the 2026-09-05 scraper waves. Now
+app/main.py's lifespan creates one redis.asyncio.ConnectionPool per process
+(via create_redis_pool), stores it on app.state.redis_pool, and get_redis
+binds a lightweight client to that shared pool instead of opening its own.
+"""
+
+import pytest
+import redis.asyncio as redis
+from fastapi import Depends, FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+from app.config import settings
+from app.core.redis import create_redis_pool, get_redis
+
+
+@pytest.mark.unit
+class TestCreateRedisPool:
+    """create_redis_pool() builds the pool the lifespan stores on app.state."""
+
+    async def test_honours_max_connections_setting(self, monkeypatch, test_redis_url):
+        monkeypatch.setattr(settings, "REDIS_URL", test_redis_url)
+        monkeypatch.setattr(settings, "REDIS_MAX_CONNECTIONS", 7)
+
+        pool = create_redis_pool()
+        try:
+            assert pool.max_connections == 7
+        finally:
+            await pool.disconnect()
+
+    async def test_pool_is_really_connectable(self, monkeypatch, test_redis_url):
+        monkeypatch.setattr(settings, "REDIS_URL", test_redis_url)
+
+        pool = create_redis_pool()
+        try:
+            client = redis.Redis(connection_pool=pool)
+            assert await client.ping() is True
+        finally:
+            await pool.disconnect()
+
+    async def test_exhausted_pool_raises_a_clear_error(self, monkeypatch, test_redis_url):
+        monkeypatch.setattr(settings, "REDIS_URL", test_redis_url)
+        monkeypatch.setattr(settings, "REDIS_MAX_CONNECTIONS", 1)
+
+        pool = create_redis_pool()
+        try:
+            held = await pool.get_connection()
+            try:
+                with pytest.raises(RedisConnectionError, match="Too many connections"):
+                    await pool.get_connection()
+            finally:
+                await pool.release(held)
+        finally:
+            await pool.disconnect()
+
+    async def test_disconnect_actually_closes_pooled_connections(self, monkeypatch, test_redis_url):
+        monkeypatch.setattr(settings, "REDIS_URL", test_redis_url)
+
+        pool = create_redis_pool()
+        client = redis.Redis(connection_pool=pool)
+        await client.ping()  # establishes a connection, then releases it to the pool
+        held_connection = pool._available_connections[0]
+        assert held_connection.is_connected is True
+
+        await pool.disconnect()
+
+        assert held_connection.is_connected is False
+
+
+@pytest.mark.unit
+class TestGetRedisDependency:
+    """get_redis() must bind to the shared pool and never close it itself."""
+
+    async def test_two_dependency_resolutions_share_the_pool_and_survive_close(
+        self, monkeypatch, test_redis_url
+    ):
+        monkeypatch.setattr(settings, "REDIS_URL", test_redis_url)
+        pool = create_redis_pool()
+
+        app = FastAPI()
+        app.state.redis_pool = pool
+
+        @app.get("/ping")
+        async def ping_route(
+            request: Request,
+            redis_client: redis.Redis = Depends(get_redis),  # type: ignore[type-arg]
+        ):
+            await redis_client.ping()
+            return {
+                "client_pool_id": id(redis_client.connection_pool),
+                "state_pool_id": id(request.app.state.redis_pool),
+            }
+
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                first = await client.get("/ping")
+                second = await client.get("/ping")
+
+            assert first.status_code == 200
+            assert second.status_code == 200
+            assert first.json()["client_pool_id"] == first.json()["state_pool_id"]
+            assert first.json()["client_pool_id"] == second.json()["client_pool_id"]
+
+            # get_redis() closes its per-request client in `finally`; that must
+            # not tear down the pool other requests (or workers) still share.
+            survivor = redis.Redis(connection_pool=pool)
+            assert await survivor.ping() is True
+        finally:
+            await pool.disconnect()


### PR DESCRIPTION
Closes #381

## Summary

- `get_redis()` called `redis.from_url(...)` on every dependency resolution and closed the client in `finally`, so every request that depended on it paid a fresh TCP connect. During the 2026-09-05 scraper waves this was the dominant cause of `Error 24 ... Too many open files` at ~780/min (the frontend SSR root layout alone calls `/api/v1/banners/current` twice per page view, dark + light).
- `app/core/redis.py` now has `create_redis_pool()`, which builds one `redis.asyncio.ConnectionPool` from `settings.REDIS_URL` / the new `settings.REDIS_MAX_CONNECTIONS` (default 64, matching `--limit-concurrency` in `docker-compose.prod.yml`).
- `app/main.py`'s lifespan creates that pool once per process, stores it on `app.state.redis_pool`, and disposes it (`pool.disconnect()`) at shutdown. With `--workers 4` (#379) that's four pools, one per worker, as intended.
- `get_redis(request: Request)` now binds a lightweight client to the shared pool and never closes the pool itself — redis-py only auto-closes a pool it created internally (confirmed against installed redis-py 5.3.1: "If a pool is passed in, do not close it").
- The signature change is transparent to every consumer: all ~50 call sites use `Depends(get_redis)`, and FastAPI injects `Request` through any depth of the dependency chain. `tests/conftest.py`'s `dependency_overrides[get_redis]` also keeps working unchanged, since FastAPI resolves an override by its own signature, not the original's.
- Beyond `REDIS_MAX_CONNECTIONS`, redis-py already raises a clear `ConnectionError("Too many connections")` when the pool is exhausted — verified with a real test, not asserted from memory.
- `app/tasks/ml_tag_suggestion_job.py` was left untouched per the issue.

## Verification

- New tests in `tests/unit/test_redis_pool.py`, all against a real Redis instance (no mocks):
  - `create_redis_pool()` honours `REDIS_MAX_CONNECTIONS`, produces a really-connectable pool, raises `ConnectionError` on exhaustion, and `disconnect()` actually closes pooled connections (checked via the connection's public `is_connected`).
  - Two `get_redis()` dependency resolutions in the same app share the identical pool object, and closing the per-request client in `finally` does not tear down the pool (a fresh client on the same pool still pings successfully afterward).
- Added a `test_redis_url` fixture to `tests/conftest.py` alongside the existing `redis_client` fixture, for tests that need a DSN string rather than a ready client.
- `mypy app/`: clean (173 files).
- `ruff check` / `ruff format --check`: clean.
- Full suite: `2780 passed, 33 skipped` (all pre-existing skips — MariaDB-only tests under the Postgres test backend, missing local ML models, etc.), run with `-n 4 --dist loadgroup` against the isolated `shuushuu_pytest_i381` Postgres database. Output was pristine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SU6KhFCrbutgMxi7AjtyuR