### PR TITLE
test: add testfixture dev account for the frontend e2e suite

### DIFF
--- a/scripts/create_test_users.py
+++ b/scripts/create_test_users.py
@@ -60,6 +60,18 @@ TEST_ACCOUNTS: list[dict[str, Any]] = [
         "admin": 0,
         "group": "Taggers",
     },
+    # A plain user (no admin, no group) the frontend's Playwright suite reserves
+    # for one spec file that seeds favourite tags and flips the grid/list
+    # preference, both persisted per account, so it needs an account no other
+    # spec logs in as. See VIEW_PREFERENCE_ACCOUNTS in
+    # <shuushuu-frontend-repo>/test-credentials.ts.
+    {
+        "username": "testfixture",
+        "password": "shuutestfixture",
+        "email": "testfixture@shuushuu.com",
+        "admin": 0,
+        "group": None,
+    },
 ]
 
 

--- a/tests/integration/test_create_test_users.py
+++ b/tests/integration/test_create_test_users.py
@@ -16,8 +16,8 @@ from scripts.create_test_users import TEST_ACCOUNTS, create_test_users
 
 # The test database is seeded with user_id=1 "testuser" (tests/conftest.py);
 # usernames are case-insensitive, so the script must treat "testUser" as
-# already present and create only the other three.
-EXPECTED_CREATED = ["testadmin", "testmod", "testtagger"]
+# already present and create only the other four.
+EXPECTED_CREATED = ["testadmin", "testmod", "testtagger", "testfixture"]
 
 
 async def _seed_groups(db: AsyncSession) -> dict[str, int]:
@@ -64,6 +64,7 @@ async def test_assigns_group_membership(db_session: AsyncSession):
     assert await _group_titles(db_session, "testadmin") == {"Admins"}
     assert await _group_titles(db_session, "testmod") == {"Mods"}
     assert await _group_titles(db_session, "testtagger") == {"Taggers"}
+    assert await _group_titles(db_session, "testfixture") == set()
     assert await _group_titles(db_session, "testUser") == set()
 
 


### PR DESCRIPTION
## Summary

Adds a fifth throwaway dev account, `testfixture`, to `scripts/create_test_users.py`: a plain user with no admin flag and no group.

The frontend's `recommended-favorites.spec.ts` needs an account it owns outright. It seeds favourite tags and, with anonymousobject/shuushuu-frontend#421, flips the grid/list view preference. Both are persisted per account, and Playwright runs spec files in parallel. Every existing account is already claimed by another spec for the view preference (the frontend's `VIEW_PREFERENCE_ACCOUNTS` registry), and two specs mutating one account's favourites is the coupling in anonymousobject/shuushuu-frontend#418. The matching frontend change registers the new role and moves that spec onto it.

## Tests

`tests/integration/test_create_test_users.py` now expects the fifth account to be created with no group membership. Verified red before the script change and green after. `tests/unit/test_db_utils.py` unchanged and green. mypy and ruff clean on both files.

## Rollout

- Dev: script already run against the dev database; `testfixture` logs in.
- Test host (`shuu`): needs one run of `scripts/create_test_users.py` after this merges. Future prod restores create it automatically.
- CI does not run Playwright, so nothing else depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNoxNBcTrbQyAD55cVmfCh
