### PR TITLE
fix(db_retry): retry Postgres deadlocks, not MariaDB errnos

### DIFF
--- a/app/core/db_retry.py
+++ b/app/core/db_retry.py
@@ -6,9 +6,9 @@ fresh one:
 **40P01 (deadlock_detected)** — two transactions take locks on the same rows or
 index entries in opposite orders and Postgres breaks the cycle by aborting one.
 Retrying is not a workaround here, it *is* the contract: Postgres expects the
-victim to replay. Confirmed site: flagging a repost (whose migration updates
-``ml_tag_suggestions`` across the original's tags) while the ML pipeline
-inserts suggestions for a neighbouring image.
+victim to replay. Site opted in after a MariaDB deadlock (#335): flagging a
+repost (whose migration updates ``ml_tag_suggestions`` across the original's
+tags) while the ML pipeline inserts suggestions for a neighbouring image.
 
 **40001 (serialization_failure)** — a write would break the transaction's
 snapshot under REPEATABLE READ or SERIALIZABLE. The app runs at the READ

--- a/app/core/db_retry.py
+++ b/app/core/db_retry.py
@@ -1,32 +1,29 @@
-"""Retry helper for transient MariaDB write conflicts. See ADR-0004.
+"""Retry helper for transient Postgres write conflicts. See ADR-0004.
 
 Two different errors, one remedy — end the transaction and replay the unit on a
 fresh one:
 
-**1020 (ER_CHECKREAD)** — with ``innodb_snapshot_isolation=ON`` (MariaDB 11.8),
-a locking statement that meets row/index versions committed *after* the
-transaction's snapshot aborts instead of returning stale data. The snapshot is
-pinned by the request's first read — the auth query — so the conflict window
-spans nearly the whole request, and any two requests writing the same rows (or
-inserting into the same index positions) concurrently can collide. Confirmed
-sites: the upload temp-row INSERT into ``images``; concurrent ``PATCH
-/users/me`` UPDATEs of one ``users`` row; ``ml_raw_predictions`` ingest racing
-the suggestion pipeline.
-
-**1213 (ER_LOCK_DEADLOCK)** — two transactions take locks on the same rows or
-index gaps in opposite orders and InnoDB breaks the cycle by rolling one back.
-Retrying is not a workaround here, it *is* the contract: MariaDB expects the
+**40P01 (deadlock_detected)** — two transactions take locks on the same rows or
+index entries in opposite orders and Postgres breaks the cycle by aborting one.
+Retrying is not a workaround here, it *is* the contract: Postgres expects the
 victim to replay. Confirmed site: flagging a repost (whose migration updates
 ``ml_tag_suggestions`` across the original's tags) while the ML pipeline
 inserts suggestions for a neighbouring image.
 
-Both leave the transaction dead, so both need the same rollback-and-replay.
-1205 (ER_LOCK_WAIT_TIMEOUT) is deliberately NOT included: it fires only after
-``innodb_lock_wait_timeout`` seconds, so replaying it multiplies an already
-pathological request latency rather than resolving a momentary collision.
+**40001 (serialization_failure)** — a write would break the transaction's
+snapshot under REPEATABLE READ or SERIALIZABLE. The app runs at the READ
+COMMITTED default, so this is rare, but Postgres documents the same remedy
+for it, so it takes the same path.
+
+Both leave the transaction aborted, so both need the same rollback-and-replay.
+55P03 (lock_not_available, raised when ``lock_timeout`` elapses) is
+deliberately NOT included: it fires only after the timeout, so replaying it
+multiplies an already pathological request latency rather than resolving a
+momentary collision.
 
 A savepoint is NOT sufficient for either — rolling back to a savepoint keeps
-the transaction (and its snapshot) alive, so the conflict would recur.
+the transaction (and its snapshot) alive, and Postgres refuses further
+statements in an aborted transaction anyway.
 
 Usage — wrap a *self-contained transactional unit* and retry it:
 
@@ -51,35 +48,36 @@ Rules for the callable:
 
 This is deliberately opt-in per write path rather than request-replay
 middleware: replaying a whole request would re-run its non-DB side effects.
+
+The SQLSTATE lives on ``exc.orig.sqlstate``: SQLAlchemy's asyncpg adapter
+copies it there when it translates the driver error, and wraps the result as
+a plain ``DBAPIError`` (not ``OperationalError``), so that is what is caught.
 """
 
 from collections.abc import Awaitable, Callable
 
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
 
 logger = get_logger(__name__)
 
-SNAPSHOT_CONFLICT_ERRNO = 1020
-DEADLOCK_ERRNO = 1213
-TRANSIENT_CONFLICT_ERRNOS = frozenset({SNAPSHOT_CONFLICT_ERRNO, DEADLOCK_ERRNO})
+DEADLOCK_SQLSTATE = "40P01"
+SERIALIZATION_FAILURE_SQLSTATE = "40001"
+TRANSIENT_CONFLICT_SQLSTATES = frozenset({DEADLOCK_SQLSTATE, SERIALIZATION_FAILURE_SQLSTATE})
 TRANSIENT_CONFLICT_ATTEMPTS = 3
 
 
-def _conflict_errno(exc: OperationalError) -> int | None:
-    """The MariaDB errno `exc` carries, or None when it carries none."""
-    args = getattr(exc.orig, "args", None)
-    if not args:
-        return None
-    errno = args[0]
-    return errno if isinstance(errno, int) else None
+def _conflict_sqlstate(exc: DBAPIError) -> str | None:
+    """The SQLSTATE `exc` carries, or None when the driver error has none."""
+    sqlstate = getattr(exc.orig, "sqlstate", None)
+    return sqlstate if isinstance(sqlstate, str) else None
 
 
-def is_transient_conflict(exc: OperationalError) -> bool:
+def is_transient_conflict(exc: DBAPIError) -> bool:
     """True when `exc` is a conflict a fresh transaction can resolve."""
-    return _conflict_errno(exc) in TRANSIENT_CONFLICT_ERRNOS
+    return _conflict_sqlstate(exc) in TRANSIENT_CONFLICT_SQLSTATES
 
 
 async def retry_on_transient_conflict[T](
@@ -98,7 +96,7 @@ async def retry_on_transient_conflict[T](
     for attempt in range(1, attempts + 1):
         try:
             return await fn()
-        except OperationalError as e:
+        except DBAPIError as e:
             if not is_transient_conflict(e) or attempt == attempts:
                 raise
             await db.rollback()
@@ -106,6 +104,6 @@ async def retry_on_transient_conflict[T](
                 "transient_conflict_retry",
                 what=what,
                 attempt=attempt,
-                errno=_conflict_errno(e),
+                sqlstate=_conflict_sqlstate(e),
             )
     raise AssertionError("unreachable")  # pragma: no cover

--- a/docs/adr/0004-transient-write-conflicts-are-retried-at-the-write-path.md
+++ b/docs/adr/0004-transient-write-conflicts-are-retried-at-the-write-path.md
@@ -1,18 +1,20 @@
 # Transient write conflicts are retried at the write path
 
-MariaDB aborts a transaction for two reasons that a fresh transaction resolves: ER_CHECKREAD (1020), raised under `innodb_snapshot_isolation=ON` when a locking statement meets a row version committed after this transaction's snapshot, and ER_LOCK_DEADLOCK (1213), raised when InnoDB breaks a lock cycle by rolling one side back. Both leave the transaction dead, and neither indicates a problem with the request. `retry_on_transient_conflict()` wraps a self-contained transactional unit, rolls back between attempts so each retry gets a fresh snapshot and no inherited locks, and replays up to three times. Write paths opt in individually rather than being covered by middleware.
+Postgres aborts a transaction for two reasons that a fresh transaction resolves: `deadlock_detected` (SQLSTATE 40P01), raised for the transaction Postgres aborts to break a lock cycle, and `serialization_failure` (40001), raised when a write would break the snapshot under REPEATABLE READ or SERIALIZABLE. Both leave the transaction aborted, and neither indicates a problem with the request. `retry_on_transient_conflict()` wraps a self-contained transactional unit, rolls back between attempts so each retry gets a fresh snapshot and no inherited locks, and replays up to three times. Write paths opt in individually rather than being covered by middleware.
+
+This ADR was written against MariaDB (errnos 1020 and 1213). After the 2026-08-22 cutover the helper was found to be inert on Postgres: SQLAlchemy's asyncpg adapter wraps a Postgres error as `DBAPIError` with the SQLSTATE on `orig.sqlstate`, not as `OperationalError` with an integer errno. The contract is unchanged; the match is now by SQLSTATE.
 
 ## Considered Options
 
-- **Surfacing the error** is what shipped, and a moderator flagging a repost while the ML pipeline writes suggestions eats a 500 with the migration abandoned partway (#335). For 1213 this also contradicts MariaDB's contract, which is that the deadlock victim replays.
+- **Surfacing the error** is what shipped, and a moderator flagging a repost while the ML pipeline writes suggestions eats a 500 with the migration abandoned partway (#335). For 40P01 this also contradicts Postgres's contract, which is that the deadlock victim replays.
 - **Request-replay middleware** would cover every path at once, but a replayed request re-runs its non-DB side effects — R2 enqueues, rating recalculation, file writes, email. Opting in per path keeps those below the retried unit where a replay cannot reach them.
 - **Ordering the lock acquisition** so the two writers cannot form a cycle removes one specific pair, at the cost of coupling the ML pipeline to the moderation path, and does nothing for the other pairs that can collide on the same rows. Narrowing the lock set is worth doing on its own merits (ADR-0005) but is a probability reduction, not a guarantee.
-- **Including ER_LOCK_WAIT_TIMEOUT (1205)** was rejected: it fires only after `innodb_lock_wait_timeout` seconds, so replaying it multiplies an already pathological request latency instead of resolving a momentary collision. It still surfaces as a 500, deliberately.
+- **Including `lock_not_available` (55P03)** was rejected: it fires only after `lock_timeout` elapsed, so replaying it multiplies an already pathological request latency instead of resolving a momentary collision. It still surfaces as a 500, deliberately.
 
 ## Consequences
 
 - A wrapped callable must be DB-only, idempotent under replay, and end at its `commit()`. Anything after the commit that can raise would send a replay through a second audit row on top of a commit that already landed.
 - `Session.rollback()` expires every ORM instance regardless of `expire_on_commit`, so a wrapped callable must re-fetch the rows it touches — including the user loaded by the auth dependency, which is why the retried admin paths re-`get()` the actor rather than closing over `current_user`.
-- Retries are bounded at three and logged as `transient_conflict_retry` with the call site and errno, so a path that starts thrashing is visible rather than silently slow.
-- Every call site added for 1020 now also absorbs deadlocks; they already satisfied the contract, so no site needed changing when 1213 was added.
+- Retries are bounded at three and logged as `transient_conflict_retry` with the call site and SQLSTATE, so a path that starts thrashing is visible rather than silently slow.
+- Every call site opted in for MariaDB's snapshot conflicts already satisfied the contract, so none needed changing when the match moved to SQLSTATE.
 - A savepoint is not a substitute for the rollback: rolling back to a savepoint keeps the transaction and its snapshot alive, so the conflict recurs.

--- a/tests/api/v1/test_admin_images.py
+++ b/tests/api/v1/test_admin_images.py
@@ -342,7 +342,7 @@ class TestImageStatusChange:
         """A deadlock (#335) is retried, not surfaced as a 500.
 
         The repost migration and the ML pipeline lock ml_tag_suggestions rows
-        and index gaps in opposite orders, so InnoDB rolls one of them back.
+        and index gaps in opposite orders, so Postgres rolls one of them back.
         The retry replays the whole unit on a fresh transaction; because the
         first attempt persisted nothing, the migration must land exactly once —
         no double-counted tags, no duplicated audit row.

--- a/tests/api/v1/test_batch_tag.py
+++ b/tests/api/v1/test_batch_tag.py
@@ -717,9 +717,9 @@ class TestBatchAddApprovesMlSuggestions:
 class TestBatchTagSnapshotConflictRetry:
     """The batch paths INSERT into tag_links/tag_history, whose FK columns make
     InnoDB locking-read the parent tags/images/users rows — and the usage_count
-    triggers on tag_links keep those parents moving. Under
-    innodb_snapshot_isolation a concurrent tag write aborts the batch with
-    ER_CHECKREAD (errno 1020), so it must retry on a fresh snapshot.
+    triggers on tag_links keep those parents moving. Concurrent tag writes
+    can trigger a Postgres deadlock (SQLSTATE 40P01), so the batch must
+    retry on a fresh transaction.
 
     The added/removed accumulators must be rebuilt per attempt: a retry that
     reuses lists from the failed attempt would report every pair twice.
@@ -732,7 +732,7 @@ class TestBatchTagSnapshotConflictRetry:
     async def test_batch_add_retries_snapshot_conflict_and_succeeds(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """A transient 1020 is retried; each pair is added and reported once."""
+        """A transient Postgres deadlock (SQLSTATE 40P01) is retried; each pair is added and reported once."""
         user = await _create_user_with_tag_permission(db_session)
         token = create_access_token(user.id)
         images = await _create_test_images(db_session, user, 2)
@@ -769,7 +769,7 @@ class TestBatchTagSnapshotConflictRetry:
     async def test_batch_remove_retries_snapshot_conflict_and_succeeds(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """A transient 1020 is retried; each pair is removed and reported once."""
+        """A transient Postgres deadlock (SQLSTATE 40P01) is retried; each pair is removed and reported once."""
         user = await _create_user_with_tag_permission(db_session, ["image_tag_remove"])
         token = create_access_token(user.id)
         images = await _create_test_images(db_session, user, 2)
@@ -808,7 +808,7 @@ class TestBatchTagSnapshotConflictRetry:
     async def test_batch_add_gives_up_after_bounded_retries(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """A persistent 1020 propagates after a bounded number of attempts."""
+        """A persistent Postgres deadlock (SQLSTATE 40P01) propagates after a bounded number of attempts."""
         user = await _create_user_with_tag_permission(db_session)
         token = create_access_token(user.id)
         images = await _create_test_images(db_session, user, 1)

--- a/tests/api/v1/test_batch_tag.py
+++ b/tests/api/v1/test_batch_tag.py
@@ -3,7 +3,7 @@
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import func, select
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import TagType
@@ -818,7 +818,7 @@ class TestBatchTagSnapshotConflictRetry:
         tag_id: int = tags[0].tag_id
 
         flush_patch, calls = _flaky_flush(100, _deadlock_error())
-        with flush_patch, pytest.raises(OperationalError):
+        with flush_patch, pytest.raises(DBAPIError):
             await client.post(
                 "/api/v1/tags/batch",
                 json={"action": "add", "tag_ids": [tag_id], "image_ids": image_ids},

--- a/tests/api/v1/test_batch_tag.py
+++ b/tests/api/v1/test_batch_tag.py
@@ -716,7 +716,7 @@ class TestBatchAddApprovesMlSuggestions:
 @pytest.mark.api
 class TestBatchTagSnapshotConflictRetry:
     """The batch paths INSERT into tag_links/tag_history, whose FK columns make
-    InnoDB locking-read the parent tags/images/users rows — and the usage_count
+    Postgres locking-read the parent tags/images/users rows — and the usage_count
     triggers on tag_links keep those parents moving. Concurrent tag writes
     can trigger a Postgres deadlock (SQLSTATE 40P01), so the batch must
     retry on a fresh transaction.

--- a/tests/api/v1/test_batch_tag.py
+++ b/tests/api/v1/test_batch_tag.py
@@ -15,7 +15,7 @@ from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
 from app.services.tag_type_flags import refresh_image_tag_type_flags
-from tests.transient_conflict import _flaky_flush, _snapshot_conflict_error
+from tests.transient_conflict import _deadlock_error, _flaky_flush
 
 
 async def _create_user_with_tag_permission(
@@ -741,7 +741,7 @@ class TestBatchTagSnapshotConflictRetry:
         image_ids = [img.image_id for img in images]
         tag_id: int = tags[0].tag_id
 
-        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error("tag_history"))
+        flush_patch, calls = _flaky_flush(1, _deadlock_error())
         with flush_patch:
             response = await client.post(
                 "/api/v1/tags/batch",
@@ -782,7 +782,7 @@ class TestBatchTagSnapshotConflictRetry:
             db_session.add(TagLinks(image_id=image_id, tag_id=tag_id, user_id=user.user_id))
         await db_session.commit()
 
-        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error("tag_history"))
+        flush_patch, calls = _flaky_flush(1, _deadlock_error())
         with flush_patch:
             response = await client.post(
                 "/api/v1/tags/batch",
@@ -817,7 +817,7 @@ class TestBatchTagSnapshotConflictRetry:
         image_ids = [img.image_id for img in images]
         tag_id: int = tags[0].tag_id
 
-        flush_patch, calls = _flaky_flush(100, _snapshot_conflict_error("tag_history"))
+        flush_patch, calls = _flaky_flush(100, _deadlock_error())
         with flush_patch, pytest.raises(OperationalError):
             await client.post(
                 "/api/v1/tags/batch",

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -13,7 +13,7 @@ from decimal import Decimal
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import TagType, settings
@@ -4705,7 +4705,7 @@ class TestFavoriteRatingSnapshotConflictRetry:
         await db_session.refresh(image)
 
         flush_patch, calls = _flaky_flush(100, _deadlock_error())
-        with flush_patch, pytest.raises(OperationalError):
+        with flush_patch, pytest.raises(DBAPIError):
             await authenticated_client.post(f"/api/v1/images/{image.image_id}/favorite")
 
         assert len(calls) == 3  # bounded: no infinite retry loop
@@ -4725,7 +4725,7 @@ class TestFavoriteRatingSnapshotConflictRetry:
         flush_patch, calls = _flaky_flush(
             100, _db_error("23505", "duplicate key value violates unique constraint")
         )
-        with flush_patch, pytest.raises(OperationalError):
+        with flush_patch, pytest.raises(DBAPIError):
             await authenticated_client.post(f"/api/v1/images/{image.image_id}/favorite")
 
         assert len(calls) == 1  # not retried
@@ -4880,7 +4880,7 @@ class TestTagWriteSnapshotConflictRetry:
         tag_id: int = tag.tag_id
 
         flush_patch, calls = _flaky_flush(100, _deadlock_error())
-        with flush_patch, pytest.raises(OperationalError):
+        with flush_patch, pytest.raises(DBAPIError):
             await authenticated_client.post(f"/api/v1/images/{image_id}/tags/{tag_id}")
 
         assert len(calls) == 3  # bounded: no infinite retry loop
@@ -4911,7 +4911,7 @@ class TestTagWriteSnapshotConflictRetry:
         flush_patch, calls = _flaky_flush(
             100, _db_error("23505", "duplicate key value violates unique constraint")
         )
-        with flush_patch, pytest.raises(OperationalError):
+        with flush_patch, pytest.raises(DBAPIError):
             await authenticated_client.post(f"/api/v1/images/{image_id}/tags/{tag_id}")
 
         assert len(calls) == 1  # not retried

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -4574,11 +4574,11 @@ class TestRateImage:
 @pytest.mark.api
 class TestFavoriteRatingSnapshotConflictRetry:
     """favorite/unfavorite/rate do read-modify-write UPDATEs on shared
-    images/users rows, so under innodb_snapshot_isolation a concurrent commit
-    can abort them with ER_CHECKREAD (errno 1020) — a double-click is enough.
-    Each write path must retry on a fresh snapshot instead of surfacing a 500.
+    images/users rows, so concurrent updates can trigger a Postgres deadlock
+    (SQLSTATE 40P01) — a double-click is enough. Each write path must retry
+    on a fresh transaction instead of surfacing a 500.
 
-    These exercise the real retry helper (app/core/db_retry.py); the 1020 is
+    These exercise the real retry helper (app/core/db_retry.py); the deadlock is
     injected into the wrapped unit's explicit flush, mirroring the upload path's
     TestUploadSnapshotConflictRetry."""
 
@@ -4590,10 +4590,10 @@ class TestFavoriteRatingSnapshotConflictRetry:
         sample_image_data: dict,
         sample_user: Users,
     ):
-        """A transient 1020 on the favorite counter write is retried and succeeds.
+        """A transient Postgres deadlock (SQLSTATE 40P01) on the favorite counter write is retried and succeeds.
 
-        needs_commit: the retry performs a real session rollback to obtain a
-        fresh snapshot; under the default SAVEPOINT isolation that rollback
+        needs_commit: the retry performs a real transaction rollback to obtain a
+        fresh transaction; under the default SAVEPOINT isolation that rollback
         would unwind the fixture's committed image/user rows too, which can't
         happen in production where they are durably committed.
         """
@@ -4628,7 +4628,7 @@ class TestFavoriteRatingSnapshotConflictRetry:
         sample_image_data: dict,
         sample_user: Users,
     ):
-        """A transient 1020 on the unfavorite counter write is retried and succeeds."""
+        """A transient Postgres deadlock (SQLSTATE 40P01) on the unfavorite counter write is retried and succeeds."""
         image = Images(**sample_image_data)
         db_session.add(image)
         await db_session.commit()
@@ -4668,7 +4668,7 @@ class TestFavoriteRatingSnapshotConflictRetry:
         sample_image_data: dict,
         sample_user: Users,
     ):
-        """A transient 1020 on the rating write is retried and the rating succeeds."""
+        """A transient Postgres deadlock (SQLSTATE 40P01) on the rating write is retried and the rating succeeds."""
         image = Images(**sample_image_data)
         db_session.add(image)
         await db_session.commit()
@@ -4693,7 +4693,7 @@ class TestFavoriteRatingSnapshotConflictRetry:
         db_session: AsyncSession,
         sample_image_data: dict,
     ):
-        """A persistent 1020 propagates after a bounded number of attempts.
+        """A persistent Postgres deadlock (SQLSTATE 40P01) propagates after a bounded number of attempts.
 
         needs_commit: each retry rolls back for a fresh snapshot, so the image
         must be durably committed to survive re-fetch across attempts (as in
@@ -4716,7 +4716,7 @@ class TestFavoriteRatingSnapshotConflictRetry:
         db_session: AsyncSession,
         sample_image_data: dict,
     ):
-        """Non-1020 database errors propagate immediately with no retry."""
+        """Non-deadlock database errors propagate immediately with no retry."""
         image = Images(**sample_image_data)
         db_session.add(image)
         await db_session.commit()
@@ -4736,11 +4736,11 @@ class TestTagWriteSnapshotConflictRetry:
     """Adding or removing a tag INSERTs into tag_history, whose tag_id/image_id/
     user_id are FK columns — so InnoDB takes a locking read on each parent row.
     The usage_count triggers on tag_links keep the parent `tags` row moving, and
-    the image_posts trigger does the same to `users`, so under
-    innodb_snapshot_isolation a concurrent tag write aborts this one with
-    ER_CHECKREAD (errno 1020). Two users tagging at the same moment is enough.
+    the image_posts trigger does the same to `users`, so concurrent tag writes
+    can trigger a Postgres deadlock (SQLSTATE 40P01). Two users tagging at the
+    same moment is enough.
 
-    Both paths must retry on a fresh snapshot instead of surfacing a 500.
+    Both paths must retry on a fresh transaction instead of surfacing a 500.
 
     Each test captures image_id/tag_id as ints before calling the endpoint: the
     app under test shares this session (conftest overrides get_db with
@@ -4756,7 +4756,7 @@ class TestTagWriteSnapshotConflictRetry:
         sample_user: Users,
         sample_image_data: dict,
     ):
-        """A transient 1020 during the tag add is retried and the tag lands once.
+        """A transient Postgres deadlock (SQLSTATE 40P01) during the tag add is retried and the tag lands once.
 
         needs_commit: the retry performs a real session rollback to obtain a
         fresh snapshot; under the default SAVEPOINT isolation that rollback
@@ -4812,7 +4812,7 @@ class TestTagWriteSnapshotConflictRetry:
         sample_user: Users,
         sample_image_data: dict,
     ):
-        """A transient 1020 during the tag removal is retried and the link goes."""
+        """A transient Postgres deadlock (SQLSTATE 40P01) during the tag removal is retried and the link goes."""
         image_data = sample_image_data.copy()
         image_data["user_id"] = sample_user.user_id
         image = Images(**image_data)
@@ -4863,7 +4863,7 @@ class TestTagWriteSnapshotConflictRetry:
         sample_user: Users,
         sample_image_data: dict,
     ):
-        """A persistent 1020 propagates after a bounded number of attempts."""
+        """A persistent Postgres deadlock (SQLSTATE 40P01) propagates after a bounded number of attempts."""
         image_data = sample_image_data.copy()
         image_data["user_id"] = sample_user.user_id
         image = Images(**image_data)
@@ -4892,7 +4892,7 @@ class TestTagWriteSnapshotConflictRetry:
         sample_user: Users,
         sample_image_data: dict,
     ):
-        """Non-1020 database errors propagate immediately with no retry."""
+        """Non-deadlock database errors propagate immediately with no retry."""
         image_data = sample_image_data.copy()
         image_data["user_id"] = sample_user.user_id
         image = Images(**image_data)

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -4574,8 +4574,9 @@ class TestRateImage:
 @pytest.mark.api
 class TestFavoriteRatingSnapshotConflictRetry:
     """favorite/unfavorite/rate do read-modify-write UPDATEs on shared
-    images/users rows, so concurrent updates can trigger a Postgres deadlock
-    (SQLSTATE 40P01) — a double-click is enough. Each write path must retry
+    images/users rows, so concurrent updates triggered a MariaDB snapshot
+    conflict (ER_CHECKREAD) — a double-click was enough. On Postgres these
+    sites keep their retry per ADR-0004, so each write path must still retry
     on a fresh transaction instead of surfacing a 500.
 
     These exercise the real retry helper (app/core/db_retry.py); the deadlock is
@@ -4734,7 +4735,7 @@ class TestFavoriteRatingSnapshotConflictRetry:
 @pytest.mark.api
 class TestTagWriteSnapshotConflictRetry:
     """Adding or removing a tag INSERTs into tag_history, whose tag_id/image_id/
-    user_id are FK columns — so InnoDB takes a locking read on each parent row.
+    user_id are FK columns — so Postgres takes a locking read on each parent row.
     The usage_count triggers on tag_links keep the parent `tags` row moving, and
     the image_posts trigger does the same to `users`, so concurrent tag writes
     can trigger a Postgres deadlock (SQLSTATE 40P01). Two users tagging at the

--- a/tests/api/v1/test_images.py
+++ b/tests/api/v1/test_images.py
@@ -22,7 +22,7 @@ from app.models.ml_tag_suggestion import MlTagSuggestions
 from app.models.permissions import Groups, UserGroups
 from app.models.tag_history import TagHistory
 from app.services.tag_type_flags import refresh_image_tag_type_flags
-from tests.transient_conflict import _db_error, _flaky_flush, _snapshot_conflict_error
+from tests.transient_conflict import _db_error, _deadlock_error, _flaky_flush
 
 
 @pytest.mark.api
@@ -4603,7 +4603,7 @@ class TestFavoriteRatingSnapshotConflictRetry:
         await db_session.refresh(image)
         initial_favorites = image.favorites
 
-        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error())
+        flush_patch, calls = _flaky_flush(1, _deadlock_error())
         with flush_patch:
             response = await authenticated_client.post(f"/api/v1/images/{image.image_id}/favorite")
 
@@ -4641,7 +4641,7 @@ class TestFavoriteRatingSnapshotConflictRetry:
         await db_session.refresh(image)
         favorites_before = image.favorites
 
-        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error())
+        flush_patch, calls = _flaky_flush(1, _deadlock_error())
         with flush_patch:
             response = await authenticated_client.delete(
                 f"/api/v1/images/{image.image_id}/favorite"
@@ -4674,7 +4674,7 @@ class TestFavoriteRatingSnapshotConflictRetry:
         await db_session.commit()
         await db_session.refresh(image)
 
-        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error())
+        flush_patch, calls = _flaky_flush(1, _deadlock_error())
         with flush_patch:
             response = await authenticated_client.post(
                 f"/api/v1/images/{image.image_id}/rating?rating=8"
@@ -4704,7 +4704,7 @@ class TestFavoriteRatingSnapshotConflictRetry:
         await db_session.commit()
         await db_session.refresh(image)
 
-        flush_patch, calls = _flaky_flush(100, _snapshot_conflict_error())
+        flush_patch, calls = _flaky_flush(100, _deadlock_error())
         with flush_patch, pytest.raises(OperationalError):
             await authenticated_client.post(f"/api/v1/images/{image.image_id}/favorite")
 
@@ -4722,7 +4722,9 @@ class TestFavoriteRatingSnapshotConflictRetry:
         await db_session.commit()
         await db_session.refresh(image)
 
-        flush_patch, calls = _flaky_flush(100, _db_error(1062, "Duplicate entry"))
+        flush_patch, calls = _flaky_flush(
+            100, _db_error("23505", "duplicate key value violates unique constraint")
+        )
         with flush_patch, pytest.raises(OperationalError):
             await authenticated_client.post(f"/api/v1/images/{image.image_id}/favorite")
 
@@ -4776,7 +4778,7 @@ class TestTagWriteSnapshotConflictRetry:
         image_id: int = image.image_id
         tag_id: int = tag.tag_id
 
-        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error("tag_history"))
+        flush_patch, calls = _flaky_flush(1, _deadlock_error())
         with flush_patch:
             response = await authenticated_client.post(f"/api/v1/images/{image_id}/tags/{tag_id}")
 
@@ -4829,7 +4831,7 @@ class TestTagWriteSnapshotConflictRetry:
         db_session.add(TagLinks(image_id=image_id, tag_id=tag_id, user_id=sample_user.user_id))
         await db_session.commit()
 
-        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error("tag_history"))
+        flush_patch, calls = _flaky_flush(1, _deadlock_error())
         with flush_patch:
             response = await authenticated_client.delete(f"/api/v1/images/{image_id}/tags/{tag_id}")
 
@@ -4877,7 +4879,7 @@ class TestTagWriteSnapshotConflictRetry:
         image_id: int = image.image_id
         tag_id: int = tag.tag_id
 
-        flush_patch, calls = _flaky_flush(100, _snapshot_conflict_error("tag_history"))
+        flush_patch, calls = _flaky_flush(100, _deadlock_error())
         with flush_patch, pytest.raises(OperationalError):
             await authenticated_client.post(f"/api/v1/images/{image_id}/tags/{tag_id}")
 
@@ -4906,7 +4908,9 @@ class TestTagWriteSnapshotConflictRetry:
         image_id: int = image.image_id
         tag_id: int = tag.tag_id
 
-        flush_patch, calls = _flaky_flush(100, _db_error(1062, "Duplicate entry"))
+        flush_patch, calls = _flaky_flush(
+            100, _db_error("23505", "duplicate key value violates unique constraint")
+        )
         with flush_patch, pytest.raises(OperationalError):
             await authenticated_client.post(f"/api/v1/images/{image_id}/tags/{tag_id}")
 

--- a/tests/api/v1/test_ml_tag_suggestions.py
+++ b/tests/api/v1/test_ml_tag_suggestions.py
@@ -1614,16 +1614,16 @@ class TestReviewMlTagSuggestions:
 @pytest.mark.api
 class TestReviewMlTagSuggestionsSnapshotConflictRetry:
     """A background ml_remap run rewriting ml_tag_suggestions rows while a
-    reviewer approves on the same image trips MariaDB ER_CHECKREAD (errno
-    1020) under innodb_snapshot_isolation — reproduced on dev 2026-07-23. The
-    review apply must retry on a fresh snapshot instead of surfacing a 500
-    (see app/core/db_retry.py and app/services/ml_suggestion_review.py)."""
+    reviewer approves on the same image can hit a Postgres deadlock
+    (SQLSTATE 40P01) — reproduced on dev 2026-07-23. The review apply must
+    retry on a fresh transaction instead of surfacing a 500 (see
+    app/core/db_retry.py and app/services/ml_suggestion_review.py)."""
 
     @pytest.mark.needs_commit
     async def test_review_approve_retries_snapshot_conflict_and_succeeds(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """A transient 1020 on the review commit is retried and the approval succeeds.
+        """A transient Postgres deadlock (40P01) on the review commit is retried and the approval succeeds.
 
         needs_commit: the retry performs a real session rollback for a fresh
         snapshot; under the default SAVEPOINT isolation that rollback would
@@ -1632,8 +1632,7 @@ class TestReviewMlTagSuggestionsSnapshotConflictRetry:
         """
         from unittest.mock import patch
 
-        import pymysql
-        from sqlalchemy.exc import OperationalError
+        from tests.transient_conflict import _deadlock_error
 
         user = Users(
             username="snapshotreview",
@@ -1686,14 +1685,7 @@ class TestReviewMlTagSuggestionsSnapshotConflictRetry:
         async def flaky_commit(self, *args, **kwargs):
             calls.append(1)
             if len(calls) == 1:
-                raise OperationalError(
-                    "UPDATE ml_tag_suggestions ...",
-                    None,
-                    pymysql.err.OperationalError(
-                        1020,
-                        "Record has changed since last read in table 'ml_tag_suggestions'",
-                    ),
-                )
+                raise _deadlock_error()
             await real_commit(self, *args, **kwargs)
 
         access_token = create_access_token(user_id=user.user_id)

--- a/tests/api/v1/test_ml_tag_suggestions.py
+++ b/tests/api/v1/test_ml_tag_suggestions.py
@@ -1614,10 +1614,12 @@ class TestReviewMlTagSuggestions:
 @pytest.mark.api
 class TestReviewMlTagSuggestionsSnapshotConflictRetry:
     """A background ml_remap run rewriting ml_tag_suggestions rows while a
-    reviewer approves on the same image can hit a Postgres deadlock
-    (SQLSTATE 40P01) — reproduced on dev 2026-07-23. The review apply must
-    retry on a fresh transaction instead of surfacing a 500 (see
-    app/core/db_retry.py and app/services/ml_suggestion_review.py)."""
+    reviewer approves on the same image hit a MariaDB snapshot conflict
+    (ER_CHECKREAD) — observed on dev 2026-07-23, before the Postgres cutover.
+    The review apply must retry on a fresh transaction instead of surfacing a
+    500 (see app/core/db_retry.py and app/services/ml_suggestion_review.py);
+    this test injects the fabricated Postgres deadlock (SQLSTATE 40P01) error
+    to prove the retry contract still holds at this site."""
 
     @pytest.mark.needs_commit
     async def test_review_approve_retries_snapshot_conflict_and_succeeds(

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -31,7 +31,7 @@ from app.models.permissions import GroupPerms, Groups, Perms, UserGroups
 from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
-from tests.transient_conflict import _flaky_flush, _snapshot_conflict_error
+from tests.transient_conflict import _deadlock_error, _flaky_flush
 
 
 async def create_auth_user(
@@ -2524,7 +2524,7 @@ class TestApplyTagSuggestionsSnapshotConflictRetry:
         image_id: int = image.image_id
         suggestion_ids = [s.suggestion_id for s in suggestions]
 
-        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error("tag_history"))
+        flush_patch, calls = _flaky_flush(1, _deadlock_error())
         with flush_patch:
             response = await client.post(
                 f"/api/v1/admin/reports/{report_id}/apply-tag-suggestions",
@@ -2574,7 +2574,7 @@ class TestApplyTagSuggestionsSnapshotConflictRetry:
         report_id: int = report.report_id
         suggestion_id: int = suggestion.suggestion_id
 
-        flush_patch, calls = _flaky_flush(100, _snapshot_conflict_error("tag_history"))
+        flush_patch, calls = _flaky_flush(100, _deadlock_error())
         with flush_patch, pytest.raises(OperationalError):
             await client.post(
                 f"/api/v1/admin/reports/{report_id}/apply-tag-suggestions",

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -2480,7 +2480,7 @@ class TestAdminApplyTagSuggestions:
 @pytest.mark.api
 class TestApplyTagSuggestionsSnapshotConflictRetry:
     """apply_tag_suggestions INSERTs into tag_links/tag_history, whose FK columns
-    make InnoDB locking-read the parent tags/images/users rows, and the
+    make Postgres locking-read the parent tags/images/users rows, and the
     usage_count trigger on tag_links keeps those parents moving. Concurrent
     tag writes can trigger a Postgres deadlock (SQLSTATE 40P01), so it must
     retry on a fresh transaction.

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -2481,9 +2481,9 @@ class TestAdminApplyTagSuggestions:
 class TestApplyTagSuggestionsSnapshotConflictRetry:
     """apply_tag_suggestions INSERTs into tag_links/tag_history, whose FK columns
     make InnoDB locking-read the parent tags/images/users rows, and the
-    usage_count trigger on tag_links keeps those parents moving. Under
-    innodb_snapshot_isolation a concurrent tag write aborts this one with
-    ER_CHECKREAD (errno 1020), so it must retry on a fresh snapshot.
+    usage_count trigger on tag_links keeps those parents moving. Concurrent
+    tag writes can trigger a Postgres deadlock (SQLSTATE 40P01), so it must
+    retry on a fresh transaction.
 
     The applied_tags/removed_tags accumulators must be rebuilt per attempt, or a
     retry reports each tag once per attempt.
@@ -2493,7 +2493,7 @@ class TestApplyTagSuggestionsSnapshotConflictRetry:
     async def test_apply_retries_snapshot_conflict_and_succeeds(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """A transient 1020 is retried; each tag is applied and reported once."""
+        """A transient Postgres deadlock (SQLSTATE 40P01) is retried; each tag is applied and reported once."""
         admin, password = await create_auth_user(db_session, username="applyretry1", admin=True)
         await grant_permission(db_session, admin.user_id, "report_manage")
         image = await create_test_image(db_session, admin.user_id)
@@ -2550,7 +2550,7 @@ class TestApplyTagSuggestionsSnapshotConflictRetry:
     async def test_apply_gives_up_after_bounded_retries(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """A persistent 1020 propagates after a bounded number of attempts."""
+        """A persistent Postgres deadlock (SQLSTATE 40P01) propagates after a bounded number of attempts."""
         admin, password = await create_auth_user(db_session, username="applyretry2", admin=True)
         await grant_permission(db_session, admin.user_id, "report_manage")
         image = await create_test_image(db_session, admin.user_id)

--- a/tests/api/v1/test_reports.py
+++ b/tests/api/v1/test_reports.py
@@ -9,7 +9,7 @@ Tests cover:
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import (
@@ -2575,7 +2575,7 @@ class TestApplyTagSuggestionsSnapshotConflictRetry:
         suggestion_id: int = suggestion.suggestion_id
 
         flush_patch, calls = _flaky_flush(100, _deadlock_error())
-        with flush_patch, pytest.raises(OperationalError):
+        with flush_patch, pytest.raises(DBAPIError):
             await client.post(
                 f"/api/v1/admin/reports/{report_id}/apply-tag-suggestions",
                 json={"approved_suggestion_ids": [suggestion_id]},

--- a/tests/api/v1/test_upload.py
+++ b/tests/api/v1/test_upload.py
@@ -502,12 +502,10 @@ async def test_images_source_url_roundtrip(db_session: AsyncSession):
 
 
 class TestUploadSnapshotConflictRetry:
-    """Concurrent uploads trip MariaDB ER_CHECKREAD (errno 1020) on the temp-row
-    INSERT: with innodb_snapshot_isolation=ON, a locking insert that meets index
-    entries committed after this transaction's snapshot aborts instead of
-    proceeding, and every in-flight upload writes identical placeholder values
-    into the same index positions. The upload route must retry on a fresh
-    snapshot instead of surfacing a 500."""
+    """Concurrent uploads trip a Postgres deadlock (SQLSTATE 40P01) on the temp-row
+    INSERT: two transactions take row locks in opposite orders and Postgres aborts one
+    to break the cycle. The upload route must retry on a fresh transaction instead
+    of surfacing a 500."""
 
     @pytest.mark.asyncio
     @pytest.mark.needs_commit
@@ -548,10 +546,10 @@ class TestUploadSnapshotConflictRetry:
     async def test_upload_gives_up_after_bounded_retries(
         self, upload_client: AsyncClient, verified_user: Users
     ):
-        """A persistent 1020 gives up after a bounded number of attempts.
+        """A persistent Postgres deadlock (SQLSTATE 40P01) gives up after a bounded number of attempts.
 
         The exhausted error surfaces as the route's own 500 rather than a raw
-        OperationalError: the retried unit sits inside upload's try/except, so
+        DBAPIError: the retried unit sits inside upload's try/except, so
         the failure also rolls back and unlinks the staged file.
         """
         flush_patch, calls = _flaky_flush(100, _deadlock_error())
@@ -604,14 +602,11 @@ class TestUploadSnapshotConflictRetry:
 
 @pytest.mark.api
 class TestUploadTagLinkSnapshotConflictRetry:
-    """The upload's tag-link write is exposed to ER_CHECKREAD too, and for
-    longer than the temp-row INSERT: tag_links/tag_history INSERTs take locking
-    reads on their FK parents, and the usage_count trigger on tag_links keeps
-    the parent `tags` row moving whenever anyone else tags that tag.
-
-    The conflict is aimed at the second explicit flush (the tag-link write)
-    rather than the first (which mints the image_id), so this fails on any
-    implementation that only retries the id-minting INSERT.
+    """The upload's tag-link write is exposed to a Postgres deadlock (SQLSTATE 40P01) too:
+    tag_links/tag_history INSERTs take locking writes that can conflict with concurrent
+    updates from other users tagging the same tags. The conflict is aimed at the second
+    explicit flush (the tag-link write) rather than the first (which mints the image_id),
+    so this fails on any implementation that only retries the id-minting INSERT.
     """
 
     @pytest.mark.asyncio
@@ -622,7 +617,7 @@ class TestUploadTagLinkSnapshotConflictRetry:
         verified_user: Users,
         db_session: AsyncSession,
     ):
-        """A transient 1020 on the tag-link write is retried and the upload succeeds."""
+        """A transient Postgres deadlock (SQLSTATE 40P01) on the tag-link write is retried and the upload succeeds."""
         from sqlalchemy import select
 
         from app.models.image import Images

--- a/tests/api/v1/test_upload.py
+++ b/tests/api/v1/test_upload.py
@@ -16,9 +16,9 @@ from app.models.user import Users
 from app.schemas.image import SimilarImageResult
 from tests.transient_conflict import (
     _db_error,
+    _deadlock_error,
     _flaky_flush,
     _flaky_flush_nth,
-    _snapshot_conflict_error,
 )
 
 
@@ -514,7 +514,7 @@ class TestUploadSnapshotConflictRetry:
     async def test_upload_retries_snapshot_conflict_and_succeeds(
         self, upload_client: AsyncClient, verified_user: Users
     ):
-        """A transient 1020 on the temp-row INSERT is retried and the upload succeeds.
+        """A transient Postgres deadlock (40P01) on the temp-row INSERT is retried and the upload succeeds.
 
         needs_commit: the retry performs a real session rollback to obtain a
         fresh snapshot; under the default SAVEPOINT isolation that rollback
@@ -522,7 +522,7 @@ class TestUploadSnapshotConflictRetry:
         INSERT), which can't happen in production where the user is durably
         committed.
         """
-        flush_patch, calls = _flaky_flush(1, _snapshot_conflict_error())
+        flush_patch, calls = _flaky_flush(1, _deadlock_error())
         with (
             _mock_upload_storage("snapshotretry1"),
             patch(
@@ -554,7 +554,7 @@ class TestUploadSnapshotConflictRetry:
         OperationalError: the retried unit sits inside upload's try/except, so
         the failure also rolls back and unlinks the staged file.
         """
-        flush_patch, calls = _flaky_flush(100, _snapshot_conflict_error())
+        flush_patch, calls = _flaky_flush(100, _deadlock_error())
         with (
             _mock_upload_storage("snapshotretry2"),
             patch(
@@ -579,7 +579,9 @@ class TestUploadSnapshotConflictRetry:
         self, upload_client: AsyncClient, verified_user: Users
     ):
         """Database errors outside the transient set fail immediately with no retry."""
-        flush_patch, calls = _flaky_flush(100, _db_error(1062, "Duplicate entry"))
+        flush_patch, calls = _flaky_flush(
+            100, _db_error("23505", "duplicate key value violates unique constraint")
+        )
         with (
             _mock_upload_storage("snapshotretry3"),
             patch(
@@ -633,7 +635,7 @@ class TestUploadTagLinkSnapshotConflictRetry:
         await db_session.refresh(tag)
         tag_id: int = tag.tag_id
 
-        flush_patch, calls = _flaky_flush_nth(2, _snapshot_conflict_error("tag_history"))
+        flush_patch, calls = _flaky_flush_nth(2, _deadlock_error())
         with (
             _mock_upload_storage("tagsnapshotretry1"),
             patch(

--- a/tests/api/v1/test_upload.py
+++ b/tests/api/v1/test_upload.py
@@ -502,10 +502,10 @@ async def test_images_source_url_roundtrip(db_session: AsyncSession):
 
 
 class TestUploadSnapshotConflictRetry:
-    """Concurrent uploads trip a Postgres deadlock (SQLSTATE 40P01) on the temp-row
-    INSERT: two transactions take row locks in opposite orders and Postgres aborts one
-    to break the cycle. The upload route must retry on a fresh transaction instead
-    of surfacing a 500."""
+    """Concurrent uploads hit a MariaDB snapshot conflict (ER_CHECKREAD) on the
+    temp-row INSERT before the Postgres cutover. On Postgres this site keeps its
+    retry per ADR-0004; the test injects the fabricated Postgres deadlock
+    (SQLSTATE 40P01) error to prove the retry contract still holds here."""
 
     @pytest.mark.asyncio
     @pytest.mark.needs_commit

--- a/tests/api/v1/test_user_favorite_tags.py
+++ b/tests/api/v1/test_user_favorite_tags.py
@@ -421,9 +421,10 @@ class TestReorder:
     async def test_reorder_retries_on_transient_conflict(
         self, client: AsyncClient, db_session: AsyncSession
     ) -> None:
-        """Same ADR-0004 coverage as a confirmed Postgres deadlock (SQLSTATE 40P01)
-        scenario: a transient conflict on the position UPDATEs is retried, and
-        the retried unit re-fetches its rows rather than reusing stale ones.
+        """Same ADR-0004 coverage as the other retry tests in this module: the
+        test injects the fabricated Postgres deadlock (SQLSTATE 40P01) error
+        so a transient conflict on the position UPDATEs is retried, and the
+        retried unit re-fetches its rows rather than reusing stale ones.
 
         needs_commit: same reason as the add-favorite retry tests — the
         seeded favorites must be durably committed to survive the internal

--- a/tests/api/v1/test_user_favorite_tags.py
+++ b/tests/api/v1/test_user_favorite_tags.py
@@ -268,7 +268,7 @@ class TestAddFavorite:
     async def test_add_tag_retries_on_transient_conflict_and_lands_once(
         self, client: AsyncClient, db_session: AsyncSession
     ) -> None:
-        """ADR-0004: a transient snapshot conflict at commit is retried, not
+        """ADR-0004: a transient Postgres deadlock (SQLSTATE 40P01) at commit is retried, not
         surfaced as a 500 — and the retried unit re-derives its INSERT rather
         than replaying a stale one, so exactly one row lands.
 
@@ -421,8 +421,8 @@ class TestReorder:
     async def test_reorder_retries_on_transient_conflict(
         self, client: AsyncClient, db_session: AsyncSession
     ) -> None:
-        """Same ADR-0004 coverage as user_profile_update's confirmed 1020
-        site: a transient conflict on the position UPDATEs is retried, and
+        """Same ADR-0004 coverage as a confirmed Postgres deadlock (SQLSTATE 40P01)
+        scenario: a transient conflict on the position UPDATEs is retried, and
         the retried unit re-fetches its rows rather than reusing stale ones.
 
         needs_commit: same reason as the add-favorite retry tests — the

--- a/tests/api/v1/test_user_favorite_tags.py
+++ b/tests/api/v1/test_user_favorite_tags.py
@@ -14,7 +14,7 @@ from app.models.tag import Tags
 from app.models.tag_link import TagLinks
 from app.models.user import Users
 from app.models.user_favorite import UserFavoriteLinks, UserFavoriteTags
-from tests.transient_conflict import _flaky_commit, _snapshot_conflict_error
+from tests.transient_conflict import _deadlock_error, _flaky_commit
 
 CHAR_A = 9801  # linked to SRC_A and SRC_B (two combos)
 SRC_A = 9803
@@ -279,7 +279,7 @@ class TestAddFavorite:
         ids = await _seed(db_session)
         headers = await _login(client)
 
-        commit_patch, calls = _flaky_commit(1, _snapshot_conflict_error("user_favorite_tags"))
+        commit_patch, calls = _flaky_commit(1, _deadlock_error())
         with commit_patch:
             response = await client.post(
                 "/api/v1/users/me/favorite-tags", json={"tag_id": SRC_A}, headers=headers
@@ -308,7 +308,7 @@ class TestAddFavorite:
         ids = await _seed(db_session)
         headers = await _login(client)
 
-        commit_patch, calls = _flaky_commit(1, _snapshot_conflict_error("user_favorite_links"))
+        commit_patch, calls = _flaky_commit(1, _deadlock_error())
         with commit_patch:
             response = await client.post(
                 "/api/v1/users/me/favorite-tags",
@@ -433,7 +433,7 @@ class TestReorder:
         await _favorite_all(db_session, ids)
         headers = await _login(client)
 
-        commit_patch, calls = _flaky_commit(1, _snapshot_conflict_error("user_favorite_links"))
+        commit_patch, calls = _flaky_commit(1, _deadlock_error())
         with commit_patch:
             response = await client.put(
                 "/api/v1/users/me/favorite-tags/order",

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -3593,11 +3593,10 @@ class TestHideRepostsSetting:
 
 
 class TestUserUpdateSnapshotConflictRetry:
-    """Concurrent PATCHes of one users row trip MariaDB ER_CHECKREAD (errno
-    1020) under innodb_snapshot_isolation — the losing transaction's UPDATE
-    meets a row version committed after its snapshot. The update must retry on
-    a fresh snapshot instead of surfacing a 500. (Observed in practice when
-    the frontend's settings auto-save fires several PATCHes back-to-back.)"""
+    """Concurrent PATCHes of one users row can hit a Postgres deadlock
+    (SQLSTATE 40P01). The update must retry on a fresh transaction instead
+    of surfacing a 500. (Observed in practice when the frontend's settings
+    auto-save fires several PATCHes back-to-back.)"""
 
     async def _make_user_and_token(self, db_session: AsyncSession) -> tuple[Users, str]:
         user = Users(
@@ -3618,7 +3617,7 @@ class TestUserUpdateSnapshotConflictRetry:
     async def test_patch_me_retries_snapshot_conflict_and_succeeds(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """A transient 1020 on the users UPDATE is retried and the PATCH succeeds.
+        """A transient Postgres deadlock (40P01) on the users UPDATE is retried and the PATCH succeeds.
 
         needs_commit: the retry performs a real session rollback for a fresh
         snapshot; under SAVEPOINT isolation that rollback would unwind the
@@ -3626,8 +3625,7 @@ class TestUserUpdateSnapshotConflictRetry:
         """
         from unittest.mock import patch
 
-        import pymysql
-        from sqlalchemy.exc import OperationalError
+        from tests.transient_conflict import _deadlock_error
 
         _, token = await self._make_user_and_token(db_session)
 
@@ -3637,13 +3635,7 @@ class TestUserUpdateSnapshotConflictRetry:
         async def flaky_commit(self, *args, **kwargs):
             calls.append(1)
             if len(calls) == 1:
-                raise OperationalError(
-                    "UPDATE users ...",
-                    None,
-                    pymysql.err.OperationalError(
-                        1020, "Record has changed since last read in table 'users'"
-                    ),
-                )
+                raise _deadlock_error()
             await real_commit(self, *args, **kwargs)
 
         with patch.object(AsyncSession, "commit", flaky_commit):
@@ -3662,7 +3654,7 @@ class TestUserUpdateSnapshotConflictRetry:
     async def test_patch_me_gives_up_after_bounded_retries(
         self, client: AsyncClient, db_session: AsyncSession
     ):
-        """A persistent 1020 propagates after a bounded number of attempts.
+        """A persistent Postgres deadlock (SQLSTATE 40P01) propagates after a bounded number of attempts.
 
         needs_commit: each retry re-SELECTs the user after a real rollback;
         under SAVEPOINT isolation that rollback unwinds the fixture's user row
@@ -3670,8 +3662,9 @@ class TestUserUpdateSnapshotConflictRetry:
         """
         from unittest.mock import patch
 
-        import pymysql
-        from sqlalchemy.exc import OperationalError
+        from sqlalchemy.exc import DBAPIError
+
+        from tests.transient_conflict import _deadlock_error
 
         _, token = await self._make_user_and_token(db_session)
 
@@ -3679,17 +3672,11 @@ class TestUserUpdateSnapshotConflictRetry:
 
         async def always_conflict(self, *args, **kwargs):
             calls.append(1)
-            raise OperationalError(
-                "UPDATE users ...",
-                None,
-                pymysql.err.OperationalError(
-                    1020, "Record has changed since last read in table 'users'"
-                ),
-            )
+            raise _deadlock_error()
 
         with (
             patch.object(AsyncSession, "commit", always_conflict),
-            pytest.raises(OperationalError),
+            pytest.raises(DBAPIError),
         ):
             await client.patch(
                 "/api/v1/users/me",

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -3593,10 +3593,13 @@ class TestHideRepostsSetting:
 
 
 class TestUserUpdateSnapshotConflictRetry:
-    """Concurrent PATCHes of one users row can hit a Postgres deadlock
-    (SQLSTATE 40P01). The update must retry on a fresh transaction instead
-    of surfacing a 500. (Observed in practice when the frontend's settings
-    auto-save fires several PATCHes back-to-back.)"""
+    """Concurrent PATCHes of one users row hit a MariaDB snapshot conflict
+    (ER_CHECKREAD), observed in practice when the frontend's settings
+    auto-save fires several PATCHes back-to-back. On Postgres, two PATCHes
+    of one row serialize on the row lock rather than deadlocking, but this
+    site keeps its retry per ADR-0004; the test injects the fabricated
+    Postgres deadlock (SQLSTATE 40P01) error to prove the retry contract
+    still holds here."""
 
     async def _make_user_and_token(self, db_session: AsyncSession) -> tuple[Users, str]:
         user = Users(

--- a/tests/integration/test_db_retry_deadlock.py
+++ b/tests/integration/test_db_retry_deadlock.py
@@ -1,0 +1,54 @@
+"""The retry helper against a real Postgres deadlock (app/core/db_retry.py).
+
+The unit tests fabricate the adapter's error; this provokes the genuine one.
+Two sessions update the same two users rows in opposite order. Postgres
+detects the cycle after deadlock_timeout (1s by default) and aborts one side
+with SQLSTATE 40P01; the aborted side must replay on a fresh transaction and
+succeed.
+"""
+
+import asyncio
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db_retry import retry_on_transient_conflict
+
+# needs_commit: users 1-3 are really committed, so both sessions see them.
+pytestmark = [pytest.mark.integration, pytest.mark.needs_commit, pytest.mark.postgres_only]
+
+
+async def test_deadlock_victim_replays_and_succeeds(db_session, engine):
+    sessions = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    # Both sides must hold their first row before either asks for the second,
+    # or there is no cycle. Only the first attempt waits: a replay runs after
+    # the winner committed and just proceeds.
+    first_locks_taken = asyncio.Barrier(2)
+    calls = {"a": 0, "b": 0}
+
+    async def cross_update(name: str, first: int, second: int) -> str:
+        async with sessions() as db:
+
+            async def unit() -> str:
+                calls[name] += 1
+                await db.execute(
+                    text("UPDATE users SET location = :v WHERE user_id = :id"),
+                    {"v": name, "id": first},
+                )
+                if calls[name] == 1:
+                    await first_locks_taken.wait()
+                await db.execute(
+                    text("UPDATE users SET location = :v WHERE user_id = :id"),
+                    {"v": name, "id": second},
+                )
+                await db.commit()
+                return name
+
+            return await retry_on_transient_conflict(db, unit, what=f"deadlock_{name}")
+
+    results = await asyncio.gather(cross_update("a", 1, 2), cross_update("b", 2, 1))
+
+    assert sorted(results) == ["a", "b"]
+    # Exactly one side was the victim and replayed once.
+    assert sorted(calls.values()) == [1, 2]

--- a/tests/services/test_ml_suggestion_pipeline.py
+++ b/tests/services/test_ml_suggestion_pipeline.py
@@ -31,7 +31,7 @@ from app.services.ml_suggestion_pipeline import (
     persist_predictions,
     store_predictions,
 )
-from tests.transient_conflict import _flaky_commit, _snapshot_conflict_error
+from tests.transient_conflict import _deadlock_error, _flaky_commit
 
 PIPELINE = "app.services.ml_suggestion_pipeline"
 
@@ -789,7 +789,7 @@ async def test_persist_predictions_retries_transient_conflict(db_session, tmp_pa
         {"tag_id": 161, "confidence": 0.88, "model_version": "v3"},
     ]
 
-    commit_patch, calls = _flaky_commit(1, _snapshot_conflict_error("ml_raw_predictions"))
+    commit_patch, calls = _flaky_commit(1, _deadlock_error())
     with (
         commit_patch,
         patch(f"{PIPELINE}.resolve_external_tags", _resolver_to_tag_ids(mapped)),

--- a/tests/services/test_ml_suggestion_review_bulk.py
+++ b/tests/services/test_ml_suggestion_review_bulk.py
@@ -422,16 +422,16 @@ class TestAncestorCleanupOnApprove:
 
 class TestBulkReviewSnapshotConflictRetry:
     """A background ml_remap run rewriting ml_tag_suggestions rows while a
-    bulk review commits over the same rows trips MariaDB ER_CHECKREAD (errno
-    1020) under innodb_snapshot_isolation. bulk_review_suggestions must retry
-    on a fresh snapshot instead of propagating the 500 (see
-    app/core/db_retry.py and app/services/ml_suggestion_review.py)."""
+    bulk review commits over the same rows can hit a Postgres deadlock
+    (SQLSTATE 40P01). bulk_review_suggestions must retry on a fresh
+    transaction instead of propagating the 500 (see app/core/db_retry.py and
+    app/services/ml_suggestion_review.py)."""
 
     @pytest.mark.needs_commit
     async def test_bulk_review_approve_retries_snapshot_conflict_and_succeeds(
         self, db_session: AsyncSession
     ):
-        """A transient 1020 on the bulk commit is retried and the approval succeeds.
+        """A transient Postgres deadlock (40P01) on the bulk commit is retried and the approval succeeds.
 
         needs_commit: the retry performs a real session rollback for a fresh
         snapshot; under the default SAVEPOINT isolation that rollback would
@@ -440,8 +440,7 @@ class TestBulkReviewSnapshotConflictRetry:
         """
         from unittest.mock import patch
 
-        import pymysql
-        from sqlalchemy.exc import OperationalError
+        from tests.transient_conflict import _deadlock_error
 
         user = await _make_user(db_session, "snapshot")
         image = await _make_image(db_session, user, "snapshot")
@@ -463,14 +462,7 @@ class TestBulkReviewSnapshotConflictRetry:
         async def flaky_commit(self, *args, **kwargs):
             calls.append(1)
             if len(calls) == 1:
-                raise OperationalError(
-                    "UPDATE ml_tag_suggestions ...",
-                    None,
-                    pymysql.err.OperationalError(
-                        1020,
-                        "Record has changed since last read in table 'ml_tag_suggestions'",
-                    ),
-                )
+                raise _deadlock_error()
             await real_commit(self, *args, **kwargs)
 
         with patch.object(AsyncSession, "commit", flaky_commit):

--- a/tests/transient_conflict.py
+++ b/tests/transient_conflict.py
@@ -1,12 +1,11 @@
-"""Helpers for testing the MariaDB transient-conflict retry (app/core/db_retry.py).
+"""Helpers for testing the Postgres transient-conflict retry (app/core/db_retry.py).
 
 Two errors get the same rollback-and-replay treatment:
 
-- ER_CHECKREAD (1020), raised under ``innodb_snapshot_isolation=ON`` when a
-  locking statement meets a row version committed after this transaction's
-  snapshot rather than reading the stale version.
-- ER_LOCK_DEADLOCK (1213), raised when InnoDB breaks a lock cycle by rolling
-  one of the transactions back.
+- 40P01 deadlock_detected: two transactions took row locks in opposite orders
+  and Postgres aborted one to break the cycle.
+- 40001 serialization_failure: a write would break the transaction's snapshot
+  (REPEATABLE READ / SERIALIZABLE; rare under the READ COMMITTED default).
 
 Write paths wrap their transactional unit in ``retry_on_transient_conflict`` so
 either one is retried on a fresh transaction instead of surfacing a 500.
@@ -18,35 +17,35 @@ requests.
 
 from unittest.mock import patch
 
-import pymysql
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.dialects.postgresql.asyncpg import AsyncAdapt_asyncpg_dbapi
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-def _db_error(errno: int, message: str) -> OperationalError:
-    """Build the sqlalchemy error the aiomysql/pymysql driver raises for `errno`."""
-    return OperationalError("UPDATE ...", None, pymysql.err.OperationalError(errno, message))
+def _db_error(sqlstate: str, message: str) -> DBAPIError:
+    """Build the error SQLAlchemy raises for a Postgres error with `sqlstate`.
 
-
-def _snapshot_conflict_error(table: str = "images") -> OperationalError:
-    """The error MariaDB raises under innodb_snapshot_isolation (ER_CHECKREAD).
-
-    `table` is the table the conflict is reported against. For the tag write
-    paths that is `tag_history`: its INSERT takes a locking read on each FK
-    parent (tags/images/users), and ER_CHECKREAD names the child table's
-    handler, not the parent row that actually moved.
+    The asyncpg adapter translates asyncpg's PostgresError into its own dbapi
+    Error, copying the SQLSTATE onto .sqlstate/.pgcode, and SQLAlchemy wraps
+    that as a plain DBAPIError (not OperationalError) — which is what the
+    helper must catch.
     """
-    return _db_error(1020, f"Record has changed since last read in table '{table}'")
+    orig = AsyncAdapt_asyncpg_dbapi.Error(message)
+    orig.sqlstate = orig.pgcode = sqlstate
+    return DBAPIError("UPDATE ...", None, orig)
 
 
-def _deadlock_error() -> OperationalError:
-    """The error MariaDB raises when it picks this transaction as the deadlock
-    victim (ER_LOCK_DEADLOCK). Carries no table name — InnoDB reports the cycle,
-    not a single row."""
-    return _db_error(1213, "Deadlock found when trying to get lock; try restarting transaction")
+def _deadlock_error() -> DBAPIError:
+    """The error Postgres raises for the transaction it aborts to break a lock cycle."""
+    return _db_error("40P01", "deadlock detected")
 
 
-def _flaky_commit(fail_times: int, error: OperationalError):
+def _serialization_error() -> DBAPIError:
+    """The error Postgres raises when a write would break the transaction's snapshot."""
+    return _db_error("40001", "could not serialize access due to concurrent update")
+
+
+def _flaky_commit(fail_times: int, error: DBAPIError):
     """Patch AsyncSession.commit to raise `error` for the first `fail_times`
     calls, then delegate to the real commit.
 
@@ -67,7 +66,7 @@ def _flaky_commit(fail_times: int, error: OperationalError):
     return patch.object(AsyncSession, "commit", commit), calls
 
 
-def _flaky_flush(fail_times: int, error: OperationalError):
+def _flaky_flush(fail_times: int, error: DBAPIError):
     """Patch AsyncSession.flush to raise `error` for the first `fail_times`
     calls, then delegate to the real flush. Only a route's explicit
     ``await db.flush()`` goes through AsyncSession.flush (autoflush runs inside
@@ -85,7 +84,7 @@ def _flaky_flush(fail_times: int, error: OperationalError):
     return patch.object(AsyncSession, "flush", flush), calls
 
 
-def _flaky_flush_nth(n: int, error: OperationalError):
+def _flaky_flush_nth(n: int, error: DBAPIError):
     """Like `_flaky_flush`, but fails only the `n`th explicit flush (1-indexed).
 
     Use this to aim the conflict at a specific write within a route that

--- a/tests/unit/test_db_retry.py
+++ b/tests/unit/test_db_retry.py
@@ -1,22 +1,10 @@
 """Tests for the transient-conflict retry helper (app/core/db_retry.py)."""
 
-import pymysql
 import pytest
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError, OperationalError
 
 from app.core.db_retry import is_transient_conflict, retry_on_transient_conflict
-
-
-def _db_error(errno: int, message: str) -> OperationalError:
-    return OperationalError("STATEMENT", None, pymysql.err.OperationalError(errno, message))
-
-
-def _conflict() -> OperationalError:
-    return _db_error(1020, "Record has changed since last read in table 'images'")
-
-
-def _deadlock() -> OperationalError:
-    return _db_error(1213, "Deadlock found when trying to get lock; try restarting transaction")
+from tests.transient_conflict import _db_error, _deadlock_error, _serialization_error
 
 
 class _StubSession:
@@ -30,23 +18,33 @@ class _StubSession:
 
 
 class TestIsTransientConflict:
-    def test_matches_snapshot_conflict_errno_1020(self):
-        assert is_transient_conflict(_conflict()) is True
+    def test_matches_deadlock_40p01(self):
+        assert is_transient_conflict(_deadlock_error()) is True
 
-    def test_matches_deadlock_errno_1213(self):
-        assert is_transient_conflict(_deadlock()) is True
+    def test_matches_serialization_failure_40001(self):
+        assert is_transient_conflict(_serialization_error()) is True
 
-    def test_rejects_other_errnos(self):
+    def test_rejects_unique_violation(self):
         # Duplicate key is a real data conflict, not a transient lock conflict:
         # replaying it produces the same error, so it must surface to the caller.
-        assert is_transient_conflict(_db_error(1062, "Duplicate entry")) is False
+        assert is_transient_conflict(_db_error("23505", "duplicate key value")) is False
 
-    def test_rejects_lock_wait_timeout(self):
-        # 1205 is deliberately excluded — see the module docstring.
-        assert is_transient_conflict(_db_error(1205, "Lock wait timeout exceeded")) is False
+    def test_rejects_lock_timeout(self):
+        # 55P03 fires only after lock_timeout elapsed, so replaying it multiplies
+        # an already pathological latency — see the module docstring.
+        assert (
+            is_transient_conflict(_db_error("55P03", "canceling statement due to lock timeout"))
+            is False
+        )
 
-    def test_rejects_error_without_args(self):
-        assert is_transient_conflict(OperationalError("STATEMENT", None, Exception())) is False
+    def test_rejects_error_without_sqlstate(self):
+        assert is_transient_conflict(DBAPIError("STATEMENT", None, Exception())) is False
+
+    def test_rejects_operational_error_without_sqlstate(self):
+        # A driver-level OperationalError (connection dropped) carries no SQLSTATE.
+        assert (
+            is_transient_conflict(OperationalError("STATEMENT", None, Exception("gone"))) is False
+        )
 
 
 class TestRetryOnTransientConflict:
@@ -61,22 +59,6 @@ class TestRetryOnTransientConflict:
         assert db.rollbacks == 0
 
     @pytest.mark.asyncio
-    async def test_retries_conflict_with_rollback_between_attempts(self):
-        db = _StubSession()
-        calls = 0
-
-        async def fn() -> str:
-            nonlocal calls
-            calls += 1
-            if calls < 3:
-                raise _conflict()
-            return "ok"
-
-        assert await retry_on_transient_conflict(db, fn, what="test") == "ok"
-        assert calls == 3
-        assert db.rollbacks == 2  # one per failed attempt
-
-    @pytest.mark.asyncio
     async def test_retries_deadlock_with_rollback_between_attempts(self):
         db = _StubSession()
         calls = 0
@@ -84,8 +66,24 @@ class TestRetryOnTransientConflict:
         async def fn() -> str:
             nonlocal calls
             calls += 1
+            if calls < 3:
+                raise _deadlock_error()
+            return "ok"
+
+        assert await retry_on_transient_conflict(db, fn, what="test") == "ok"
+        assert calls == 3
+        assert db.rollbacks == 2  # one per failed attempt
+
+    @pytest.mark.asyncio
+    async def test_retries_serialization_failure_with_rollback_between_attempts(self):
+        db = _StubSession()
+        calls = 0
+
+        async def fn() -> str:
+            nonlocal calls
+            calls += 1
             if calls < 2:
-                raise _deadlock()
+                raise _serialization_error()
             return "ok"
 
         assert await retry_on_transient_conflict(db, fn, what="test") == "ok"
@@ -100,24 +98,24 @@ class TestRetryOnTransientConflict:
         async def fn() -> None:
             nonlocal calls
             calls += 1
-            raise _conflict()
+            raise _deadlock_error()
 
-        with pytest.raises(OperationalError):
+        with pytest.raises(DBAPIError):
             await retry_on_transient_conflict(db, fn, what="test")
         assert calls == 3  # default bound
         assert db.rollbacks == 2  # no rollback after the final, re-raised failure
 
     @pytest.mark.asyncio
-    async def test_does_not_retry_other_operational_errors(self):
+    async def test_does_not_retry_other_db_errors(self):
         db = _StubSession()
         calls = 0
 
         async def fn() -> None:
             nonlocal calls
             calls += 1
-            raise _db_error(1062, "Duplicate entry")
+            raise _db_error("23505", "duplicate key value")
 
-        with pytest.raises(OperationalError):
+        with pytest.raises(DBAPIError):
             await retry_on_transient_conflict(db, fn, what="test")
         assert calls == 1
         assert db.rollbacks == 0
@@ -141,9 +139,9 @@ class TestRetryOnTransientConflict:
         async def fn() -> None:
             nonlocal calls
             calls += 1
-            raise _conflict()
+            raise _deadlock_error()
 
-        with pytest.raises(OperationalError):
+        with pytest.raises(DBAPIError):
             await retry_on_transient_conflict(db, fn, what="test", attempts=5)
         assert calls == 5
         assert db.rollbacks == 4


### PR DESCRIPTION
PR 1 of 4 for the MariaDB retirement. Plan: docs/plans/2026-Q3/2026-09-10-mariadb-retirement-impl.md (design: `2026-09-10-mariadb-retirement-design.md`, decision 2).

## The defect

Since the 2026-08-22 Postgres cutover the transient-conflict retry helper has been inert. It caught `sqlalchemy.exc.OperationalError` and matched integer MariaDB errnos (1020, 1213) on `orig.args[0]`. SQLAlchemy's asyncpg adapter surfaces a Postgres error as a bare `DBAPIError` with the SQLSTATE on `orig.sqlstate`, so a real deadlock never matched and surfaced as a 500. ADR-0004's contract was void.

## The fix

- `app/core/db_retry.py` catches `DBAPIError` (a superclass of `OperationalError`, so nothing narrows) and retries on SQLSTATE `40P01` deadlock_detected and `40001` serialization_failure. `55P03` lock_not_available is deliberately excluded, as 1205 was before. The log line carries the SQLSTATE.
- `tests/integration/test_db_retry_deadlock.py` provokes a real two-session deadlock and proves the victim replays and succeeds. It carries `postgres_only` because CI still runs a MariaDB job until PR 3.
- `tests/transient_conflict.py` fabricates the error the way the adapter really builds it; every test that injects a conflict (28 call sites across 10 files) uses it, and the `pytest.raises(OperationalError)` guards around injected deadlocks became `pytest.raises(DBAPIError)`.
- ADR-0004 rewritten for the SQLSTATE contract. Docstrings say which conflicts were observed on MariaDB and which are injected.

## Verification

Full suite on the final commit: 2790 passed, 33 skipped, 80 warnings (unchanged from main). `mypy app/` clean.

Deferred: test classes still named `...SnapshotConflictRetry` (cosmetic; ~20 renames across 8 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJ1ryWZMt6jVJ8iEN9f7PQ
