### PR TITLE
fix(logging): capture request_complete on unhandled exceptions; log every request

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -276,9 +276,9 @@ class Settings(BaseSettings):
     # Logging
     LOG_LEVEL: str = "INFO"
     LOG_FORMAT: str = "json"
-    # Requests slower than this (ms) are logged at INFO even when they succeed;
-    # faster successful requests drop to DEBUG so routine traffic doesn't flood
-    # the aggregated logs. See RequestLoggingMiddleware in app/main.py.
+    # Requests slower than this (ms) are logged at WARNING even when they
+    # succeed, so they stand out from the INFO baseline every other request
+    # logs at. See _log_level_for in app/main.py.
     SLOW_REQUEST_LOG_MS: float = 1000.0
 
     # Review System

--- a/app/main.py
+++ b/app/main.py
@@ -38,19 +38,21 @@ _REDACTED_PARAMS = {"token", "code", "access_token", "refresh_token", "password"
 def _log_level_for(status_code: int, elapsed_ms: float) -> str:
     """Pick the access-log level for a completed request.
 
-    Nginx already logs every request (with the real client IP), so the API's
-    per-request log only needs to carry the high-signal lines: server errors,
-    client faults (kept so anonymous 401s can be clustered by source), and slow
-    requests. Routine fast 2xx traffic — the bulk of the volume — drops to DEBUG,
-    which production suppresses.
+    Nginx already logs every request (with the real client IP), but only the
+    API can tie duration and outcome to the same request_id used across
+    services — so every request logs `request_complete`, not just the
+    high-signal ones. Routine fast 2xx/3xx traffic — the bulk of the volume —
+    logs at INFO. Server errors, client faults (kept so anonymous 401s can be
+    clustered by source), and slow requests are promoted above that baseline
+    so they still stand out.
     """
     if status_code >= 500:
         return "error"
     if status_code >= 400:
         return "warning"
     if elapsed_ms >= settings.SLOW_REQUEST_LOG_MS:
-        return "info"
-    return "debug"
+        return "warning"
+    return "info"
 
 
 def _redact_query(query_string: str) -> str:
@@ -84,9 +86,37 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         # Add request ID to request state for access in endpoints
         request.state.request_id = request_id
 
+        path = str(request.url.path) + (
+            "?" + _redact_query(str(request.url.query)) if request.url.query else ""
+        )
+        # client_host + user_agent let anonymous 401s be clustered by source
+        # (one user fat-fingering vs. credential stuffing). request.client is
+        # None when the ASGI server reports no client (e.g. some test harnesses).
+        client_host = request.client.host if request.client else None
+        user_agent = request.headers.get("user-agent")
+
         try:
             start = time.monotonic()
-            response = await call_next(request)
+            try:
+                response = await call_next(request)
+            except Exception:
+                # call_next never returned, so this is the only chance to log
+                # request_complete for this request — without it, a 500 from an
+                # unhandled exception is invisible to every "API errors" query
+                # (see the 2026-09-05 outage). Re-raise so FastAPI/Starlette's
+                # ServerErrorMiddleware still sends the client a 500.
+                elapsed_ms = round((time.monotonic() - start) * 1000, 1)
+                logger.error(
+                    "request_complete",
+                    method=request.method,
+                    path=path,
+                    status_code=500,
+                    elapsed_ms=elapsed_ms,
+                    client_host=client_host,
+                    user_agent=user_agent,
+                    exc_info=True,
+                )
+                raise
             elapsed_ms = round((time.monotonic() - start) * 1000, 1)
             # Add request ID to response headers for debugging
             response.headers["X-Request-ID"] = request_id
@@ -94,15 +124,11 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             log(
                 "request_complete",
                 method=request.method,
-                path=str(request.url.path)
-                + ("?" + _redact_query(str(request.url.query)) if request.url.query else ""),
+                path=path,
                 status_code=response.status_code,
                 elapsed_ms=elapsed_ms,
-                # client_host + user_agent let anonymous 401s be clustered by source
-                # (one user fat-fingering vs. credential stuffing). request.client is
-                # None when the ASGI server reports no client (e.g. some test harnesses).
-                client_host=request.client.host if request.client else None,
-                user_agent=request.headers.get("user-agent"),
+                client_host=client_host,
+                user_agent=user_agent,
             )
             return response
         finally:

--- a/docs/log-operations.md
+++ b/docs/log-operations.md
@@ -77,6 +77,13 @@ ssh shuu-prod-logs
 
 Use the **Explore** tab in Grafana, datasource `Loki`.
 
+`request_complete` is now emitted for every request, not just failures: INFO
+for routine 2xx/3xx traffic, WARNING for slow requests and 4xx, ERROR for
+5xx. An unhandled exception in a route also logs `request_complete` at ERROR
+(with a traceback) before the 500 is sent to the client, so `{service="api",
+level=~"error|critical"}` below now catches API-side outages too, not just
+responses the app itself turned into a 5xx.
+
 ### Last hour of API errors
 
 ```logql

--- a/tests/test_request_logging.py
+++ b/tests/test_request_logging.py
@@ -3,7 +3,8 @@
 import logging
 
 import pytest
-from httpx import AsyncClient
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
 
 from app.config import settings
 from app.main import _log_level_for
@@ -12,23 +13,26 @@ from app.main import _log_level_for
 class TestLogLevelForRequest:
     """The access-log level is chosen by response status and latency.
 
-    Routine fast 2xx traffic (the bulk of the volume) drops to DEBUG, which is
-    suppressed in production, while server errors, client faults, and slow
-    requests stay visible. Nginx keeps the full per-request access log with real
-    client IPs, so the API log is free to keep only the high-signal lines.
+    Every request now logs `request_complete` at INFO or above (#320) so
+    duration data is available for the successful bulk of traffic, not just
+    failures. Slow requests and client faults (kept so anonymous 401s can be
+    clustered by source) are promoted to WARNING so they still stand out from
+    routine traffic; server errors go to ERROR. Nginx keeps the full
+    per-request access log with real client IPs, so the API log doesn't need
+    to carry that separately.
     """
 
-    def test_fast_success_is_debug(self):
-        assert _log_level_for(200, 5.0) == "debug"
-        assert _log_level_for(204, 0.4) == "debug"
+    def test_fast_success_is_info(self):
+        assert _log_level_for(200, 5.0) == "info"
+        assert _log_level_for(204, 0.4) == "info"
 
-    def test_redirect_is_debug(self):
-        assert _log_level_for(304, 2.0) == "debug"
+    def test_redirect_is_info(self):
+        assert _log_level_for(304, 2.0) == "info"
 
-    def test_slow_success_is_info(self):
+    def test_slow_success_is_warning(self):
         slow = settings.SLOW_REQUEST_LOG_MS
-        assert _log_level_for(200, slow) == "info"
-        assert _log_level_for(200, slow + 1) == "info"
+        assert _log_level_for(200, slow) == "warning"
+        assert _log_level_for(200, slow + 1) == "warning"
 
     def test_client_error_is_warning_regardless_of_latency(self):
         # 4xx stays visible even when fast so anonymous 401s can be clustered by
@@ -78,15 +82,17 @@ async def test_client_error_logs_client_host_and_user_agent(
 
 
 @pytest.mark.api
-async def test_fast_success_request_logged_at_debug(
+async def test_fast_success_request_logged_at_info(
     client: AsyncClient, caplog: pytest.LogCaptureFixture
 ):
-    """Routine fast 2xx traffic is logged at DEBUG so production (INFO+) drops it.
+    """Routine fast 2xx traffic now logs request_complete at INFO (#320).
 
-    The line is still emitted — just below INFO — so it's available in dev/debug
-    but doesn't flood the aggregated logs in production.
+    Previously this dropped to DEBUG and was suppressed in production
+    (INFO+), leaving successful requests with no duration trace. Production
+    runs at ~27 req/s, so INFO for everything is cheap enough not to need
+    sampling.
     """
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INFO):
         response = await client.get("/health")
     assert response.status_code == 200
 
@@ -96,7 +102,65 @@ async def test_fast_success_request_logged_at_debug(
     assert request_logs, (
         f"no request_complete log emitted; got {[record.getMessage() for record in caplog.records]}"
     )
-    assert all(record.levelno == logging.DEBUG for record in request_logs), (
-        "fast 2xx request_complete should log at DEBUG; got "
+    assert all(record.levelno == logging.INFO for record in request_logs), (
+        "fast 2xx request_complete should log at INFO; got "
         f"{[record.levelname for record in request_logs]}"
     )
+
+
+@pytest.mark.api
+async def test_unhandled_exception_logs_request_complete_at_error_and_still_returns_500(
+    app: FastAPI, caplog: pytest.LogCaptureFixture
+):
+    """An unhandled exception must still produce a request_complete log (#380).
+
+    Before this fix, an exception propagating out of a route skipped the
+    middleware's logging entirely — the 2026-09-05 outage's thousands of
+    exceptions never showed up in Loki because `request_complete` is only
+    logged after `call_next` *returns*. The middleware must now catch the
+    exception, log `request_complete` at ERROR with status_code=500 and a
+    traceback, then re-raise so Starlette's ServerErrorMiddleware still sends
+    the client a 500.
+    """
+    captured: dict[str, str] = {}
+
+    async def _raise_unhandled_exception(request: Request) -> None:
+        # Grab the request_id the middleware attached before we blow up, so
+        # the assertions below can confirm it made it into the error log.
+        captured["request_id"] = request.state.request_id
+        raise RuntimeError("boom - intentional failure for the #380 test")
+
+    original_route_count = len(app.router.routes)
+    app.add_api_route("/__test_unhandled_exception", _raise_unhandled_exception, methods=["GET"])
+    try:
+        # raise_app_exceptions=False mirrors production: uvicorn never lets an
+        # app exception reach the client directly, it just sees the 500 that
+        # Starlette's ServerErrorMiddleware already sent before re-raising for
+        # server-side logging. The default (True) would instead surface the
+        # RuntimeError to this test as a raised exception.
+        async with AsyncClient(
+            transport=ASGITransport(app=app, raise_app_exceptions=False),
+            base_url="http://test",
+        ) as ac:
+            with caplog.at_level(logging.ERROR):
+                response = await ac.get("/__test_unhandled_exception")
+    finally:
+        del app.router.routes[original_route_count:]
+
+    # The client still gets a 500 — the exception must not escape the ASGI app.
+    assert response.status_code == 500
+
+    request_logs = [
+        record for record in caplog.records if "request_complete" in record.getMessage()
+    ]
+    assert len(request_logs) == 1, (
+        "expected exactly one request_complete log for the failed request; got "
+        f"{[record.getMessage() for record in caplog.records]}"
+    )
+    log_record = request_logs[0]
+    assert log_record.levelno == logging.ERROR, f"expected ERROR level; got {log_record.levelname}"
+
+    message = log_record.getMessage()
+    assert captured["request_id"] in message, f"request_id missing from access log; got {message!r}"
+    # exc_info=True must actually carry a traceback, not just be requested.
+    assert "Traceback" in message, f"traceback missing from access log; got {message!r}"


### PR DESCRIPTION
## Summary

- `RequestLoggingMiddleware.dispatch` only logged `request_complete` after `call_next` returned, so an unhandled exception (a 500) produced no log line at all — the root cause of the 2026-09-05 outage being invisible in Loki even though nginx's 5xx count caught it. The middleware now catches the exception, logs `request_complete` at ERROR with `status_code=500`, `elapsed_ms`, method, path, `client_host`, `user_agent`, and `exc_info=True`, then re-raises so Starlette's `ServerErrorMiddleware` still sends the client a 500.
- `request_complete` is now emitted for every request, not just 4xx/5xx and slow ones. Fast successful requests move from DEBUG (suppressed in production) to INFO. Slow successful requests move from INFO to WARNING so they still stand out above the new INFO baseline — this preserves the existing "slow requests get flagged" behavior of `SLOW_REQUEST_LOG_MS` rather than silently dropping it. Prod is ~27 req/s, so no sampling was added.
- Updated `docs/log-operations.md` with a short note on the new level semantics and that unhandled exceptions are now covered.
- Left Alloy's uvicorn-traceback-tagging alone (the *optional* half of #380): it needs a new regex stage plus reworking the level-default template logic in `docker/alloy/config.alloy`, not a one-line change.
- Did not touch nginx access-log request timing (#320 item 1) — separate and out of scope here.

Closes #380
Part of #320 (item 2; item 1 nginx timing is still open)

## Test plan

- [x] New test: an unhandled exception in a route produces exactly one `request_complete` log at ERROR (with `status_code=500`, the request_id, and a real traceback) and the client still receives a 500 — verified against the real middleware + a dynamically registered raising route, using `ASGITransport(raise_app_exceptions=False)` to mirror how uvicorn actually delivers a 500 to real clients.
- [x] Updated `_log_level_for` unit tests for the new INFO/WARNING/ERROR tiering.
- [x] Updated the fast-2xx test to assert INFO instead of DEBUG.
- [x] `uv run pytest tests/` (Postgres backend): 2776 passed, 33 skipped, 0 failed.
- [x] `uv run mypy app/`: no issues in 173 source files.
- [x] `uv run ruff check` / `ruff format --check` on touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SU6KhFCrbutgMxi7AjtyuR