### PR TITLE
feat(search): answer GET /search from Postgres with pg_trgm

### DIFF
--- a/alembic/versions/0004_tag_search_fold.py
+++ b/alembic/versions/0004_tag_search_fold.py
@@ -1,0 +1,62 @@
+"""tag search: fold function, trigram and prefix indexes
+
+Revision ID: 0004_tag_search_fold
+Revises: e20bac5f3ac3
+Create Date: 2026-09-11
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0004_tag_search_fold"
+down_revision: str | Sequence[str] | None = "e20bac5f3ac3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+EXTENSIONS = ("pg_trgm", "unaccent", "fuzzystrmatch")
+
+# IMMUTABLE is a promise that lets the function sit inside an index
+# expression; changing the unaccent dictionary later means reindexing.
+# Both names are schema-qualified so the migration and the app inline the
+# same function whatever search_path says.
+FOLD_FUNCTION = """
+CREATE OR REPLACE FUNCTION public.fold_search_text(text) RETURNS text
+LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+AS $$ SELECT lower(public.unaccent('public.unaccent'::regdictionary, $1)) $$
+"""
+
+# (name, table, index definition after "ON <table>")
+INDEXES = (
+    ("ix_tags_title_fold_trgm", "tags", "USING gin (public.fold_search_text(title::text) gin_trgm_ops)"),
+    ("ix_tags_desc_fold_trgm", "tags", 'USING gin (public.fold_search_text("desc") gin_trgm_ops)'),
+    (
+        "ix_tag_external_links_url_fold_trgm",
+        "tag_external_links",
+        "USING gin (public.fold_search_text(url) gin_trgm_ops)",
+    ),
+    ("ix_tags_title_fold_prefix", "tags", "(public.fold_search_text(title::text) text_pattern_ops)"),
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    for extension in EXTENSIONS:
+        op.execute(f"CREATE EXTENSION IF NOT EXISTS {extension}")
+    op.execute(FOLD_FUNCTION)
+    # CONCURRENTLY cannot run inside a transaction; the autocommit block
+    # commits the migration so far and runs these statements on their own.
+    with op.get_context().autocommit_block():
+        for name, table, definition in INDEXES:
+            op.execute(f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} ON {table} {definition}")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.get_context().autocommit_block():
+        for name, _table, _definition in INDEXES:
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")
+    op.execute("DROP FUNCTION IF EXISTS public.fold_search_text(text)")
+    # The extensions stay: dropping them is an operator decision.

--- a/app/api/v1/search.py
+++ b/app/api/v1/search.py
@@ -9,13 +9,10 @@ from sqlalchemy.orm import aliased
 
 from app.api.dependencies import SortOrder, TagSortBy
 from app.core.database import get_db
-from app.core.logging import get_logger
 from app.models.tag import Tags
 from app.schemas.search import SearchResponse, TagSearchHit
 from app.services.artist_identity import parse_identity_query, resolve_identity, site_display_name
 from app.services.tag_search import search_tags
-
-logger = get_logger(__name__)
 
 router = APIRouter(prefix="/search", tags=["search"])
 
@@ -114,9 +111,8 @@ async def search(
 
     # Exact artist-identity layer: if the query names a specific external
     # identity (bare ID, "pixiv <id>", or a profile URL), prepend the tag that
-    # owns it — even if the text search missed it or ranked it lower.
-    # Runs after the engine call above; the owning tag must still satisfy the
-    # request's own filters.
+    # owns it — even if the text search missed it or ranked it lower. Runs
+    # after the engine call above.
     #
     # The owning tag must still satisfy the request's own `type`/
     # `exclude_aliases` filters before it's surfaced — this layer supplements

--- a/app/api/v1/search.py
+++ b/app/api/v1/search.py
@@ -1,13 +1,11 @@
-"""Search endpoint powered by Meilisearch."""
+"""Search endpoint, answered from Postgres (app/services/tag_search.py)."""
 
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
-from fastapi.exceptions import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
-from starlette import status
 
 from app.api.dependencies import SortOrder, TagSortBy
 from app.core.database import get_db
@@ -15,27 +13,15 @@ from app.core.logging import get_logger
 from app.models.tag import Tags
 from app.schemas.search import SearchResponse, TagSearchHit
 from app.services.artist_identity import parse_identity_query, resolve_identity, site_display_name
-from app.services.search import SearchService
+from app.services.tag_search import search_tags
 
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/search", tags=["search"])
 
 
-def get_search_service() -> SearchService:
-    """Get the search service instance.
-
-    This is overridden at startup once Meilisearch is initialized.
-    Returns 503 if Meilisearch is not available.
-    """
-    raise HTTPException(
-        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-        detail="Search service is not available",
-    )
-
-
 async def _identity_hit_already_on_first_page(
-    search_service: SearchService,
+    db: AsyncSession,
     tag_id: int,
     q: str,
     *,
@@ -44,26 +30,21 @@ async def _identity_hit_already_on_first_page(
     exclude_aliases: bool,
     sort: list[str] | None,
 ) -> bool:
-    """Whether Meilisearch's first page (offset=0) for this query already has tag_id.
+    """Whether the first page (offset=0) for this query already has tag_id.
 
     Used only when the caller requested a later page, so the exact-identity
-    layer's "already found by Meilisearch" check has a stable, page-
-    independent answer — see the comment in `search()`. Best-effort: a
-    failure here shouldn't 503 an otherwise-successful request, so it's
-    treated as "already found" (no `total` inflation) rather than raising.
+    layer's "already found" check has a stable, page-independent answer —
+    see the comment in `search()`.
     """
-    try:
-        first_page = await search_service.search_tags(
-            q,
-            limit=limit,
-            offset=0,
-            type_filter=type_id,
-            exclude_aliases=exclude_aliases,
-            sort=sort,
-        )
-    except Exception:
-        logger.warning("meilisearch_identity_first_page_check_failed", query=q, exc_info=True)
-        return True
+    first_page = await search_tags(
+        db,
+        q,
+        limit=limit,
+        offset=0,
+        type_filter=type_id,
+        exclude_aliases=exclude_aliases,
+        sort=sort,
+    )
     return tag_id in first_page.tag_ids
 
 
@@ -85,32 +66,21 @@ async def search(
         Query(description="Sort field (omit for relevance ranking)"),
     ] = None,
     sort_order: Annotated[SortOrder, Query(description="Sort order")] = "DESC",
-    search_service: SearchService = Depends(get_search_service),
 ) -> SearchResponse:
-    """Search across entities using Meilisearch.
-
-    Currently supports tag search. Returns results in relevance order unless
-    sort_by is provided, in which case the user's sort dominates.
-    """
+    """Search tags. Relevance order unless sort_by is given, in which case the sort dominates."""
     sort = [f"{sort_by}:{sort_order.lower()}"] if sort_by is not None else None
 
-    try:
-        result = await search_service.search_tags(
-            q,
-            limit=limit,
-            offset=offset,
-            type_filter=type_id,
-            exclude_aliases=exclude_aliases,
-            sort=sort,
-        )
-    except Exception:
-        logger.warning("meilisearch_search_failed", query=q, exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Search service is temporarily unavailable",
-        ) from None
+    result = await search_tags(
+        db,
+        q,
+        limit=limit,
+        offset=offset,
+        type_filter=type_id,
+        exclude_aliases=exclude_aliases,
+        sort=sort,
+    )
 
-    # Fetch full tag records from Postgres, preserving Meilisearch order.
+    # Fetch full tag records from Postgres, preserving the engine's rank order.
     # Outerjoin a self-aliased Tags so alias hits include the parent's title
     # as alias_of_name — same pattern as list_tags in app/api/v1/tags.py.
     hits: list[TagSearchHit] = []
@@ -144,13 +114,13 @@ async def search(
 
     # Exact artist-identity layer: if the query names a specific external
     # identity (bare ID, "pixiv <id>", or a profile URL), prepend the tag that
-    # owns it — even if Meilisearch's fuzzy match missed or ranked it lower.
-    # Runs after the Meilisearch call above, so Meilisearch downtime still
-    # 503s exactly as before this layer existed.
+    # owns it — even if the text search missed it or ranked it lower.
+    # Runs after the engine call above; the owning tag must still satisfy the
+    # request's own filters.
     #
     # The owning tag must still satisfy the request's own `type`/
     # `exclude_aliases` filters before it's surfaced — this layer supplements
-    # Meilisearch's ranking, it doesn't bypass the filters Meilisearch itself
+    # the engine's ranking, it doesn't bypass the filters the engine itself
     # enforced. Skipping this check would leak the tag into type-filtered or
     # alias-excluded result sets it doesn't belong in.
     #
@@ -162,7 +132,7 @@ async def search(
     # every page would independently decide it's "new" and re-increment
     # `total`, giving each page a different, ever-growing total for the same
     # query. To keep `total` identical no matter which page is requested,
-    # "already found by Meilisearch" is always resolved against Meilisearch's
+    # "already found by the engine" is always resolved against the engine's
     # first page for this query — reusing this request's own result when
     # offset is already 0, otherwise issuing one extra lookup at offset=0.
     identity = parse_identity_query(q) if q else None
@@ -177,17 +147,17 @@ async def search(
 
             # Alias rows of the matched canonical are redundant with the
             # flagged canonical hit (shown first) -- during the
-            # alias-coexistence period, Meilisearch can independently match
+            # alias-coexistence period, the engine can independently match
             # both the canonical and a legacy alias tag (e.g. one titled
             # "Pixiv 21412050") for the same identity query, rendering as
             # two visually-identical suggestion rows. Drop them from THIS
             # page's hits regardless of offset -- an alias row can land on
             # a later page even when the canonical itself is only ever
             # injected/flagged on the first page (see below). `total` is
-            # adjusted down by exactly what's dropped from this page: a
-            # per-page estimate, the same spirit as Meilisearch's own
-            # estimated_total_hits, since these rows disappear entirely
-            # once aliases are fully retired.
+            # adjusted down by exactly what's dropped from this page, so a
+            # query whose alias rows straddle a page boundary reports a
+            # slightly different total per page -- tolerated because these
+            # rows disappear entirely once aliases are fully retired.
             alias_rows = [h for h in hits if h.alias_of == exact_tag.tag_id]
             if alias_rows:
                 hits = [h for h in hits if h.alias_of != exact_tag.tag_id]
@@ -197,7 +167,7 @@ async def search(
                 already_found = exact_tag.tag_id in result.tag_ids
             else:
                 already_found = await _identity_hit_already_on_first_page(
-                    search_service,
+                    db,
                     exact_tag.tag_id,  # type: ignore[arg-type]
                     q,
                     limit=limit,
@@ -219,7 +189,7 @@ async def search(
                     exact_hit.matched_identity = label
                     hits.insert(0, exact_hit)
                     # Prepending onto an already-full page would exceed the
-                    # requested page size; drop the lowest-ranked meili hit
+                    # requested page size; drop the lowest-ranked engine hit
                     # to keep the limit contract.
                     hits = hits[:limit]
 

--- a/app/core/pg_schema.py
+++ b/app/core/pg_schema.py
@@ -2,14 +2,46 @@
 
 The models' view of the schema, which tests/integration/test_schema_sync.py
 compares against the migration chain. Everything the chain creates that
-create_all cannot express lives here: the citext extension and the counter
-triggers (ADR-0009).
+create_all cannot express lives here: the citext extension, the counter
+triggers (ADR-0009), and the tag-search fold function and indexes (mirrors
+alembic/versions/0004_tag_search_fold.py).
 """
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from app.core.pg_triggers import install_counter_triggers
+
+_SEARCH_EXTENSIONS = ("pg_trgm", "unaccent", "fuzzystrmatch")
+
+# Kept in sync by hand with alembic/versions/0004_tag_search_fold.py: the
+# migration runs these via CREATE INDEX CONCURRENTLY in an autocommit block,
+# which this function's single transaction cannot do, so the two copies
+# differ only in that one word.
+_FOLD_FUNCTION = """
+CREATE OR REPLACE FUNCTION public.fold_search_text(text) RETURNS text
+LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+AS $$ SELECT lower(public.unaccent('public.unaccent'::regdictionary, $1)) $$
+"""
+
+_SEARCH_INDEXES = (
+    (
+        "ix_tags_title_fold_trgm",
+        "tags",
+        "USING gin (public.fold_search_text(title::text) gin_trgm_ops)",
+    ),
+    ("ix_tags_desc_fold_trgm", "tags", 'USING gin (public.fold_search_text("desc") gin_trgm_ops)'),
+    (
+        "ix_tag_external_links_url_fold_trgm",
+        "tag_external_links",
+        "USING gin (public.fold_search_text(url) gin_trgm_ops)",
+    ),
+    (
+        "ix_tags_title_fold_prefix",
+        "tags",
+        "(public.fold_search_text(title::text) text_pattern_ops)",
+    ),
+)
 
 
 async def build_pg_schema(conn: AsyncConnection) -> None:
@@ -28,5 +60,10 @@ async def build_pg_schema(conn: AsyncConnection) -> None:
     await conn.execute(text("DROP SCHEMA public CASCADE"))
     await conn.execute(text("CREATE SCHEMA public"))
     await conn.execute(text("CREATE EXTENSION IF NOT EXISTS citext"))
+    for extension in _SEARCH_EXTENSIONS:
+        await conn.execute(text(f"CREATE EXTENSION IF NOT EXISTS {extension}"))
     await conn.run_sync(SQLModel.metadata.create_all)
     await install_counter_triggers(conn)
+    await conn.execute(text(_FOLD_FUNCTION))
+    for name, table, definition in _SEARCH_INDEXES:
+        await conn.execute(text(f"CREATE INDEX {name} ON {table} {definition}"))

--- a/app/main.py
+++ b/app/main.py
@@ -159,7 +159,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # Initialize Meilisearch search service
     from meilisearch_python_sdk import AsyncClient as MeilisearchClient
 
-    from app.api.v1.search import get_search_service
     from app.services.search import SearchService, configure_tags_index, set_search_service
 
     meilisearch_client = None
@@ -171,8 +170,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         search_service = SearchService(meilisearch_client)
         await configure_tags_index(meilisearch_client)
 
-        # Override the search endpoint's dependency via FastAPI's mechanism
-        app.dependency_overrides[get_search_service] = lambda: search_service
         set_search_service(search_service)
         logger.info("meilisearch_initialized", url=settings.MEILISEARCH_URL)
     except Exception:
@@ -188,7 +185,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     # Shutdown
     logger.info("application_shutting_down")
-    app.dependency_overrides.pop(get_search_service, None)
     set_search_service(None)
     if meilisearch_client:
         await meilisearch_client.aclose()

--- a/app/services/tag_search.py
+++ b/app/services/tag_search.py
@@ -15,6 +15,9 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.core.logging import get_logger
 from app.utils.like_escape import escape_like_pattern
 
@@ -237,3 +240,44 @@ scored AS (
 )
 SELECT tag_id FROM scored ORDER BY tier, typos, pos, eff_usage DESC, tag_id ASC LIMIT :limit OFFSET :offset"""
     return SearchStatements(ids_sql, count_sql, params)
+
+
+async def search_tags(
+    db: AsyncSession,
+    query: str,
+    *,
+    limit: int = 20,
+    offset: int = 0,
+    type_filter: int | None = None,
+    exclude_aliases: bool = False,
+    sort: list[str] | None = None,
+) -> TagSearchResult:
+    """Run one tag search and return the page's ids in rank order with an exact total.
+
+    Args:
+        db: Session; the SET LOCALs bind to its current transaction.
+        query: Search text. Empty lists every tag.
+        limit: Page size.
+        offset: Rows to skip.
+        type_filter: TagType constant, or None for all types.
+        exclude_aliases: Drop rows whose alias_of is set.
+        sort: Meilisearch-style spec such as ["title:asc"]; None means relevance.
+    """
+    statements = build_search(
+        query,
+        limit=limit,
+        offset=offset,
+        type_filter=type_filter,
+        exclude_aliases=exclude_aliases,
+        sort=sort,
+    )
+    # One command per execute: asyncpg rejects multi-statement strings. SET
+    # LOCAL lasts for this transaction only, so a pooled connection never
+    # carries it to the next request.
+    await db.execute(text("SET LOCAL pg_trgm.word_similarity_threshold = 0.5"))
+    await db.execute(text("SET LOCAL jit = off"))
+    rows = await db.execute(text(statements.ids_sql), statements.params)
+    tag_ids = [row.tag_id for row in rows.all()]
+    total = int((await db.execute(text(statements.count_sql), statements.params)).scalar_one())
+    logger.debug("tag_search", query=query, hits=len(tag_ids), total=total)
+    return TagSearchResult(tag_ids=tag_ids, total=total)

--- a/app/services/tag_search.py
+++ b/app/services/tag_search.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from typing import Any
 
 from app.core.logging import get_logger
+from app.utils.like_escape import escape_like_pattern
 
 logger = get_logger(__name__)
 
@@ -59,3 +61,179 @@ def gates_for(query: str, tokens: list[str]) -> SearchGates:
     fuzzy = not prefix_only and any(_letter_count(token) >= MIN_FUZZY_LETTERS for token in tokens)
     secondary = not prefix_only and all(len(token) >= MIN_SECONDARY_TOKEN_CHARS for token in tokens)
     return SearchGates(prefix_only=prefix_only, fuzzy=fuzzy, secondary=secondary)
+
+
+# Meilisearch sort fields -> SQL. usage_count resolves to the effective count so
+# alias rows rank by their parent's popularity.
+_EFFECTIVE_USAGE = "COALESCE(parent.usage_count, t.usage_count)"
+_SORT_COLUMNS = {
+    "usage_count": _EFFECTIVE_USAGE,
+    "title": "t.title",
+    "type": "t.type",
+    "date_added": "t.date_added",
+    "tag_id": "t.tag_id",
+}
+
+# The word list of a folded string: split on runs that are not letters,
+# digits, or underscore; drop empties. The same expression tokenizes the
+# query (`:q`) and each title, so both sides agree on what a word is.
+_WORDS = (
+    "array_remove(regexp_split_to_array(public.fold_search_text({expr}), '[^[:alnum:]_]+'), '')"
+)
+
+_BASE_FROM = "FROM tags t LEFT JOIN tags parent ON parent.tag_id = t.alias_of"
+_DESC_FOLD = 'public.fold_search_text("desc")'
+
+
+@dataclass(frozen=True)
+class SearchStatements:
+    """The two statements one search runs, sharing one parameter dict."""
+
+    ids_sql: str
+    count_sql: str
+    params: dict[str, Any]
+
+
+def _contains_all(expr: str, token_count: int) -> str:
+    """`expr` contains every token: AND of folded LIKE per token."""
+    return " AND ".join(
+        f"{expr} LIKE public.fold_search_text(:like_tok{i})" for i in range(token_count)
+    )
+
+
+def _order_clause(sort: list[str] | None) -> str | None:
+    if not sort:
+        return None
+    field, _, direction_token = sort[0].partition(":")
+    if field not in _SORT_COLUMNS:
+        raise ValueError(f"Unsupported sort field: {field!r}")
+    direction = "ASC" if direction_token.lower() == "asc" else "DESC"
+    return f"{_SORT_COLUMNS[field]} {direction}, t.tag_id {direction}"
+
+
+def build_search(
+    query: str,
+    *,
+    limit: int,
+    offset: int,
+    type_filter: int | None,
+    exclude_aliases: bool,
+    sort: list[str] | None,
+) -> SearchStatements:
+    """Build the ids and count statements for one search. Pure."""
+    query = query.strip()
+    tokens = query.split()
+    params: dict[str, Any] = {"limit": limit, "offset": offset}
+    filters: list[str] = []
+    if type_filter is not None:
+        filters.append("t.type = :type_filter")
+        params["type_filter"] = type_filter
+    if exclude_aliases:
+        filters.append("t.alias_of IS NULL")
+    order = _order_clause(sort)
+
+    # Empty query: list every tag.
+    if not tokens:
+        where = f"WHERE {' AND '.join(filters)}" if filters else ""
+        ids_sql = (
+            f"SELECT t.tag_id {_BASE_FROM} {where} "
+            f"ORDER BY {order or f'{_EFFECTIVE_USAGE} DESC, t.tag_id ASC'} "
+            "LIMIT :limit OFFSET :offset"
+        )
+        return SearchStatements(ids_sql, f"SELECT count(*) FROM tags t {where}", params)
+
+    params["q"] = query
+    params["prefix_q"] = f"{escape_like_pattern(query)}%"
+    for i, token in enumerate(tokens):
+        params[f"like_tok{i}"] = f"%{escape_like_pattern(token)}%"
+    gates = gates_for(query, tokens)
+
+    # Short or sub-trigram query: title prefix on the btree index, nothing else.
+    if gates.prefix_only:
+        filters.insert(
+            0, "public.fold_search_text(t.title::text) LIKE public.fold_search_text(:prefix_q)"
+        )
+        where = f"WHERE {' AND '.join(filters)}"
+        exact_first = (
+            "CASE WHEN public.fold_search_text(t.title::text) = public.fold_search_text(:q) "
+            "THEN 0 ELSE 1 END"
+        )
+        ids_sql = (
+            f"SELECT t.tag_id {_BASE_FROM} {where} "
+            f"ORDER BY {order or f'{exact_first}, {_EFFECTIVE_USAGE} DESC, t.tag_id ASC'} "
+            "LIMIT :limit OFFSET :offset"
+        )
+        return SearchStatements(ids_sql, f"SELECT count(*) FROM tags t {where}", params)
+
+    # General path: the candidate set is a UNION, never an OR — an OR that
+    # mixes these branches defeats the planner's bitmap and scans the table.
+    branches = [
+        f"SELECT tag_id FROM tags WHERE {_contains_all('public.fold_search_text(title::text)', len(tokens))}"
+    ]
+    if gates.fuzzy:
+        branches.append(
+            "SELECT tag_id FROM tags WHERE public.fold_search_text(:q) <% public.fold_search_text(title::text)"
+        )
+    if gates.secondary:
+        params["like_q"] = f"%{escape_like_pattern(query)}%"
+        branches.append(f"SELECT tag_id FROM tags WHERE {_contains_all(_DESC_FOLD, len(tokens))}")
+        branches.append(
+            "SELECT tag_id FROM tag_external_links "
+            "WHERE public.fold_search_text(url) LIKE public.fold_search_text(:like_q)"
+        )
+    # Digits match literally somewhere, whatever branch admitted the row.
+    for i, token in enumerate(tokens):
+        if _DIGITS.match(token):
+            filters.append(
+                f"(public.fold_search_text(t.title::text) LIKE public.fold_search_text(:like_tok{i})"
+                f' OR public.fold_search_text(t."desc") LIKE public.fold_search_text(:like_tok{i})'
+                f" OR EXISTS (SELECT 1 FROM tag_external_links l WHERE l.tag_id = t.tag_id"
+                f" AND public.fold_search_text(l.url) LIKE public.fold_search_text(:like_tok{i})))"
+            )
+    candidates = "candidates AS (\n    " + "\n    UNION\n    ".join(branches) + "\n)"
+    where = f"WHERE {' AND '.join(filters)}" if filters else ""
+    count_sql = f"WITH {candidates} SELECT count(*) FROM tags t JOIN candidates c ON c.tag_id = t.tag_id {where}"
+
+    if order:
+        ids_sql = (
+            f"WITH {candidates} SELECT t.tag_id {_BASE_FROM} JOIN candidates c ON c.tag_id = t.tag_id "
+            f"{where} ORDER BY {order} LIMIT :limit OFFSET :offset"
+        )
+        return SearchStatements(ids_sql, count_sql, params)
+
+    # Relevance. Tiers 0-3 are literal matches, so their typo count is 0 by
+    # construction and the CASE keeps the levenshtein work for tier 4 only.
+    qwords = (
+        "qwords AS (SELECT w, ord, ord = max(ord) OVER () AS is_last "
+        f"FROM unnest({_WORDS.format(expr=':q')}) WITH ORDINALITY AS u(w, ord))"
+    )
+    ids_sql = f"""WITH {qwords},
+{candidates},
+scored AS (
+    SELECT t.tag_id, {_EFFECTIVE_USAGE} AS eff_usage, tiers.tier,
+        CASE WHEN tiers.tier < 4 THEN 0 ELSE (
+            SELECT sum(best.d) FROM qwords CROSS JOIN LATERAL (
+                SELECT min(CASE WHEN qwords.is_last
+                               THEN least(levenshtein(qwords.w, x), levenshtein(qwords.w, left(x, length(qwords.w))))
+                               ELSE levenshtein(qwords.w, x) END) AS d
+                FROM unnest(f.tw) AS x) AS best) END AS typos,
+        CASE WHEN tiers.tier < 4 THEN COALESCE((
+            SELECT min(xo.ord) FROM unnest(f.tw) WITH ORDINALITY AS xo(x, ord), qwords
+            WHERE position(qwords.w IN xo.x) > 0), 999)
+        ELSE COALESCE((
+            SELECT min(xo.ord) FROM unnest(f.tw) WITH ORDINALITY AS xo(x, ord), qwords
+            WHERE levenshtein(qwords.w, xo.x) = (SELECT min(levenshtein(qwords.w, x2)) FROM unnest(f.tw) AS x2)), 999) END AS pos
+    {_BASE_FROM}
+    JOIN candidates c ON c.tag_id = t.tag_id
+    CROSS JOIN LATERAL (SELECT public.fold_search_text(t.title::text) AS ft, {_WORDS.format(expr="t.title::text")} AS tw) AS f
+    CROSS JOIN LATERAL (SELECT CASE
+        WHEN f.ft = public.fold_search_text(:q) THEN 0
+        WHEN f.ft LIKE public.fold_search_text(:prefix_q) THEN 1
+        WHEN NOT EXISTS (SELECT 1 FROM qwords WHERE NOT is_last AND NOT (w = ANY(f.tw)))
+         AND EXISTS (SELECT 1 FROM unnest(f.tw) AS x, qwords WHERE qwords.is_last AND left(x, length(qwords.w)) = qwords.w) THEN 2
+        WHEN {_contains_all("f.ft", len(tokens))} THEN 3
+        ELSE 4 END AS tier) AS tiers
+    {where}
+)
+SELECT tag_id FROM scored ORDER BY tier, typos, pos, eff_usage DESC, tag_id ASC LIMIT :limit OFFSET :offset"""
+    return SearchStatements(ids_sql, count_sql, params)

--- a/app/services/tag_search.py
+++ b/app/services/tag_search.py
@@ -80,8 +80,12 @@ _SORT_COLUMNS = {
 # The word list of a folded string: split on runs that are not letters,
 # digits, or underscore; drop empties. The same expression tokenizes the
 # query (`:q`) and each title, so both sides agree on what a word is.
+# Words are capped at 255 characters: fuzzystrmatch.levenshtein errors above
+# that, and unaccent can expand text (ß -> ss).
 _WORDS = (
+    "ARRAY(SELECT left(w, 255) FROM unnest("
     "array_remove(regexp_split_to_array(public.fold_search_text({expr}), '[^[:alnum:]_]+'), '')"
+    ") AS w)"
 )
 
 _BASE_FROM = "FROM tags t LEFT JOIN tags parent ON parent.tag_id = t.alias_of"

--- a/app/services/tag_search.py
+++ b/app/services/tag_search.py
@@ -1,0 +1,65 @@
+"""Tag search in Postgres with pg_trgm.
+
+Design: docs/plans/2026-Q3/2026-09-11-postgres-tag-search-design.md.
+
+`gates_for` and `build_search` are pure: they turn a query into SQL text and
+bind parameters and are unit-tested without a database. `search_tags` runs
+the statements. The SQL depends on the objects created by migration
+0004_tag_search_fold: `public.fold_search_text(text)` and the four
+`ix_*_fold_*` indexes.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Three consecutive letters or digits (underscore excluded): the shortest
+# literal a trigram index can look up.
+_ALNUM_RUN = re.compile(r"[^\W_]{3}")
+# A token of only digits is an identifier (pixiv artist ID, year): it must
+# match literally, never fuzzily.
+_DIGITS = re.compile(r"^\d+$")
+
+# Meilisearch's minimum word length for one typo; below it a word matches
+# literally only.
+MIN_FUZZY_LETTERS = 5
+# A one-character token contains-matches nearly every description.
+MIN_SECONDARY_TOKEN_CHARS = 2
+
+
+@dataclass(frozen=True)
+class TagSearchResult:
+    """Ordered tag ids for one page, plus the exact total."""
+
+    tag_ids: list[int]
+    total: int
+
+
+@dataclass(frozen=True)
+class SearchGates:
+    """Which candidate branches a query runs."""
+
+    prefix_only: bool  # title-prefix path only: no CTE, no fuzzy/desc/URL
+    fuzzy: bool  # trigram word-similarity branch
+    secondary: bool  # description and external-URL branches
+
+
+def _letter_count(token: str) -> int:
+    return sum(char.isalpha() for char in token)
+
+
+def gates_for(query: str, tokens: list[str]) -> SearchGates:
+    """Decide the branches for `query` (already stripped) and its whitespace tokens."""
+    prefix_only = len(query) < 3 or _ALNUM_RUN.search(query) is None
+    fuzzy = (
+        not prefix_only
+        and any(_letter_count(token) >= MIN_FUZZY_LETTERS for token in tokens)
+        and not any("_" in token for token in tokens)
+    )
+    secondary = not prefix_only and all(len(token) >= MIN_SECONDARY_TOKEN_CHARS for token in tokens)
+    return SearchGates(prefix_only=prefix_only, fuzzy=fuzzy, secondary=secondary)

--- a/app/services/tag_search.py
+++ b/app/services/tag_search.py
@@ -56,10 +56,6 @@ def _letter_count(token: str) -> int:
 def gates_for(query: str, tokens: list[str]) -> SearchGates:
     """Decide the branches for `query` (already stripped) and its whitespace tokens."""
     prefix_only = len(query) < 3 or _ALNUM_RUN.search(query) is None
-    fuzzy = (
-        not prefix_only
-        and any(_letter_count(token) >= MIN_FUZZY_LETTERS for token in tokens)
-        and not any("_" in token for token in tokens)
-    )
+    fuzzy = not prefix_only and any(_letter_count(token) >= MIN_FUZZY_LETTERS for token in tokens)
     secondary = not prefix_only and all(len(token) >= MIN_SECONDARY_TOKEN_CHARS for token in tokens)
     return SearchGates(prefix_only=prefix_only, fuzzy=fuzzy, secondary=secondary)

--- a/tests/api/v1/test_search.py
+++ b/tests/api/v1/test_search.py
@@ -1,886 +1,264 @@
-"""Tests for the search API endpoint (/api/v1/search)."""
-
-from unittest.mock import AsyncMock
+"""Tests for the search API endpoint (/api/v1/search), Postgres engine."""
 
 import pytest
-from fastapi import FastAPI
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.v1.search import get_search_service
 from app.config import TagType
 from app.models.tag import Tags
 from app.models.tag_external_link import TagExternalLinks
-from app.services.search import TagSearchResult
 
 
-@pytest.fixture
-def mock_search_service():
-    """Create a mock SearchService with async search_tags method."""
-    service = AsyncMock()
-    service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
-    return service
+async def _seed(db_session: AsyncSession, *tags: Tags) -> list[Tags]:
+    db_session.add_all(tags)
+    await db_session.commit()
+    for tag in tags:
+        await db_session.refresh(tag)
+    return list(tags)
 
 
-@pytest.fixture
-def search_client(app: FastAPI, mock_search_service):
-    """Override the search service dependency on the test app."""
-    app.dependency_overrides[get_search_service] = lambda: mock_search_service
-    return app
-
-
-@pytest.fixture
-async def client_with_search(search_client: FastAPI):
-    """AsyncClient wired to the app with search service override."""
-    from httpx import ASGITransport
-
-    async with AsyncClient(
-        transport=ASGITransport(app=search_client),
-        base_url="http://test",
-    ) as ac:
-        yield ac
+async def _seed_identity_owner(
+    db_session: AsyncSession, *, title: str = "TKennshou", alias_titles: tuple[str, ...] = ()
+) -> tuple[Tags, list[Tags]]:
+    """An artist owning pixiv id 21412050, plus optional alias rows pointing at it."""
+    (owner,) = await _seed(db_session, Tags(title=title, type=TagType.ARTIST, usage_count=1))
+    db_session.add(
+        TagExternalLinks(
+            tag_id=owner.tag_id,
+            url="https://www.pixiv.net/users/21412050",
+            site="pixiv",
+            external_id="21412050",
+        )
+    )
+    aliases = [Tags(title=t, type=TagType.ARTIST, alias_of=owner.tag_id) for t in alias_titles]
+    db_session.add_all(aliases)
+    await db_session.commit()
+    for alias in aliases:
+        await db_session.refresh(alias)
+    return owner, aliases
 
 
 @pytest.mark.api
 class TestSearchEndpoint:
-    """Tests for GET /api/v1/search."""
-
-    async def test_search_returns_matching_tags(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
+    async def test_search_returns_matching_tags_exact_first(
+        self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Search returns full tag data for IDs returned by Meilisearch."""
-        # Create tags in DB
-        tag1 = Tags(title="Sakura", desc="Cherry blossom", type=TagType.CHARACTER)
-        tag2 = Tags(title="Sakura Kinomoto", desc="Card Captor", type=TagType.CHARACTER)
-        db_session.add_all([tag1, tag2])
-        await db_session.commit()
-        await db_session.refresh(tag1)
-        await db_session.refresh(tag2)
-
-        # Mock Meilisearch returning both tag IDs
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[tag1.tag_id, tag2.tag_id], total=2
+        await _seed(
+            db_session,
+            Tags(
+                title="Sakura Kinomoto", desc="Card Captor", type=TagType.CHARACTER, usage_count=50
+            ),
+            Tags(title="Sakura", desc="Cherry blossom", type=TagType.CHARACTER, usage_count=5),
         )
-
-        response = await client_with_search.get("/api/v1/search", params={"q": "sakura"})
+        response = await client.get("/api/v1/search", params={"q": "sakura"})
         assert response.status_code == 200
-
         data = response.json()
         assert data["query"] == "sakura"
         assert data["entity"] == "tags"
         assert data["total"] == 2
         assert data["limit"] == 20
         assert data["offset"] == 0
-        assert len(data["hits"]) == 2
-        assert data["hits"][0]["title"] == "Sakura"
-        assert data["hits"][1]["title"] == "Sakura Kinomoto"
+        assert [hit["title"] for hit in data["hits"]] == ["Sakura", "Sakura Kinomoto"]
 
-    async def test_search_missing_query_lists_all(
-        self,
-        client_with_search: AsyncClient,
-        mock_search_service: AsyncMock,
+    @pytest.mark.parametrize("params", [{}, {"q": ""}])
+    async def test_missing_or_empty_query_lists_all(
+        self, client: AsyncClient, db_session: AsyncSession, params
     ):
-        """Omitting 'q' entirely defaults to a placeholder search."""
-        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
-
-        response = await client_with_search.get("/api/v1/search")
-        assert response.status_code == 200
-        assert mock_search_service.search_tags.call_args[0][0] == ""
-
-    async def test_search_empty_query_lists_all(
-        self,
-        client_with_search: AsyncClient,
-        mock_search_service: AsyncMock,
-    ):
-        """Empty 'q' is a placeholder search: Meilisearch returns all docs
-        (filter + sort still apply). Used by the frontend's tag-list view."""
-        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
-
-        response = await client_with_search.get("/api/v1/search", params={"q": ""})
-        assert response.status_code == 200
-
-        # The empty string should reach the service unchanged.
-        mock_search_service.search_tags.assert_called_once()
-        assert mock_search_service.search_tags.call_args[0][0] == ""
-
-    async def test_search_with_type_filter(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
-    ):
-        """The type filter is forwarded to search_tags."""
-        tag = Tags(title="Naruto", desc="Anime source", type=TagType.SOURCE)
-        db_session.add(tag)
-        await db_session.commit()
-        await db_session.refresh(tag)
-
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[tag.tag_id], total=1
+        await _seed(
+            db_session,
+            Tags(title="popular", type=TagType.THEME, usage_count=100),
+            Tags(title="rare", type=TagType.THEME, usage_count=1),
         )
+        response = await client.get("/api/v1/search", params=params)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert [hit["title"] for hit in data["hits"]] == ["popular", "rare"]
 
-        response = await client_with_search.get(
+    async def test_search_with_type_filter(self, client: AsyncClient, db_session: AsyncSession):
+        await _seed(
+            db_session,
+            Tags(title="Naruto", type=TagType.SOURCE),
+            Tags(title="Naruto Uzumaki", type=TagType.CHARACTER),
+        )
+        response = await client.get(
             "/api/v1/search", params={"q": "naruto", "type": TagType.SOURCE}
         )
         assert response.status_code == 200
+        assert [hit["title"] for hit in response.json()["hits"]] == ["Naruto"]
 
-        # Verify the type filter was passed through to the service
-        mock_search_service.search_tags.assert_called_once_with(
-            "naruto",
-            limit=20,
-            offset=0,
-            type_filter=TagType.SOURCE,
-            exclude_aliases=False,
-            sort=None,
+    async def test_search_with_exclude_aliases(self, client: AsyncClient, db_session: AsyncSession):
+        (canonical,) = await _seed(db_session, Tags(title="test canonical", type=TagType.THEME))
+        await _seed(
+            db_session, Tags(title="test alias", type=TagType.THEME, alias_of=canonical.tag_id)
         )
-
-    async def test_search_with_exclude_aliases(
-        self,
-        client_with_search: AsyncClient,
-        mock_search_service: AsyncMock,
-    ):
-        """The exclude_aliases flag is forwarded to search_tags."""
-        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
-
-        response = await client_with_search.get(
-            "/api/v1/search", params={"q": "test", "exclude_aliases": True}
-        )
+        response = await client.get("/api/v1/search", params={"q": "test", "exclude_aliases": True})
         assert response.status_code == 200
+        assert [hit["title"] for hit in response.json()["hits"]] == ["test canonical"]
 
-        mock_search_service.search_tags.assert_called_once_with(
-            "test",
-            limit=20,
-            offset=0,
-            type_filter=None,
-            exclude_aliases=True,
-            sort=None,
-        )
-
-    async def test_search_preserves_meilisearch_order(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
-    ):
-        """Response preserves Meilisearch relevance order, not DB ID order."""
-        # Create tags with ascending IDs
-        tag_a = Tags(title="Alpha", type=TagType.THEME)
-        tag_b = Tags(title="Beta", type=TagType.THEME)
-        tag_c = Tags(title="Gamma", type=TagType.THEME)
-        db_session.add_all([tag_a, tag_b, tag_c])
-        await db_session.commit()
-        await db_session.refresh(tag_a)
-        await db_session.refresh(tag_b)
-        await db_session.refresh(tag_c)
-
-        # Meilisearch returns them in reverse order (by relevance)
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[tag_c.tag_id, tag_a.tag_id, tag_b.tag_id], total=3
-        )
-
-        response = await client_with_search.get("/api/v1/search", params={"q": "test"})
+    async def test_search_no_results(self, client: AsyncClient):
+        response = await client.get("/api/v1/search", params={"q": "nonexistent"})
         assert response.status_code == 200
-
-        data = response.json()
-        titles = [hit["title"] for hit in data["hits"]]
-        assert titles == ["Gamma", "Alpha", "Beta"]
-
-    async def test_search_no_results(
-        self,
-        client_with_search: AsyncClient,
-        mock_search_service: AsyncMock,
-    ):
-        """Empty Meilisearch results yield empty hits list."""
-        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
-
-        response = await client_with_search.get("/api/v1/search", params={"q": "nonexistent"})
-        assert response.status_code == 200
-
-        data = response.json()
-        assert data["hits"] == []
-        assert data["total"] == 0
-        assert data["query"] == "nonexistent"
+        assert response.json() == {
+            "query": "nonexistent",
+            "entity": "tags",
+            "hits": [],
+            "total": 0,
+            "limit": 20,
+            "offset": 0,
+        }
 
     async def test_search_with_limit_and_offset(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
+        self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Custom limit and offset are forwarded and reflected in response."""
-        tag = Tags(title="Test", type=TagType.THEME)
-        db_session.add(tag)
-        await db_session.commit()
-        await db_session.refresh(tag)
-
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[tag.tag_id], total=50
+        await _seed(
+            db_session,
+            *[
+                Tags(title=f"test {i:02d}", type=TagType.THEME, usage_count=100 - i)
+                for i in range(8)
+            ],
         )
-
-        response = await client_with_search.get(
-            "/api/v1/search", params={"q": "test", "limit": 10, "offset": 5}
-        )
+        response = await client.get("/api/v1/search", params={"q": "test", "limit": 3, "offset": 5})
         assert response.status_code == 200
-
         data = response.json()
-        assert data["limit"] == 10
+        assert data["total"] == 8
+        assert data["limit"] == 3
         assert data["offset"] == 5
-        assert data["total"] == 50
+        assert [hit["title"] for hit in data["hits"]] == ["test 05", "test 06", "test 07"]
 
-        mock_search_service.search_tags.assert_called_once_with(
-            "test",
-            limit=10,
-            offset=5,
-            type_filter=None,
-            exclude_aliases=False,
-            sort=None,
-        )
-
-    async def test_search_returns_503_when_meilisearch_unavailable(
-        self,
-        app: FastAPI,
-    ):
-        """Without Meilisearch, the search endpoint returns 503."""
-        from httpx import ASGITransport
-
-        # No dependency override — default get_search_service raises HTTPException(503)
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as ac:
-            response = await ac.get("/api/v1/search", params={"q": "test"})
-        assert response.status_code == 503
-        assert response.json()["detail"] == "Search service is not available"
-
-    async def test_search_returns_503_when_meilisearch_fails_mid_request(
-        self,
-        client_with_search: AsyncClient,
-        mock_search_service: AsyncMock,
-    ):
-        """If Meilisearch errors during search, endpoint returns 503."""
-        mock_search_service.search_tags.side_effect = Exception("Connection refused")
-
-        response = await client_with_search.get("/api/v1/search", params={"q": "test"})
-        assert response.status_code == 503
-        assert "temporarily unavailable" in response.json()["detail"]
-
-    async def test_search_rejects_offset_over_max_total_hits(
-        self,
-        client_with_search: AsyncClient,
-        mock_search_service: AsyncMock,
-    ):
-        """Offset above the index max_total_hits cap returns 422."""
-        response = await client_with_search.get(
-            "/api/v1/search", params={"q": "test", "offset": 500_001}
-        )
+    async def test_search_rejects_offset_over_max(self, client: AsyncClient):
+        response = await client.get("/api/v1/search", params={"q": "test", "offset": 500_001})
         assert response.status_code == 422
 
-    async def test_search_passes_sort_to_service(
-        self,
-        client_with_search: AsyncClient,
-        mock_search_service: AsyncMock,
-    ):
-        """sort_by + sort_order map to a Meilisearch sort string."""
-        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
-
-        response = await client_with_search.get(
-            "/api/v1/search",
-            params={"q": "sakura", "sort_by": "title", "sort_order": "ASC"},
+    async def test_search_honours_sort(self, client: AsyncClient, db_session: AsyncSession):
+        await _seed(
+            db_session,
+            Tags(title="sakura b", type=TagType.THEME, usage_count=1),
+            Tags(title="sakura a", type=TagType.THEME, usage_count=100),
         )
-        assert response.status_code == 200
+        response = await client.get(
+            "/api/v1/search", params={"q": "sakura", "sort_by": "title", "sort_order": "ASC"}
+        )
+        assert [hit["title"] for hit in response.json()["hits"]] == ["sakura a", "sakura b"]
 
-        call_kwargs = mock_search_service.search_tags.call_args[1]
-        assert call_kwargs["sort"] == ["title:asc"]
-
-    async def test_search_default_sort_is_none(
-        self,
-        client_with_search: AsyncClient,
-        mock_search_service: AsyncMock,
-    ):
-        """No sort_by means sort=None — relevance ranking."""
-        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
-
-        response = await client_with_search.get("/api/v1/search", params={"q": "sakura"})
-        assert response.status_code == 200
-
-        call_kwargs = mock_search_service.search_tags.call_args[1]
-        assert call_kwargs["sort"] is None
-
-    async def test_search_rejects_invalid_sort_by(
-        self,
-        client_with_search: AsyncClient,
-    ):
-        """sort_by not in the allowed set returns 422."""
-        response = await client_with_search.get(
-            "/api/v1/search",
-            params={"q": "sakura", "sort_by": "not_a_field"},
+    async def test_search_rejects_invalid_sort_by(self, client: AsyncClient):
+        response = await client.get(
+            "/api/v1/search", params={"q": "sakura", "sort_by": "not_a_field"}
         )
         assert response.status_code == 422
 
     async def test_search_populates_alias_of_name_for_alias_hits(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
+        self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Alias hits include alias_of_name and alias_of_usage_count from the parent."""
-        canonical = Tags(title="cat ears", type=TagType.THEME, usage_count=5000)
-        db_session.add(canonical)
-        await db_session.commit()
-        await db_session.refresh(canonical)
-
-        alias = Tags(title="neko mimi", type=TagType.THEME, alias_of=canonical.tag_id)
-        db_session.add(alias)
-        await db_session.commit()
-        await db_session.refresh(alias)
-
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[alias.tag_id, canonical.tag_id], total=2
+        (canonical,) = await _seed(
+            db_session, Tags(title="feline", type=TagType.THEME, usage_count=42)
         )
+        await _seed(db_session, Tags(title="cat", type=TagType.THEME, alias_of=canonical.tag_id))
+        response = await client.get("/api/v1/search", params={"q": "cat"})
+        hit = response.json()["hits"][0]
+        assert hit["title"] == "cat"
+        assert hit["is_alias"] is True
+        assert hit["alias_of_name"] == "feline"
+        assert hit["alias_of_usage_count"] == 42
 
-        response = await client_with_search.get("/api/v1/search", params={"q": "cat"})
-        assert response.status_code == 200
 
-        hits = response.json()["hits"]
-        assert len(hits) == 2
-
-        alias_hit = next(h for h in hits if h["tag_id"] == alias.tag_id)
-        assert alias_hit["alias_of"] == canonical.tag_id
-        assert alias_hit["alias_of_name"] == "cat ears"
-        assert alias_hit["alias_of_usage_count"] == 5000
-        assert alias_hit["is_alias"] is True
-
-        canonical_hit = next(h for h in hits if h["tag_id"] == canonical.tag_id)
-        assert canonical_hit["alias_of"] is None
-        assert canonical_hit["alias_of_name"] is None
-        assert canonical_hit["alias_of_usage_count"] is None
-        assert canonical_hit["is_alias"] is False
-
-    async def test_search_handles_missing_db_tags_gracefully(
-        self,
-        client_with_search: AsyncClient,
-        mock_search_service: AsyncMock,
+@pytest.mark.api
+class TestExactIdentityLayer:
+    async def test_bare_id_prepends_owner_with_matched_identity(
+        self, client: AsyncClient, db_session: AsyncSession
     ):
-        """If Meilisearch returns IDs that don't exist in DB, they're skipped."""
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[99999, 99998], total=2
-        )
-
-        response = await client_with_search.get("/api/v1/search", params={"q": "ghost"})
+        owner, _ = await _seed_identity_owner(db_session)
+        response = await client.get("/api/v1/search", params={"q": "21412050"})
         assert response.status_code == 200
-
         data = response.json()
-        # Total comes from Meilisearch, but hits only include DB-verified tags
-        assert data["total"] == 2
-        assert data["hits"] == []
-
-    async def test_exact_identity_query_prepends_artist_hit(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
-    ):
-        """A bare pixiv ID returns the owning artist first, flagged with matched_identity."""
-        artist = Tags(title="Some Artist", type=TagType.ARTIST)
-        db_session.add(artist)
-        await db_session.commit()
-        await db_session.refresh(artist)
-
-        link = TagExternalLinks(
-            tag_id=artist.tag_id,
-            url="https://www.pixiv.net/users/21412050",
-            site="pixiv",
-            external_id="21412050",
-        )
-        db_session.add(link)
-        await db_session.commit()
-
-        # Meilisearch has nothing for the bare-ID query — the exact layer is the
-        # only source of this hit.
-        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
-
-        response = await client_with_search.get("/api/v1/search", params={"q": "21412050"})
-        assert response.status_code == 200
-
-        data = response.json()
-        hits = data["hits"]
-        assert hits[0]["tag_id"] == artist.tag_id
-        assert hits[0]["matched_identity"] == "Pixiv 21412050"
-        # The exact hit wasn't already counted by Meilisearch, so total gains one.
+        assert data["hits"][0]["tag_id"] == owner.tag_id
+        assert data["hits"][0]["matched_identity"] == "Pixiv 21412050"
+        # The owner is also a text hit through its URL, so the total is not inflated.
         assert data["total"] == 1
-
-    async def test_exact_hit_not_duplicated_when_meili_also_returns_it(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
-    ):
-        """If the fuzzy layer already found the artist, it appears once, flagged."""
-        artist = Tags(title="Some Artist", type=TagType.ARTIST)
-        db_session.add(artist)
-        await db_session.commit()
-        await db_session.refresh(artist)
-
-        link = TagExternalLinks(
-            tag_id=artist.tag_id,
-            url="https://www.pixiv.net/users/21412050",
-            site="pixiv",
-            external_id="21412050",
-        )
-        db_session.add(link)
-        await db_session.commit()
-
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[artist.tag_id], total=1
-        )
-
-        response = await client_with_search.get("/api/v1/search", params={"q": "21412050"})
-        assert response.status_code == 200
-
-        data = response.json()
-        hits = data["hits"]
-        assert [h["tag_id"] for h in hits].count(artist.tag_id) == 1
-        assert hits[0]["matched_identity"] == "Pixiv 21412050"
-        # The hit was already in the Meilisearch results, so total is unchanged.
-        assert data["total"] == 1
+        assert [hit["tag_id"] for hit in data["hits"]].count(owner.tag_id) == 1
 
     async def test_text_query_has_no_matched_identity(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
+        self, client: AsyncClient, db_session: AsyncSession
     ):
-        """A regular text query never sets matched_identity on its hits."""
-        tag = Tags(title="Sakura", type=TagType.CHARACTER)
-        db_session.add(tag)
-        await db_session.commit()
-        await db_session.refresh(tag)
+        await _seed_identity_owner(db_session, title="Tsunekichi")
+        response = await client.get("/api/v1/search", params={"q": "tsunekichi"})
+        assert response.json()["hits"][0]["matched_identity"] is None
 
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[tag.tag_id], total=1
-        )
-
-        response = await client_with_search.get("/api/v1/search", params={"q": "sakura"})
-        assert response.status_code == 200
-        assert all(h["matched_identity"] is None for h in response.json()["hits"])
-
-    async def test_exact_hit_insertion_respects_limit(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
+    async def test_alias_rows_of_the_owner_are_dropped(
+        self, client: AsyncClient, db_session: AsyncSession
     ):
-        """Prepending a new exact hit to an already-full page doesn't exceed limit."""
-        artist = Tags(title="Some Artist", type=TagType.ARTIST)
-        other = Tags(title="Other Tag", type=TagType.THEME)
-        db_session.add_all([artist, other])
-        await db_session.commit()
-        await db_session.refresh(artist)
-        await db_session.refresh(other)
-
-        link = TagExternalLinks(
-            tag_id=artist.tag_id,
-            url="https://www.pixiv.net/users/21412050",
-            site="pixiv",
-            external_id="21412050",
-        )
-        db_session.add(link)
-        await db_session.commit()
-
-        # Meilisearch already fills the requested page with an unrelated tag.
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[other.tag_id], total=1
-        )
-
-        response = await client_with_search.get(
-            "/api/v1/search", params={"q": "21412050", "limit": 1}
-        )
-        assert response.status_code == 200
-
+        owner, aliases = await _seed_identity_owner(db_session, alias_titles=("Pixiv 21412050",))
+        response = await client.get("/api/v1/search", params={"q": "21412050"})
         data = response.json()
-        hits = data["hits"]
-        assert len(hits) == 1
-        assert hits[0]["tag_id"] == artist.tag_id
-        assert hits[0]["matched_identity"] == "Pixiv 21412050"
+        ids = [hit["tag_id"] for hit in data["hits"]]
+        assert ids == [owner.tag_id]
+        assert data["total"] == 1
 
-    async def test_identity_query_on_later_page_does_not_inject_exact_hit(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
-    ):
-        """A page-2+ request for an identity query isn't prepended with the
-        exact hit — only the first page is boosted, so the tag never
-        duplicates itself as a user paginates."""
-        artist = Tags(title="Some Artist", type=TagType.ARTIST)
-        other = Tags(title="Other Tag", type=TagType.THEME)
-        db_session.add_all([artist, other])
-        await db_session.commit()
-        await db_session.refresh(artist)
-        await db_session.refresh(other)
-
-        link = TagExternalLinks(
-            tag_id=artist.tag_id,
-            url="https://www.pixiv.net/users/21412050",
-            site="pixiv",
-            external_id="21412050",
+    async def test_prepend_respects_limit(self, client: AsyncClient, db_session: AsyncSession):
+        owner, _ = await _seed_identity_owner(db_session)
+        await _seed(
+            db_session, Tags(title="21412050 fan club", type=TagType.THEME, usage_count=999)
         )
-        db_session.add(link)
-        await db_session.commit()
-
-        # Every page (including the offset=0 reference check) returns the
-        # same unrelated tag — the artist is nowhere in Meilisearch's results.
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[other.tag_id], total=1
-        )
-
-        response = await client_with_search.get(
-            "/api/v1/search", params={"q": "21412050", "offset": 20, "limit": 1}
-        )
-        assert response.status_code == 200
-
+        response = await client.get("/api/v1/search", params={"q": "21412050", "limit": 1})
         data = response.json()
-        hits = data["hits"]
-        assert [h["tag_id"] for h in hits] == [other.tag_id]
-        assert all(h["matched_identity"] is None for h in hits)
+        assert [hit["tag_id"] for hit in data["hits"]] == [owner.tag_id]
+        assert data["hits"][0]["matched_identity"] == "Pixiv 21412050"
 
-    async def test_identity_query_total_consistent_across_pages(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
+    async def test_later_page_does_not_inject_and_total_is_consistent(
+        self, client: AsyncClient, db_session: AsyncSession
     ):
-        """The same identity query reports the same total on page 1 and
-        page 2, even though the exact hit is only ever injected on page 1.
-
-        Meilisearch genuinely ranks the artist on page 1 (so it's *not* a
-        new hit — total shouldn't be bumped) but page 2's own slice
-        naturally doesn't contain it, since it's a different set of tags
-        entirely. A page-local-only "already found" check would wrongly
-        treat page 2 as a fresh discovery and inflate its total.
-        """
-        artist = Tags(title="Some Artist", type=TagType.ARTIST)
-        page2_tag = Tags(title="Page Two Tag", type=TagType.THEME)
-        db_session.add_all([artist, page2_tag])
-        await db_session.commit()
-        for tag in (artist, page2_tag):
-            await db_session.refresh(tag)
-
-        link = TagExternalLinks(
-            tag_id=artist.tag_id,
-            url="https://www.pixiv.net/users/21412050",
-            site="pixiv",
-            external_id="21412050",
+        owner, _ = await _seed_identity_owner(db_session)
+        await _seed(
+            db_session, Tags(title="21412050 fan club", type=TagType.THEME, usage_count=999)
         )
-        db_session.add(link)
-        await db_session.commit()
+        first = (
+            await client.get("/api/v1/search", params={"q": "21412050", "limit": 1, "offset": 0})
+        ).json()
+        second = (
+            await client.get("/api/v1/search", params={"q": "21412050", "limit": 1, "offset": 1})
+        ).json()
+        # The identity layer resolves "already found" against page 1 for both requests,
+        # so the totals agree; their exact value is the engine's count plus the
+        # injected owner when it sits beyond page 1.
+        assert first["total"] == second["total"]
+        assert all(hit["matched_identity"] is None for hit in second["hits"])
 
-        # Meilisearch itself ranks the artist first (page 1); page 2 is a
-        # different, unrelated tag entirely — same overall total (5) on
-        # both calls, as real pagination of a stable query would look.
-        def fake_search_tags(_q, *, limit, offset, type_filter, exclude_aliases, sort):
-            tag_ids = [artist.tag_id] if offset == 0 else [page2_tag.tag_id]
-            return TagSearchResult(tag_ids=tag_ids, total=5)
-
-        mock_search_service.search_tags.side_effect = fake_search_tags
-
-        page1_response = await client_with_search.get(
-            "/api/v1/search", params={"q": "21412050", "offset": 0, "limit": 1}
-        )
-        page2_response = await client_with_search.get(
-            "/api/v1/search", params={"q": "21412050", "offset": 1, "limit": 1}
-        )
-        assert page1_response.status_code == 200
-        assert page2_response.status_code == 200
-
-        page1_total = page1_response.json()["total"]
-        page2_total = page2_response.json()["total"]
-        # The artist was genuinely part of Meilisearch's own result set
-        # (ranked on page 1), so it's never counted as "new" on either page:
-        # both totals equal Meilisearch's own total, unmodified.
-        assert page1_total == 5
-        assert page2_total == page1_total
-
-        # The second lookup made an extra reference call (page 1, offset=0)
-        # to answer "already found by Meilisearch" consistently.
-        assert mock_search_service.search_tags.call_count == 3
-
-    async def test_exact_identity_query_respects_mismatched_type_filter(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
+    async def test_mismatched_type_filter_suppresses_injection(
+        self, client: AsyncClient, db_session: AsyncSession
     ):
-        """An identity query filtered to a type the owning tag isn't never
-        surfaces the exact-identity hit — it's not reachable through that
-        type's filter, so injecting it would leak a result across types."""
-        artist = Tags(title="Some Artist", type=TagType.ARTIST)
-        db_session.add(artist)
-        await db_session.commit()
-        await db_session.refresh(artist)
-
-        link = TagExternalLinks(
-            tag_id=artist.tag_id,
-            url="https://www.pixiv.net/users/21412050",
-            site="pixiv",
-            external_id="21412050",
-        )
-        db_session.add(link)
-        await db_session.commit()
-
-        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
-
-        response = await client_with_search.get(
+        await _seed_identity_owner(db_session)
+        response = await client.get(
             "/api/v1/search", params={"q": "21412050", "type": TagType.THEME}
         )
-        assert response.status_code == 200
+        assert response.json()["hits"] == []
 
-        data = response.json()
-        assert data["hits"] == []
-        assert data["total"] == 0
-
-    async def test_exact_identity_query_present_with_matching_type_filter(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
+    async def test_matching_type_filter_keeps_injection(
+        self, client: AsyncClient, db_session: AsyncSession
     ):
-        """The same identity query, filtered to the owning tag's own type,
-        still surfaces the exact-identity hit."""
-        artist = Tags(title="Some Artist", type=TagType.ARTIST)
-        db_session.add(artist)
-        await db_session.commit()
-        await db_session.refresh(artist)
-
-        link = TagExternalLinks(
-            tag_id=artist.tag_id,
-            url="https://www.pixiv.net/users/21412050",
-            site="pixiv",
-            external_id="21412050",
-        )
-        db_session.add(link)
-        await db_session.commit()
-
-        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
-
-        response = await client_with_search.get(
+        owner, _ = await _seed_identity_owner(db_session)
+        response = await client.get(
             "/api/v1/search", params={"q": "21412050", "type": TagType.ARTIST}
         )
-        assert response.status_code == 200
+        assert response.json()["hits"][0]["tag_id"] == owner.tag_id
 
-        data = response.json()
-        assert data["hits"][0]["tag_id"] == artist.tag_id
-        assert data["hits"][0]["matched_identity"] == "Pixiv 21412050"
-        assert data["total"] == 1
-
-    async def test_exact_identity_query_respects_exclude_aliases(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
+    async def test_exclude_aliases_blocks_an_alias_owner(
+        self, client: AsyncClient, db_session: AsyncSession
     ):
-        """exclude_aliases=true must suppress an exact-identity hit that
-        resolves to an alias tag, the same as it suppresses alias tags from
-        the fuzzy layer."""
-        canonical = Tags(title="Some Artist", type=TagType.ARTIST)
-        db_session.add(canonical)
-        await db_session.commit()
-        await db_session.refresh(canonical)
-
-        alias = Tags(title="Pixiv 21412050", type=TagType.ARTIST, alias_of=canonical.tag_id)
-        db_session.add(alias)
-        await db_session.commit()
-        await db_session.refresh(alias)
-
-        link = TagExternalLinks(
-            tag_id=alias.tag_id,
-            url="https://www.pixiv.net/users/21412050",
-            site="pixiv",
-            external_id="21412050",
+        # An owner that is itself an alias must not be injected when aliases are excluded.
+        (canonical,) = await _seed(db_session, Tags(title="Canonical Artist", type=TagType.ARTIST))
+        (alias_owner,) = await _seed(
+            db_session, Tags(title="Legacy", type=TagType.ARTIST, alias_of=canonical.tag_id)
         )
-        db_session.add(link)
+        db_session.add(
+            TagExternalLinks(
+                tag_id=alias_owner.tag_id,
+                url="https://www.pixiv.net/users/21412050",
+                site="pixiv",
+                external_id="21412050",
+            )
+        )
         await db_session.commit()
-
-        mock_search_service.search_tags.return_value = TagSearchResult(tag_ids=[], total=0)
-
-        response = await client_with_search.get(
+        response = await client.get(
             "/api/v1/search", params={"q": "21412050", "exclude_aliases": True}
         )
-        assert response.status_code == 200
-
-        data = response.json()
-        assert data["hits"] == []
-        assert data["total"] == 0
-
-    async def test_identity_query_drops_alias_row_when_meili_returns_both(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
-    ):
-        """A legacy alias tag of the matched canonical is redundant with the
-        flagged canonical hit and must not also appear as its own row."""
-        canonical = Tags(title="Tsunekichi", type=TagType.ARTIST)
-        db_session.add(canonical)
-        await db_session.commit()
-        await db_session.refresh(canonical)
-
-        alias = Tags(title="Pixiv 21412050", type=TagType.ARTIST, alias_of=canonical.tag_id)
-        db_session.add(alias)
-        await db_session.commit()
-        await db_session.refresh(alias)
-
-        link = TagExternalLinks(
-            tag_id=canonical.tag_id,
-            url="https://www.pixiv.net/users/21412050",
-            site="pixiv",
-            external_id="21412050",
-        )
-        db_session.add(link)
-        await db_session.commit()
-
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[alias.tag_id, canonical.tag_id], total=2
-        )
-
-        response = await client_with_search.get("/api/v1/search", params={"q": "21412050"})
-        assert response.status_code == 200
-
-        data = response.json()
-        hits = data["hits"]
-        assert [h["tag_id"] for h in hits] == [canonical.tag_id]
-        assert hits[0]["matched_identity"] == "Pixiv 21412050"
-        # Meilisearch's raw total (2) minus the dropped alias row.
-        assert data["total"] == 1
-
-    async def test_identity_query_drops_alias_row_when_meili_returns_alias_only(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
-    ):
-        """If Meilisearch only surfaced the alias (not the canonical), the
-        exact layer still prepends the canonical and drops the alias row."""
-        canonical = Tags(title="Tsunekichi", type=TagType.ARTIST)
-        db_session.add(canonical)
-        await db_session.commit()
-        await db_session.refresh(canonical)
-
-        alias = Tags(title="Pixiv 21412050", type=TagType.ARTIST, alias_of=canonical.tag_id)
-        db_session.add(alias)
-        await db_session.commit()
-        await db_session.refresh(alias)
-
-        link = TagExternalLinks(
-            tag_id=canonical.tag_id,
-            url="https://www.pixiv.net/users/21412050",
-            site="pixiv",
-            external_id="21412050",
-        )
-        db_session.add(link)
-        await db_session.commit()
-
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[alias.tag_id], total=1
-        )
-
-        response = await client_with_search.get("/api/v1/search", params={"q": "21412050"})
-        assert response.status_code == 200
-
-        data = response.json()
-        hits = data["hits"]
-        assert [h["tag_id"] for h in hits] == [canonical.tag_id]
-        assert hits[0]["matched_identity"] == "Pixiv 21412050"
-        # Meilisearch total (1) minus the dropped alias, plus the newly
-        # counted canonical: 1 - 1 + 1 == 1.
-        assert data["total"] == 1
-
-    async def test_text_query_leaves_alias_rows_untouched(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
-    ):
-        """A non-identity text query never triggers alias dedup — aliases of
-        an unrelated tag are ordinary, independent search results."""
-        canonical = Tags(title="Tsunekichi", type=TagType.ARTIST)
-        db_session.add(canonical)
-        await db_session.commit()
-        await db_session.refresh(canonical)
-
-        alias = Tags(title="Pixiv 21412050", type=TagType.ARTIST, alias_of=canonical.tag_id)
-        db_session.add(alias)
-        await db_session.commit()
-        await db_session.refresh(alias)
-
-        mock_search_service.search_tags.return_value = TagSearchResult(
-            tag_ids=[alias.tag_id, canonical.tag_id], total=2
-        )
-
-        response = await client_with_search.get("/api/v1/search", params={"q": "tsunekichi"})
-        assert response.status_code == 200
-
-        data = response.json()
-        assert {h["tag_id"] for h in data["hits"]} == {alias.tag_id, canonical.tag_id}
-        assert data["total"] == 2
-        assert all(h["matched_identity"] is None for h in data["hits"])
-
-    async def test_identity_query_drops_alias_row_on_later_page(
-        self,
-        client_with_search: AsyncClient,
-        db_session: AsyncSession,
-        mock_search_service: AsyncMock,
-    ):
-        """An alias row of the matched canonical is dropped even on a
-        page > 0 request, even though the canonical itself is only ever
-        injected/flagged on the first page."""
-        canonical = Tags(title="Tsunekichi", type=TagType.ARTIST)
-        other = Tags(title="Other Tag", type=TagType.THEME)
-        db_session.add_all([canonical, other])
-        await db_session.commit()
-        await db_session.refresh(canonical)
-        await db_session.refresh(other)
-
-        alias = Tags(title="Pixiv 21412050", type=TagType.ARTIST, alias_of=canonical.tag_id)
-        db_session.add(alias)
-        await db_session.commit()
-        await db_session.refresh(alias)
-
-        link = TagExternalLinks(
-            tag_id=canonical.tag_id,
-            url="https://www.pixiv.net/users/21412050",
-            site="pixiv",
-            external_id="21412050",
-        )
-        db_session.add(link)
-        await db_session.commit()
-
-        # The requested (later) page has the alias plus an unrelated tag; the
-        # first-page reference lookup (offset=0, used to decide whether the
-        # canonical itself is "new") finds neither the canonical nor the
-        # alias — the canonical is genuinely outside Meilisearch's match set.
-        def fake_search_tags(_q, *, limit, offset, type_filter, exclude_aliases, sort):
-            if offset == 0:
-                return TagSearchResult(tag_ids=[other.tag_id], total=5)
-            return TagSearchResult(tag_ids=[alias.tag_id, other.tag_id], total=5)
-
-        mock_search_service.search_tags.side_effect = fake_search_tags
-
-        response = await client_with_search.get(
-            "/api/v1/search", params={"q": "21412050", "offset": 20, "limit": 2}
-        )
-        assert response.status_code == 200
-
-        data = response.json()
-        hits = data["hits"]
-        # The alias is dropped; the canonical is never injected into a later
-        # page; the unrelated tag is untouched.
-        assert [h["tag_id"] for h in hits] == [other.tag_id]
-        assert all(h["matched_identity"] is None for h in hits)
-        # Meilisearch's total (5) minus the dropped alias, plus the
-        # canonical counted as new (not found on the first-page reference
-        # lookup): 5 - 1 + 1 == 5.
-        assert data["total"] == 5
+        assert all(hit["tag_id"] != alias_owner.tag_id for hit in response.json()["hits"])

--- a/tests/api/v1/test_search.py
+++ b/tests/api/v1/test_search.py
@@ -223,6 +223,25 @@ class TestExactIdentityLayer:
         assert first["total"] == second["total"]
         assert all(hit["matched_identity"] is None for hit in second["hits"])
 
+    async def test_identity_query_drops_alias_row_on_later_page(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        # Ranking for "21412050": the prefix-titled theme first, then the alias row
+        # (title contains the id), then the owner (matched only through its URL).
+        # With limit=1 the alias row is page 2's only hit and must be dropped there too.
+        owner, aliases = await _seed_identity_owner(db_session, alias_titles=("Pixiv 21412050",))
+        await _seed(
+            db_session, Tags(title="21412050 fan club", type=TagType.THEME, usage_count=999)
+        )
+        response = await client.get(
+            "/api/v1/search", params={"q": "21412050", "limit": 1, "offset": 1}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert all(hit["tag_id"] != aliases[0].tag_id for hit in data["hits"])
+        assert all(hit["alias_of"] != owner.tag_id for hit in data["hits"])
+        assert all(hit["matched_identity"] is None for hit in data["hits"])
+
     async def test_mismatched_type_filter_suppresses_injection(
         self, client: AsyncClient, db_session: AsyncSession
     ):

--- a/tests/integration/test_tag_search_corpus.py
+++ b/tests/integration/test_tag_search_corpus.py
@@ -229,3 +229,19 @@ class TestSearchCorpus:
         result = await search_tags(db_session, "", limit=2)
         assert result.total >= len(CORPUS)
         assert len(result.tag_ids) == 2
+
+    async def test_expanding_long_query_does_not_error(self, db_session: AsyncSession):
+        # 128 sharp-s characters fold to 256 characters; levenshtein caps at 255.
+        # The corpus alone never puts a row into the scored (tier-4) CTE for a
+        # query this long, so the crash would go untested without a decoy: seed
+        # one whose description literally contains the string, which admits it
+        # as a candidate but not a literal title match, forcing the levenshtein
+        # comparison that overflows.
+        await seed_corpus(db_session)
+        decoy = Tags(title="Overflow Decoy", type=TagType.THEME, desc="ß" * 128)
+        db_session.add(decoy)
+        await db_session.commit()
+        await db_session.refresh(decoy)
+        result = await search_tags(db_session, "ß" * 128, limit=10)
+        assert result.tag_ids == [decoy.tag_id]
+        assert result.total == 1

--- a/tests/integration/test_tag_search_corpus.py
+++ b/tests/integration/test_tag_search_corpus.py
@@ -1,0 +1,230 @@
+"""Acceptance corpus for Postgres tag search (spec appendix).
+
+Seeds the titles behind every query in the design doc's appendix, with the
+decoys that broke earlier ranking attempts, and asserts the top hit by title.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import TagType
+from app.models.tag import Tags
+from app.models.tag_external_link import TagExternalLinks
+from app.services.tag_search import search_tags
+
+# (title, type, usage_count, desc, alias_of_title, urls)
+CORPUS = [
+    ("cherry blossoms", TagType.THEME, 21476, "", None, []),
+    ("sakura", TagType.THEME, 0, "", "cherry blossoms", []),
+    ("Sakura", TagType.CHARACTER, 797, "", None, []),
+    ("Sakura (source)", TagType.SOURCE, 3, "", None, []),
+    ("Kinomoto Sakura", TagType.CHARACTER, 4594, "Cardcaptor Sakura", None, []),
+    ("Kinoshita Sakura", TagType.CHARACTER, 41, "", None, []),
+    ("Kinomoto Sakuya", TagType.CHARACTER, 10, "", None, []),
+    ("Kinomoto Touya", TagType.CHARACTER, 94, "", None, []),
+    ("Kinomoto Nadeshiko", TagType.CHARACTER, 27, "", None, []),
+    ("Sakurai Yukino", TagType.CHARACTER, 28, "", None, []),
+    ("Sakura Yukino", TagType.CHARACTER, 18, "", None, []),
+    ("Sakurakinoshita Ashita", TagType.CHARACTER, 14, "", None, []),
+    ("Kinom", TagType.ARTIST, 8, "", None, []),
+    ("Kinoto", TagType.ARTIST, 2, "", None, []),
+    ("Kino", TagType.CHARACTER, 504, "", None, []),
+    ("cat", TagType.THEME, 18416, "", None, []),
+    ("neko", TagType.THEME, 0, "", "cat", []),
+    ("Neko", TagType.CHARACTER, 10, "", None, []),
+    ("neko mimi", TagType.THEME, 5000, "", None, []),
+    ("Nekopara", TagType.SOURCE, 100, "", None, []),
+    ("maid", TagType.THEME, 23093, "", None, []),
+    ("school uniform", TagType.THEME, 154188, "", None, []),
+    ("school bag", TagType.THEME, 10191, "", None, []),
+    ("school swimsuit", TagType.THEME, 6409, "", None, []),
+    ("School Days", TagType.SOURCE, 900, "", None, []),
+    ("swimsuit", TagType.THEME, 8829, "", None, []),
+    ("mizugi", TagType.THEME, 0, "", "swimsuit", []),
+    ("bikini", TagType.THEME, 41801, "", None, []),
+    ("two-piece swimsuit", TagType.THEME, 0, "", "bikini", []),
+    ("Swim Swim", TagType.CHARACTER, 23, "", None, []),
+    ("long hair", TagType.THEME, 729274, "", None, []),
+    ("short hair", TagType.THEME, 474227, "", None, []),
+    ("blonde hair", TagType.THEME, 279469, "", None, []),
+    ("Somali Longhaired", TagType.CHARACTER, 1, "", None, []),
+    ("Shiroko Terror", TagType.CHARACTER, 42, "Blue Archive; long hair variant", None, []),
+    ("long", TagType.ARTIST, 1, "", None, []),
+    ("long kimono", TagType.THEME, 40260, "", None, []),
+    ("Sa", TagType.ARTIST, 1, "", None, []),
+    ("Sa.", TagType.ARTIST, 9, "", None, []),
+    ("sad", TagType.THEME, 5000, "", None, []),
+    ("Saber", TagType.CHARACTER, 20000, "", None, []),
+    ("co", TagType.ARTIST, 4, "", None, []),
+    ("cosplay", TagType.THEME, 3000, "", None, []),
+    ("Hatsune Miku", TagType.CHARACTER, 35622, "", None, []),
+    ("Hatsune Mikuo", TagType.CHARACTER, 513, "", None, []),
+    ("Hatsune", TagType.ARTIST, 10, "", None, []),
+    ("thigh highs", TagType.THEME, 162274, "", None, []),
+    ("boots", TagType.THEME, 90000, "Includes thigh-high boots", None, []),
+    ("C.C.", TagType.CHARACTER, 2788, "", None, []),
+    ("C++", TagType.THEME, 5, "", None, []),
+    ("C++ 11", TagType.THEME, 1, "", None, []),
+    ("[C]", TagType.SOURCE, 138, "", None, []),
+    ("100", TagType.ARTIST, 7, "", None, []),
+    ("100% Perfect Girl", TagType.SOURCE, 3, "", None, []),
+    ("100% Orange Juice!", TagType.SOURCE, 1, "", None, []),
+    ("Ichigo 100%", TagType.SOURCE, 47, "", None, []),
+    ("Mob Psycho 100", TagType.SOURCE, 26, "", None, []),
+    ("Pixiv 103175", TagType.ARTIST, 1, "", None, []),
+    ("Deep-Blue Series", TagType.SOURCE, 50, "", None, []),
+    ("Deep Blue Sky & Pure White Wings", TagType.SOURCE, 92, "", None, []),
+    ("Yano (yano_0o0)", TagType.ARTIST, 1, "", None, []),
+    ("Yano Mitsuki", TagType.CHARACTER, 30, "", None, []),
+    ("The Forgotten Field", TagType.SOURCE, 1, "", None, []),
+    ("The Familiar of Zero", TagType.SOURCE, 607, "", None, []),
+    ("The Fly", TagType.CHARACTER, 4, "", None, []),
+    ("The Forest of Drizzling Rain", TagType.SOURCE, 437, "", None, []),
+    ("THE", TagType.ARTIST, 6, "", None, []),
+    ("TKennshou", TagType.ARTIST, 1, "", None, ["https://www.pixiv.net/users/21412050"]),
+    ("Pixiv 21412050", TagType.ARTIST, 0, "", "TKennshou", []),
+    ("Tsunekichi", TagType.ARTIST, 14, "", None, []),
+    ("Pokémon", TagType.SOURCE, 16529, "", None, []),
+    ("Pokémon Adventures", TagType.SOURCE, 3279, "", None, []),
+    ("Pokemon Heroes", TagType.SOURCE, 12, "", None, []),
+    ("Märchen von Friedhof", TagType.CHARACTER, 1047, "", None, []),
+    ("Marchen Girl Runs", TagType.SOURCE, 3, "", None, []),
+    ("MarchAB", TagType.ARTIST, 41, "", None, []),
+    ("Maruchan", TagType.ARTIST, 68, "", None, []),
+    ("EB十", TagType.ARTIST, 152, "", None, []),
+    ("magical girl", TagType.THEME, 25205, "", None, []),
+    ("Mahou no Stage Fancy Lala", TagType.SOURCE, 100, "magical girl idol anime", None, []),
+    ("Louise Françoise le Blanc de la Vallière", TagType.CHARACTER, 447, "", None, []),
+    ("Francoise", TagType.CHARACTER, 3, "", None, []),
+    ("Claire Francois", TagType.CHARACTER, 50, "", None, []),
+]
+
+# (query, expected top-1 title) — spec appendix, asserted by title.
+EXPECTED_TOP1 = [
+    ("sakura", "sakura"),
+    ("cat", "cat"),
+    ("maid", "maid"),
+    ("neko", "neko"),
+    ("school", "school uniform"),
+    ("swimsuit", "swimsuit"),
+    ("long hair", "long hair"),
+    ("sakura kinomoto", "Kinomoto Sakura"),
+    ("kinomoto sakura", "Kinomoto Sakura"),
+    ("sa", "Sa"),
+    ("co", "co"),
+    ("long", "long"),
+    ("kinomto", "Kinomoto Sakura"),
+    ("sakrua kinomto", "Kinomoto Sakura"),
+    ("hatsune mikuu", "Hatsune Miku"),
+    ("swimsiut", "swimsuit"),
+    ("thig", "thigh highs"),
+    ("C.C.", "C.C."),
+    ("C++", "C++"),
+    ("100%", "100% Perfect Girl"),
+    ("deep-blue", "Deep-Blue Series"),
+    ("yano_0o0", "Yano (yano_0o0)"),
+    ("The Forgotten", "The Forgotten Field"),
+    ("The F", "The Familiar of Zero"),
+    ("21412050", "Pixiv 21412050"),
+    ("pixiv.net/users/21412050", "Pixiv 21412050"),
+    ("tsunekichi", "Tsunekichi"),
+    ("pokemon", "Pokémon"),
+    ("Pokémon", "Pokémon"),
+    ("marchen", "Märchen von Friedhof"),
+    ("EB十", "EB十"),
+    ("magical girl", "magical girl"),
+    ("Louise Francoise", "Louise Françoise le Blanc de la Vallière"),
+    ("marchan", "Märchen von Friedhof"),
+    ("kinomoto", "Kinomoto Sakura"),
+    ("hatsune", "Hatsune"),
+    ("sakura kino", "Kinomoto Sakura"),
+    ("kinomt", "Kinomoto Sakura"),
+]
+
+
+async def seed_corpus(db_session: AsyncSession) -> dict[str, Tags]:
+    """Insert the corpus; aliases are wired by title after the first insert."""
+    by_title: dict[str, Tags] = {}
+    for title, tag_type, usage, desc, _alias, _urls in CORPUS:
+        tag = Tags(title=title, type=tag_type, usage_count=usage, desc=desc or None)
+        db_session.add(tag)
+        by_title[title] = tag
+    await db_session.flush()
+    for title, _tag_type, _usage, _desc, alias_of_title, urls in CORPUS:
+        if alias_of_title:
+            by_title[title].alias_of = by_title[alias_of_title].tag_id
+        for url in urls:
+            db_session.add(TagExternalLinks(tag_id=by_title[title].tag_id, url=url))
+    await db_session.commit()
+    return by_title
+
+
+def titles_for(by_title: dict[str, Tags], result) -> list[str]:
+    id_to_title = {tag.tag_id: title for title, tag in by_title.items()}
+    return [id_to_title[tag_id] for tag_id in result.tag_ids]
+
+
+@pytest.mark.integration
+class TestSearchCorpus:
+    @pytest.mark.parametrize(("query", "expected"), EXPECTED_TOP1)
+    async def test_top_hit(self, db_session: AsyncSession, query: str, expected: str):
+        by_title = await seed_corpus(db_session)
+        result = await search_tags(db_session, query, limit=10)
+        titles = titles_for(by_title, result)
+        assert titles, f"{query!r} returned nothing"
+        assert titles[0] == expected, f"{query!r} -> {titles}"
+
+    async def test_numeric_query_matches_digits_literally_only(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        found = titles_for(by_title, await search_tags(db_session, "21412050"))
+        assert "TKennshou" in found  # via its external URL
+        off_by_one = await search_tags(db_session, "21412051")
+        assert off_by_one.tag_ids == []
+        assert off_by_one.total == 0
+
+    async def test_description_only_match_is_found(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        found = titles_for(by_title, await search_tags(db_session, "magical girl"))
+        assert "Mahou no Stage Fancy Lala" in found
+
+    async def test_alias_rows_rank_by_parent_count(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        # "neko" is an alias of "cat" (18,416); "Neko" the character has 10.
+        found = titles_for(by_title, await search_tags(db_session, "neko"))
+        assert found[:2] == ["neko", "Neko"]
+
+    async def test_type_filter_and_exclude_aliases(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        by_type = {tag.tag_id: tag.type for tag in by_title.values()}
+        only_characters = await search_tags(db_session, "sakura", type_filter=TagType.CHARACTER)
+        assert only_characters.tag_ids
+        assert all(by_type[tag_id] == TagType.CHARACTER for tag_id in only_characters.tag_ids)
+        no_aliases = titles_for(
+            by_title, await search_tags(db_session, "sakura", exclude_aliases=True)
+        )
+        assert "sakura" not in no_aliases  # the alias row
+        assert "Sakura" in no_aliases
+
+    async def test_total_is_exact_and_pagination_is_stable(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        first = await search_tags(db_session, "sakura", limit=3, offset=0)
+        second = await search_tags(db_session, "sakura", limit=3, offset=3)
+        assert first.total == second.total
+        assert not set(first.tag_ids) & set(second.tag_ids)
+        everything = await search_tags(db_session, "sakura", limit=100)
+        assert everything.total == len(everything.tag_ids)
+
+    async def test_explicit_sort_overrides_relevance(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        found = titles_for(
+            by_title, await search_tags(db_session, "sakura", sort=["title:asc"], limit=100)
+        )
+        # Relevance would lead with the exact "sakura"; a title sort leads with "Kinomoto ...".
+        assert found[0] == "Kinomoto Nadeshiko"
+        assert "sakura" in found
+
+    async def test_empty_query_lists_all_by_effective_usage(self, db_session: AsyncSession):
+        await seed_corpus(db_session)
+        result = await search_tags(db_session, "", limit=2)
+        assert result.total >= len(CORPUS)
+        assert len(result.tag_ids) == 2

--- a/tests/integration/test_tag_search_corpus.py
+++ b/tests/integration/test_tag_search_corpus.py
@@ -225,10 +225,11 @@ class TestSearchCorpus:
         assert "sakura" in found
 
     async def test_empty_query_lists_all_by_effective_usage(self, db_session: AsyncSession):
-        await seed_corpus(db_session)
+        by_title = await seed_corpus(db_session)
         result = await search_tags(db_session, "", limit=2)
         assert result.total >= len(CORPUS)
         assert len(result.tag_ids) == 2
+        assert titles_for(by_title, result) == ["long hair", "short hair"]
 
     async def test_expanding_long_query_does_not_error(self, db_session: AsyncSession):
         # 128 sharp-s characters fold to 256 characters; levenshtein caps at 255.

--- a/tests/integration/test_tag_search_corpus.py
+++ b/tests/integration/test_tag_search_corpus.py
@@ -219,8 +219,8 @@ class TestSearchCorpus:
         found = titles_for(
             by_title, await search_tags(db_session, "sakura", sort=["title:asc"], limit=100)
         )
-        # Relevance would lead with the exact "sakura"; a title sort leads with "Kinomoto ...".
-        assert found[0] == "Kinomoto Nadeshiko"
+        # Relevance would lead with the exact "sakura"; a title sort leads with "Kinomoto Sakura".
+        assert found[0] == "Kinomoto Sakura"
         assert "sakura" in found
 
     async def test_empty_query_lists_all_by_effective_usage(self, db_session: AsyncSession):

--- a/tests/integration/test_tag_search_corpus.py
+++ b/tests/integration/test_tag_search_corpus.py
@@ -199,11 +199,12 @@ class TestSearchCorpus:
         only_characters = await search_tags(db_session, "sakura", type_filter=TagType.CHARACTER)
         assert only_characters.tag_ids
         assert all(by_type[tag_id] == TagType.CHARACTER for tag_id in only_characters.tag_ids)
-        no_aliases = titles_for(
-            by_title, await search_tags(db_session, "sakura", exclude_aliases=True)
-        )
+        assert only_characters.total == len(only_characters.tag_ids)
+        no_aliases_result = await search_tags(db_session, "sakura", exclude_aliases=True)
+        no_aliases = titles_for(by_title, no_aliases_result)
         assert "sakura" not in no_aliases  # the alias row
         assert "Sakura" in no_aliases
+        assert no_aliases_result.total == len(no_aliases_result.tag_ids)
 
     async def test_total_is_exact_and_pagination_is_stable(self, db_session: AsyncSession):
         by_title = await seed_corpus(db_session)

--- a/tests/integration/test_tag_search_schema.py
+++ b/tests/integration/test_tag_search_schema.py
@@ -1,0 +1,42 @@
+"""The tag-search migration leaves the objects the search SQL depends on."""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+EXPECTED_INDEXES = {
+    "ix_tags_title_fold_trgm",
+    "ix_tags_desc_fold_trgm",
+    "ix_tag_external_links_url_fold_trgm",
+    "ix_tags_title_fold_prefix",
+}
+
+
+@pytest.mark.integration
+class TestTagSearchSchema:
+    async def test_extensions_installed(self, db_session: AsyncSession):
+        rows = await db_session.execute(
+            text(
+                "SELECT extname FROM pg_extension WHERE extname IN ('pg_trgm', 'unaccent', 'fuzzystrmatch')"
+            )
+        )
+        assert set(rows.scalars()) == {"pg_trgm", "unaccent", "fuzzystrmatch"}
+
+    @pytest.mark.parametrize(
+        ("raw", "folded"),
+        [
+            ("Märchen-Noir C++", "marchen-noir c++"),
+            ("EB十", "eb十"),
+            ("Pokémon", "pokemon"),
+            ("Louise Françoise", "louise francoise"),
+        ],
+    )
+    async def test_fold_search_text(self, db_session: AsyncSession, raw: str, folded: str):
+        value = await db_session.execute(text("SELECT public.fold_search_text(:raw)"), {"raw": raw})
+        assert value.scalar_one() == folded
+
+    async def test_search_indexes_exist(self, db_session: AsyncSession):
+        rows = await db_session.execute(
+            text("SELECT indexname FROM pg_indexes WHERE indexname LIKE 'ix_tag%\\_fold\\_%'")
+        )
+        assert set(rows.scalars()) == EXPECTED_INDEXES

--- a/tests/unit/test_tag_search_gates.py
+++ b/tests/unit/test_tag_search_gates.py
@@ -22,7 +22,8 @@ from app.services.tag_search import SearchGates, gates_for
         ("neko", SearchGates(prefix_only=False, fuzzy=False, secondary=True)),
         ("sakura", SearchGates(prefix_only=False, fuzzy=True, secondary=True)),
         ("sakrua kinomto", SearchGates(prefix_only=False, fuzzy=True, secondary=True)),
-        ("yano_0o0", SearchGates(prefix_only=False, fuzzy=False, secondary=True)),
+        # Five letters (the o inside 0o0 counts), so the fuzzy branch runs.
+        ("yano_0o0", SearchGates(prefix_only=False, fuzzy=True, secondary=True)),
         ("21412050", SearchGates(prefix_only=False, fuzzy=False, secondary=True)),
     ],
 )

--- a/tests/unit/test_tag_search_gates.py
+++ b/tests/unit/test_tag_search_gates.py
@@ -1,0 +1,30 @@
+"""Gates decide which candidate branches a query runs (spec: Candidate set)."""
+
+import pytest
+
+from app.services.tag_search import SearchGates, gates_for
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        # Under 3 chars, or no 3-char alphanumeric run: prefix-only path.
+        ("sa", SearchGates(prefix_only=True, fuzzy=False, secondary=False)),
+        ("C++", SearchGates(prefix_only=True, fuzzy=False, secondary=False)),
+        ("C.C.", SearchGates(prefix_only=True, fuzzy=False, secondary=False)),
+        # "the" is 3 chars but has only 3 letters: no fuzzy; "f" is 1 char: no desc/URL.
+        ("the f", SearchGates(prefix_only=False, fuzzy=False, secondary=False)),
+        # Digits form the run; no letters at all: no fuzzy, but desc/URL run.
+        ("100%", SearchGates(prefix_only=False, fuzzy=False, secondary=True)),
+        # CJK ideographs are letters and alphanumerics.
+        ("EB十", SearchGates(prefix_only=False, fuzzy=False, secondary=True)),
+        ("neko", SearchGates(prefix_only=False, fuzzy=False, secondary=True)),
+        ("sakura", SearchGates(prefix_only=False, fuzzy=True, secondary=True)),
+        ("sakrua kinomto", SearchGates(prefix_only=False, fuzzy=True, secondary=True)),
+        ("yano_0o0", SearchGates(prefix_only=False, fuzzy=False, secondary=True)),
+        ("21412050", SearchGates(prefix_only=False, fuzzy=False, secondary=True)),
+    ],
+)
+def test_gates_for(query: str, expected: SearchGates):
+    assert gates_for(query, query.split()) == expected

--- a/tests/unit/test_tag_search_sql.py
+++ b/tests/unit/test_tag_search_sql.py
@@ -40,6 +40,16 @@ class TestBuildSearch:
         assert st.params["like_q"] == "%sakura kino%"
         assert st.params["q"] == "sakura kino"
 
+    def test_relevance_order_is_tier_typos_position_usage_id(self):
+        st = _build("sakura kino")
+        assert (
+            "ORDER BY tier, typos, pos, eff_usage DESC, tag_id ASC LIMIT :limit OFFSET :offset"
+            in st.ids_sql
+        )
+        assert (
+            "CASE WHEN tiers.tier < 4 THEN 0 ELSE (" in st.ids_sql
+        )  # typo keys are lazy, tier 4 only
+
     def test_short_letters_skip_fuzzy_and_one_char_token_skips_secondary(self):
         st = _build("the f")
         assert "<%" not in st.ids_sql

--- a/tests/unit/test_tag_search_sql.py
+++ b/tests/unit/test_tag_search_sql.py
@@ -1,0 +1,85 @@
+"""build_search is pure: assert the SQL shape and bind parameters, no database."""
+
+import pytest
+
+from app.services.tag_search import build_search
+
+
+def _build(query: str, **overrides):
+    kwargs = {"limit": 10, "offset": 0, "type_filter": None, "exclude_aliases": False, "sort": None}
+    kwargs.update(overrides)
+    return build_search(query, **kwargs)
+
+
+@pytest.mark.unit
+class TestBuildSearch:
+    def test_empty_query_lists_all_by_effective_usage(self):
+        st = _build("")
+        assert "candidates" not in st.ids_sql
+        assert "COALESCE(parent.usage_count, t.usage_count) DESC, t.tag_id ASC" in st.ids_sql
+        assert st.count_sql.strip().startswith("SELECT count(*) FROM tags t")
+        assert st.params == {"limit": 10, "offset": 0}
+
+    def test_prefix_only_query_has_no_cte(self):
+        st = _build("sa")
+        assert "WITH" not in st.ids_sql
+        assert (
+            "fold_search_text(t.title::text) LIKE public.fold_search_text(:prefix_q)" in st.ids_sql
+        )
+        assert st.params["prefix_q"] == "sa%"
+        assert "levenshtein" not in st.ids_sql
+
+    def test_general_query_unions_all_four_branches(self):
+        st = _build("sakura kino")
+        assert st.ids_sql.count("UNION") == 3
+        assert "<%" in st.ids_sql  # fuzzy: "sakura" has 6 letters
+        assert 'fold_search_text("desc")' in st.ids_sql
+        assert "FROM tag_external_links WHERE" in st.ids_sql
+        assert st.params["like_tok0"] == "%sakura%"
+        assert st.params["like_tok1"] == "%kino%"
+        assert st.params["like_q"] == "%sakura kino%"
+        assert st.params["q"] == "sakura kino"
+
+    def test_short_letters_skip_fuzzy_and_one_char_token_skips_secondary(self):
+        st = _build("the f")
+        assert "<%" not in st.ids_sql
+        assert "tag_external_links" not in st.ids_sql
+        assert "UNION" not in st.ids_sql
+
+    def test_numeric_token_adds_literal_clause_and_no_fuzzy(self):
+        st = _build("21412050")
+        assert "<%" not in st.ids_sql
+        assert st.ids_sql.count("EXISTS (SELECT 1 FROM tag_external_links l") == 1
+        assert st.count_sql.count("EXISTS (SELECT 1 FROM tag_external_links l") == 1
+
+    def test_like_metacharacters_are_escaped(self):
+        st = _build("100%")
+        assert st.params["like_tok0"] == "%100\\%%"
+        assert st.params["prefix_q"] == "100\\%%"
+
+    def test_filters_apply_to_ids_and_count(self):
+        st = _build("sakura", type_filter=4, exclude_aliases=True)
+        for sql in (st.ids_sql, st.count_sql):
+            assert "t.type = :type_filter" in sql
+            assert "t.alias_of IS NULL" in sql
+        assert st.params["type_filter"] == 4
+
+    def test_explicit_sort_replaces_relevance(self):
+        st = _build("sakura", sort=["title:asc"])
+        assert "ORDER BY t.title ASC, t.tag_id ASC" in st.ids_sql
+        assert "levenshtein" not in st.ids_sql
+
+    def test_usage_count_sort_uses_effective_count(self):
+        st = _build("", sort=["usage_count:desc"])
+        assert (
+            "ORDER BY COALESCE(parent.usage_count, t.usage_count) DESC, t.tag_id DESC" in st.ids_sql
+        )
+
+    def test_unknown_sort_field_is_rejected(self):
+        with pytest.raises(ValueError, match="Unsupported sort field"):
+            _build("sakura", sort=["not_a_field:asc"])
+
+    def test_user_text_never_appears_in_sql(self):
+        st = _build("'; DROP TABLE tags; --")
+        assert "DROP TABLE" not in st.ids_sql
+        assert "DROP TABLE" not in st.count_sql

--- a/tests/unit/test_tag_search_sql.py
+++ b/tests/unit/test_tag_search_sql.py
@@ -50,6 +50,12 @@ class TestBuildSearch:
             "CASE WHEN tiers.tier < 4 THEN 0 ELSE (" in st.ids_sql
         )  # typo keys are lazy, tier 4 only
 
+    def test_words_are_capped_for_levenshtein(self):
+        st = _build("sakura kino")
+        assert (
+            st.ids_sql.count("ARRAY(SELECT left(w, 255) FROM unnest(") == 2
+        )  # query words and title words
+
     def test_short_letters_skip_fuzzy_and_one_char_token_skips_secondary(self):
         st = _build("the f")
         assert "<%" not in st.ids_sql


### PR DESCRIPTION
## Summary
- Migration 0004: pg_trgm, unaccent, fuzzystrmatch; `public.fold_search_text`; three folded trigram indexes and one prefix btree
- `app/services/tag_search.py`: gates, pure SQL builder, `search_tags`
- `GET /api/v1/search` keeps its contract and answers from Postgres; the Meilisearch dependency and 503 path are gone from the route
- Acceptance corpus from the design doc appendix runs as an integration test

Design: docs/plans/2026-Q3/2026-09-11-postgres-tag-search-design.md
Plan: docs/plans/2026-Q3/2026-09-11-postgres-tag-search-impl.md

## Deploy
`make prod-migrate` creates the extensions (the DB role must own the database), the function, and the indexes concurrently. Verify with `/api/v1/search?q=kinomto`.

After prod-migrate, confirm no invalid index was left by a failed CONCURRENTLY build: `SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;` must return no rows (IF NOT EXISTS would otherwise skip a broken index silently). Confirm the DB role owns the database before migrating; the trusted extensions need it.

## Test plan
- [x] `./run-tests.sh` green (2869 passed, 8 skipped)
- [x] frontend e2e tag list + typeahead specs green against dev (tags-list.spec.ts green; two other search specs fail on pre-existing bugs (#394 and a stale hardcoded tag id))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNoxNBcTrbQyAD55cVmfCh
