### PR TITLE
feat(affinity): port the nightly rebuild to Postgres

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -46,11 +46,7 @@ AsyncSessionLocal = async_sessionmaker(
 
 
 def is_postgres(db: AsyncSession) -> bool:
-    """Whether this session is bound to Postgres — the dialect-branch switch.
-
-    (The MariaDB-only guard in user_tag_affinity deliberately tests
-    `!= "mysql"` instead: it must also refuse any third dialect.)
-    """
+    """Whether this session is bound to Postgres — the dialect-branch switch."""
     return db.get_bind().dialect.name == "postgresql"
 
 

--- a/app/models/user_tag_affinity.py
+++ b/app/models/user_tag_affinity.py
@@ -11,12 +11,11 @@ from app.models.types import UnsignedInt, UtcDateTime
 class UserTagAffinity(SQLModel, table=True):
     """Per-(user, tag) taste evidence + blended affinity score.
 
-    Rebuilt nightly by refresh_user_tag_affinity via atomic staging-table swap;
-    treat as read-only outside the refresh job. No FKs by design (same rationale
-    as tag_cooccurrence: full rebuild maintains consistency, and
-    CREATE TABLE ... LIKE would silently drop FKs after the first swap anyway).
-    Only rows meeting min support are stored: pool_cnt >= TASTE_MIN_SUPPORT or
-    rated_count >= TASTE_MIN_SUPPORT.
+    Rebuilt nightly by refresh_user_tag_affinity inside one transaction (delete
+    then batched insert); treat as read-only outside the refresh job. No FKs by
+    design: the full rebuild maintains consistency, and FK checks on the bulk
+    insert would only slow it. Only rows meeting min support are stored:
+    pool_cnt >= TASTE_MIN_SUPPORT or rated_count >= TASTE_MIN_SUPPORT.
     """
 
     __tablename__ = "user_tag_affinity"

--- a/app/services/user_tag_affinity.py
+++ b/app/services/user_tag_affinity.py
@@ -25,7 +25,7 @@ logger = get_logger(__name__)
 _PUBLIC = list(PUBLIC_IMAGE_STATUSES)
 # Advisory-lock names are server-global; scope to the current database so
 # pytest-xdist per-worker DBs get independent locks while production's single
-# DB still serializes cron + manual runs (same reasoning as tag_cooccurrence).
+# DB still serializes cron + manual runs.
 _LOCK_PREFIX = "user_tag_affinity_refresh"
 
 # Each axis contributes only when it has enough support on its own; NULL-safe
@@ -121,6 +121,10 @@ async def refresh_user_tag_affinity(
         )
         await _exec(db, "ALTER TABLE _taste_vl ADD PRIMARY KEY (image_id, tag_id)")
         await _exec(db, "CREATE INDEX ON _taste_vl (tag_id)")
+        # Temp tables carry no statistics: autovacuum can't see another
+        # session's temp tables, and CREATE TABLE AS collects none either.
+        # Without ANALYZE, the planner full-scans _taste_vl twice per batch.
+        await _exec(db, "ANALYZE _taste_vl")
 
         # 2. visible tagged images, per-canonical-tag counts, and N
         await _exec(
@@ -128,12 +132,14 @@ async def refresh_user_tag_affinity(
             "CREATE TEMP TABLE _taste_vi ON COMMIT DROP AS SELECT DISTINCT image_id FROM _taste_vl",
         )
         await _exec(db, "ALTER TABLE _taste_vi ADD PRIMARY KEY (image_id)")
+        await _exec(db, "ANALYZE _taste_vi")
         await _exec(
             db,
             "CREATE TEMP TABLE _taste_vc ON COMMIT DROP AS "
             "SELECT tag_id, COUNT(*) AS vc FROM _taste_vl GROUP BY tag_id",
         )
         await _exec(db, "ALTER TABLE _taste_vc ADD PRIMARY KEY (tag_id)")
+        await _exec(db, "ANALYZE _taste_vc")
         n = (await db.execute(text("SELECT COUNT(*) FROM _taste_vi"))).scalar() or 0
 
         # 3. eligible users (raw event counts)
@@ -150,6 +156,7 @@ async def refresh_user_tag_affinity(
             {"min_events": min_events},
         )
         await _exec(db, "ALTER TABLE _taste_elig ADD PRIMARY KEY (user_id)")
+        await _exec(db, "ANALYZE _taste_elig")
 
         # 4. deduped positive pool (favorites ∪ uploads), visible only
         await _exec(
@@ -168,6 +175,7 @@ async def refresh_user_tag_affinity(
             """,
         )
         await _exec(db, "ALTER TABLE _taste_pool ADD PRIMARY KEY (user_id, image_id)")
+        await _exec(db, "ANALYZE _taste_pool")
 
         # 5. per-user scalars (pool size, mean rating over visible images)
         await _exec(
@@ -183,6 +191,7 @@ async def refresh_user_tag_affinity(
             """,
         )
         await _exec(db, "ALTER TABLE _taste_users ADD PRIMARY KEY (user_id)")
+        await _exec(db, "ANALYZE _taste_users")
 
         # 6. clear the live table inside the transaction: readers keep the old
         #    rows until commit, and the schema (PK, lookup index, defaults)

--- a/app/services/user_tag_affinity.py
+++ b/app/services/user_tag_affinity.py
@@ -5,15 +5,13 @@ with minimum support, stores positive-pool counts (favorites ∪ uploads,
 deduped), rating stats, a popularity-normalized lift, a per-user-mean-centered
 rating delta, and the blended affinity used by /images/recommended.
 
-Mirrors app/services/tag_cooccurrence.py on the unmerged co-occurrence branch:
-materialized regular helper tables (MariaDB cannot self-join a TEMPORARY table),
-a database-scoped advisory lock, and an atomic staging-table swap. The main
-aggregation is batched by user-id ranges — the unbatched join is ~75M
-intermediate rows (5.7M favorites × ~13 tags/image), the exact shape that
-OOM-crashed MariaDB during the co-occurrence build. Issues DDL with implicit
-commits and manages its own transaction. The swapped-in table intentionally has
-NO foreign keys (CREATE TABLE ... LIKE does not copy them); acceptable for a
-read-only analytics table and avoids FK-check overhead on bulk load.
+One transaction: temp helper tables, the batched aggregation into the live
+table after clearing it, and the commit. Readers keep seeing the previous rows
+until the commit. The main aggregation is batched by user-id ranges — the
+unbatched join is ~75M intermediate rows (5.7M favorites × ~13 tags/image).
+A transaction-scoped advisory lock serializes the nightly cron and a manual
+run; it and the temp tables vanish with the transaction, so a mid-run failure
+leaves nothing behind.
 """
 
 from sqlalchemy import bindparam, text
@@ -25,7 +23,6 @@ from app.services.image_visibility import PUBLIC_IMAGE_STATUSES
 logger = get_logger(__name__)
 
 _PUBLIC = list(PUBLIC_IMAGE_STATUSES)
-_HELPERS = ("_taste_vl", "_taste_vi", "_taste_vc", "_taste_elig", "_taste_pool", "_taste_users")
 # Advisory-lock names are server-global; scope to the current database so
 # pytest-xdist per-worker DBs get independent locks while production's single
 # DB still serializes cron + manual runs (same reasoning as tag_cooccurrence).
@@ -35,19 +32,19 @@ _LOCK_PREFIX = "user_tag_affinity_refresh"
 # via COALESCE. lift > 0 is guaranteed inside its CASE (pool_cnt >= min_support
 # implies a positive numerator).
 _BATCH_INSERT = """
-INSERT INTO user_tag_affinity_new
+INSERT INTO user_tag_affinity
     (user_id, tag_id, pool_cnt, fav_count, upload_count, rated_count,
      rating_avg, lift, rating_delta, affinity)
 SELECT
     agg.user_id, agg.tag_id, agg.pool_cnt, agg.fav_count, agg.upload_count, agg.rated_count,
-    agg.rating_sum / NULLIF(agg.rated_count, 0) AS rating_avg,
+    agg.rating_sum::float / NULLIF(agg.rated_count, 0) AS rating_avg,
     CASE WHEN agg.pool_cnt > 0 AND u.pool_size > 0
-         THEN (agg.pool_cnt / u.pool_size) / ((vc.vc + :k) / :n) END AS lift,
-    agg.rating_sum / NULLIF(agg.rated_count, 0) - u.user_mean AS rating_delta,
+         THEN (agg.pool_cnt::float / u.pool_size) / ((vc.vc + :k)::float / :n) END AS lift,
+    agg.rating_sum::float / NULLIF(agg.rated_count, 0) - u.user_mean AS rating_delta,
     COALESCE(CASE WHEN agg.pool_cnt >= :min_support
-                  THEN LN((agg.pool_cnt / u.pool_size) / ((vc.vc + :k) / :n)) END, 0)
+                  THEN LN((agg.pool_cnt::float / u.pool_size) / ((vc.vc + :k)::float / :n)) END, 0)
     + :beta * COALESCE(CASE WHEN agg.rated_count >= :min_support
-                            THEN agg.rating_sum / agg.rated_count - u.user_mean END, 0)
+                            THEN agg.rating_sum::float / agg.rated_count - u.user_mean END, 0)
       AS affinity
 FROM (
     SELECT y.user_id, y.tag_id,
@@ -92,31 +89,28 @@ async def refresh_user_tag_affinity(
 ) -> int:
     """Rebuild the user_tag_affinity table; return the number of rows written.
 
-    Serialized by a connection-scoped MySQL named lock so the nightly cron and a
+    Serialized by a transaction-scoped advisory lock so the nightly cron and a
     manual run cannot collide. Returns the sentinel ``-1`` (callers should treat
     ``< 0`` as "skipped") without touching any tables if another refresh already
     holds the lock.
     """
-    if db.get_bind().dialect.name != "mysql":
-        raise NotImplementedError(
-            "refresh_user_tag_affinity is MariaDB-only (GET_LOCK, ENGINE=InnoDB "
-            "helper tables); see docs/plans/2026-Q3/2026-08-20-postgres-poc-impl.md"
-        )
-    db_name = (await db.execute(text("SELECT DATABASE()"))).scalar()
+    # Advisory-lock keys are server-global; scope to the current database so
+    # pytest-xdist per-worker DBs get independent locks while production's
+    # single DB still serializes cron + manual runs.
+    db_name = (await db.execute(text("SELECT current_database()"))).scalar()
     lock_name = f"{_LOCK_PREFIX}:{db_name}"
-    locked = (await db.execute(text("SELECT GET_LOCK(:n, 0)"), {"n": lock_name})).scalar()
+    locked = (
+        await db.execute(text("SELECT pg_try_advisory_xact_lock(hashtext(:n))"), {"n": lock_name})
+    ).scalar()
     if not locked:
         logger.info("user_tag_affinity_refresh_skipped_locked")
         return -1
     try:
-        for t in _HELPERS:
-            await _exec(db, f"DROP TABLE IF EXISTS {t}")
-
         # 1. canonical, visible links
         await _exec(
             db,
             """
-            CREATE TABLE _taste_vl ENGINE=InnoDB AS
+            CREATE TEMP TABLE _taste_vl ON COMMIT DROP AS
             SELECT DISTINCT tl.image_id, COALESCE(t.alias_of, t.tag_id) AS tag_id
             FROM tag_links tl
             JOIN images i ON i.image_id = tl.image_id
@@ -125,18 +119,18 @@ async def refresh_user_tag_affinity(
             """,
             {"public_statuses": _PUBLIC},
         )
-        await _exec(
-            db, "ALTER TABLE _taste_vl ADD PRIMARY KEY (image_id, tag_id), ADD KEY k_tag (tag_id)"
-        )
+        await _exec(db, "ALTER TABLE _taste_vl ADD PRIMARY KEY (image_id, tag_id)")
+        await _exec(db, "CREATE INDEX ON _taste_vl (tag_id)")
 
         # 2. visible tagged images, per-canonical-tag counts, and N
         await _exec(
-            db, "CREATE TABLE _taste_vi ENGINE=InnoDB AS SELECT DISTINCT image_id FROM _taste_vl"
+            db,
+            "CREATE TEMP TABLE _taste_vi ON COMMIT DROP AS SELECT DISTINCT image_id FROM _taste_vl",
         )
         await _exec(db, "ALTER TABLE _taste_vi ADD PRIMARY KEY (image_id)")
         await _exec(
             db,
-            "CREATE TABLE _taste_vc ENGINE=InnoDB AS "
+            "CREATE TEMP TABLE _taste_vc ON COMMIT DROP AS "
             "SELECT tag_id, COUNT(*) AS vc FROM _taste_vl GROUP BY tag_id",
         )
         await _exec(db, "ALTER TABLE _taste_vc ADD PRIMARY KEY (tag_id)")
@@ -146,7 +140,7 @@ async def refresh_user_tag_affinity(
         await _exec(
             db,
             """
-            CREATE TABLE _taste_elig ENGINE=InnoDB AS
+            CREATE TEMP TABLE _taste_elig ON COMMIT DROP AS
             SELECT user_id FROM (
                 SELECT user_id FROM favorites
                 UNION ALL SELECT user_id FROM image_ratings
@@ -161,7 +155,7 @@ async def refresh_user_tag_affinity(
         await _exec(
             db,
             """
-            CREATE TABLE _taste_pool ENGINE=InnoDB AS
+            CREATE TEMP TABLE _taste_pool ON COMMIT DROP AS
             SELECT x.user_id, x.image_id, MAX(x.is_fav) AS is_fav, MAX(x.is_upl) AS is_upl
             FROM (
                 SELECT f.user_id, f.image_id, 1 AS is_fav, 0 AS is_upl
@@ -179,10 +173,10 @@ async def refresh_user_tag_affinity(
         await _exec(
             db,
             """
-            CREATE TABLE _taste_users ENGINE=InnoDB AS
+            CREATE TEMP TABLE _taste_users ON COMMIT DROP AS
             SELECT e.user_id,
                 (SELECT COUNT(*) FROM _taste_pool p WHERE p.user_id = e.user_id) AS pool_size,
-                (SELECT AVG(r.rating) FROM image_ratings r
+                (SELECT AVG(r.rating)::float FROM image_ratings r
                   JOIN _taste_vi vi ON vi.image_id = r.image_id
                   WHERE r.user_id = e.user_id) AS user_mean
             FROM _taste_elig e
@@ -190,9 +184,10 @@ async def refresh_user_tag_affinity(
         )
         await _exec(db, "ALTER TABLE _taste_users ADD PRIMARY KEY (user_id)")
 
-        # 6. staging table (LIKE copies PK + lookup index + defaults)
-        await _exec(db, "DROP TABLE IF EXISTS user_tag_affinity_new")
-        await _exec(db, "CREATE TABLE user_tag_affinity_new LIKE user_tag_affinity")
+        # 6. clear the live table inside the transaction: readers keep the old
+        #    rows until commit, and the schema (PK, lookup index, defaults)
+        #    stays exactly what the migration chain created.
+        await _exec(db, "DELETE FROM user_tag_affinity")
 
         # 7. batched aggregation: contiguous user-id ranges over the sorted
         #    eligible ids, so BETWEEN lo AND hi covers exactly one chunk.
@@ -217,36 +212,15 @@ async def refresh_user_tag_affinity(
                 },
             )
 
-        n_rows = (
-            await db.execute(text("SELECT COUNT(*) FROM user_tag_affinity_new"))
-        ).scalar() or 0
-
-        # 8. atomic swap, then clean up
-        await _exec(db, "DROP TABLE IF EXISTS user_tag_affinity_old")
-        await _exec(
-            db,
-            "RENAME TABLE user_tag_affinity TO user_tag_affinity_old, "
-            "user_tag_affinity_new TO user_tag_affinity",
-        )
-        await _exec(db, "DROP TABLE user_tag_affinity_old")
-        for t in _HELPERS:
-            await _exec(db, f"DROP TABLE IF EXISTS {t}")
+        n_rows = (await db.execute(text("SELECT COUNT(*) FROM user_tag_affinity"))).scalar() or 0
         await db.commit()
         return n_rows
     finally:
-        # A mid-run failure can leave the session's transaction in a state
-        # that makes RELEASE_LOCK itself raise (e.g. PendingRollbackError) --
-        # swallowed below, that would return a still-locked connection to the
-        # pool and wedge every later refresh at -1 until the pool recycles it.
-        # A healthy post-commit session tolerates rollback() fine, so this is
-        # a no-op on the success path.
+        # A mid-run failure leaves the transaction aborted; rolling it back
+        # releases the advisory lock and drops the temp tables so the same
+        # session can run again. A healthy post-commit session tolerates
+        # rollback() fine, so this is a no-op on the success path.
         try:
             await db.rollback()
         except Exception:
-            pass
-        # Connection-scoped lock survives the DDL implicit-commits on this session.
-        try:
-            await db.execute(text("SELECT RELEASE_LOCK(:n)"), {"n": lock_name})
-        except Exception:
-            # lock auto-releases on connection close; never mask the real exception
             pass

--- a/app/tasks/taste_profile.py
+++ b/app/tasks/taste_profile.py
@@ -12,8 +12,9 @@ async def refresh_user_tag_affinity_job(ctx: dict[str, Any]) -> None:
     Nightly refresh of the user_tag_affinity table (05:00 UTC).
 
     Skips silently if another refresh is already running (advisory lock not
-    acquired). ~30+ minutes on dev-scale data (5.7M favorites), batched to
-    keep MariaDB memory bounded.
+    acquired). Batched by user-id range: the unbatched join across favorites,
+    ratings, and uploads is tens of millions of intermediate rows. Duration on
+    prod-scale data is recorded in the PR that ported this job to Postgres.
     """
     from app.config import settings
     from app.core.database import get_async_session

--- a/tests/integration/test_fk_constraint_names.py
+++ b/tests/integration/test_fk_constraint_names.py
@@ -103,9 +103,8 @@ async def test_one_fk_constraint_per_column_set(db_session: AsyncSession) -> Non
 
 # The FK coverage decided 2026-08-29 (users cleanup after PR #370): membership
 # and grant links die with the user/group/perm; donations outlive the donor.
-# user_tag_affinity stays FK-less BY DESIGN — its nightly staging-table swap
-# (CREATE TABLE ... LIKE, app/services/user_tag_affinity.py) does not copy FKs,
-# so one added here would silently vanish at the next rebuild.
+# user_tag_affinity stays FK-less BY DESIGN (see its model docstring): the
+# nightly full rebuild keeps it consistent without per-row FK checks.
 _EXPECTED_USER_REFERENCE_FKS = [
     ("user_groups", "user_id", "users", "CASCADE"),
     ("user_groups", "group_id", "groups", "CASCADE"),

--- a/tests/services/test_user_tag_affinity.py
+++ b/tests/services/test_user_tag_affinity.py
@@ -13,7 +13,7 @@ from app.models.user import Users
 from app.models.user_tag_affinity import UserTagAffinity
 from app.services.user_tag_affinity import _LOCK_PREFIX, refresh_user_tag_affinity
 
-pytestmark = [pytest.mark.integration, pytest.mark.needs_commit]
+pytestmark = [pytest.mark.integration, pytest.mark.needs_commit, pytest.mark.postgres_only]
 
 
 async def test_table_roundtrip(db_session):

--- a/tests/services/test_user_tag_affinity.py
+++ b/tests/services/test_user_tag_affinity.py
@@ -13,9 +13,7 @@ from app.models.user import Users
 from app.models.user_tag_affinity import UserTagAffinity
 from app.services.user_tag_affinity import _LOCK_PREFIX, refresh_user_tag_affinity
 
-# mariadb_only: refresh_user_tag_affinity raises NotImplementedError off-MariaDB
-# by design (GET_LOCK, ENGINE=InnoDB helper tables).
-pytestmark = [pytest.mark.integration, pytest.mark.needs_commit, pytest.mark.mariadb_only]
+pytestmark = [pytest.mark.integration, pytest.mark.needs_commit]
 
 
 async def test_table_roundtrip(db_session):
@@ -321,50 +319,44 @@ async def test_rerun_is_idempotent(db_session):
 
 
 async def test_lock_skip_returns_sentinel(db_session, engine):
-    # A second connection (from the shared per-test `engine`) holds the lock
-    # -> refresh skips with -1. MySQL named locks are connection-scoped, so a
-    # fresh connection() checkout from the same engine is a distinct session.
+    # A second connection holds the advisory lock in an open transaction ->
+    # refresh skips with -1. Advisory locks are per-session, so a fresh
+    # connection() checkout from the shared per-test `engine` is a distinct
+    # holder.
     from sqlalchemy import text as sqla_text
 
-    db_name = (await db_session.execute(sqla_text("SELECT DATABASE()"))).scalar()
+    db_name = (await db_session.execute(sqla_text("SELECT current_database()"))).scalar()
     lock_name = f"{_LOCK_PREFIX}:{db_name}"
     async with engine.connect() as other:
-        got = (await other.execute(sqla_text("SELECT GET_LOCK(:n, 0)"), {"n": lock_name})).scalar()
-        assert got == 1
+        got = (
+            await other.execute(
+                sqla_text("SELECT pg_try_advisory_xact_lock(hashtext(:n))"), {"n": lock_name}
+            )
+        ).scalar()
+        assert got is True
         n = await refresh_user_tag_affinity(db_session, **REFRESH_KW)
         assert n == -1
-        await other.execute(sqla_text("SELECT RELEASE_LOCK(:n)"), {"n": lock_name})
+        await other.rollback()
 
 
 async def test_lock_released_after_mid_run_failure(db_session, engine):
     # Forces a real (not mocked) mid-run failure: a second connection holds
-    # an open, uncommitted `FOR UPDATE` on a real `_taste_vl` table, so the
-    # service's own first statement after acquiring the advisory lock -- its
-    # defensive `DROP TABLE IF EXISTS _taste_vl` -- blocks on a metadata lock
-    # and genuinely errors once lock_wait_timeout is exceeded. This verifies
-    # the failure propagates (isn't silently swallowed) AND that the
-    # advisory lock isn't leaked: a second refresh on the SAME session, once
-    # the blocker releases, must succeed rather than returning the
-    # locked-out sentinel (-1), which is what would happen if RELEASE_LOCK
-    # in the `finally` failed on a still-poisoned session and got swallowed.
+    # user_tag_affinity in ACCESS EXCLUSIVE mode inside an open transaction,
+    # so the service's DELETE blocks and, with lock_timeout set on the service
+    # session, genuinely errors. This verifies the failure propagates (isn't
+    # silently swallowed) AND that the advisory lock isn't leaked: a second
+    # refresh on the SAME session, once the blocker releases, must succeed
+    # rather than returning the locked-out sentinel (-1). The SET rides in the
+    # aborted transaction, so the rollback in the service's finally clears it.
     from sqlalchemy import text as sqla_text
-    from sqlalchemy.exc import OperationalError
+    from sqlalchemy.exc import DBAPIError
 
     async with engine.connect() as blocker:
-        await blocker.execute(sqla_text("DROP TABLE IF EXISTS _taste_vl"))
-        await blocker.execute(sqla_text("CREATE TABLE _taste_vl (id INT) ENGINE=InnoDB"))
-        await blocker.commit()
-        await blocker.execute(sqla_text("INSERT INTO _taste_vl VALUES (1)"))
-        await blocker.commit()
-        await blocker.execute(sqla_text("SELECT * FROM _taste_vl FOR UPDATE"))  # open txn
-
-        await db_session.execute(sqla_text("SET SESSION lock_wait_timeout = 1"))
-        with pytest.raises(OperationalError, match="Lock wait timeout exceeded"):
+        await blocker.execute(sqla_text("LOCK TABLE user_tag_affinity IN ACCESS EXCLUSIVE MODE"))
+        await db_session.execute(sqla_text("SET lock_timeout = '1s'"))
+        with pytest.raises(DBAPIError, match="lock timeout"):
             await refresh_user_tag_affinity(db_session, **REFRESH_KW)
-
-        await blocker.rollback()  # release the metadata lock
-        await blocker.execute(sqla_text("DROP TABLE IF EXISTS _taste_vl"))
-        await blocker.commit()
+        await blocker.rollback()  # release the table lock
 
     n = await refresh_user_tag_affinity(db_session, **REFRESH_KW)
     assert n >= 0  # lock was released after the failure, not leaked

--- a/tests/tasks/test_taste_profile_job.py
+++ b/tests/tasks/test_taste_profile_job.py
@@ -13,7 +13,7 @@ async def test_disabled_returns_without_opening_a_session(monkeypatch):
     """TASTE_REFRESH_ENABLED=False short-circuits before get_async_session().
 
     No DB fixture is used here on purpose: settings.DATABASE_URL points at
-    the docker-compose-internal `mariadb` host, unreachable from the test
+    the docker-compose-internal `postgres` host, unreachable from the test
     runner, so if the guard didn't fire before that call this test would
     fail with a real connection error rather than passing accidentally.
     """


### PR DESCRIPTION
PR 2 of 4 for the MariaDB retirement. Plan: docs/plans/2026-Q3/2026-09-10-mariadb-retirement-impl.md (design: `2026-09-10-mariadb-retirement-design.md`, decision 3).

## The defect

The nightly `user_tag_affinity` rebuild was MariaDB-only and raised `NotImplementedError` on any other dialect. The arq cron at 05:00 UTC has failed every night since the 2026-08-22 cutover, so the recommended feed and the taste-profile endpoint have served pre-cutover data.

## The port

`app/services/user_tag_affinity.py` now runs the rebuild as one Postgres transaction:

- `ON COMMIT DROP` temp helper tables, which Postgres can self-join, replace the `ENGINE=InnoDB` scratch tables.
- A transaction-scoped advisory lock (`pg_try_advisory_xact_lock`, still scoped by database name) replaces `GET_LOCK`; rollback releases it, so the wedged-connection failure mode is gone.
- Delete-then-insert inside the transaction replaces the `RENAME TABLE` swap. Readers keep the old rows until commit, the migrated schema stays exact (the old swap silently dropped the table's constraints), and a nightly rename would have accumulated suffixed index names.
- Every ratio carries an explicit `::float` cast. `pool_cnt / pool_size` is integer division on Postgres and would have zeroed lift and affinity.

The 13 affinity tests lose their `mariadb_only` marker and run; the two lock tests use `pg_try_advisory_xact_lock` and a real `LOCK TABLE … ACCESS EXCLUSIVE` blocker with `lock_timeout`.

## Verification

Full suite on the final commit: 2803 passed, 20 skipped, 80 warnings (unchanged from main; +13 passed / −13 skipped are the affinity tests now running). `mypy app/` clean.

## Rehearsal on the dev restore (prod-scale data)

Run once with `scripts/refresh_user_tag_affinity.py` against the dev restore (the same row volume as prod) after the ANALYZE fix landed:

| | |
|---|---|
| Wall time | 4 min 59 s |
| Rows written | 1,194,275 |
| Job timeout | 7200 s |

The final reviewer measured the temp tables without statistics at roughly 76 s per batch (two full scans of the 14.7M-row `_taste_vl`), and 33 s with `ANALYZE`; the six `ANALYZE` statements are in the last commit.

## Before the first nightly run on prod

The rebuild is now one transaction for its whole duration. Checklist for the prod database, run as the app role:

```sql
SHOW statement_timeout;                   -- expect 0
SHOW lock_timeout;                        -- expect 0 (a role-level value would abort the DELETE behind any conflicting lock)
SHOW idle_in_transaction_session_timeout; -- expect 0
SHOW transaction_timeout;                 -- expect 0
SHOW temp_file_limit;                     -- expect -1
SHOW temp_tablespaces;                    -- empty means temp tables land in the data directory
```

- Free space on the data volume: at least 2 GB. On the dev restore the temp tables were 923 MB (`_taste_vl`) plus 432 MB (`_taste_pool`), plus per-batch spill.
- Do not run a migration that alters `user_tag_affinity` during the 05:00 UTC window. The rebuild holds ROW EXCLUSIVE throughout; DDL would queue behind it and then block every reader behind its own ACCESS EXCLUSIVE request.
- Watch the first run's duration in the arq log against the 7200 s job timeout. A timeout or cancel is safe: the server aborts the transaction and the old rows survive.
- `SHOW work_mem;` is informational. At the dev restore's 4 MB the batch hash-aggregate spills to disk; if prod is similar, `SET LOCAL work_mem = '256MB'` as the first statement of the transaction is the idiomatic fix. Measure before adding; it is a tuning change outside this PR.

The dev restore shows 0 for all four timeouts and holds no stale helper tables. The nightly delete-then-insert leaves one dead tuple per old row for autovacuum (the dev table is 1.19M rows in 160 MB, so the autovacuum threshold fires right after the first run), and the transaction pins xmin for its duration; both will be recorded in the retirement ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJ1ryWZMt6jVJ8iEN9f7PQ
