### PR TITLE
feat(search): tag-list filters on GET /search

### DIFF
--- a/app/api/v1/search.py
+++ b/app/api/v1/search.py
@@ -69,7 +69,14 @@ async def search(
     ] = "all",
     min_usage: Annotated[
         int | None,
-        Query(ge=0, description="Minimum effective usage count (the parent's for aliases)"),
+        Query(
+            ge=0,
+            le=2_147_483_647,
+            description=(
+                "Minimum effective usage count (the parent's for aliases); "
+                "capped at the Postgres integer range"
+            ),
+        ),
     ] = None,
     added_from: Annotated[date | None, Query(description="Added on or after this UTC date")] = None,
     added_to: Annotated[date | None, Query(description="Added on or before this UTC date")] = None,

--- a/app/api/v1/search.py
+++ b/app/api/v1/search.py
@@ -78,6 +78,17 @@ async def search(
             ),
         ),
     ] = None,
+    max_usage: Annotated[
+        int | None,
+        Query(
+            ge=0,
+            le=2_147_483_647,
+            description=(
+                "Maximum effective usage count (the parent's for aliases); "
+                "capped at the Postgres integer range"
+            ),
+        ),
+    ] = None,
     added_from: Annotated[date | None, Query(description="Added on or after this UTC date")] = None,
     added_to: Annotated[date | None, Query(description="Added on or before this UTC date")] = None,
     has_alias: Annotated[
@@ -104,6 +115,8 @@ async def search(
     """Search tags. Relevance order unless sort_by is given, in which case the sort dominates."""
     if added_from is not None and added_to is not None and added_from > added_to:
         raise HTTPException(status_code=422, detail="added_from must not be after added_to")
+    if min_usage is not None and max_usage is not None and min_usage > max_usage:
+        raise HTTPException(status_code=422, detail="min_usage must not exceed max_usage")
     if source_linked is not None and type_id not in (TagType.SOURCE, TagType.CHARACTER):
         raise HTTPException(
             status_code=422, detail="source_linked requires type 2 (source) or 4 (character)"
@@ -112,6 +125,7 @@ async def search(
         type_filter=type_id,
         aliases=aliases,
         min_usage=min_usage,
+        max_usage=max_usage,
         added_from=added_from,
         added_to=added_to,
         has_alias=has_alias,

--- a/app/api/v1/search.py
+++ b/app/api/v1/search.py
@@ -1,18 +1,20 @@
 """Search endpoint, answered from Postgres (app/services/tag_search.py)."""
 
+from datetime import date
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.api.dependencies import SortOrder, TagSortBy
+from app.config import TagType
 from app.core.database import get_db
 from app.models.tag import Tags
 from app.schemas.search import SearchResponse, TagSearchHit
 from app.services.artist_identity import parse_identity_query, resolve_identity, site_display_name
-from app.services.tag_search import search_tags
+from app.services.tag_search import Aliases, SearchFilters, YesNo, search_tags
 
 router = APIRouter(prefix="/search", tags=["search"])
 
@@ -23,8 +25,7 @@ async def _identity_hit_already_on_first_page(
     q: str,
     *,
     limit: int,
-    type_id: int | None,
-    exclude_aliases: bool,
+    filters: SearchFilters,
     sort: list[str] | None,
 ) -> bool:
     """Whether the first page (offset=0) for this query already has tag_id.
@@ -38,11 +39,19 @@ async def _identity_hit_already_on_first_page(
         q,
         limit=limit,
         offset=0,
-        type_filter=type_id,
-        exclude_aliases=exclude_aliases,
+        filters=filters,
         sort=sort,
     )
     return tag_id in first_page.tag_ids
+
+
+def _passes_alias_filter(tag: Tags, aliases: Aliases) -> bool:
+    """Whether the identity owner may be injected under the request's alias filter."""
+    if aliases == "hide":
+        return tag.alias_of is None
+    if aliases == "only":
+        return tag.alias_of is not None
+    return True
 
 
 @router.get("", response_model=SearchResponse)
@@ -55,7 +64,28 @@ async def search(
         ),
     ] = "",
     type_id: Annotated[int | None, Query(description="Filter by tag type", alias="type")] = None,
-    exclude_aliases: Annotated[bool, Query(description="Exclude alias tags")] = False,
+    aliases: Annotated[
+        Aliases, Query(description="hide alias rows, show only alias rows, or all (default)")
+    ] = "all",
+    min_usage: Annotated[
+        int | None,
+        Query(ge=0, description="Minimum effective usage count (the parent's for aliases)"),
+    ] = None,
+    added_from: Annotated[date | None, Query(description="Added on or after this UTC date")] = None,
+    added_to: Annotated[date | None, Query(description="Added on or before this UTC date")] = None,
+    has_alias: Annotated[
+        YesNo | None, Query(description="Has at least one alias pointing at it")
+    ] = None,
+    is_child: Annotated[YesNo | None, Query(description="Has a parent tag")] = None,
+    has_children: Annotated[
+        YesNo | None, Query(description="Is the parent of at least one tag")
+    ] = None,
+    source_linked: Annotated[
+        YesNo | None,
+        Query(
+            description="Characters: has a source link. Sources: has a linked character. Needs type 2 or 4."
+        ),
+    ] = None,
     limit: Annotated[int, Query(ge=1, le=100, description="Max results")] = 20,
     offset: Annotated[int, Query(ge=0, le=500_000, description="Results to skip")] = 0,
     sort_by: Annotated[
@@ -65,17 +95,26 @@ async def search(
     sort_order: Annotated[SortOrder, Query(description="Sort order")] = "DESC",
 ) -> SearchResponse:
     """Search tags. Relevance order unless sort_by is given, in which case the sort dominates."""
+    if added_from is not None and added_to is not None and added_from > added_to:
+        raise HTTPException(status_code=422, detail="added_from must not be after added_to")
+    if source_linked is not None and type_id not in (TagType.SOURCE, TagType.CHARACTER):
+        raise HTTPException(
+            status_code=422, detail="source_linked requires type 2 (source) or 4 (character)"
+        )
+    filters = SearchFilters(
+        type_filter=type_id,
+        aliases=aliases,
+        min_usage=min_usage,
+        added_from=added_from,
+        added_to=added_to,
+        has_alias=has_alias,
+        is_child=is_child,
+        has_children=has_children,
+        source_linked=source_linked,
+    )
     sort = [f"{sort_by}:{sort_order.lower()}"] if sort_by is not None else None
 
-    result = await search_tags(
-        db,
-        q,
-        limit=limit,
-        offset=offset,
-        type_filter=type_id,
-        exclude_aliases=exclude_aliases,
-        sort=sort,
-    )
+    result = await search_tags(db, q, limit=limit, offset=offset, filters=filters, sort=sort)
 
     # Fetch full tag records from Postgres, preserving the engine's rank order.
     # Outerjoin a self-aliased Tags so alias hits include the parent's title
@@ -112,13 +151,18 @@ async def search(
     # Exact artist-identity layer: if the query names a specific external
     # identity (bare ID, "pixiv <id>", or a profile URL), prepend the tag that
     # owns it — even if the text search missed it or ranked it lower. Runs
-    # after the engine call above.
+    # after the engine call above, and only when the request carries no
+    # structural filter (SearchFilters.is_structural) — identity queries are
+    # bare ids typed into a typeahead, not a deliberate narrowing of the tag
+    # list, so a request that also sets e.g. min_usage or added_from is
+    # browsing the list rather than looking up one artist, and skips this
+    # layer entirely.
     #
-    # The owning tag must still satisfy the request's own `type`/
-    # `exclude_aliases` filters before it's surfaced — this layer supplements
-    # the engine's ranking, it doesn't bypass the filters the engine itself
-    # enforced. Skipping this check would leak the tag into type-filtered or
-    # alias-excluded result sets it doesn't belong in.
+    # The owning tag must still satisfy the request's own `type`/`aliases`
+    # filters before it's surfaced — this layer supplements the engine's
+    # ranking, it doesn't bypass the filters the engine itself enforced.
+    # Skipping this check would leak the tag into type-filtered or
+    # alias-filtered result sets it doesn't belong in.
     #
     # Pagination semantics: the hit is only ever injected/reflagged into the
     # FIRST page (offset == 0). Doing this on later pages too would make the
@@ -131,13 +175,13 @@ async def search(
     # "already found by the engine" is always resolved against the engine's
     # first page for this query — reusing this request's own result when
     # offset is already 0, otherwise issuing one extra lookup at offset=0.
-    identity = parse_identity_query(q) if q else None
+    identity = parse_identity_query(q) if q and not filters.is_structural else None
     if identity is not None:
         exact_tag = await resolve_identity(db, identity)
         if (
             exact_tag is not None
             and (type_id is None or exact_tag.type == type_id)
-            and not (exclude_aliases and exact_tag.alias_of is not None)
+            and _passes_alias_filter(exact_tag, aliases)
         ):
             label = f"{site_display_name(identity.site)} {identity.external_id}"
 
@@ -167,8 +211,7 @@ async def search(
                     exact_tag.tag_id,  # type: ignore[arg-type]
                     q,
                     limit=limit,
-                    type_id=type_id,
-                    exclude_aliases=exclude_aliases,
+                    filters=filters,
                     sort=sort,
                 )
             if not already_found:

--- a/app/services/tag_search.py
+++ b/app/services/tag_search.py
@@ -98,6 +98,7 @@ class SearchFilters:
     type_filter: int | None = None
     aliases: Aliases = "all"
     min_usage: int | None = None
+    max_usage: int | None = None
     added_from: date | None = None
     added_to: date | None = None
     has_alias: YesNo | None = None
@@ -112,6 +113,7 @@ class SearchFilters:
             value is not None
             for value in (
                 self.min_usage,
+                self.max_usage,
                 self.added_from,
                 self.added_to,
                 self.has_alias,
@@ -140,6 +142,9 @@ def _filter_clauses(filters: SearchFilters, params: dict[str, Any]) -> list[str]
     if filters.min_usage is not None:
         clauses.append(f"{_EFFECTIVE_USAGE} >= :min_usage")
         params["min_usage"] = filters.min_usage
+    if filters.max_usage is not None:
+        clauses.append(f"{_EFFECTIVE_USAGE} <= :max_usage")
+        params["max_usage"] = filters.max_usage
     # date_added is a naive UTC timestamp: bind naive midnights, half-open at
     # the far end so the column stays bare for a future index.
     if filters.added_from is not None:
@@ -235,7 +240,11 @@ def build_search(
     params: dict[str, Any] = {"limit": limit, "offset": offset}
     filters_sql = _filter_clauses(filters, params)
     # The count needs the parent join only when the effective count is filtered.
-    count_from = _BASE_FROM if filters.min_usage is not None else "FROM tags t"
+    count_from = (
+        _BASE_FROM
+        if filters.min_usage is not None or filters.max_usage is not None
+        else "FROM tags t"
+    )
     order = _order_clause(sort)
 
     # Empty query: list every tag.

--- a/app/services/tag_search.py
+++ b/app/services/tag_search.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Any
+from datetime import date, datetime, time, timedelta
+from typing import Any, Literal
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -77,6 +78,107 @@ _SORT_COLUMNS = {
     "tag_id": "t.tag_id",
 }
 
+Aliases = Literal["hide", "only", "all"]
+YesNo = Literal["yes", "no"]
+
+# Tag types that carry character_source_links rows, and the column each side
+# of the link uses (app.config.TagType values; imported here as literals to
+# keep this module free of app.config).
+_SOURCE_LINK_COLUMN = {4: "character_tag_id", 2: "source_tag_id"}
+
+
+@dataclass(frozen=True)
+class SearchFilters:
+    """Structural filters applied to both the page of ids and the exact count.
+
+    `type_filter` and `aliases` narrow the corpus the way the old kwargs did;
+    the rest are the tag-list filters. Field names match the API parameters.
+    """
+
+    type_filter: int | None = None
+    aliases: Aliases = "all"
+    min_usage: int | None = None
+    added_from: date | None = None
+    added_to: date | None = None
+    has_alias: YesNo | None = None
+    is_child: YesNo | None = None
+    has_children: YesNo | None = None
+    source_linked: YesNo | None = None
+
+    @property
+    def is_structural(self) -> bool:
+        """True when any filter beyond type and aliases is set."""
+        return any(
+            value is not None
+            for value in (
+                self.min_usage,
+                self.added_from,
+                self.added_to,
+                self.has_alias,
+                self.is_child,
+                self.has_children,
+                self.source_linked,
+            )
+        )
+
+
+def _exists(subquery: str, value: YesNo) -> str:
+    prefix = "" if value == "yes" else "NOT "
+    return f"{prefix}EXISTS ({subquery})"
+
+
+def _filter_clauses(filters: SearchFilters, params: dict[str, Any]) -> list[str]:
+    """WHERE predicates for `filters`, binding their values into `params`."""
+    clauses: list[str] = []
+    if filters.type_filter is not None:
+        clauses.append("t.type = :type_filter")
+        params["type_filter"] = filters.type_filter
+    if filters.aliases == "hide":
+        clauses.append("t.alias_of IS NULL")
+    elif filters.aliases == "only":
+        clauses.append("t.alias_of IS NOT NULL")
+    if filters.min_usage is not None:
+        clauses.append(f"{_EFFECTIVE_USAGE} >= :min_usage")
+        params["min_usage"] = filters.min_usage
+    # date_added is a naive UTC timestamp: bind naive midnights, half-open at
+    # the far end so the column stays bare for a future index.
+    if filters.added_from is not None:
+        clauses.append("t.date_added >= :added_from_ts")
+        params["added_from_ts"] = datetime.combine(filters.added_from, time.min)
+    if filters.added_to is not None:
+        clauses.append("t.date_added < :added_to_next_ts")
+        params["added_to_next_ts"] = datetime.combine(
+            filters.added_to + timedelta(days=1), time.min
+        )
+    if filters.has_alias is not None:
+        clauses.append(
+            _exists("SELECT 1 FROM tags a WHERE a.alias_of = t.tag_id", filters.has_alias)
+        )
+    if filters.is_child is not None:
+        clauses.append(
+            "t.inheritedfrom_id IS NOT NULL"
+            if filters.is_child == "yes"
+            else "t.inheritedfrom_id IS NULL"
+        )
+    if filters.has_children is not None:
+        clauses.append(
+            _exists(
+                "SELECT 1 FROM tags c WHERE c.inheritedfrom_id = t.tag_id", filters.has_children
+            )
+        )
+    if filters.source_linked is not None:
+        column = _SOURCE_LINK_COLUMN.get(filters.type_filter or 0)
+        if column is None:
+            raise ValueError("source_linked requires type_filter 2 (source) or 4 (character)")
+        clauses.append(
+            _exists(
+                f"SELECT 1 FROM character_source_links l WHERE l.{column} = t.tag_id",
+                filters.source_linked,
+            )
+        )
+    return clauses
+
+
 # The word list of a folded string: split on runs that are not letters,
 # digits, or underscore; drop empties. The same expression tokenizes the
 # query (`:q`) and each title, so both sides agree on what a word is.
@@ -123,31 +225,27 @@ def build_search(
     *,
     limit: int,
     offset: int,
-    type_filter: int | None,
-    exclude_aliases: bool,
+    filters: SearchFilters,
     sort: list[str] | None,
 ) -> SearchStatements:
     """Build the ids and count statements for one search. Pure."""
     query = query.strip()
     tokens = query.split()
     params: dict[str, Any] = {"limit": limit, "offset": offset}
-    filters: list[str] = []
-    if type_filter is not None:
-        filters.append("t.type = :type_filter")
-        params["type_filter"] = type_filter
-    if exclude_aliases:
-        filters.append("t.alias_of IS NULL")
+    filters_sql = _filter_clauses(filters, params)
+    # The count needs the parent join only when the effective count is filtered.
+    count_from = _BASE_FROM if filters.min_usage is not None else "FROM tags t"
     order = _order_clause(sort)
 
     # Empty query: list every tag.
     if not tokens:
-        where = f"WHERE {' AND '.join(filters)}" if filters else ""
+        where = f"WHERE {' AND '.join(filters_sql)}" if filters_sql else ""
         ids_sql = (
             f"SELECT t.tag_id {_BASE_FROM} {where} "
             f"ORDER BY {order or f'{_EFFECTIVE_USAGE} DESC, t.tag_id ASC'} "
             "LIMIT :limit OFFSET :offset"
         )
-        return SearchStatements(ids_sql, f"SELECT count(*) FROM tags t {where}", params)
+        return SearchStatements(ids_sql, f"SELECT count(*) {count_from} {where}", params)
 
     params["q"] = query
     params["prefix_q"] = f"{escape_like_pattern(query)}%"
@@ -157,10 +255,10 @@ def build_search(
 
     # Short or sub-trigram query: title prefix on the btree index, nothing else.
     if gates.prefix_only:
-        filters.insert(
+        filters_sql.insert(
             0, "public.fold_search_text(t.title::text) LIKE public.fold_search_text(:prefix_q)"
         )
-        where = f"WHERE {' AND '.join(filters)}"
+        where = f"WHERE {' AND '.join(filters_sql)}"
         exact_first = (
             "CASE WHEN public.fold_search_text(t.title::text) = public.fold_search_text(:q) "
             "THEN 0 ELSE 1 END"
@@ -170,7 +268,7 @@ def build_search(
             f"ORDER BY {order or f'{exact_first}, {_EFFECTIVE_USAGE} DESC, t.tag_id ASC'} "
             "LIMIT :limit OFFSET :offset"
         )
-        return SearchStatements(ids_sql, f"SELECT count(*) FROM tags t {where}", params)
+        return SearchStatements(ids_sql, f"SELECT count(*) {count_from} {where}", params)
 
     # General path: the candidate set is a UNION, never an OR — an OR that
     # mixes these branches defeats the planner's bitmap and scans the table.
@@ -191,15 +289,15 @@ def build_search(
     # Digits match literally somewhere, whatever branch admitted the row.
     for i, token in enumerate(tokens):
         if _DIGITS.match(token):
-            filters.append(
+            filters_sql.append(
                 f"(public.fold_search_text(t.title::text) LIKE public.fold_search_text(:like_tok{i})"
                 f' OR public.fold_search_text(t."desc") LIKE public.fold_search_text(:like_tok{i})'
                 f" OR EXISTS (SELECT 1 FROM tag_external_links l WHERE l.tag_id = t.tag_id"
                 f" AND public.fold_search_text(l.url) LIKE public.fold_search_text(:like_tok{i})))"
             )
     candidates = "candidates AS (\n    " + "\n    UNION\n    ".join(branches) + "\n)"
-    where = f"WHERE {' AND '.join(filters)}" if filters else ""
-    count_sql = f"WITH {candidates} SELECT count(*) FROM tags t JOIN candidates c ON c.tag_id = t.tag_id {where}"
+    where = f"WHERE {' AND '.join(filters_sql)}" if filters_sql else ""
+    count_sql = f"WITH {candidates} SELECT count(*) {count_from} JOIN candidates c ON c.tag_id = t.tag_id {where}"
 
     if order:
         ids_sql = (
@@ -252,8 +350,7 @@ async def search_tags(
     *,
     limit: int = 20,
     offset: int = 0,
-    type_filter: int | None = None,
-    exclude_aliases: bool = False,
+    filters: SearchFilters = SearchFilters(),
     sort: list[str] | None = None,
 ) -> TagSearchResult:
     """Run one tag search and return the page's ids in rank order with an exact total.
@@ -263,16 +360,14 @@ async def search_tags(
         query: Search text. Empty lists every tag.
         limit: Page size.
         offset: Rows to skip.
-        type_filter: TagType constant, or None for all types.
-        exclude_aliases: Drop rows whose alias_of is set.
+        filters: Type, alias, and structural filters; see SearchFilters.
         sort: Sort spec such as ["title:asc"]; None means relevance.
     """
     statements = build_search(
         query,
         limit=limit,
         offset=offset,
-        type_filter=type_filter,
-        exclude_aliases=exclude_aliases,
+        filters=filters,
         sort=sort,
     )
     # One command per execute: asyncpg rejects multi-statement strings. SET

--- a/app/services/tag_search.py
+++ b/app/services/tag_search.py
@@ -163,13 +163,14 @@ def _filter_clauses(filters: SearchFilters, params: dict[str, Any]) -> list[str]
     if filters.has_children is not None:
         clauses.append(
             _exists(
-                "SELECT 1 FROM tags c WHERE c.inheritedfrom_id = t.tag_id", filters.has_children
+                "SELECT 1 FROM tags child WHERE child.inheritedfrom_id = t.tag_id",
+                filters.has_children,
             )
         )
     if filters.source_linked is not None:
-        column = _SOURCE_LINK_COLUMN.get(filters.type_filter or 0)
-        if column is None:
+        if filters.type_filter not in _SOURCE_LINK_COLUMN:
             raise ValueError("source_linked requires type_filter 2 (source) or 4 (character)")
+        column = _SOURCE_LINK_COLUMN[filters.type_filter]
         clauses.append(
             _exists(
                 f"SELECT 1 FROM character_source_links l WHERE l.{column} = t.tag_id",

--- a/tests/api/v1/test_search.py
+++ b/tests/api/v1/test_search.py
@@ -1,10 +1,13 @@
 """Tests for the search API endpoint (/api/v1/search), Postgres engine."""
 
+from datetime import UTC, datetime
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import TagType
+from app.models.character_source_link import CharacterSourceLinks
 from app.models.tag import Tags
 from app.models.tag_external_link import TagExternalLinks
 
@@ -87,12 +90,12 @@ class TestSearchEndpoint:
         assert response.status_code == 200
         assert [hit["title"] for hit in response.json()["hits"]] == ["Naruto"]
 
-    async def test_search_with_exclude_aliases(self, client: AsyncClient, db_session: AsyncSession):
+    async def test_search_with_aliases_hide(self, client: AsyncClient, db_session: AsyncSession):
         (canonical,) = await _seed(db_session, Tags(title="test canonical", type=TagType.THEME))
         await _seed(
             db_session, Tags(title="test alias", type=TagType.THEME, alias_of=canonical.tag_id)
         )
-        response = await client.get("/api/v1/search", params={"q": "test", "exclude_aliases": True})
+        response = await client.get("/api/v1/search", params={"q": "test", "aliases": "hide"})
         assert response.status_code == 200
         assert [hit["title"] for hit in response.json()["hits"]] == ["test canonical"]
 
@@ -277,7 +280,142 @@ class TestExactIdentityLayer:
             )
         )
         await db_session.commit()
-        response = await client.get(
-            "/api/v1/search", params={"q": "21412050", "exclude_aliases": True}
-        )
+        response = await client.get("/api/v1/search", params={"q": "21412050", "aliases": "hide"})
         assert all(hit["tag_id"] != alias_owner.tag_id for hit in response.json()["hits"])
+
+
+@pytest.mark.api
+class TestTagListFilters:
+    async def _seed_family(self, db_session: AsyncSession) -> dict[str, Tags]:
+        (canonical,) = await _seed(
+            db_session, Tags(title="feline", type=TagType.THEME, usage_count=500)
+        )
+        (alias,) = await _seed(
+            db_session, Tags(title="feline alias", type=TagType.THEME, alias_of=canonical.tag_id)
+        )
+        (parent,) = await _seed(
+            db_session, Tags(title="feline parent", type=TagType.THEME, usage_count=40)
+        )
+        (child,) = await _seed(
+            db_session,
+            Tags(
+                title="feline child",
+                type=TagType.THEME,
+                usage_count=3,
+                inheritedfrom_id=parent.tag_id,
+            ),
+        )
+        (character,) = await _seed(
+            db_session, Tags(title="feline girl", type=TagType.CHARACTER, usage_count=20)
+        )
+        (loner,) = await _seed(
+            db_session, Tags(title="feline loner", type=TagType.CHARACTER, usage_count=7)
+        )
+        (source,) = await _seed(
+            db_session, Tags(title="feline show", type=TagType.SOURCE, usage_count=90)
+        )
+        db_session.add(
+            CharacterSourceLinks(character_tag_id=character.tag_id, source_tag_id=source.tag_id)
+        )
+        await db_session.commit()
+        return {
+            "canonical": canonical,
+            "alias": alias,
+            "parent": parent,
+            "child": child,
+            "character": character,
+            "loner": loner,
+            "source": source,
+        }
+
+    async def _titles(self, client: AsyncClient, **params) -> tuple[list[str], int]:
+        response = await client.get("/api/v1/search", params={"q": "feline", **params})
+        assert response.status_code == 200, response.text
+        data = response.json()
+        return [hit["title"] for hit in data["hits"]], data["total"]
+
+    async def test_aliases_only_and_all(self, client: AsyncClient, db_session: AsyncSession):
+        await self._seed_family(db_session)
+        only, only_total = await self._titles(client, aliases="only")
+        assert only == ["feline alias"] and only_total == 1
+        every, every_total = await self._titles(client, aliases="all")
+        assert "feline alias" in every and every_total == 7
+
+    async def test_min_usage_counts_the_alias_by_its_parent(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        await self._seed_family(db_session)
+        titles, total = await self._titles(client, aliases="all", min_usage=100)
+        assert set(titles) == {"feline", "feline alias"} and total == 2
+
+    async def test_added_range(self, client: AsyncClient, db_session: AsyncSession):
+        family = await self._seed_family(db_session)
+        family["loner"].date_added = datetime(2020, 6, 15, 12, 0, tzinfo=UTC)
+        await db_session.commit()
+        titles, total = await self._titles(client, added_from="2020-01-01", added_to="2020-12-31")
+        assert titles == ["feline loner"] and total == 1
+        titles, total = await self._titles(client, added_to="2019-12-31")
+        assert titles == [] and total == 0
+
+    async def test_added_from_after_added_to_is_422(self, client: AsyncClient):
+        response = await client.get(
+            "/api/v1/search", params={"q": "", "added_from": "2021-01-01", "added_to": "2020-01-01"}
+        )
+        assert response.status_code == 422
+
+    async def test_has_alias_is_child_has_children(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        await self._seed_family(db_session)
+        assert (await self._titles(client, has_alias="yes"))[0] == ["feline"]
+        assert (await self._titles(client, is_child="yes"))[0] == ["feline child"]
+        assert (await self._titles(client, has_children="yes"))[0] == ["feline parent"]
+        titles, _ = await self._titles(client, has_children="no", is_child="no", has_alias="no")
+        assert (
+            "feline parent" not in titles
+            and "feline child" not in titles
+            and "feline" not in titles
+        )
+
+    async def test_source_linked_by_type(self, client: AsyncClient, db_session: AsyncSession):
+        await self._seed_family(db_session)
+        assert (await self._titles(client, type=TagType.CHARACTER, source_linked="yes"))[0] == [
+            "feline girl"
+        ]
+        assert (await self._titles(client, type=TagType.CHARACTER, source_linked="no"))[0] == [
+            "feline loner"
+        ]
+        assert (await self._titles(client, type=TagType.SOURCE, source_linked="yes"))[0] == [
+            "feline show"
+        ]
+
+    @pytest.mark.parametrize("params", [{}, {"type": TagType.THEME}, {"type": TagType.ARTIST}])
+    async def test_source_linked_needs_character_or_source_type(self, client: AsyncClient, params):
+        response = await client.get(
+            "/api/v1/search", params={"q": "", "source_linked": "yes", **params}
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"aliases": "sometimes"},
+            {"min_usage": -1},
+            {"has_alias": "maybe"},
+            {"added_from": "2020-13-01"},
+        ],
+    )
+    async def test_invalid_values_are_422(self, client: AsyncClient, params):
+        response = await client.get("/api/v1/search", params={"q": "", **params})
+        assert response.status_code == 422
+
+    async def test_identity_prepend_skips_under_a_structural_filter(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        owner, _ = await _seed_identity_owner(db_session)
+        response = await client.get("/api/v1/search", params={"q": "21412050", "min_usage": 0})
+        data = response.json()
+        assert all(hit["matched_identity"] is None for hit in data["hits"])
+        assert owner.tag_id in [
+            hit["tag_id"] for hit in data["hits"]
+        ]  # still a plain text hit via its URL

--- a/tests/api/v1/test_search.py
+++ b/tests/api/v1/test_search.py
@@ -357,6 +357,21 @@ class TestTagListFilters:
         titles, total = await self._titles(client, aliases="all", min_usage=100)
         assert set(titles) == {"feline", "feline alias"} and total == 2
 
+    async def test_max_usage_bounds_the_effective_count(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        await self._seed_family(db_session)
+        titles, total = await self._titles(client, aliases="all", min_usage=100, max_usage=600)
+        assert set(titles) == {"feline", "feline alias"} and total == 2
+        titles, total = await self._titles(client, max_usage=10)
+        assert set(titles) == {"feline child", "feline loner"} and total == 2
+
+    async def test_min_usage_above_max_usage_is_422(self, client: AsyncClient):
+        response = await client.get(
+            "/api/v1/search", params={"q": "", "min_usage": 5, "max_usage": 4}
+        )
+        assert response.status_code == 422
+
     async def test_added_range(self, client: AsyncClient, db_session: AsyncSession):
         family = await self._seed_family(db_session)
         family["loner"].date_added = datetime(2020, 6, 15, 12, 0, tzinfo=UTC)
@@ -410,6 +425,8 @@ class TestTagListFilters:
             {"aliases": "sometimes"},
             {"min_usage": -1},
             {"min_usage": 2147483648},
+            {"max_usage": -1},
+            {"max_usage": 2147483648},
             {"has_alias": "maybe"},
             {"added_from": "2020-13-01"},
         ],

--- a/tests/api/v1/test_search.py
+++ b/tests/api/v1/test_search.py
@@ -409,6 +409,7 @@ class TestTagListFilters:
         [
             {"aliases": "sometimes"},
             {"min_usage": -1},
+            {"min_usage": 2147483648},
             {"has_alias": "maybe"},
             {"added_from": "2020-13-01"},
         ],
@@ -416,6 +417,10 @@ class TestTagListFilters:
     async def test_invalid_values_are_422(self, client: AsyncClient, params):
         response = await client.get("/api/v1/search", params={"q": "", **params})
         assert response.status_code == 422
+
+    async def test_min_usage_at_the_integer_maximum_is_accepted(self, client: AsyncClient):
+        response = await client.get("/api/v1/search", params={"q": "", "min_usage": 2147483647})
+        assert response.status_code == 200
 
     async def test_identity_prepend_skips_under_a_structural_filter(
         self, client: AsyncClient, db_session: AsyncSession

--- a/tests/api/v1/test_search.py
+++ b/tests/api/v1/test_search.py
@@ -263,7 +263,7 @@ class TestExactIdentityLayer:
         )
         assert response.json()["hits"][0]["tag_id"] == owner.tag_id
 
-    async def test_exclude_aliases_blocks_an_alias_owner(
+    async def test_aliases_hide_blocks_an_alias_owner(
         self, client: AsyncClient, db_session: AsyncSession
     ):
         # An owner that is itself an alias must not be injected when aliases are excluded.
@@ -282,6 +282,15 @@ class TestExactIdentityLayer:
         await db_session.commit()
         response = await client.get("/api/v1/search", params={"q": "21412050", "aliases": "hide"})
         assert all(hit["tag_id"] != alias_owner.tag_id for hit in response.json()["hits"])
+
+    async def test_aliases_only_blocks_a_canonical_owner(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        owner, _ = await _seed_identity_owner(db_session, alias_titles=("Pixiv 21412050",))
+        response = await client.get("/api/v1/search", params={"q": "21412050", "aliases": "only"})
+        data = response.json()
+        assert all(hit["matched_identity"] is None for hit in data["hits"])
+        assert all(hit["tag_id"] != owner.tag_id for hit in data["hits"])
 
 
 @pytest.mark.api
@@ -370,12 +379,9 @@ class TestTagListFilters:
         assert (await self._titles(client, has_alias="yes"))[0] == ["feline"]
         assert (await self._titles(client, is_child="yes"))[0] == ["feline child"]
         assert (await self._titles(client, has_children="yes"))[0] == ["feline parent"]
-        titles, _ = await self._titles(client, has_children="no", is_child="no", has_alias="no")
-        assert (
-            "feline parent" not in titles
-            and "feline child" not in titles
-            and "feline" not in titles
-        )
+        titles, total = await self._titles(client, has_children="no", is_child="no", has_alias="no")
+        assert set(titles) == {"feline alias", "feline girl", "feline loner", "feline show"}
+        assert total == 4
 
     async def test_source_linked_by_type(self, client: AsyncClient, db_session: AsyncSession):
         await self._seed_family(db_session)
@@ -389,7 +395,9 @@ class TestTagListFilters:
             "feline show"
         ]
 
-    @pytest.mark.parametrize("params", [{}, {"type": TagType.THEME}, {"type": TagType.ARTIST}])
+    @pytest.mark.parametrize(
+        "params", [{}, {"type": 0}, {"type": TagType.THEME}, {"type": TagType.ARTIST}]
+    )
     async def test_source_linked_needs_character_or_source_type(self, client: AsyncClient, params):
         response = await client.get(
             "/api/v1/search", params={"q": "", "source_linked": "yes", **params}

--- a/tests/integration/test_tag_search_corpus.py
+++ b/tests/integration/test_tag_search_corpus.py
@@ -4,13 +4,16 @@ Seeds the titles behind every query in the design doc's appendix, with the
 decoys that broke earlier ranking attempts, and asserts the top hit by title.
 """
 
+from datetime import UTC, date, datetime
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import TagType
+from app.models.character_source_link import CharacterSourceLinks
 from app.models.tag import Tags
 from app.models.tag_external_link import TagExternalLinks
-from app.services.tag_search import search_tags
+from app.services.tag_search import SearchFilters, search_tags
 
 # (title, type, usage_count, desc, alias_of_title, urls)
 CORPUS = [
@@ -97,6 +100,21 @@ CORPUS = [
     ("Louise Françoise le Blanc de la Vallière", TagType.CHARACTER, 447, "", None, []),
     ("Francoise", TagType.CHARACTER, 3, "", None, []),
     ("Claire Francois", TagType.CHARACTER, 50, "", None, []),
+    ("sailor uniform", TagType.THEME, 30000, "", None, []),
+    ("blazer", TagType.THEME, 12000, "", None, []),
+    ("Cardcaptor Sakura", TagType.SOURCE, 6000, "", None, []),
+]
+
+# (parent_title, child_title): inheritedfrom_id wiring
+HIERARCHY = [
+    ("school uniform", "sailor uniform"),
+    ("school uniform", "blazer"),
+    ("Pokémon", "Pokémon Adventures"),
+]
+# (character_title, source_title): character_source_links rows
+SOURCE_LINKS = [
+    ("Kinomoto Sakura", "Cardcaptor Sakura"),
+    ("Kinomoto Touya", "Cardcaptor Sakura"),
 ]
 
 # (query, expected top-1 title) — spec appendix, asserted by title.
@@ -155,6 +173,15 @@ async def seed_corpus(db_session: AsyncSession) -> dict[str, Tags]:
             by_title[title].alias_of = by_title[alias_of_title].tag_id
         for url in urls:
             db_session.add(TagExternalLinks(tag_id=by_title[title].tag_id, url=url))
+    for parent_title, child_title in HIERARCHY:
+        by_title[child_title].inheritedfrom_id = by_title[parent_title].tag_id
+    for character_title, source_title in SOURCE_LINKS:
+        db_session.add(
+            CharacterSourceLinks(
+                character_tag_id=by_title[character_title].tag_id,
+                source_tag_id=by_title[source_title].tag_id,
+            )
+        )
     await db_session.commit()
     return by_title
 
@@ -196,11 +223,15 @@ class TestSearchCorpus:
     async def test_type_filter_and_exclude_aliases(self, db_session: AsyncSession):
         by_title = await seed_corpus(db_session)
         by_type = {tag.tag_id: tag.type for tag in by_title.values()}
-        only_characters = await search_tags(db_session, "sakura", type_filter=TagType.CHARACTER)
+        only_characters = await search_tags(
+            db_session, "sakura", filters=SearchFilters(type_filter=TagType.CHARACTER)
+        )
         assert only_characters.tag_ids
         assert all(by_type[tag_id] == TagType.CHARACTER for tag_id in only_characters.tag_ids)
         assert only_characters.total == len(only_characters.tag_ids)
-        no_aliases_result = await search_tags(db_session, "sakura", exclude_aliases=True)
+        no_aliases_result = await search_tags(
+            db_session, "sakura", filters=SearchFilters(aliases="hide")
+        )
         no_aliases = titles_for(by_title, no_aliases_result)
         assert "sakura" not in no_aliases  # the alias row
         assert "Sakura" in no_aliases
@@ -220,8 +251,8 @@ class TestSearchCorpus:
         found = titles_for(
             by_title, await search_tags(db_session, "sakura", sort=["title:asc"], limit=100)
         )
-        # Relevance would lead with the exact "sakura"; a title sort leads with "Kinomoto Sakura".
-        assert found[0] == "Kinomoto Sakura"
+        # Relevance would lead with the exact "sakura"; a title sort leads with "Cardcaptor Sakura".
+        assert found[0] == "Cardcaptor Sakura"
         assert "sakura" in found
 
     async def test_empty_query_lists_all_by_effective_usage(self, db_session: AsyncSession):
@@ -246,3 +277,99 @@ class TestSearchCorpus:
         result = await search_tags(db_session, "ß" * 128, limit=10)
         assert result.tag_ids == [decoy.tag_id]
         assert result.total == 1
+
+    async def test_min_usage_filters_on_effective_count(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        result = await search_tags(
+            db_session, "sakura", filters=SearchFilters(aliases="all", min_usage=20000), limit=50
+        )
+        titles = titles_for(by_title, result)
+        assert "sakura" in titles  # alias of cherry blossoms (21,476)
+        assert "Sakura" not in titles  # the character has 797
+        assert result.total == len(result.tag_ids)
+
+    async def test_aliases_only(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        result = await search_tags(db_session, "", filters=SearchFilters(aliases="only"), limit=100)
+        titles = titles_for(by_title, result)
+        assert set(titles) == {t for t, _, _, _, alias, _ in CORPUS if alias}
+        assert result.total == len(titles)
+
+    async def test_added_range_uses_the_utc_date(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        by_title["blazer"].date_added = datetime(2020, 6, 30, 23, 59, tzinfo=UTC)
+        await db_session.commit()
+        inside = await search_tags(
+            db_session,
+            "",
+            filters=SearchFilters(added_from=date(2020, 6, 30), added_to=date(2020, 6, 30)),
+        )
+        assert titles_for(by_title, inside) == ["blazer"] and inside.total == 1
+        outside = await search_tags(
+            db_session, "", filters=SearchFilters(added_to=date(2020, 6, 29))
+        )
+        assert outside.tag_ids == [] and outside.total == 0
+
+    async def test_hierarchy_filters(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        parents = titles_for(
+            by_title,
+            await search_tags(db_session, "", filters=SearchFilters(has_children="yes"), limit=100),
+        )
+        assert set(parents) == {"school uniform", "Pokémon"}
+        children = titles_for(
+            by_title,
+            await search_tags(db_session, "", filters=SearchFilters(is_child="yes"), limit=100),
+        )
+        assert set(children) == {"sailor uniform", "blazer", "Pokémon Adventures"}
+        no_parent = await search_tags(
+            db_session, "", filters=SearchFilters(is_child="no"), limit=100
+        )
+        assert no_parent.total == len(CORPUS) - 3
+
+    async def test_has_alias(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        result = await search_tags(
+            db_session, "", filters=SearchFilters(has_alias="yes"), limit=100
+        )
+        assert set(titles_for(by_title, result)) == {
+            "cherry blossoms",
+            "cat",
+            "swimsuit",
+            "bikini",
+            "TKennshou",
+        }
+
+    async def test_source_linked_both_sides(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        linked_chars = await search_tags(
+            db_session,
+            "",
+            filters=SearchFilters(type_filter=TagType.CHARACTER, source_linked="yes"),
+            limit=100,
+        )
+        assert set(titles_for(by_title, linked_chars)) == {"Kinomoto Sakura", "Kinomoto Touya"}
+        unlinked_chars = await search_tags(
+            db_session,
+            "kinomoto",
+            filters=SearchFilters(type_filter=TagType.CHARACTER, source_linked="no"),
+            limit=100,
+        )
+        assert "Kinomoto Sakura" not in titles_for(by_title, unlinked_chars)
+        assert "Kinomoto Nadeshiko" in titles_for(by_title, unlinked_chars)
+        linked_sources = await search_tags(
+            db_session,
+            "",
+            filters=SearchFilters(type_filter=TagType.SOURCE, source_linked="yes"),
+            limit=100,
+        )
+        assert titles_for(by_title, linked_sources) == ["Cardcaptor Sakura"]
+
+    async def test_filters_apply_on_the_prefix_path_too(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        result = await search_tags(
+            db_session, "sa", filters=SearchFilters(aliases="only"), limit=100
+        )
+        titles = titles_for(by_title, result)
+        assert titles and all(by_title[t].alias_of is not None for t in titles)
+        assert result.total == len(titles)

--- a/tests/integration/test_tag_search_corpus.py
+++ b/tests/integration/test_tag_search_corpus.py
@@ -186,6 +186,13 @@ async def seed_corpus(db_session: AsyncSession) -> dict[str, Tags]:
     return by_title
 
 
+def by_title_usage(by_title: dict[str, Tags], tag: Tags) -> int:
+    if tag.alias_of is None:
+        return tag.usage_count
+    parent = next(t for t in by_title.values() if t.tag_id == tag.alias_of)
+    return parent.usage_count
+
+
 def titles_for(by_title: dict[str, Tags], result) -> list[str]:
     id_to_title = {tag.tag_id: title for title, tag in by_title.items()}
     return [id_to_title[tag_id] for tag_id in result.tag_ids]
@@ -287,6 +294,23 @@ class TestSearchCorpus:
         assert "sakura" in titles  # alias of cherry blossoms (21,476)
         assert "Sakura" not in titles  # the character has 797
         assert result.total == len(result.tag_ids)
+
+    async def test_max_usage_zero_excludes_aliases_of_used_tags(self, db_session: AsyncSession):
+        by_title = await seed_corpus(db_session)
+        unused = await search_tags(
+            db_session, "", filters=SearchFilters(aliases="all", max_usage=0), limit=100
+        )
+        assert unused.total == 0  # every zero-count row in the corpus is an alias of a used tag
+        rare = await search_tags(
+            db_session, "", filters=SearchFilters(aliases="all", max_usage=1), limit=100
+        )
+        titles = titles_for(by_title, rare)
+        assert titles and "Kinomoto Sakura" not in titles
+        assert rare.total == len(rare.tag_ids)
+        for title in titles:
+            tag = by_title[title]
+            effective = by_title_usage(by_title, tag)
+            assert effective <= 1, (title, effective)
 
     async def test_aliases_only(self, db_session: AsyncSession):
         by_title = await seed_corpus(db_session)

--- a/tests/unit/test_tag_search_sql.py
+++ b/tests/unit/test_tag_search_sql.py
@@ -155,8 +155,14 @@ class TestBuildSearch:
     def test_has_children_yes_and_no(self):
         yes = _build("", SearchFilters(has_children="yes"))
         no = _build("", SearchFilters(has_children="no"))
-        assert "EXISTS (SELECT 1 FROM tags c WHERE c.inheritedfrom_id = t.tag_id)" in yes.ids_sql
-        assert "NOT EXISTS (SELECT 1 FROM tags c WHERE c.inheritedfrom_id = t.tag_id)" in no.ids_sql
+        assert (
+            "EXISTS (SELECT 1 FROM tags child WHERE child.inheritedfrom_id = t.tag_id)"
+            in yes.ids_sql
+        )
+        assert (
+            "NOT EXISTS (SELECT 1 FROM tags child WHERE child.inheritedfrom_id = t.tag_id)"
+            in no.ids_sql
+        )
 
     def test_source_linked_picks_the_column_by_type(self):
         character = _build("", SearchFilters(type_filter=4, source_linked="yes"))

--- a/tests/unit/test_tag_search_sql.py
+++ b/tests/unit/test_tag_search_sql.py
@@ -1,12 +1,14 @@
 """build_search is pure: assert the SQL shape and bind parameters, no database."""
 
+from datetime import date, datetime
+
 import pytest
 
-from app.services.tag_search import build_search
+from app.services.tag_search import SearchFilters, build_search
 
 
-def _build(query: str, **overrides):
-    kwargs = {"limit": 10, "offset": 0, "type_filter": None, "exclude_aliases": False, "sort": None}
+def _build(query: str, filters: SearchFilters | None = None, **overrides):
+    kwargs = {"limit": 10, "offset": 0, "filters": filters or SearchFilters(), "sort": None}
     kwargs.update(overrides)
     return build_search(query, **kwargs)
 
@@ -74,7 +76,7 @@ class TestBuildSearch:
         assert st.params["prefix_q"] == "100\\%%"
 
     def test_filters_apply_to_ids_and_count(self):
-        st = _build("sakura", type_filter=4, exclude_aliases=True)
+        st = _build("sakura", filters=SearchFilters(type_filter=4, aliases="hide"))
         for sql in (st.ids_sql, st.count_sql):
             assert "t.type = :type_filter" in sql
             assert "t.alias_of IS NULL" in sql
@@ -99,3 +101,93 @@ class TestBuildSearch:
         st = _build("'; DROP TABLE tags; --")
         assert "DROP TABLE" not in st.ids_sql
         assert "DROP TABLE" not in st.count_sql
+
+    @pytest.mark.parametrize("query", ["", "sa", "sakura"])
+    def test_aliases_tri_state_reaches_ids_and_count(self, query: str):
+        hide = _build(query, SearchFilters(aliases="hide"))
+        only = _build(query, SearchFilters(aliases="only"))
+        every = _build(query, SearchFilters(aliases="all"))
+        for sql in (hide.ids_sql, hide.count_sql):
+            assert "t.alias_of IS NULL" in sql
+        for sql in (only.ids_sql, only.count_sql):
+            assert "t.alias_of IS NOT NULL" in sql
+        for sql in (every.ids_sql, every.count_sql):
+            assert "alias_of IS" not in sql
+
+    @pytest.mark.parametrize("query", ["", "sa", "sakura"])
+    def test_min_usage_uses_effective_count_and_joins_parent_in_count(self, query: str):
+        st = _build(query, SearchFilters(min_usage=50))
+        for sql in (st.ids_sql, st.count_sql):
+            assert "COALESCE(parent.usage_count, t.usage_count) >= :min_usage" in sql
+        assert "LEFT JOIN tags parent ON parent.tag_id = t.alias_of" in st.count_sql
+        assert st.params["min_usage"] == 50
+
+    def test_count_skips_parent_join_without_min_usage(self):
+        st = _build("sakura", SearchFilters(aliases="hide"))
+        assert "parent" not in st.count_sql
+
+    def test_added_range_binds_naive_utc_midnights(self):
+        st = _build("", SearchFilters(added_from=date(2020, 6, 1), added_to=date(2020, 6, 30)))
+        assert "t.date_added >= :added_from_ts" in st.ids_sql
+        assert "t.date_added < :added_to_next_ts" in st.count_sql
+        assert st.params["added_from_ts"] == datetime(2020, 6, 1)
+        assert st.params["added_to_next_ts"] == datetime(2020, 7, 1)
+        assert st.params["added_from_ts"].tzinfo is None
+
+    def test_added_from_alone(self):
+        st = _build("", SearchFilters(added_from=date(2021, 1, 1)))
+        assert "added_from_ts" in st.ids_sql
+        assert "added_to_next_ts" not in st.ids_sql
+
+    def test_has_alias_yes_and_no(self):
+        yes = _build("", SearchFilters(has_alias="yes"))
+        no = _build("", SearchFilters(has_alias="no"))
+        assert "EXISTS (SELECT 1 FROM tags a WHERE a.alias_of = t.tag_id)" in yes.ids_sql
+        assert "NOT EXISTS (SELECT 1 FROM tags a WHERE a.alias_of = t.tag_id)" in no.count_sql
+        assert "NOT EXISTS" not in yes.ids_sql
+
+    def test_is_child_yes_and_no(self):
+        assert (
+            "t.inheritedfrom_id IS NOT NULL" in _build("", SearchFilters(is_child="yes")).count_sql
+        )
+        assert "t.inheritedfrom_id IS NULL" in _build("", SearchFilters(is_child="no")).ids_sql
+
+    def test_has_children_yes_and_no(self):
+        yes = _build("", SearchFilters(has_children="yes"))
+        no = _build("", SearchFilters(has_children="no"))
+        assert "EXISTS (SELECT 1 FROM tags c WHERE c.inheritedfrom_id = t.tag_id)" in yes.ids_sql
+        assert "NOT EXISTS (SELECT 1 FROM tags c WHERE c.inheritedfrom_id = t.tag_id)" in no.ids_sql
+
+    def test_source_linked_picks_the_column_by_type(self):
+        character = _build("", SearchFilters(type_filter=4, source_linked="yes"))
+        source = _build("", SearchFilters(type_filter=2, source_linked="no"))
+        assert (
+            "EXISTS (SELECT 1 FROM character_source_links l WHERE l.character_tag_id = t.tag_id)"
+            in character.ids_sql
+        )
+        assert (
+            "NOT EXISTS (SELECT 1 FROM character_source_links l WHERE l.source_tag_id = t.tag_id)"
+            in source.count_sql
+        )
+
+    @pytest.mark.parametrize("type_filter", [None, 1, 3])
+    def test_source_linked_without_character_or_source_type_is_rejected(self, type_filter):
+        with pytest.raises(ValueError, match="source_linked"):
+            _build("", SearchFilters(type_filter=type_filter, source_linked="yes"))
+
+    def test_is_structural_flag(self):
+        assert not SearchFilters().is_structural
+        assert not SearchFilters(type_filter=4, aliases="hide").is_structural
+        assert SearchFilters(min_usage=0).is_structural
+        assert SearchFilters(added_to=date(2020, 1, 1)).is_structural
+        assert SearchFilters(has_children="no").is_structural
+
+    def test_filters_combine_with_query_and_type(self):
+        st = _build(
+            "sakura", SearchFilters(type_filter=4, aliases="hide", min_usage=10, has_alias="no")
+        )
+        for sql in (st.ids_sql, st.count_sql):
+            assert "t.type = :type_filter" in sql
+            assert "t.alias_of IS NULL" in sql
+            assert ">= :min_usage" in sql
+            assert "NOT EXISTS (SELECT 1 FROM tags a WHERE a.alias_of = t.tag_id)" in sql

--- a/tests/unit/test_tag_search_sql.py
+++ b/tests/unit/test_tag_search_sql.py
@@ -126,6 +126,19 @@ class TestBuildSearch:
         st = _build("sakura", SearchFilters(aliases="hide"))
         assert "parent" not in st.count_sql
 
+    @pytest.mark.parametrize("query", ["", "sa", "sakura"])
+    def test_max_usage_uses_effective_count_and_joins_parent_in_count(self, query: str):
+        st = _build(query, SearchFilters(max_usage=5))
+        for sql in (st.ids_sql, st.count_sql):
+            assert "COALESCE(parent.usage_count, t.usage_count) <= :max_usage" in sql
+        assert "LEFT JOIN tags parent ON parent.tag_id = t.alias_of" in st.count_sql
+        assert st.params["max_usage"] == 5
+
+    def test_min_and_max_usage_together(self):
+        st = _build("", SearchFilters(min_usage=10, max_usage=20))
+        assert ">= :min_usage" in st.count_sql and "<= :max_usage" in st.count_sql
+        assert SearchFilters(max_usage=0).is_structural
+
     def test_added_range_binds_naive_utc_midnights(self):
         st = _build("", SearchFilters(added_from=date(2020, 6, 1), added_to=date(2020, 6, 30)))
         assert "t.date_added >= :added_from_ts" in st.ids_sql


### PR DESCRIPTION
## Summary

Structural filters for the tag list on `GET /api/v1/search`, built as `EXISTS` predicates inside the Postgres search builder (`app/services/tag_search.py`), so they compose with the text search on every path (empty list, prefix-only, general).

- `aliases=hide|only|all` (default `all`) **replaces** `exclude_aliases` with no shim. Only the tags page sent the old flag; the typeaheads keep the default.
- `min_usage` / `max_usage` on the *effective* count (`COALESCE(parent.usage_count, t.usage_count)`), both bounded to the int32 range; `min_usage > max_usage` → 422.
- `added_from` / `added_to` as naive-UTC midnight bounds (`>= from`, `< to + 1 day`); `from > to` → 422.
- `has_alias`, `is_child`, `has_children` as `yes|no`.
- `source_linked=yes|no`, which requires `type` 2 (source) or 4 (character), else 422.
- The identity prepend layer (exact-match rows floated to the top) is skipped whenever any filter beyond `type`/`aliases` is set, so a structural query never shows a row the filters would exclude.

## Deploy note

Ship together with anonymousobject/shuushuu-frontend#426. The frontend on that PR sends `aliases=hide` where it used to send `exclude_aliases=true`; either side deployed alone silently shows aliases in the tag list.

## Tests

- `tests/unit/test_tag_search_sql.py`: builder output per filter, the parent join gating, `is_structural`.
- `tests/api/v1/test_search.py::TestTagListFilters`: a seeded family fixture with exact-set assertions per filter and the three 422s.
- `tests/integration/test_tag_search_corpus.py`: the 86-row corpus gains a hierarchy and source links so every filter runs against real Postgres.

Plan: `docs/plans/2026-Q3/2026-09-12-tag-list-filters-impl.md` (design in the frontend repo, `docs/plans/2026-Q3/2026-09-12-tag-list-filters-design.md`). Stacked on #393 and #395, both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNoxNBcTrbQyAD55cVmfCh
